### PR TITLE
[codex] add e2e http smoke workflow

### DIFF
--- a/.github/workflows/e2e-http-smoke.yml
+++ b/.github/workflows/e2e-http-smoke.yml
@@ -1,0 +1,62 @@
+name: E2E HTTP Smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/e2e-http-smoke.yml"
+      - "tests/e2e_http/**"
+      - "docker-compose.yml"
+      - "Makefile"
+      - "Dockerfile"
+      - "scripts/**"
+      - "aperag/**"
+      - "envs/**"
+
+jobs:
+  e2e-http-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space for Docker build
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+          docker system prune -af --volumes || true
+          df -h
+
+      - name: Install Hurl
+        run: |
+          HURL_VERSION="7.1.0"
+          curl -fsSL -o /tmp/hurl.tar.gz "https://github.com/Orange-OpenSource/hurl/releases/download/${HURL_VERSION}/hurl-${HURL_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xzf /tmp/hurl.tar.gz -C /tmp
+          sudo mv /tmp/hurl-${HURL_VERSION}-x86_64-unknown-linux-gnu/bin/hurl /usr/local/bin/hurl
+          hurl --version
+
+      - name: Run HTTP smoke suite
+        env:
+          E2E_REMOVE_VOLUMES: "1"
+        run: |
+          ./tests/e2e_http/scripts/run_compose_smoke.sh
+
+      - name: Upload bootstrap artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-http-bootstrap-artifacts
+          path: tests/e2e_http/bootstrap/.generated
+          if-no-files-found: ignore
+
+      - name: Dump Compose diagnostics on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.yml ps || true
+          docker compose -f docker-compose.yml logs --no-color api celeryworker celerybeat postgres redis qdrant es || true

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ static-check:
 	uvx mypy ./aperag
 
 # Testing suite
-.PHONY: test unit-test e2e-test e2e-performance-test
+.PHONY: test unit-test e2e-test e2e-performance-test e2e-http-bootstrap e2e-http-smoke e2e-http-compose-up e2e-http-compose-down e2e-http-compose-smoke
 test:
 	uv run pytest tests/ -v
 
@@ -211,6 +211,21 @@ e2e-performance-test:
 		--benchmark-storage=tests/report \
 		--benchmark-save=benchmark-result-$$(date +%Y%m%d%H%M%S) \
 		tests/e2e_test/
+
+e2e-http-bootstrap:
+	@./tests/e2e_http/bootstrap/bootstrap.sh
+
+e2e-http-smoke:
+	@./tests/e2e_http/scripts/run_smoke.sh
+
+e2e-http-compose-up:
+	@./tests/e2e_http/runners/compose/up.sh
+
+e2e-http-compose-down:
+	@./tests/e2e_http/runners/compose/down.sh
+
+e2e-http-compose-smoke:
+	@./tests/e2e_http/scripts/run_compose_smoke.sh
 
 # RAG evaluation
 .PHONY: evaluate

--- a/tests/e2e_http/README.md
+++ b/tests/e2e_http/README.md
@@ -1,0 +1,48 @@
+# ApeRAG HTTP E2E
+
+This suite is the new black-box HTTP E2E entrypoint for ApeRAG.
+
+Design constraints:
+- Targets a freshly started, empty ApeRAG service.
+- Exercises user-visible behavior only through HTTP APIs.
+- Keeps test content independent from the environment launcher.
+- Treats `hurl/` as the current execution implementation, not the suite identity.
+
+Top-level layout:
+- `hurl/smoke/`: minimal provider-independent smoke coverage
+- `hurl/full/`: broader HTTP coverage that may depend on providers or longer flows
+- `bootstrap/`: prepares the minimum testable state on an empty service
+- `runners/`: environment launchers such as Compose or K8s
+- `scripts/`: wrappers that connect runner, bootstrap, and Hurl execution
+- `testdata/`: stable input files used by HTTP tests
+
+Current v1 scope:
+- Readiness endpoint: `GET /health`
+- Auth smoke: login, current user, logout
+- Collection smoke: create, get, list, update, delete
+- Document smoke: upload, get detail, delete
+- API key smoke: create, use, update, delete
+
+Non-goals for v1:
+- Replacing existing `tests/e2e_test`
+- Covering WebSocket or streaming chat flows
+- Depending on external model providers in the smoke path
+
+Important behavior notes from the current implementation:
+- Smoke tests create and clean up their own business resources.
+- `document` smoke intentionally validates upload and basic lifecycle only; it does not require provider-backed indexing to complete.
+- API key smoke explicitly logs out before bearer-only checks so cookie auth does not mask key behavior.
+
+Typical local flow against an existing ApeRAG instance:
+
+```bash
+export E2E_BASE_URL=http://127.0.0.1:8000
+./tests/e2e_http/bootstrap/bootstrap.sh
+./tests/e2e_http/scripts/run_smoke.sh
+```
+
+Typical local flow with the first Compose runner:
+
+```bash
+./tests/e2e_http/scripts/run_compose_smoke.sh
+```

