### PR TITLE
feat: add Elasticsearch timeout and retry settings

### DIFF
--- a/aperag/config.py
+++ b/aperag/config.py
@@ -108,8 +108,9 @@ class Config(BaseSettings):
     redis_password: str = Field("", alias="REDIS_PASSWORD")
 
     # Fulltext search
-    enable_fulltext_search: bool = Field(True, alias="ENABLE_FULLTEXT_SEARCH")
     es_host: str = Field("http://localhost:9200", alias="ES_HOST")
+    es_timeout: int = Field(30, alias="ES_TIMEOUT")  # ES request timeout in seconds
+    es_max_retries: int = Field(3, alias="ES_MAX_RETRIES")  # Max retries for ES requests
 
     # Qianfan
     qianfan_api_key: str = Field("", alias="QIANFAN_API_KEY")

--- a/aperag/flow/runners/fulltext_search.py
+++ b/aperag/flow/runners/fulltext_search.py
@@ -68,7 +68,14 @@ class FulltextSearchService:
         from aperag.index.fulltext_index import fulltext_indexer
 
         index = generate_vector_db_collection_name(collection.id)
-        async with IKExtractor({"index_name": index, "es_host": settings.es_host}) as extractor:
+        async with IKExtractor(
+            {
+                "index_name": index,
+                "es_host": settings.es_host,
+                "es_timeout": settings.es_timeout,
+                "es_max_retries": settings.es_max_retries,
+            }
+        ) as extractor:
             keywords = await extractor.extract(query)
 
         # Find the related documents using keywords


### PR DESCRIPTION
- Introduced `es_timeout` and `es_max_retries` configuration options in `config.py`.
- Updated `FulltextSearchService` and `FulltextIndexer` to utilize the new settings for Elasticsearch clients.
- Enhanced error handling in `IKExtractor` and `FulltextIndexer` to log failures during document search and keyword extraction.