### PR TITLE
feat: update

### DIFF
--- a/aperag/migration/sql/model_configs_init.sql
+++ b/aperag/migration/sql/model_configs_init.sql
@@ -1,5 +1,5 @@
 -- Model configuration initialization SQL script
--- Generated directly from configuration data on 2025-10-14 14:05:20
+-- Generated directly from configuration data on 2025-11-11 10:30:02
 -- This script populates llm_provider and llm_provider_models tables
 
 BEGIN;
@@ -1466,6 +1466,36 @@ INSERT INTO llm_provider_models (
     provider_name, api, model, custom_llm_provider, context_window, max_input_tokens, max_output_tokens, tags,
     gmt_created, gmt_updated
 ) VALUES (
+    'anthropic', 'completion', 'claude-haiku-4-5', 'anthropic', 200000, 200000, 64000, '["vision", "__autogen__"]'::jsonb,
+    NOW(), NOW()
+)
+ON CONFLICT (provider_name, api, model) DO UPDATE SET
+    custom_llm_provider = EXCLUDED.custom_llm_provider,
+    context_window = EXCLUDED.context_window,
+    max_input_tokens = EXCLUDED.max_input_tokens,
+    max_output_tokens = EXCLUDED.max_output_tokens,
+    tags = EXCLUDED.tags,
+    gmt_updated = NOW();
+
+INSERT INTO llm_provider_models (
+    provider_name, api, model, custom_llm_provider, context_window, max_input_tokens, max_output_tokens, tags,
+    gmt_created, gmt_updated
+) VALUES (
+    'anthropic', 'completion', 'claude-haiku-4-5-20251001', 'anthropic', 200000, 200000, 64000, '["vision", "__autogen__"]'::jsonb,
+    NOW(), NOW()
+)
+ON CONFLICT (provider_name, api, model) DO UPDATE SET
+    custom_llm_provider = EXCLUDED.custom_llm_provider,
+    context_window = EXCLUDED.context_window,
+    max_input_tokens = EXCLUDED.max_input_tokens,
+    max_output_tokens = EXCLUDED.max_output_tokens,
+    tags = EXCLUDED.tags,
+    gmt_updated = NOW();
+
+INSERT INTO llm_provider_models (
+    provider_name, api, model, custom_llm_provider, context_window, max_input_tokens, max_output_tokens, tags,
+    gmt_created, gmt_updated
+) VALUES (
     'anthropic', 'completion', 'claude-opus-4-1', 'anthropic', 200000, 200000, 32000, '["vision", "__autogen__"]'::jsonb,
     NOW(), NOW()
 )
@@ -2158,6 +2188,21 @@ INSERT INTO llm_provider_models (
     gmt_created, gmt_updated
 ) VALUES (
     'gemini', 'completion', 'gemini/gemini-flash-lite-latest', 'gemini', 1048576, 1048576, 65535, '["vision", "__autogen__"]'::jsonb,
+    NOW(), NOW()
+)
+ON CONFLICT (provider_name, api, model) DO UPDATE SET
+    custom_llm_provider = EXCLUDED.custom_llm_provider,
+    context_window = EXCLUDED.context_window,
+    max_input_tokens = EXCLUDED.max_input_tokens,
+    max_output_tokens = EXCLUDED.max_output_tokens,
+    tags = EXCLUDED.tags,
+    gmt_updated = NOW();
+
+INSERT INTO llm_provider_models (
+    provider_name, api, model, custom_llm_provider, context_window, max_input_tokens, max_output_tokens, tags,
+    gmt_created, gmt_updated
+) VALUES (
+    'gemini', 'completion', 'gemini/gemini-live-2.5-flash-preview-native-audio-09-2025', 'gemini', 1048576, 1048576, 65535, '["vision", "__autogen__"]'::jsonb,
     NOW(), NOW()
 )
 ON CONFLICT (provider_name, api, model) DO UPDATE SET
@@ -9156,6 +9201,6 @@ ON CONFLICT (provider_name, api, model) DO UPDATE SET
 
 COMMIT;
 
--- Script completed. Generated on 2025-10-14 14:05:20
+-- Script completed. Generated on 2025-11-11 10:30:02
 -- Total providers: 9
--- Total models: 598
+-- Total models: 601


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `anthropic` models `claude-haiku-4-5` and `claude-haiku-4-5-20251001`, and `gemini` model `gemini/gemini-live-2.5-flash-preview-native-audio-09-2025`; updates timestamps and increases total models to 601.
> 
> - **SQL seed updates** (`aperag/migration/sql/model_configs_init.sql`):
>   - Add `llm_provider_models` entries:
>     - `anthropic`:
>       - `claude-haiku-4-5`
>       - `claude-haiku-4-5-20251001`
>     - `gemini`:
>       - `gemini/gemini-live-2.5-flash-preview-native-audio-09-2025`
>   - Update generated timestamps and model count (598 → 601).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b5c89d8b7517763ffb1814225bc83ced320e4be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->