--- a/tests/e2e_http/bootstrap/.gitignore
+++ b/tests/e2e_http/bootstrap/.gitignore
@@ -1,0 +1,1 @@
+.generated/

--- a/tests/e2e_http/bootstrap/PROTOCOL.md
+++ b/tests/e2e_http/bootstrap/PROTOCOL.md
@@ -1,0 +1,64 @@
+# Bootstrap Protocol
+
+`bootstrap/` is responsible for making a freshly started ApeRAG service testable.
+
+It must not:
+- launch the environment
+- choose the runner
+- create business resources such as collections or documents for smoke tests
+
+It may:
+- prepare a test user
+- verify login works
+- emit a run identifier and naming prefix
+- publish file paths and basic execution metadata for the suite
+
+## Inputs
+
+The current bootstrap script reads these environment variables:
+
+- `E2E_BASE_URL`
+  HTTP base URL for the target ApeRAG service.
+  Default: `http://127.0.0.1:8000`
+
+- `E2E_BOOTSTRAP_MODE`
+  Supported values:
+  - `public-register` (default): register the first user through `/api/v1/register`
+  - `dev-api`: create an admin user through `/api/v1/test/register_admin`
+
+- `E2E_RUN_ID`
+  Optional explicit run identifier. If omitted, bootstrap generates one.
+
+- `E2E_USERNAME`
+  Optional explicit username. If omitted, bootstrap derives one from `E2E_RUN_ID`.
+
+- `E2E_PASSWORD`
+  Optional explicit password. If omitted, bootstrap derives one from `E2E_RUN_ID`.
+
+- `E2E_EMAIL`
+  Optional explicit email. If omitted, bootstrap derives one from `E2E_USERNAME`.
+
+- `E2E_ENV_FILE`
+  Output file for generated exports.
+  Default: `tests/e2e_http/bootstrap/.generated/e2e.env`
+
+## Outputs
+
+Bootstrap writes an env file that can be sourced by runners or suite wrappers.
+
+Current outputs:
+- `E2E_BASE_URL`
+- `E2E_BOOTSTRAP_MODE`
+- `E2E_RUN_ID`
+- `E2E_USERNAME`
+- `E2E_PASSWORD`
+- `E2E_EMAIL`
+- `E2E_ARTIFACTS_DIR`
+- `E2E_TESTDATA_DIR`
+
+## Contract notes
+
+- The suite consumes bootstrap outputs only through env variables.
+- Smoke tests create and clean up their own business resources.
+- Provider/model setup is intentionally excluded from v1 bootstrap to keep smoke mostly provider-independent.
+- Bootstrap verifies only that a test user can be created and logged in; it does not create collections, documents, bots, or provider resources.

