### PR TITLE
fix(rechunker): parts.metadata use md_nesting as key

### DIFF
--- a/aperag/docparser/chunking.py
+++ b/aperag/docparser/chunking.py
@@ -110,7 +110,7 @@ class Rechunker:
             if not part.content:
                 continue
 
-            nesting = part.metadata.get("nesting", 0)
+            nesting = part.metadata.get("md_nesting", 0)
             title_level = 0
             title = ""
             if hasattr(part, "level"):  # TitlePart


### PR DESCRIPTION
Use correct key md_nesting for nesting level metadata