### PR TITLE
feat: bugfix issue 1421

### DIFF
--- a/aperag/tasks/reconciler.py
+++ b/aperag/tasks/reconciler.py
@@ -409,11 +409,12 @@ class CollectionSummaryReconciler:
     def _get_summaries_needing_reconciliation(self, session: Session) -> List[CollectionSummary]:
         """
         Get all collection summaries that need reconciliation
+        Only select summaries with PENDING status and version mismatch
         """
         stmt = select(CollectionSummary).where(
-            or_(
+            and_(
                 CollectionSummary.version != CollectionSummary.observed_version,
-                CollectionSummary.status != CollectionSummaryStatus.GENERATING,
+                CollectionSummary.status == CollectionSummaryStatus.PENDING,
             )
         )
         result = session.execute(stmt)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Narrows collection summary reconciliation scope to avoid processing in-progress items.
> 
> - Updates `CollectionSummaryReconciler._get_summaries_needing_reconciliation` to require `status == PENDING` and `version != observed_version` (replacing prior condition that merely excluded `GENERATING`)
> - Updates method docstring to reflect the stricter selection criteria
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ded8d9d0004966e925bb440a129fc928023561bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->