### PR TITLE
feat: support chunking large text block

### DIFF
--- a/aperag/utils/tokenizer.py
+++ b/aperag/utils/tokenizer.py
@@ -1,0 +1,23 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Callable, List
+
+import tiktoken
+
+
+def get_default_tokenizer() -> Callable[[str], List[int]]:
+    encoding = tiktoken.get_encoding(os.environ.get("DEFAULT_ENCODING_MODEL", "cl100k_base"))
+    return encoding.encode

--- a/config/settings.py
+++ b/config/settings.py
@@ -252,7 +252,7 @@ EMBEDDING_BACKEND = env.str("EMBEDDING_BACKEND", default="local")
 EMBEDDING_SERVICE_URL = env.str("EMBEDDING_SERVICE_URL", default="http://localhost:9997")
 # model is used by infinity, model_uid is used by xinference
 EMBEDDING_SERVICE_MODEL = env.str("EMBEDDING_SERVICE_MODEL", default="bge-large-zh-v1.5")
-EMBEDDING_SERVICE_TOKEN = env.str("EMBEDDING_SERVICE_TOKEN")
+EMBEDDING_SERVICE_TOKEN = env.str("EMBEDDING_SERVICE_TOKEN", default="")
 EMBEDDING_SERVICE_MODEL_UID = env.str("EMBEDDING_SERVICE_MODEL_UID", default="")
 SENSITIVE_FILTER_MODEL = env.str("SENSITIVE_FILTER_MODEL", default="")
 

--- a/envs/.env.template
+++ b/envs/.env.template
@@ -68,6 +68,16 @@ RERANK_BACKEND=local
 RERANK_SERVICE_URL=http://localhost:9997
 RERANK_SERVICE_MODEL_UID=
 
+# Specifies the cache directory for tiktoken. This prevents the need to re-download models on each run.
+# You can also pre-download models to this directory.
+#
+# For example:
+#   TIKTOKEN_URL="https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"
+#   wget -O "${TIKTOKEN_CACHE_DIR}/$(echo -n "$TIKTOKEN_URL" | sha1sum | head -c 40)" "$TIKTOKEN_URL"
+TIKTOKEN_CACHE_DIR=~/.cache/tiktoken
+DEFAULT_ENCODING_MODEL=cl100k_base
+
+
 DATABASE_URL="postgres://postgres:postgres@127.0.0.1:5432/postgres"
 
 BAICHUAN_API_KEY=

--- a/poetry.lock
+++ b/poetry.lock
@@ -2369,15 +2369,15 @@ test = ["Cython (>=0.29.24)"]
 
 [[package]]
 name = "httpx"
-version = "0.28.1"
+version = "0.27.2"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "platform_python_implementation == \"CPython\""
 files = [
-    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
-    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
 ]
 
 [package.dependencies]
@@ -2386,6 +2386,7 @@ certifi = "*"
 h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = "==1.*"
 idna = "*"
+sniffio = "*"
 
 [package.extras]
 brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
@@ -8323,4 +8324,4 @@ all = ["clickhouse-connect", "elasticsearch", "pymilvus", "pymongo", "weaviate-c
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0"
-content-hash = "b3fb247fbbfccbca7304051f3bff4136ffa7f78dc80a1c18c5e04ea8767c02ca"
+content-hash = "68acfa02c69f02625c001b7f688ee60990efc9b7d41ff655bf9d088483ddcf0d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ qianfan = "^0.0.6"
 zhipuai = "^1.0.7"
 pillow = "^10.0.0"
 openai = "1.3.5"
+# Pinning the httpx version is necessary to resolve a compatibility issue with the openai library.
+# Error message: "TypeError: AsyncClient.__init__() got an unexpected keyword argument 'proxies'"
+httpx = "0.27.2"
 dashscope = "^1.13.3"
 python-pptx = "^0.6.23"
 unstructured = {extras = ["xlxs", "html"], version = "^0.11.0"}


### PR DESCRIPTION
This PR supports chunking large texts with the `TokenTextSplitter`.

Inside the `TokenTextSplitter`, the tiktoken library is used to count tokens in the text. By default, it uses the `cl100k_base` encoding model, which is the encoding model used by GPT series models; for other LLMs, it might introduce some bias, but it doesn't matter for this use case.