### PR TITLE
feat: add liveness and readiness probes for API and Celery worker

### DIFF
--- a/deploy/aperag/templates/api-deployment.yaml
+++ b/deploy/aperag/templates/api-deployment.yaml
@@ -181,6 +181,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.api.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /data
               name: data

--- a/deploy/aperag/templates/celeryworker-deployment.yaml
+++ b/deploy/aperag/templates/celeryworker-deployment.yaml
@@ -177,6 +177,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with index .Values "celery-worker" "livenessProbe" }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with index .Values "celery-worker" "readinessProbe" }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /data
               name: data

--- a/deploy/aperag/values.yaml
+++ b/deploy/aperag/values.yaml
@@ -239,7 +239,7 @@ celery-worker:
       command:
         - sh
         - -c
-        - "celery -A config.celery status > /dev/null 2>&1"
+        - "celery -A config.celery status -d celery@$(hostname) > /dev/null 2>&1"
     initialDelaySeconds: 15
     periodSeconds: 30
     timeoutSeconds: 5
@@ -250,7 +250,7 @@ celery-worker:
       command:
         - sh
         - -c
-        - "celery -A config.celery status > /dev/null 2>&1"
+        - "celery -A config.celery status -d celery@$(hostname) > /dev/null 2>&1"
     initialDelaySeconds: 15
     periodSeconds: 30
     timeoutSeconds: 5

--- a/deploy/aperag/values.yaml
+++ b/deploy/aperag/values.yaml
@@ -192,6 +192,24 @@ api:
     CACHE_ENABLED: "True"
     CACHE_TTL: "86400"
 
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 8000
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 8000
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
 
 celery-worker:
   replicaCount: 1
@@ -216,6 +234,28 @@ celery-worker:
             matchLabels:
               app.aperag.io/component: celery-worker
           topologyKey: kubernetes.io/hostname
+  livenessProbe:
+    exec:
+      command:
+        - sh
+        - -c
+        - "celery -A config.celery status > /dev/null 2>&1"
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  readinessProbe:
+    exec:
+      command:
+        - sh
+        - -c
+        - "celery -A config.celery status > /dev/null 2>&1"
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
 
 celerybeat:
   replicaCount: 1

--- a/deploy/aperag/values.yaml
+++ b/deploy/aperag/values.yaml
@@ -240,8 +240,8 @@ celery-worker:
         - sh
         - -c
         - "celery -A config.celery status > /dev/null 2>&1"
-    initialDelaySeconds: 10
-    periodSeconds: 10
+    initialDelaySeconds: 15
+    periodSeconds: 30
     timeoutSeconds: 5
     failureThreshold: 3
     successThreshold: 1
@@ -251,8 +251,8 @@ celery-worker:
         - sh
         - -c
         - "celery -A config.celery status > /dev/null 2>&1"
-    initialDelaySeconds: 5
-    periodSeconds: 5
+    initialDelaySeconds: 15
+    periodSeconds: 30
     timeoutSeconds: 5
     failureThreshold: 3
     successThreshold: 1


### PR DESCRIPTION
- Implemented liveness and readiness probes in `values.yaml` for both API and Celery worker.
- Updated deployment templates to include the new probe configurations, enhancing application health monitoring.