--- a/tests/e2e_http/bootstrap/bootstrap.sh
+++ b/tests/e2e_http/bootstrap/bootstrap.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GENERATED_DIR="${ROOT_DIR}/tests/e2e_http/bootstrap/.generated"
+mkdir -p "${GENERATED_DIR}"
+
+E2E_BASE_URL="${E2E_BASE_URL:-http://127.0.0.1:8000}"
+E2E_BOOTSTRAP_MODE="${E2E_BOOTSTRAP_MODE:-public-register}"
+E2E_RUN_ID="${E2E_RUN_ID:-$(date +%Y%m%d%H%M%S)}"
+E2E_USERNAME="${E2E_USERNAME:-e2e_${E2E_RUN_ID}}"
+E2E_PASSWORD="${E2E_PASSWORD:-E2E_${E2E_RUN_ID}_pass}"
+E2E_EMAIL="${E2E_EMAIL:-${E2E_USERNAME}@example.com}"
+E2E_ENV_FILE="${E2E_ENV_FILE:-${GENERATED_DIR}/e2e.env}"
+E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-${GENERATED_DIR}/artifacts}"
+E2E_TESTDATA_DIR="${E2E_TESTDATA_DIR:-${ROOT_DIR}/tests/e2e_http/testdata}"
+
+mkdir -p "${E2E_ARTIFACTS_DIR}"
+
+wait_for_health() {
+  local attempts="${1:-60}"
+  local sleep_seconds="${2:-2}"
+  local i
+
+  for ((i = 1; i <= attempts; i++)); do
+    if curl --silent --show-error --fail "${E2E_BASE_URL}/health" >/dev/null; then
+      return 0
+    fi
+    sleep "${sleep_seconds}"
+  done
+
+  echo "Timed out waiting for ${E2E_BASE_URL}/health" >&2
+  return 1
+}
+
+register_via_public_api() {
+  local payload response body status
+  payload="$(cat <<EOF
+{"username":"${E2E_USERNAME}","email":"${E2E_EMAIL}","password":"${E2E_PASSWORD}"}
+EOF
+)"
+
+  response="$(
+    curl --silent --show-error \
+      --write-out $'\n%{http_code}' \
+      --header 'Content-Type: application/json' \
+      --request POST \
+      --data "${payload}" \
+      "${E2E_BASE_URL}/api/v1/register"
+  )"
+  status="$(printf '%s' "${response}" | tail -n 1)"
+  body="$(printf '%s' "${response}" | sed '$d')"
+
+  if [[ "${status}" == "200" ]]; then
+    echo "Registered ${E2E_USERNAME} via public API"
+    return 0
+  fi
+
+  if [[ "${status}" == "400" && "${body}" == *"already exists"* ]]; then
+    echo "User ${E2E_USERNAME} already exists, continuing with login"
+    return 0
+  fi
+
+  echo "Public bootstrap failed with status ${status}: ${body}" >&2
+  return 1
+}
+
+register_via_dev_api() {
+  local payload response body status
+  payload="$(cat <<EOF
+{"username":"${E2E_USERNAME}","email":"${E2E_EMAIL}","password":"${E2E_PASSWORD}"}
+EOF
+)"
+
+  response="$(
+    curl --silent --show-error \
+      --write-out $'\n%{http_code}' \
+      --header 'Content-Type: application/json' \
+      --request POST \
+      --data "${payload}" \
+      "${E2E_BASE_URL}/api/v1/test/register_admin"
+  )"
+  status="$(printf '%s' "${response}" | tail -n 1)"
+  body="$(printf '%s' "${response}" | sed '$d')"
+
+  if [[ "${status}" == "200" ]]; then
+    echo "Registered ${E2E_USERNAME} via dev API"
+    return 0
+  fi
+
+  if [[ "${status}" == "400" && "${body}" == *"already exists"* ]]; then
+    echo "User ${E2E_USERNAME} already exists, continuing with login"
+    return 0
+  fi
+
+  echo "Dev bootstrap failed with status ${status}: ${body}" >&2
+  return 1
+}
+
+verify_login() {
+  local payload cookie_file
+  payload="$(cat <<EOF
+{"username":"${E2E_USERNAME}","password":"${E2E_PASSWORD}"}
+EOF
+)"
+  cookie_file="${GENERATED_DIR}/bootstrap.cookies"
+
+  curl --silent --show-error --fail \
+    --cookie-jar "${cookie_file}" \
+    --header 'Content-Type: application/json' \
+    --request POST \
+    --data "${payload}" \
+    "${E2E_BASE_URL}/api/v1/login" >/dev/null
+}
+
+write_env_file() {
+  cat >"${E2E_ENV_FILE}" <<EOF
+export E2E_BASE_URL='${E2E_BASE_URL}'
+export E2E_BOOTSTRAP_MODE='${E2E_BOOTSTRAP_MODE}'
+export E2E_RUN_ID='${E2E_RUN_ID}'
+export E2E_USERNAME='${E2E_USERNAME}'
+export E2E_PASSWORD='${E2E_PASSWORD}'
+export E2E_EMAIL='${E2E_EMAIL}'
+export E2E_ARTIFACTS_DIR='${E2E_ARTIFACTS_DIR}'
+export E2E_TESTDATA_DIR='${E2E_TESTDATA_DIR}'
+EOF
+}
+
+main() {
+  wait_for_health
+
+  case "${E2E_BOOTSTRAP_MODE}" in
+    public-register)
+      register_via_public_api
+      ;;
+    dev-api)
+      register_via_dev_api
+      ;;
+    *)
+      echo "Unsupported E2E_BOOTSTRAP_MODE=${E2E_BOOTSTRAP_MODE}" >&2
+      exit 1
+      ;;
+  esac
+
+  verify_login
+  write_env_file
+
+  echo "Bootstrap complete. Env file written to ${E2E_ENV_FILE}"
+}
+
+main "$@"

