### PR TITLE
chore: remove langchain-huggingface dependency to reduce image size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ authors = [
 requires-python = "<3.13,>=3.11.12"
 dependencies = [
     "langchain<1.0.0,>=0.3.23",
-    "langchain-huggingface<1.0.0,>=0.1.2",
     "llama-index<1.0.0,>=0.12.28",
     "uvicorn[standard]<1.0.0,>=0.23.1",
     "pydantic[email]>=2.10.3,<3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -213,7 +213,6 @@ dependencies = [
     { name = "graspologic" },
     { name = "jsonref" },
     { name = "langchain" },
-    { name = "langchain-huggingface" },
     { name = "litellm" },
     { name = "llama-index" },
     { name = "llama-index-embeddings-google" },
@@ -311,7 +310,6 @@ requires-dist = [
     { name = "graspologic", specifier = ">=3.4.1,<4.0.0" },
     { name = "jsonref", specifier = ">=1.1.0" },
     { name = "langchain", specifier = ">=0.3.23,<1.0.0" },
-    { name = "langchain-huggingface", specifier = ">=0.1.2,<1.0.0" },
     { name = "litellm", specifier = ">=1.73.0rc1" },
     { name = "llama-index", specifier = ">=0.12.28,<1.0.0" },
     { name = "llama-index-embeddings-google", specifier = ">=0.3.1,<1.0.0" },
@@ -2519,22 +2517,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/e7/d649de03ddf3427e3e45107936f7fd048a4eea91db6ca56fd9b3b2d28c85/langchain_core-0.3.54.tar.gz", hash = "sha256:55ce38939038e19b1271f36f512335462d7f64057b531598b3651d2b403e1b42", size = 553286, upload-time = "2025-04-17T19:26:43.04Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/f4/413c051df2c63cb21455ad97f221edd359c2d2b070616f3697e0b7ce14cd/langchain_core-0.3.54-py3-none-any.whl", hash = "sha256:cd42155d9089e2fd4695ee02a4b2bc6daf55b9d4e1a37639647cf2455ed4fa04", size = 433875, upload-time = "2025-04-17T19:26:41.726Z" },
-]
-
-[[package]]
-name = "langchain-huggingface"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "huggingface-hub" },
-    { name = "langchain-core" },
-    { name = "sentence-transformers" },
-    { name = "tokenizers" },
-    { name = "transformers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/0f/8277d993d5307f06523e72c9bc8a505ed028f7b1c1e5276d8e89044b6036/langchain_huggingface-0.1.2.tar.gz", hash = "sha256:4a66d5c449298fd353bd84c9ed01f9bf4303bf2e4ffce14aab8c55c584eee57c", size = 16129, upload-time = "2024-10-31T18:56:53.894Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/f8/77a303ddc492f6eed8bf0979f2bc6db4fa6eb1089c5e9f0f977dd87bc9c2/langchain_huggingface-0.1.2-py3-none-any.whl", hash = "sha256:7de5cfcae32bfb6a99c084fc16176f02583a4f8d94febb6bb45bed5b34699174", size = 21251, upload-time = "2024-10-31T18:56:52.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The largest dependencies (NVIDIA, PyTorch, and Triton) are introduced by langchain_huggingface, but langchain_huggingface itself is practically useless.


```bash
root@api-84d85c84dc-rmvp8:/opt/venv/lib/python3.11/site-packages# du -sh ./* | sort -hr | head 
2.7G	./nvidia
1.5G	./torch
685M	./triton
203M	./cusparselt
128M	./llvmlite
83M	./scipy
83M	./googleapiclient
54M	./pandas
50M	./gensim
48M	./transformers
root@api-84d85c84dc-rmvp8:/opt/venv/lib/python3.11/site-packages# 
```


```bash
~ uv tree
Resolved 397 packages in 0.91ms
aperag v0.1.0
├── alembic v1.16.1
│   ├── mako v1.3.10
│   │   └── markupsafe v3.0.2
│   ├── sqlalchemy v2.0.40
│   │   ├── typing-extensions v4.13.2
│   │   └── greenlet v3.2.0 (extra: asyncio)
│   └── typing-extensions v4.13.2
├── arrow v1.3.0
│   ├── python-dateutil v2.9.0.post0
│   │   └── six v1.17.0
│   └── types-python-dateutil v2.9.0.20241206
├── asyncpg v0.30.0
├── auth0-python v4.7.0
│   ├── aiohttp v3.11.16
│   │   ├── aiohappyeyeballs v2.6.1
│   │   ├── aiosignal v1.3.2
│   │   │   └── frozenlist v1.6.0
│   │   ├── attrs v25.3.0
│   │   ├── frozenlist v1.6.0
│   │   ├── multidict v6.4.3
│   │   ├── propcache v0.3.1
│   │   └── yarl v1.20.0
│   │       ├── idna v3.10
│   │       ├── multidict v6.4.3
│   │       └── propcache v0.3.1
│   ├── cryptography v41.0.7
│   │   └── cffi v1.17.1
│   │       └── pycparser v2.22
│   ├── pyjwt v2.10.1
│   │   └── cryptography v41.0.7 (extra: crypto) (*)
│   ├── pyopenssl v23.3.0
│   │   └── cryptography v41.0.7 (*)
│   ├── requests v2.32.3
│   │   ├── certifi v2025.1.31
│   │   ├── charset-normalizer v3.4.1
│   │   ├── idna v3.10
│   │   └── urllib3 v2.4.0
│   └── urllib3 v2.4.0
├── boto3 v1.37.37
│   ├── botocore v1.37.37
│   │   ├── jmespath v0.10.0
│   │   ├── python-dateutil v2.9.0.post0 (*)
│   │   └── urllib3 v2.4.0
│   ├── jmespath v0.10.0
│   └── s3transfer v0.11.5
│       └── botocore v1.37.37 (*)
├── celery v5.5.1
│   ├── billiard v4.2.1
│   ├── click v8.1.8
│   ├── click-didyoumean v0.3.1
│   │   └── click v8.1.8
│   ├── click-plugins v1.1.1
│   │   └── click v8.1.8
│   ├── click-repl v0.3.0
│   │   ├── click v8.1.8
│   │   └── prompt-toolkit v3.0.51
│   │       └── wcwidth v0.2.13
│   ├── kombu v5.5.3
│   │   ├── amqp v5.3.1
│   │   │   └── vine v5.1.0
│   │   ├── tzdata v2025.2
│   │   └── vine v5.1.0
│   ├── python-dateutil v2.9.0.post0 (*)
│   └── vine v5.1.0
├── channels v4.2.2
│   ├── asgiref v3.8.1
│   └── django v5.0.14
│       ├── asgiref v3.8.1
│       └── sqlparse v0.5.3
├── cryptography v41.0.7 (*)
├── dashscope v1.23.1
│   ├── aiohttp v3.11.16 (*)
│   ├── requests v2.32.3 (*)
│   └── websocket-client v1.8.0
├── django-celery-beat v2.8.0
│   ├── celery v5.5.1 (*)
│   ├── cron-descriptor v1.4.5
│   ├── django v5.0.14 (*)
│   ├── django-timezone-field v7.1
│   │   └── django v5.0.14 (*)
│   ├── python-crontab v3.2.0
│   │   └── python-dateutil v2.9.0.post0 (*)
│   └── tzdata v2025.2
├── django-environ v0.12.0
├── elasticsearch v8.18.0
│   ├── elastic-transport v8.17.1
│   │   ├── certifi v2025.1.31
│   │   └── urllib3 v2.4.0
│   ├── python-dateutil v2.9.0.post0 (*)
│   └── typing-extensions v4.13.2
├── fastapi[standard] v0.115.12
│   ├── pydantic v2.10.6
│   │   ├── annotated-types v0.7.0
│   │   ├── pydantic-core v2.27.2
│   │   │   └── typing-extensions v4.13.2
│   │   ├── typing-extensions v4.13.2
│   │   └── email-validator v2.2.0 (extra: email)
│   │       ├── dnspython v2.7.0
│   │       └── idna v3.10
│   ├── starlette v0.46.2
│   │   └── anyio v4.9.0
│   │       ├── idna v3.10
│   │       ├── sniffio v1.3.1
│   │       └── typing-extensions v4.13.2
│   ├── typing-extensions v4.13.2
│   ├── email-validator v2.2.0 (extra: standard) (*)
│   ├── fastapi-cli[standard] v0.0.7 (extra: standard)
│   │   ├── rich-toolkit v0.14.7
│   │   │   ├── click v8.1.8
│   │   │   ├── rich v14.0.0
│   │   │   │   ├── markdown-it-py v3.0.0
│   │   │   │   │   ├── mdurl v0.1.2
│   │   │   │   │   └── linkify-it-py v2.0.3 (extra: linkify)
│   │   │   │   │       └── uc-micro-py v1.0.3
│   │   │   │   └── pygments v2.19.1
│   │   │   └── typing-extensions v4.13.2
│   │   ├── typer v0.15.2
│   │   │   ├── click v8.1.8
│   │   │   ├── rich v14.0.0 (*)
│   │   │   ├── shellingham v1.5.4
│   │   │   └── typing-extensions v4.13.2
│   │   ├── uvicorn[standard] v0.34.2
│   │   │   ├── click v8.1.8
│   │   │   ├── h11 v0.14.0
│   │   │   ├── httptools v0.6.4 (extra: standard)
│   │   │   ├── python-dotenv v1.1.0 (extra: standard)
│   │   │   ├── pyyaml v6.0.2 (extra: standard)
│   │   │   ├── uvloop v0.21.0 (extra: standard)
│   │   │   ├── watchfiles v0.24.0 (extra: standard)
│   │   │   │   └── anyio v4.9.0 (*)
│   │   │   └── websockets v15.0.1 (extra: standard)
│   │   └── uvicorn[standard] v0.34.2 (extra: standard) (*)
│   ├── httpx v0.27.0 (extra: standard)
│   │   ├── anyio v4.9.0 (*)
│   │   ├── certifi v2025.1.31
│   │   ├── httpcore v1.0.8
│   │   │   ├── certifi v2025.1.31
│   │   │   └── h11 v0.14.0
│   │   ├── idna v3.10
│   │   ├── sniffio v1.3.1
│   │   └── h2 v4.2.0 (extra: http2)
│   │       ├── hpack v4.1.0
│   │       └── hyperframe v6.1.0
│   ├── jinja2 v3.1.6 (extra: standard)
│   │   └── markupsafe v3.0.2
│   ├── python-multipart v0.0.20 (extra: standard)
│   └── uvicorn[standard] v0.34.2 (extra: standard) (*)
├── fastapi-users[sqlalchemy] v14.0.1
│   ├── email-validator v2.2.0 (*)
│   ├── fastapi v0.115.12 (*)
│   ├── makefun v1.16.0
│   ├── pwdlib[argon2, bcrypt] v0.2.1
│   │   ├── argon2-cffi v23.1.0 (extra: argon2)
│   │   │   └── argon2-cffi-bindings v21.2.0
│   │   │       └── cffi v1.17.1 (*)
│   │   └── bcrypt v4.3.0 (extra: bcrypt)
│   ├── pyjwt[crypto] v2.10.1 (*)
│   ├── python-multipart v0.0.20
│   └── fastapi-users-db-sqlalchemy v7.0.0 (extra: sqlalchemy)
│       ├── fastapi-users v14.0.1 (*)
│       └── sqlalchemy[asyncio] v2.0.40 (*)
├── flower v2.0.1
│   ├── celery v5.5.1 (*)
│   ├── humanize v4.12.2
│   ├── prometheus-client v0.21.1
│   ├── pytz v2025.2
│   └── tornado v6.4.2
├── func-timeout v4.3.5
├── gevent v23.9.1
│   ├── greenlet v3.2.0
│   ├── zope-event v5.0
│   │   └── setuptools v78.1.0
│   └── zope-interface v7.2
│       └── setuptools v78.1.0
├── gitpython v3.1.44
│   └── gitdb v4.0.12
│       └── smmap v5.0.2
├── graspologic v3.4.2.dev4
│   ├── anytree v2.13.0
│   ├── beartype v0.18.5
│   ├── gensim v4.3.3
│   │   ├── numpy v1.26.4
│   │   ├── scipy v1.12.0
│   │   │   └── numpy v1.26.4
│   │   └── smart-open v7.1.0
│   │       └── wrapt v1.17.2
│   ├── graspologic-native v1.2.5
│   ├── hyppo v0.4.0
│   │   ├── autograd v1.7.0
│   │   │   └── numpy v1.26.4
│   │   ├── numba v0.61.2
│   │   │   ├── llvmlite v0.44.0
│   │   │   └── numpy v1.26.4
│   │   ├── numpy v1.26.4
│   │   ├── scikit-learn v1.6.1
│   │   │   ├── joblib v1.4.2
│   │   │   ├── numpy v1.26.4
│   │   │   ├── scipy v1.12.0 (*)
│   │   │   └── threadpoolctl v3.6.0
│   │   └── scipy v1.12.0 (*)
│   ├── joblib v1.4.2
│   ├── matplotlib v3.10.1
│   │   ├── contourpy v1.3.2
│   │   │   └── numpy v1.26.4
│   │   ├── cycler v0.12.1
│   │   ├── fonttools v4.57.0
│   │   ├── kiwisolver v1.4.8
│   │   ├── numpy v1.26.4
│   │   ├── packaging v24.2
│   │   ├── pillow v10.4.0
│   │   ├── pyparsing v3.2.3
│   │   └── python-dateutil v2.9.0.post0 (*)
│   ├── networkx v3.4.2
│   ├── numpy v1.26.4
│   ├── pot v0.9.5
│   │   ├── numpy v1.26.4
│   │   └── scipy v1.12.0 (*)
│   ├── scikit-learn v1.6.1 (*)
│   ├── scipy v1.12.0 (*)
│   ├── seaborn v0.13.2
│   │   ├── matplotlib v3.10.1 (*)
│   │   ├── numpy v1.26.4
│   │   └── pandas v2.2.3
│   │       ├── numpy v1.26.4
│   │       ├── python-dateutil v2.9.0.post0 (*)
│   │       ├── pytz v2025.2
│   │       └── tzdata v2025.2
│   ├── statsmodels v0.14.4
│   │   ├── numpy v1.26.4
│   │   ├── packaging v24.2
│   │   ├── pandas v2.2.3 (*)
│   │   ├── patsy v1.0.1
│   │   │   └── numpy v1.26.4
│   │   └── scipy v1.12.0 (*)
│   ├── typing-extensions v4.13.2
│   └── umap-learn v0.5.7
│       ├── numba v0.61.2 (*)
│       ├── numpy v1.26.4
│       ├── pynndescent v0.5.13
│       │   ├── joblib v1.4.2
│       │   ├── llvmlite v0.44.0
│       │   ├── numba v0.61.2 (*)
│       │   ├── scikit-learn v1.6.1 (*)
│       │   └── scipy v1.12.0 (*)
│       ├── scikit-learn v1.6.1 (*)
│       ├── scipy v1.12.0 (*)
│       └── tqdm v4.67.1
├── jsonref v1.1.0
├── langchain v0.3.23
│   ├── langchain-core v0.3.54
│   │   ├── jsonpatch v1.33
│   │   │   └── jsonpointer v3.0.0
│   │   ├── langsmith v0.3.32
│   │   │   ├── httpx v0.27.0 (*)
│   │   │   ├── orjson v3.10.16
│   │   │   ├── packaging v24.2
│   │   │   ├── pydantic v2.10.6 (*)
│   │   │   ├── requests v2.32.3 (*)
│   │   │   ├── requests-toolbelt v1.0.0
│   │   │   │   └── requests v2.32.3 (*)
│   │   │   └── zstandard v0.23.0
│   │   ├── packaging v24.2
│   │   ├── pydantic v2.10.6 (*)
│   │   ├── pyyaml v6.0.2
│   │   ├── tenacity v8.5.0
│   │   └── typing-extensions v4.13.2
│   ├── langchain-text-splitters v0.3.8
│   │   └── langchain-core v0.3.54 (*)
│   ├── langsmith v0.3.32 (*)
│   ├── pydantic v2.10.6 (*)
│   ├── pyyaml v6.0.2
│   ├── requests v2.32.3 (*)
│   └── sqlalchemy v2.0.40 (*)
├── langchain-huggingface v0.1.2
│   ├── huggingface-hub v0.30.2
│   │   ├── filelock v3.18.0
│   │   ├── fsspec v2024.12.0
│   │   │   └── aiohttp v3.11.16 (extra: http) (*)
│   │   ├── packaging v24.2
│   │   ├── pyyaml v6.0.2
│   │   ├── requests v2.32.3 (*)
│   │   ├── tqdm v4.67.1
│   │   └── typing-extensions v4.13.2
│   ├── langchain-core v0.3.54 (*)
│   ├── sentence-transformers v4.1.0
│   │   ├── huggingface-hub v0.30.2 (*)
│   │   ├── pillow v10.4.0
│   │   ├── scikit-learn v1.6.1 (*)
│   │   ├── scipy v1.12.0 (*)
│   │   ├── torch v2.6.0
│   │   │   ├── filelock v3.18.0
│   │   │   ├── fsspec v2024.12.0 (*)
│   │   │   ├── jinja2 v3.1.6 (*)
│   │   │   ├── networkx v3.4.2
│   │   │   ├── sympy v1.13.1
│   │   │   │   └── mpmath v1.3.0
│   │   │   └── typing-extensions v4.13.2
│   │   ├── tqdm v4.67.1
│   │   ├── transformers v4.49.0
│   │   │   ├── filelock v3.18.0
│   │   │   ├── huggingface-hub v0.30.2 (*)
│   │   │   ├── numpy v1.26.4
│   │   │   ├── packaging v24.2
│   │   │   ├── pyyaml v6.0.2
│   │   │   ├── regex v2024.11.6
│   │   │   ├── requests v2.32.3 (*)
│   │   │   ├── safetensors v0.5.3
│   │   │   ├── tokenizers v0.21.1
│   │   │   │   └── huggingface-hub v0.30.2 (*)
│   │   │   └── tqdm v4.67.1
│   │   └── typing-extensions v4.13.2
│   ├── tokenizers v0.21.1 (*)
│   └── transformers v4.49.0 (*)
├── litellm v1.73.0
│   ├── aiohttp v3.11.16 (*)
│   ├── click v8.1.8
│   ├── httpx v0.27.0 (*)
│   ├── importlib-metadata v8.6.1
│   │   └── zipp v3.21.0
│   ├── jinja2 v3.1.6 (*)
│   ├── jsonschema v4.23.0
│   │   ├── attrs v25.3.0
│   │   ├── jsonschema-specifications v2024.10.1
│   │   │   └── referencing v0.36.2
│   │   │       ├── attrs v25.3.0
│   │   │       ├── rpds-py v0.24.0
│   │   │       └── typing-extensions v4.13.2
│   │   ├── referencing v0.36.2 (*)
│   │   └── rpds-py v0.24.0
│   ├── openai v1.75.0
│   │   ├── anyio v4.9.0 (*)
│   │   ├── distro v1.9.0
│   │   ├── httpx v0.27.0 (*)
│   │   ├── jiter v0.9.0
│   │   ├── pydantic v2.10.6 (*)
│   │   ├── sniffio v1.3.1
│   │   ├── tqdm v4.67.1
│   │   └── typing-extensions v4.13.2
│   ├── pydantic v2.10.6 (*)
│   ├── python-dotenv v1.1.0
│   ├── tiktoken v0.9.0
│   │   ├── regex v2024.11.6
│   │   └── requests v2.32.3 (*)
│   └── tokenizers v0.21.1 (*)
├── llama-index v0.12.31
│   ├── llama-index-agent-openai v0.4.6
│   │   ├── llama-index-core v0.12.31
│   │   │   ├── aiohttp v3.11.16 (*)
│   │   │   ├── banks v2.1.1
│   │   │   │   ├── deprecated v1.2.18
│   │   │   │   │   └── wrapt v1.17.2
│   │   │   │   ├── griffe v1.7.2
│   │   │   │   │   └── colorama v0.4.6
│   │   │   │   ├── jinja2 v3.1.6 (*)
│   │   │   │   ├── platformdirs v4.3.7
│   │   │   │   └── pydantic v2.10.6 (*)
│   │   │   ├── dataclasses-json v0.6.7
│   │   │   │   ├── marshmallow v3.26.1
│   │   │   │   │   └── packaging v24.2
│   │   │   │   └── typing-inspect v0.9.0
│   │   │   │       ├── mypy-extensions v1.0.0
│   │   │   │       └── typing-extensions v4.13.2
│   │   │   ├── deprecated v1.2.18 (*)
│   │   │   ├── dirtyjson v1.0.8
│   │   │   ├── filetype v1.2.0
│   │   │   ├── fsspec v2024.12.0 (*)
│   │   │   ├── httpx v0.27.0 (*)
│   │   │   ├── nest-asyncio v1.6.0
│   │   │   ├── networkx v3.4.2
│   │   │   ├── nltk v3.9.1
│   │   │   │   ├── click v8.1.8
│   │   │   │   ├── joblib v1.4.2
│   │   │   │   ├── regex v2024.11.6
│   │   │   │   └── tqdm v4.67.1
│   │   │   ├── numpy v1.26.4
│   │   │   ├── pillow v10.4.0
│   │   │   ├── pydantic v2.10.6 (*)
│   │   │   ├── pyyaml v6.0.2
│   │   │   ├── requests v2.32.3 (*)
│   │   │   ├── sqlalchemy[asyncio] v2.0.40 (*)
│   │   │   ├── tenacity v8.5.0
│   │   │   ├── tiktoken v0.9.0 (*)
│   │   │   ├── tqdm v4.67.1
│   │   │   ├── typing-extensions v4.13.2
│   │   │   ├── typing-inspect v0.9.0 (*)
│   │   │   └── wrapt v1.17.2
│   │   ├── llama-index-llms-openai v0.3.37
│   │   │   ├── llama-index-core v0.12.31 (*)
│   │   │   └── openai v1.75.0 (*)
│   │   └── openai v1.75.0 (*)
│   ├── llama-index-cli v0.4.1
│   │   ├── llama-index-core v0.12.31 (*)
│   │   ├── llama-index-embeddings-openai v0.3.1
│   │   │   ├── llama-index-core v0.12.31 (*)
│   │   │   └── openai v1.75.0 (*)
│   │   └── llama-index-llms-openai v0.3.37 (*)
│   ├── llama-index-core v0.12.31 (*)
│   ├── llama-index-embeddings-openai v0.3.1 (*)
│   ├── llama-index-indices-managed-llama-cloud v0.6.11
│   │   ├── llama-cloud v0.1.18
│   │   │   ├── certifi v2025.1.31
│   │   │   ├── httpx v0.27.0 (*)
│   │   │   └── pydantic v2.10.6 (*)
│   │   └── llama-index-core v0.12.31 (*)
│   ├── llama-index-llms-openai v0.3.37 (*)
│   ├── llama-index-multi-modal-llms-openai v0.4.3
│   │   ├── llama-index-core v0.12.31 (*)
│   │   └── llama-index-llms-openai v0.3.37 (*)
│   ├── llama-index-program-openai v0.3.1
│   │   ├── llama-index-agent-openai v0.4.6 (*)
│   │   ├── llama-index-core v0.12.31 (*)
│   │   └── llama-index-llms-openai v0.3.37 (*)
│   ├── llama-index-question-gen-openai v0.3.0
│   │   ├── llama-index-core v0.12.31 (*)
│   │   ├── llama-index-llms-openai v0.3.37 (*)
│   │   └── llama-index-program-openai v0.3.1 (*)
│   ├── llama-index-readers-file v0.4.7
│   │   ├── beautifulsoup4 v4.13.4
│   │   │   ├── soupsieve v2.6
│   │   │   └── typing-extensions v4.13.2
│   │   ├── llama-index-core v0.12.31 (*)
│   │   ├── pandas v2.2.3 (*)
│   │   ├── pypdf v5.4.0
│   │   └── striprtf v0.0.26
│   ├── llama-index-readers-llama-parse v0.4.0
│   │   ├── llama-index-core v0.12.31 (*)
│   │   └── llama-parse v0.6.12
│   │       └── llama-cloud-services v0.6.12
│   │           ├── click v8.1.8
│   │           ├── llama-cloud v0.1.18 (*)
│   │           ├── llama-index-core v0.12.31 (*)
│   │           ├── platformdirs v4.3.7
│   │           ├── pydantic v2.10.6 (*)
│   │           └── python-dotenv v1.1.0
│   └── nltk v3.9.1 (*)
├── llama-index-embeddings-google v0.3.1
│   ├── google-generativeai v0.5.4
│   │   ├── google-ai-generativelanguage v0.6.4
│   │   │   ├── google-api-core[grpc] v2.24.2
│   │   │   │   ├── google-auth v2.39.0
│   │   │   │   │   ├── cachetools v5.5.2
│   │   │   │   │   ├── pyasn1-modules v0.4.2
│   │   │   │   │   │   └── pyasn1 v0.6.1
│   │   │   │   │   └── rsa v4.9.1
│   │   │   │   │       └── pyasn1 v0.6.1
│   │   │   │   ├── googleapis-common-protos v1.70.0
│   │   │   │   │   └── protobuf v4.25.6
│   │   │   │   ├── proto-plus v1.26.1
│   │   │   │   │   └── protobuf v4.25.6
│   │   │   │   ├── protobuf v4.25.6
│   │   │   │   ├── requests v2.32.3 (*)
│   │   │   │   ├── grpcio v1.67.1 (extra: grpc)
│   │   │   │   └── grpcio-status v1.63.0rc1 (extra: grpc)
│   │   │   │       ├── googleapis-common-protos v1.70.0 (*)
│   │   │   │       ├── grpcio v1.67.1
│   │   │   │       └── protobuf v4.25.6
│   │   │   ├── google-auth v2.39.0 (*)
│   │   │   ├── proto-plus v1.26.1 (*)
│   │   │   └── protobuf v4.25.6
│   │   ├── google-api-core v2.24.2 (*)
│   │   ├── google-api-python-client v2.167.0
│   │   │   ├── google-api-core v2.24.2 (*)
│   │   │   ├── google-auth v2.39.0 (*)
│   │   │   ├── google-auth-httplib2 v0.2.0
│   │   │   │   ├── google-auth v2.39.0 (*)
│   │   │   │   └── httplib2 v0.22.0
│   │   │   │       └── pyparsing v3.2.3
│   │   │   ├── httplib2 v0.22.0 (*)
│   │   │   └── uritemplate v4.1.1
│   │   ├── google-auth v2.39.0 (*)
│   │   ├── protobuf v4.25.6
│   │   ├── pydantic v2.10.6 (*)
│   │   ├── tqdm v4.67.1
│   │   └── typing-extensions v4.13.2
│   └── llama-index-core v0.12.31 (*)
├── llama-index-embeddings-langchain v0.3.0
│   └── llama-index-core v0.12.31 (*)
├── llama-index-vector-stores-qdrant v0.6.0
│   ├── grpcio v1.67.1
│   ├── llama-index-core v0.12.31 (*)
│   └── qdrant-client v1.13.3
│       ├── grpcio v1.67.1
│       ├── grpcio-tools v1.63.0rc1
│       │   ├── grpcio v1.67.1
│       │   ├── protobuf v4.25.6
│       │   └── setuptools v78.1.0
│       ├── httpx[http2] v0.27.0 (*)
│       ├── numpy v1.26.4
│       ├── portalocker v2.10.1
│       ├── pydantic v2.10.6 (*)
│       └── urllib3 v2.4.0
├── markdown-it-py[linkify] v3.0.0 (*)
├── markitdown[all] v0.1.1
│   ├── beautifulsoup4 v4.13.4 (*)
│   ├── charset-normalizer v3.4.1
│   ├── magika v0.6.2
│   │   ├── click v8.1.8
│   │   ├── numpy v1.26.4
│   │   ├── onnxruntime v1.21.1
│   │   │   ├── coloredlogs v15.0.1
│   │   │   │   └── humanfriendly v10.0
│   │   │   ├── flatbuffers v25.2.10
│   │   │   ├── numpy v1.26.4
│   │   │   ├── packaging v24.2
│   │   │   ├── protobuf v4.25.6
│   │   │   └── sympy v1.13.1 (*)
│   │   └── python-dotenv v1.1.0
│   ├── markdownify v1.1.0
│   │   ├── beautifulsoup4 v4.13.4 (*)
│   │   └── six v1.17.0
│   ├── requests v2.32.3 (*)
│   ├── azure-ai-documentintelligence v1.0.2 (extra: all)
│   │   ├── azure-core v1.34.0
│   │   │   ├── requests v2.32.3 (*)
│   │   │   ├── six v1.17.0
│   │   │   └── typing-extensions v4.13.2
│   │   ├── isodate v0.7.2
│   │   └── typing-extensions v4.13.2
│   ├── azure-identity v1.22.0 (extra: all)
│   │   ├── azure-core v1.34.0 (*)
│   │   ├── cryptography v41.0.7 (*)
│   │   ├── msal v1.32.3
│   │   │   ├── cryptography v41.0.7 (*)
│   │   │   ├── pyjwt[crypto] v2.10.1 (*)
│   │   │   └── requests v2.32.3 (*)
│   │   ├── msal-extensions v1.3.1
│   │   │   └── msal v1.32.3 (*)
│   │   └── typing-extensions v4.13.2
│   ├── mammoth v1.9.0 (extra: all)
│   │   └── cobble v0.1.4
│   ├── olefile v0.47 (extra: all)
│   ├── openpyxl v3.1.5 (extra: all)
│   │   └── et-xmlfile v2.0.0
│   ├── pandas v2.2.3 (extra: all) (*)
│   ├── pdfminer-six v20231228 (extra: all)
│   │   ├── charset-normalizer v3.4.1
│   │   └── cryptography v41.0.7 (*)
│   ├── pydub v0.25.1 (extra: all)
│   ├── python-pptx v0.6.23 (extra: all)
│   │   ├── lxml v5.3.2
│   │   ├── pillow v10.4.0
│   │   └── xlsxwriter v3.2.3
│   ├── speechrecognition v3.14.3 (extra: all)
│   │   └── typing-extensions v4.13.2
│   ├── xlrd v2.0.1 (extra: all)
│   └── youtube-transcript-api v1.0.3 (extra: all)
│       ├── defusedxml v0.7.1
│       └── requests v2.32.3 (*)
├── nano-vectordb v0.0.4.3
│   └── numpy v1.26.4
├── nebula3-python v3.8.3
│   ├── future v1.0.0
│   ├── httplib2 v0.22.0 (*)
│   ├── httpx[http2] v0.27.0 (*)
│   ├── pytz v2025.2
│   └── six v1.17.0
├── neo4j v5.28.1
│   └── pytz v2025.2
├── numpy v1.26.4
├── openai v1.75.0 (*)
├── opik v1.7.34
│   ├── boto3-stubs[bedrock-runtime] v1.38.36
│   │   ├── botocore-stubs v1.38.30
│   │   │   └── types-awscrt v0.27.2
│   │   ├── types-s3transfer v0.13.0
│   │   ├── typing-extensions v4.13.2
│   │   └── mypy-boto3-bedrock-runtime v1.38.4 (extra: bedrock-runtime)
│   │       └── typing-extensions v4.13.2
│   ├── click v8.1.8
│   ├── httpx v0.27.0 (*)
│   ├── jinja2 v3.1.6 (*)
│   ├── litellm v1.73.0 (*)
│   ├── openai v1.75.0 (*)
│   ├── pydantic v2.10.6 (*)
│   ├── pydantic-settings v2.9.1
│   │   ├── pydantic v2.10.6 (*)
│   │   ├── python-dotenv v1.1.0
│   │   └── typing-inspection v0.4.0
│   │       └── typing-extensions v4.13.2
│   ├── pytest v8.3.5
│   │   ├── iniconfig v2.1.0
│   │   ├── packaging v24.2
│   │   └── pluggy v1.5.0
│   ├── rapidfuzz v3.13.0
│   ├── rich v14.0.0 (*)
│   ├── sentry-sdk v3.0.0a2
│   │   ├── certifi v2025.1.31
│   │   ├── opentelemetry-sdk v1.34.1
│   │   │   ├── opentelemetry-api v1.34.1
│   │   │   │   ├── importlib-metadata v8.6.1 (*)
│   │   │   │   └── typing-extensions v4.13.2
│   │   │   ├── opentelemetry-semantic-conventions v0.55b1
│   │   │   │   ├── opentelemetry-api v1.34.1 (*)
│   │   │   │   └── typing-extensions v4.13.2
│   │   │   └── typing-extensions v4.13.2
│   │   └── urllib3 v2.4.0
│   ├── tenacity v8.5.0
│   ├── tqdm v4.67.1
│   └── uuid6 v2025.0.0
├── oss2 v2.19.1
│   ├── aliyun-python-sdk-core v2.16.0
│   │   ├── cryptography v41.0.7 (*)
│   │   └── jmespath v0.10.0
│   ├── aliyun-python-sdk-kms v2.16.5
│   │   └── aliyun-python-sdk-core v2.16.0 (*)
│   ├── crcmod v1.7
│   ├── pycryptodome v3.22.0
│   ├── requests v2.32.3 (*)
│   └── six v1.17.0
├── pgvector v0.4.1
│   └── numpy v1.26.4
├── pillow v10.4.0
├── pipmaster v0.5.4
│   ├── ascii-colors v0.7.0
│   └── setuptools v78.1.0
├── psycopg v3.2.9
│   └── typing-extensions v4.13.2
├── psycopg-pool v3.2.6
│   └── typing-extensions v4.13.2
├── psycopg2-binary v2.9.10
├── py7zr v0.22.0
│   ├── brotli v1.1.0
│   ├── inflate64 v1.0.1
│   ├── multivolumefile v0.2.3
│   ├── psutil v7.0.0
│   ├── pybcj v1.0.3
│   ├── pycryptodomex v3.22.0
│   ├── pyppmd v1.1.1
│   ├── pyzstd v0.16.2
│   └── texttable v1.7.0
├── pydantic[email] v2.10.6 (*)
├── pydantic-settings v2.9.1 (*)
├── pytablewriter v1.2.1
│   ├── dataproperty v1.1.0
│   │   ├── mbstrdecoder v1.1.4
│   │   │   └── chardet v5.2.0
│   │   └── typepy[datetime] v1.3.4
│   │       ├── mbstrdecoder v1.1.4 (*)
│   │       ├── packaging v24.2 (extra: datetime)
│   │       ├── python-dateutil v2.9.0.post0 (extra: datetime) (*)
│   │       └── pytz v2025.2 (extra: datetime)
│   ├── mbstrdecoder v1.1.4 (*)
│   ├── pathvalidate v3.2.3
│   ├── setuptools v78.1.0
│   ├── tabledata v1.3.4
│   │   ├── dataproperty v1.1.0 (*)
│   │   └── typepy v1.3.4 (*)
│   ├── tcolorpy v0.1.7
│   └── typepy[datetime] v1.3.4 (*)
├── python-dotenv v1.1.0
├── qdrant-client v1.13.3 (*)
├── qianfan v0.4.12.3
│   ├── aiohttp v3.11.16 (*)
│   ├── aiolimiter v1.2.1
│   ├── bce-python-sdk v0.9.29
│   │   ├── future v1.0.0
│   │   ├── pycryptodome v3.22.0
│   │   └── six v1.17.0
│   ├── cachetools v5.5.2
│   ├── diskcache v5.6.3
│   ├── multiprocess v0.70.16
│   │   └── dill v0.3.8
│   ├── prompt-toolkit v3.0.51 (*)
│   ├── pydantic v2.10.6 (*)
│   ├── python-dotenv v1.1.0
│   ├── pyyaml v6.0.2
│   ├── requests v2.32.3 (*)
│   ├── rich v14.0.0 (*)
│   ├── tenacity v8.5.0
│   └── typer v0.15.2 (*)
├── rarfile v4.2
├── redis v4.6.0
├── requests v2.32.3 (*)
├── socksio v1.0.0
├── sqlalchemy v2.0.40 (*)
├── terminal v0.4.0
├── uvicorn[standard] v0.34.2 (*)
├── watchfiles v0.24.0 (*)
├── whitenoise v6.9.0
├── ragas v0.2.15 (extra: evaluation)
│   ├── appdirs v1.4.4
│   ├── datasets v3.5.0
│   │   ├── aiohttp v3.11.16 (*)
│   │   ├── dill v0.3.8
│   │   ├── filelock v3.18.0
│   │   ├── fsspec[http] v2024.12.0 (*)
│   │   ├── huggingface-hub v0.30.2 (*)
│   │   ├── multiprocess v0.70.16 (*)
│   │   ├── numpy v1.26.4
│   │   ├── packaging v24.2
│   │   ├── pandas v2.2.3 (*)
│   │   ├── pyarrow v19.0.1
│   │   ├── pyyaml v6.0.2
│   │   ├── requests v2.32.3 (*)
│   │   ├── tqdm v4.67.1
│   │   └── xxhash v3.5.0
│   ├── diskcache v5.6.3
│   ├── langchain v0.3.23 (*)
│   ├── langchain-community v0.3.21
│   │   ├── aiohttp v3.11.16 (*)
│   │   ├── dataclasses-json v0.6.7 (*)
│   │   ├── httpx-sse v0.4.0
│   │   ├── langchain v0.3.23 (*)
│   │   ├── langchain-core v0.3.54 (*)
│   │   ├── langsmith v0.3.32 (*)
│   │   ├── numpy v1.26.4
│   │   ├── pydantic-settings v2.9.1 (*)
│   │   ├── pyyaml v6.0.2
│   │   ├── requests v2.32.3 (*)
│   │   ├── sqlalchemy v2.0.40 (*)
│   │   └── tenacity v8.5.0
│   ├── langchain-core v0.3.54 (*)
│   ├── langchain-openai v0.3.14
│   │   ├── langchain-core v0.3.54 (*)
│   │   ├── openai v1.75.0 (*)
│   │   └── tiktoken v0.9.0 (*)
│   ├── nest-asyncio v1.6.0
│   ├── numpy v1.26.4
│   ├── openai v1.75.0 (*)
│   ├── pydantic v2.10.6 (*)
│   └── tiktoken v0.9.0 (*)
├── nano-vectordb v0.0.4.3 (extra: lightrag-dev) (*)
├── datamodel-code-generator v0.30.0 (group: dev)
│   ├── argcomplete v3.6.2
│   ├── black v25.1.0
│   │   ├── click v8.1.8
│   │   ├── mypy-extensions v1.0.0
│   │   ├── packaging v24.2
│   │   ├── pathspec v0.12.1
│   │   └── platformdirs v4.3.7
│   ├── genson v1.3.0
│   ├── inflect v7.5.0
│   │   ├── more-itertools v10.6.0
│   │   └── typeguard v4.4.2
│   │       └── typing-extensions v4.13.2
│   ├── isort v6.0.1
│   ├── jinja2 v3.1.6 (*)
│   ├── packaging v24.2
│   ├── pydantic v2.10.6 (*)
│   ├── pyyaml v6.0.2
│   └── tomli v2.2.1
├── deptry v0.23.0 (group: dev)
│   ├── click v8.1.8
│   ├── packaging v24.2
│   └── requirements-parser v0.11.0
│       ├── packaging v24.2
│       └── types-setuptools v78.1.0.20250329
│           └── setuptools v78.1.0
├── mypy v1.15.0 (group: dev)
│   ├── mypy-extensions v1.0.0
│   └── typing-extensions v4.13.2
├── ruff v0.11.6 (group: dev)
├── types-chardet v5.0.4.6 (group: dev)
├── types-redis v4.6.0.20241004 (group: dev)
│   ├── cryptography v41.0.7 (*)
│   └── types-pyopenssl v24.1.0.20240722
│       ├── cryptography v41.0.7 (*)
│       └── types-cffi v1.17.0.20250326
│           └── types-setuptools v78.1.0.20250329 (*)
├── types-requests v2.32.0.20250328 (group: dev)
│   └── urllib3 v2.4.0
├── types-toml v0.10.8.20240310 (group: dev)
└── vulture v2.14 (group: dev)
(*) Package tree already displayed
```