--- a/tests/e2e_http/hurl/full/README.md
+++ b/tests/e2e_http/hurl/full/README.md
@@ -1,0 +1,11 @@
+# Full HTTP E2E
+
+This directory is reserved for broader HTTP coverage after the smoke layer is stable.
+
+Expected future categories:
+- provider-dependent API coverage
+- document download and richer document lifecycle cases
+- bot and non-streaming chat flows
+- graph HTTP APIs
+
+WebSocket and streaming-specific coverage should remain in a thin supplemental layer rather than being forced into Hurl.

--- a/tests/e2e_http/hurl/smoke/00_health.hurl
+++ b/tests/e2e_http/hurl/smoke/00_health.hurl
@@ -1,0 +1,6 @@
+GET {{base_url}}/health
+HTTP 200
+[Asserts]
+header "content-type" contains "application/json"
+jsonpath "$.status" == "healthy"
+jsonpath "$.service" == "aperag-api"

--- a/tests/e2e_http/hurl/smoke/01_auth.hurl
+++ b/tests/e2e_http/hurl/smoke/01_auth.hurl
@@ -1,0 +1,21 @@
+POST {{base_url}}/api/v1/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+[Asserts]
+header "content-type" contains "application/json"
+jsonpath "$.username" == "{{username}}"
+jsonpath "$.is_active" == true
+
+GET {{base_url}}/api/v1/user
+HTTP 200
+[Asserts]
+header "content-type" contains "application/json"
+jsonpath "$.username" == "{{username}}"
+jsonpath "$.is_active" == true
+
+POST {{base_url}}/api/v1/logout
+HTTP 200

--- a/tests/e2e_http/hurl/smoke/02_collection.hurl
+++ b/tests/e2e_http/hurl/smoke/02_collection.hurl
@@ -1,0 +1,68 @@
+POST {{base_url}}/api/v1/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+POST {{base_url}}/api/v1/collections
+Content-Type: application/json
+{
+  "title": "Smoke Collection {{run_id}}",
+  "description": "HTTP smoke collection",
+  "type": "document",
+  "config": {
+    "source": "system",
+    "enable_vector": false,
+    "enable_fulltext": false,
+    "enable_knowledge_graph": false,
+    "enable_summary": false,
+    "enable_vision": false
+  }
+}
+HTTP 200
+[Captures]
+collection_id: jsonpath "$.id"
+[Asserts]
+header "content-type" contains "application/json"
+jsonpath "$.type" == "document"
+jsonpath "$.status" == "ACTIVE"
+jsonpath "$.config.source" == "system"
+jsonpath "$.config.enable_knowledge_graph" == false
+
+GET {{base_url}}/api/v1/collections/{{collection_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{collection_id}}"
+jsonpath "$.type" == "document"
+
+GET {{base_url}}/api/v1/collections?page=1&page_size=50
+HTTP 200
+[Asserts]
+header "content-type" contains "application/json"
+
+PUT {{base_url}}/api/v1/collections/{{collection_id}}
+Content-Type: application/json
+{
+  "title": "Smoke Collection {{run_id}} Updated",
+  "description": "HTTP smoke collection updated",
+  "config": {
+    "source": "system",
+    "enable_vector": false,
+    "enable_fulltext": false,
+    "enable_knowledge_graph": false,
+    "enable_summary": false,
+    "enable_vision": false
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{collection_id}}"
+jsonpath "$.title" == "Smoke Collection {{run_id}} Updated"
+
+DELETE {{base_url}}/api/v1/collections/{{collection_id}}
+HTTP 200
+
+GET {{base_url}}/api/v1/collections/{{collection_id}}
+HTTP 404

--- a/tests/e2e_http/hurl/smoke/03_document_basic.hurl
+++ b/tests/e2e_http/hurl/smoke/03_document_basic.hurl
@@ -1,0 +1,56 @@
+POST {{base_url}}/api/v1/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+POST {{base_url}}/api/v1/collections
+Content-Type: application/json
+{
+  "title": "Document Smoke {{run_id}}",
+  "description": "HTTP document smoke collection",
+  "type": "document",
+  "config": {
+    "source": "system",
+    "enable_vector": false,
+    "enable_fulltext": false,
+    "enable_knowledge_graph": false,
+    "enable_summary": false,
+    "enable_vision": false
+  }
+}
+HTTP 200
+[Captures]
+collection_id: jsonpath "$.id"
+
+POST {{base_url}}/api/v1/collections/{{collection_id}}/documents
+[MultipartFormData]
+files: file,tests/e2e_http/testdata/minimal-document.txt; type=text/plain
+HTTP 200
+[Captures]
+document_id: jsonpath "$.items[0].id"
+[Asserts]
+header "content-type" contains "application/json"
+jsonpath "$.items[0].id" == "{{document_id}}"
+jsonpath "$.items[0].name" == "tests/e2e_http/testdata/minimal-document.txt"
+jsonpath "$.items[0].graph_index_status" == "SKIPPED"
+
+GET {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{document_id}}"
+jsonpath "$.name" == "tests/e2e_http/testdata/minimal-document.txt"
+jsonpath "$.graph_index_status" == "SKIPPED"
+jsonpath "$.summary_index_status" == "SKIPPED"
+jsonpath "$.vision_index_status" == "SKIPPED"
+
+DELETE {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{document_id}}"
+jsonpath "$.status" == "DELETED"
+
+DELETE {{base_url}}/api/v1/collections/{{collection_id}}
+HTTP 200

--- a/tests/e2e_http/hurl/smoke/04_api_key.hurl
+++ b/tests/e2e_http/hurl/smoke/04_api_key.hurl
@@ -1,0 +1,60 @@
+POST {{base_url}}/api/v1/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+POST {{base_url}}/api/v1/apikeys
+Content-Type: application/json
+{
+  "description": "smoke key {{run_id}}"
+}
+HTTP 200
+[Captures]
+api_key_id: jsonpath "$.id"
+api_key_value: jsonpath "$.key"
+[Asserts]
+header "content-type" contains "application/json"
+jsonpath "$.id" == "{{api_key_id}}"
+jsonpath "$.key" == "{{api_key_value}}"
+jsonpath "$.description" == "smoke key {{run_id}}"
+
+GET {{base_url}}/api/v1/apikeys
+HTTP 200
+
+POST {{base_url}}/api/v1/logout
+HTTP 200
+
+GET {{base_url}}/api/v1/collections
+Authorization: Bearer {{api_key_value}}
+HTTP 200
+
+POST {{base_url}}/api/v1/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+PUT {{base_url}}/api/v1/apikeys/{{api_key_id}}
+Content-Type: application/json
+{
+  "description": "smoke key {{run_id}} updated"
+}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{api_key_id}}"
+jsonpath "$.description" == "smoke key {{run_id}} updated"
+
+DELETE {{base_url}}/api/v1/apikeys/{{api_key_id}}
+HTTP 200
+
+POST {{base_url}}/api/v1/logout
+HTTP 200
+
+GET {{base_url}}/api/v1/collections
+Authorization: Bearer {{api_key_value}}
+HTTP 401

--- a/tests/e2e_http/runners/compose/README.md
+++ b/tests/e2e_http/runners/compose/README.md
@@ -1,0 +1,16 @@
+# Compose Runner
+
+This runner is the first convenience launcher for the HTTP E2E suite.
+
+Responsibilities:
+- start the ApeRAG environment
+- wait for `GET /health`
+- leave execution of bootstrap and Hurl requests to other layers
+
+Non-responsibilities:
+- creating test users
+- creating collections or documents
+- embedding provider setup
+- defining what smoke means
+
+This runner is intentionally replaceable. The suite must remain runnable against future K8s-backed environments with the same bootstrap and Hurl files.

--- a/tests/e2e_http/runners/compose/down.sh
+++ b/tests/e2e_http/runners/compose/down.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ "${E2E_REMOVE_VOLUMES:-0}" == "1" ]]; then
+  docker compose --profile docray --profile docray-gpu --profile neo4j --profile nebula --profile jaeger -f docker-compose.yml down -v
+else
+  docker compose --profile docray --profile docray-gpu --profile neo4j --profile nebula --profile jaeger -f docker-compose.yml down
+fi

--- a/tests/e2e_http/runners/compose/up.sh
+++ b/tests/e2e_http/runners/compose/up.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+E2E_BASE_URL="${E2E_BASE_URL:-http://127.0.0.1:8000}"
+E2E_COMPOSE_SERVICES="${E2E_COMPOSE_SERVICES:-postgres redis qdrant es api celeryworker celerybeat}"
+E2E_HEALTH_ATTEMPTS="${E2E_HEALTH_ATTEMPTS:-90}"
+E2E_HEALTH_SLEEP_SECONDS="${E2E_HEALTH_SLEEP_SECONDS:-2}"
+
+if [[ ! -f "${ROOT_DIR}/.env" ]]; then
+  cp "${ROOT_DIR}/envs/env.template" "${ROOT_DIR}/.env"
+fi
+
+docker compose -f docker-compose.yml up -d --build ${E2E_COMPOSE_SERVICES}
+
+for ((i = 1; i <= E2E_HEALTH_ATTEMPTS; i++)); do
+  if curl --silent --show-error --fail "${E2E_BASE_URL}/health" >/dev/null; then
+    echo "Compose runner ready at ${E2E_BASE_URL}"
+    exit 0
+  fi
+  sleep "${E2E_HEALTH_SLEEP_SECONDS}"
+done
+
+echo "Compose runner failed to reach healthy state at ${E2E_BASE_URL}" >&2
+exit 1

--- a/tests/e2e_http/runners/k8s/README.md
+++ b/tests/e2e_http/runners/k8s/README.md
@@ -1,0 +1,10 @@
+# K8s Runner Placeholder
+
+This directory is intentionally reserved for a future Kubernetes-backed runner.
+
+The HTTP suite must keep working with the same:
+- bootstrap protocol
+- Hurl files
+- testdata layout
+
+Only the launcher should change when moving from Compose to K8s.

--- a/tests/e2e_http/scripts/run_compose_smoke.sh
+++ b/tests/e2e_http/scripts/run_compose_smoke.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+cleanup() {
+  if [[ "${E2E_KEEP_UP:-0}" != "1" ]]; then
+    "${ROOT_DIR}/tests/e2e_http/runners/compose/down.sh"
+  fi
+}
+
+trap cleanup EXIT
+
+"${ROOT_DIR}/tests/e2e_http/runners/compose/up.sh"
+"${ROOT_DIR}/tests/e2e_http/bootstrap/bootstrap.sh"
+"${ROOT_DIR}/tests/e2e_http/scripts/run_smoke.sh"

--- a/tests/e2e_http/scripts/run_smoke.sh
+++ b/tests/e2e_http/scripts/run_smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+E2E_ENV_FILE="${E2E_ENV_FILE:-${ROOT_DIR}/tests/e2e_http/bootstrap/.generated/e2e.env}"
+
+if [[ ! -f "${E2E_ENV_FILE}" ]]; then
+  echo "Missing bootstrap env file: ${E2E_ENV_FILE}" >&2
+  echo "Run ./tests/e2e_http/bootstrap/bootstrap.sh first." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "${E2E_ENV_FILE}"
+
+SMOKE_DIR="${ROOT_DIR}/tests/e2e_http/hurl/smoke"
+
+for file in "${SMOKE_DIR}"/*.hurl; do
+  echo "Running ${file}"
+  hurl --test \
+    --file-root "${ROOT_DIR}" \
+    --variable base_url="${E2E_BASE_URL}" \
+    --variable username="${E2E_USERNAME}" \
+    --variable password="${E2E_PASSWORD}" \
+    --variable run_id="${E2E_RUN_ID}" \
+    --variable testdata_dir="${E2E_TESTDATA_DIR}" \
+    "${file}"
+done

--- a/tests/e2e_http/testdata/minimal-document.txt
+++ b/tests/e2e_http/testdata/minimal-document.txt
@@ -1,0 +1,1 @@
+This is a minimal ApeRAG HTTP E2E smoke document.


### PR DESCRIPTION
## Summary
- add a new `tests/e2e_http/` black-box smoke suite for fresh ApeRAG deployments
- add compose runner/bootstrap scripts plus `health/auth/collection/document/api_key` Hurl smoke coverage
- add a GitHub Actions workflow that builds the stack and runs the HTTP smoke suite end to end

## Why
The repository needed a minimal, provider-independent E2E path that can exercise a fresh deployment through HTTP only and run in CI.

## Validation
- `bash -n tests/e2e_http/runners/compose/up.sh`
- `bash -n tests/e2e_http/scripts/run_smoke.sh`
- `bash -n tests/e2e_http/scripts/run_compose_smoke.sh`
- `E2E_REMOVE_VOLUMES=1 ./tests/e2e_http/scripts/run_compose_smoke.sh`
