### PR TITLE
fix: narrow LightRAG delete/update scope

### DIFF
--- a/aperag/db/repositories/graph.py
+++ b/aperag/db/repositories/graph.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import and_, delete, func, or_, select, text
+from sqlalchemy import and_, delete, func, or_, select, text, union_all
 from sqlalchemy.dialects.postgresql import insert
 
 from aperag.db.models import LightRAGGraphEdge, LightRAGGraphNode
@@ -505,6 +505,76 @@ class GraphRepositoryMixin:
             return degrees
 
         return self._execute_query(_get_degrees_batch)
+
+    def get_top_degree_graph_nodes(self, workspace: str, limit: int) -> Tuple[Dict[str, Dict[str, Any]], int]:
+        """Get top-degree graph nodes with node payloads in a single repository call."""
+
+        def _get_top_degree_graph_nodes(session):
+            total_stmt = select(func.count(LightRAGGraphNode.id)).where(LightRAGGraphNode.workspace == workspace)
+            total_nodes = session.execute(total_stmt).scalar() or 0
+            if total_nodes == 0 or limit <= 0:
+                return {}, total_nodes
+
+            outgoing = (
+                select(
+                    LightRAGGraphEdge.source_entity_id.label("entity_id"),
+                    func.count().label("degree_part"),
+                )
+                .where(LightRAGGraphEdge.workspace == workspace)
+                .group_by(LightRAGGraphEdge.source_entity_id)
+            )
+            incoming = (
+                select(
+                    LightRAGGraphEdge.target_entity_id.label("entity_id"),
+                    func.count().label("degree_part"),
+                )
+                .where(LightRAGGraphEdge.workspace == workspace)
+                .group_by(LightRAGGraphEdge.target_entity_id)
+            )
+
+            degree_parts = union_all(outgoing, incoming).subquery()
+            degree_totals = (
+                select(
+                    degree_parts.c.entity_id,
+                    func.sum(degree_parts.c.degree_part).label("degree"),
+                )
+                .group_by(degree_parts.c.entity_id)
+                .subquery()
+            )
+
+            stmt = (
+                select(LightRAGGraphNode, degree_totals.c.degree)
+                .join(
+                    degree_totals,
+                    and_(
+                        LightRAGGraphNode.workspace == workspace,
+                        LightRAGGraphNode.entity_id == degree_totals.c.entity_id,
+                    ),
+                )
+                .where(LightRAGGraphNode.workspace == workspace, degree_totals.c.degree > 0)
+                .order_by(degree_totals.c.degree.desc(), LightRAGGraphNode.entity_id)
+                .limit(limit)
+            )
+
+            result = session.execute(stmt)
+            nodes = {}
+            for node, degree in result:
+                node_dict = {
+                    "entity_id": node.entity_id,
+                    "entity_type": node.entity_type,
+                    "description": node.description,
+                    "source_id": node.source_id,
+                    "file_path": node.file_path,
+                    "created_at": int(node.createtime.timestamp()) if node.createtime else None,
+                    "degree": int(degree or 0),
+                }
+                if node.entity_name and node.entity_name != node.entity_id:
+                    node_dict["entity_name"] = node.entity_name
+                nodes[node.entity_id] = {k: v for k, v in node_dict.items() if v is not None}
+
+            return nodes, total_nodes
+
+        return self._execute_query(_get_top_degree_graph_nodes)
 
     def get_graph_edges_batch(
         self, workspace: str, edge_pairs: List[Tuple[str, str]]

--- a/aperag/db/repositories/graph.py
+++ b/aperag/db/repositories/graph.py
@@ -19,12 +19,30 @@ from sqlalchemy import and_, delete, func, or_, select, text
 from sqlalchemy.dialects.postgresql import insert
 
 from aperag.db.models import LightRAGGraphEdge, LightRAGGraphNode
+from aperag.graph.lightrag.prompt import GRAPH_FIELD_SEP
 
 logger = logging.getLogger(__name__)
 
 
 class GraphRepositoryMixin:
     """Graph Repository Mixin for LightRAG Graph operations using SQLAlchemy"""
+
+    @staticmethod
+    def _build_source_id_overlap_clause(column, chunk_ids: List[str]):
+        if not chunk_ids:
+            return None
+
+        conditions = []
+        for chunk_id in set(chunk_ids):
+            conditions.extend(
+                [
+                    column == chunk_id,
+                    column.like(f"{chunk_id}{GRAPH_FIELD_SEP}%"),
+                    column.like(f"%{GRAPH_FIELD_SEP}{chunk_id}{GRAPH_FIELD_SEP}%"),
+                    column.like(f"%{GRAPH_FIELD_SEP}{chunk_id}"),
+                ]
+            )
+        return or_(*conditions) if conditions else None
 
     # Node operations
     def upsert_graph_node(self, workspace: str, node_id: str, node_data: Dict[str, Any]) -> None:
@@ -313,6 +331,75 @@ class GraphRepositoryMixin:
             return [row[0] for row in result]
 
         return self._execute_query(_get_labels)
+
+    def get_graph_nodes_by_source_ids(self, workspace: str, chunk_ids: List[str]) -> Dict[str, Dict[str, Any]]:
+        """Get graph nodes whose source_id references any of the given chunk IDs"""
+        if not chunk_ids:
+            return {}
+
+        def _get_nodes(session):
+            overlap_clause = self._build_source_id_overlap_clause(LightRAGGraphNode.source_id, chunk_ids)
+            stmt = select(LightRAGGraphNode).where(
+                and_(
+                    LightRAGGraphNode.workspace == workspace,
+                    LightRAGGraphNode.source_id.is_not(None),
+                    overlap_clause,
+                )
+            )
+            result = session.execute(stmt)
+            nodes = {}
+            for node in result.unique().scalars():
+                node_dict = {
+                    "entity_id": node.entity_id,
+                    "entity_type": node.entity_type,
+                    "description": node.description,
+                    "source_id": node.source_id,
+                    "file_path": node.file_path,
+                    "created_at": int(node.createtime.timestamp()) if node.createtime else None,
+                }
+                if node.entity_name and node.entity_name != node.entity_id:
+                    node_dict["entity_name"] = node.entity_name
+                nodes[node.entity_id] = {k: v for k, v in node_dict.items() if v is not None}
+            return nodes
+
+        return self._execute_query(_get_nodes)
+
+    def get_graph_edges_by_source_ids(
+        self, workspace: str, chunk_ids: List[str]
+    ) -> Dict[Tuple[str, str], Dict[str, Any]]:
+        """Get graph edges whose source_id references any of the given chunk IDs"""
+        if not chunk_ids:
+            return {}
+
+        def _get_edges(session):
+            overlap_clause = self._build_source_id_overlap_clause(LightRAGGraphEdge.source_id, chunk_ids)
+            stmt = select(LightRAGGraphEdge).where(
+                and_(
+                    LightRAGGraphEdge.workspace == workspace,
+                    LightRAGGraphEdge.source_id.is_not(None),
+                    overlap_clause,
+                )
+            )
+            result = session.execute(stmt)
+            edges = {}
+            for edge in result.unique().scalars():
+                pair = (edge.source_entity_id, edge.target_entity_id)
+                edge_dict = {
+                    "weight": float(edge.weight) if edge.weight is not None else 0.0,
+                    "keywords": edge.keywords,
+                    "description": edge.description,
+                    "source_id": edge.source_id,
+                    "file_path": edge.file_path,
+                }
+                required_fields = {"weight", "keywords", "description", "source_id"}
+                filtered_result = {}
+                for key, value in edge_dict.items():
+                    if key in required_fields or value is not None:
+                        filtered_result[key] = value
+                edges[pair] = filtered_result
+            return edges
+
+        return self._execute_query(_get_edges)
 
     def drop_graph_workspace(self, workspace: str) -> Dict[str, str]:
         """Drop all graph data for a workspace"""

--- a/aperag/db/repositories/lightrag.py
+++ b/aperag/db/repositories/lightrag.py
@@ -25,6 +25,18 @@ from aperag.utils.utils import utc_now
 
 class LightragRepositoryMixin(SyncRepositoryProtocol):
     # LightRAG Doc Chunks Operations
+    def query_lightrag_doc_chunks_by_doc_id(self, workspace: str, doc_id: str):
+        """Query LightRAG document chunks by full document ID"""
+
+        def _query(session):
+            stmt = select(LightRAGDocChunksModel).where(
+                LightRAGDocChunksModel.workspace == workspace, LightRAGDocChunksModel.full_doc_id == doc_id
+            )
+            result = session.execute(stmt)
+            return {chunk.id: chunk for chunk in result.scalars().all()}
+
+        return self._execute_query(_query)
+
     def query_lightrag_doc_chunks_by_id(self, workspace: str, chunk_id: str):
         """Query LightRAG document chunks by ID"""
 
@@ -156,6 +168,20 @@ class LightragRepositoryMixin(SyncRepositoryProtocol):
 
         return self._execute_query(_query)
 
+    def query_lightrag_vdb_entity_by_chunk_ids(self, workspace: str, chunk_ids: list[str]):
+        """Query LightRAG VDB entities whose chunk_ids overlap with the given chunk IDs"""
+
+        def _query(session):
+            if not chunk_ids:
+                return {}
+            stmt = select(LightRAGVDBEntityModel).where(
+                LightRAGVDBEntityModel.workspace == workspace, LightRAGVDBEntityModel.chunk_ids.overlap(chunk_ids)
+            )
+            result = session.execute(stmt)
+            return {entity.id: entity for entity in result.scalars().all()}
+
+        return self._execute_query(_query)
+
     def upsert_lightrag_vdb_entity(self, workspace: str, entity_data: dict):
         """Upsert LightRAG VDB Entity records using PostgreSQL UPSERT"""
 
@@ -232,6 +258,20 @@ class LightragRepositoryMixin(SyncRepositoryProtocol):
             )
             result = session.execute(stmt)
             return result.scalars().first()
+
+        return self._execute_query(_query)
+
+    def query_lightrag_vdb_relation_by_chunk_ids(self, workspace: str, chunk_ids: list[str]):
+        """Query LightRAG VDB relations whose chunk_ids overlap with the given chunk IDs"""
+
+        def _query(session):
+            if not chunk_ids:
+                return {}
+            stmt = select(LightRAGVDBRelationModel).where(
+                LightRAGVDBRelationModel.workspace == workspace, LightRAGVDBRelationModel.chunk_ids.overlap(chunk_ids)
+            )
+            result = session.execute(stmt)
+            return {relation.id: relation for relation in result.scalars().all()}
 
         return self._execute_query(_query)
 

--- a/aperag/graph/lightrag/base.py
+++ b/aperag/graph/lightrag/base.py
@@ -446,6 +446,49 @@ class BaseGraphStorage(StorageNameSpace, ABC):
             result[node_id] = edges if edges is not None else []
         return result
 
+    async def get_nodes_edges_with_data_batch(
+        self,
+        node_ids: list[str],
+    ) -> dict[str, list[tuple[str, str, dict]]]:
+        """Get node incident edges together with edge properties in batch.
+
+        Default implementation composes existing batch primitives so callers can
+        avoid `get_node_edges()` + per-edge `get_edge()` N+1 patterns even before
+        a backend adds a specialized override.
+        """
+        result = {node_id: [] for node_id in node_ids}
+        node_edges = await self.get_nodes_edges_batch(node_ids)
+
+        edge_pairs: list[dict[str, str]] = []
+        seen_edge_pairs: set[tuple[str, str]] = set()
+        for node_id in node_ids:
+            for source, target in node_edges.get(node_id, []) or []:
+                edge_pair = (source, target)
+                if edge_pair in seen_edge_pairs:
+                    continue
+                seen_edge_pairs.add(edge_pair)
+                edge_pairs.append({"src": source, "tgt": target})
+
+        if not edge_pairs:
+            return result
+
+        edges_with_data = await self.get_edges_batch(edge_pairs)
+        for node_id in node_ids:
+            result[node_id] = [
+                (source, target, edge_data)
+                for source, target in node_edges.get(node_id, []) or []
+                if (edge_data := edges_with_data.get((source, target))) is not None
+            ]
+
+        return result
+
+    async def get_incident_edges_with_data_batch(
+        self,
+        node_ids: list[str],
+    ) -> dict[str, list[tuple[str, str, dict]]]:
+        """Intent-focused alias for batch incident-edge fetches with properties."""
+        return await self.get_nodes_edges_with_data_batch(node_ids)
+
     @abstractmethod
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
         """Insert a new node or update an existing node in the graph.

--- a/aperag/graph/lightrag/base.py
+++ b/aperag/graph/lightrag/base.py
@@ -489,6 +489,10 @@ class BaseGraphStorage(StorageNameSpace, ABC):
         """Intent-focused alias for batch incident-edge fetches with properties."""
         return await self.get_nodes_edges_with_data_batch(node_ids)
 
+    async def get_top_degree_nodes(self, limit: int) -> tuple[dict[str, dict], int] | None:
+        """Return top-degree nodes plus total node count when backend supports it."""
+        return None
+
     @abstractmethod
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
         """Insert a new node or update an existing node in the graph.

--- a/aperag/graph/lightrag/kg/neo4j_sync_impl.py
+++ b/aperag/graph/lightrag/kg/neo4j_sync_impl.py
@@ -45,6 +45,7 @@ from tenacity import (
 )
 
 from ..base import BaseGraphStorage
+from ..prompt import GRAPH_FIELD_SEP
 from ..types import KnowledgeGraph, KnowledgeGraphEdge, KnowledgeGraphNode
 from ..utils import logger
 
@@ -374,6 +375,60 @@ class Neo4JSyncStorage(BaseGraphStorage):
                 return edges_dict
 
         return await asyncio.to_thread(_sync_get_nodes_edges_batch)
+
+    async def get_nodes_by_source_ids(self, chunk_ids: list[str]) -> dict[str, dict]:
+        """Retrieve nodes whose source_id references any of the provided chunk IDs."""
+
+        def _sync_get_nodes_by_source_ids():
+            with Neo4jSyncConnectionManager.get_session(database=self._DATABASE) as session:
+                query = """
+                MATCH (n:base)
+                WHERE n.source_id IS NOT NULL
+                  AND any(source IN split(n.source_id, $sep) WHERE source IN $chunk_ids)
+                RETURN n.entity_id AS entity_id, n
+                """
+                result = session.run(query, chunk_ids=chunk_ids, sep=GRAPH_FIELD_SEP)
+                nodes = {}
+                for record in result:
+                    entity_id = record["entity_id"]
+                    node = record["n"]
+                    node_dict = dict(node)
+                    if "labels" in node_dict:
+                        node_dict["labels"] = [label for label in node_dict["labels"] if label != "base"]
+                    nodes[entity_id] = node_dict
+                return nodes
+
+        return await asyncio.to_thread(_sync_get_nodes_by_source_ids)
+
+    async def get_edges_by_source_ids(self, chunk_ids: list[str]) -> dict[tuple[str, str], dict]:
+        """Retrieve edges whose source_id references any of the provided chunk IDs."""
+
+        def _sync_get_edges_by_source_ids():
+            with Neo4jSyncConnectionManager.get_session(database=self._DATABASE) as session:
+                query = """
+                MATCH (start:base)-[r:DIRECTED]-(end:base)
+                WHERE r.source_id IS NOT NULL
+                  AND any(source IN split(r.source_id, $sep) WHERE source IN $chunk_ids)
+                RETURN start.entity_id AS src_id, end.entity_id AS tgt_id, properties(r) AS edge_properties
+                """
+                result = session.run(query, chunk_ids=chunk_ids, sep=GRAPH_FIELD_SEP)
+                edges = {}
+                for record in result:
+                    src = record["src_id"]
+                    tgt = record["tgt_id"]
+                    edge_props = dict(record["edge_properties"])
+                    for key, default in {
+                        "weight": 0.0,
+                        "source_id": None,
+                        "description": None,
+                        "keywords": None,
+                    }.items():
+                        if key not in edge_props:
+                            edge_props[key] = default
+                    edges[(src, tgt)] = edge_props
+                return edges
+
+        return await asyncio.to_thread(_sync_get_edges_by_source_ids)
 
     @retry(
         stop=stop_after_attempt(3),

--- a/aperag/graph/lightrag/kg/neo4j_sync_impl.py
+++ b/aperag/graph/lightrag/kg/neo4j_sync_impl.py
@@ -674,23 +674,38 @@ class Neo4JSyncStorage(BaseGraphStorage):
 
     async def remove_nodes(self, nodes: list[str]):
         """Delete multiple nodes."""
-        for node in nodes:
-            await self.delete_node(node)
+
+        def _sync_remove_nodes():
+            with Neo4jSyncConnectionManager.get_session(database=self._DATABASE) as session:
+                query = """
+                UNWIND $entity_ids AS entity_id
+                MATCH (n:base {entity_id: entity_id})
+                DETACH DELETE n
+                """
+                session.run(query, entity_ids=nodes)
+                logger.debug(f"Deleted {len(nodes)} nodes in batch")
+
+        if nodes:
+            await asyncio.to_thread(_sync_remove_nodes)
 
     async def remove_edges(self, edges: list[tuple[str, str]]):
         """Delete multiple edges."""
 
-        def _sync_remove_edge(source: str, target: str):
+        def _sync_remove_edges():
             with Neo4jSyncConnectionManager.get_session(database=self._DATABASE) as session:
                 query = """
-                MATCH (source:base {entity_id: $source_entity_id})-[r]-(target:base {entity_id: $target_entity_id})
+                UNWIND $edges AS edge
+                MATCH (source:base {entity_id: edge.src})-[r]-(target:base {entity_id: edge.tgt})
                 DELETE r
                 """
-                session.run(query, source_entity_id=source, target_entity_id=target)
-                logger.debug(f"Deleted edge from '{source}' to '{target}'")
+                session.run(
+                    query,
+                    edges=[{"src": source, "tgt": target} for source, target in edges],
+                )
+                logger.debug(f"Deleted {len(edges)} edges in batch")
 
-        for source, target in edges:
-            await asyncio.to_thread(_sync_remove_edge, source, target)
+        if edges:
+            await asyncio.to_thread(_sync_remove_edges)
 
     async def drop(self) -> dict[str, str]:
         """Drop all data from storage."""

--- a/aperag/graph/lightrag/kg/neo4j_sync_impl.py
+++ b/aperag/graph/lightrag/kg/neo4j_sync_impl.py
@@ -646,6 +646,46 @@ class Neo4JSyncStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_all_labels)
 
+    async def get_top_degree_nodes(self, limit: int) -> tuple[dict[str, dict], int] | None:
+        """Get top-degree nodes directly from Neo4j without loading all labels first."""
+
+        def _sync_get_top_degree_nodes():
+            with Neo4jSyncConnectionManager.get_session(database=self._DATABASE) as session:
+                total_query = """
+                MATCH (n:base)
+                WHERE n.entity_id IS NOT NULL
+                RETURN count(n) AS total
+                """
+                total_result = session.run(total_query)
+                total_record = total_result.single()
+                total_nodes = int(total_record["total"]) if total_record and total_record["total"] is not None else 0
+                if total_nodes == 0 or limit <= 0:
+                    return {}, total_nodes
+
+                query = """
+                MATCH (n:base)
+                WHERE n.entity_id IS NOT NULL
+                OPTIONAL MATCH (n)-[r]-()
+                WITH n, count(r) AS degree
+                WHERE degree > 0
+                RETURN n.entity_id AS entity_id, properties(n) AS node_properties, degree
+                ORDER BY degree DESC, entity_id
+                LIMIT $limit
+                """
+                result = session.run(query, limit=limit)
+
+                nodes = {}
+                for record in result:
+                    entity_id = record["entity_id"]
+                    raw_data = dict(record["node_properties"])
+                    raw_data.setdefault("entity_id", entity_id)
+                    raw_data["degree"] = int(record["degree"] or 0)
+                    nodes[entity_id] = raw_data
+
+                return nodes, total_nodes
+
+        return await asyncio.to_thread(_sync_get_top_degree_nodes)
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=4, max=10),

--- a/aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py
+++ b/aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py
@@ -302,6 +302,16 @@ class PGOpsSyncGraphStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_edges_by_source_ids)
 
+    async def get_top_degree_nodes(self, limit: int) -> tuple[dict[str, dict], int] | None:
+        """Get top-degree nodes directly from PostgreSQL without a full label scan."""
+
+        def _sync_get_top_degree_nodes():
+            from aperag.db.ops import db_ops
+
+            return db_ops.get_top_degree_graph_nodes(self.workspace, limit)
+
+        return await asyncio.to_thread(_sync_get_top_degree_nodes)
+
     async def get_knowledge_graph(self, node_label: str, max_depth: int = 3, max_nodes: int = 1000) -> KnowledgeGraph:
         """
         Get a connected subgraph of nodes matching the specified label.

--- a/aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py
+++ b/aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py
@@ -282,6 +282,26 @@ class PGOpsSyncGraphStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_all_labels)
 
+    async def get_nodes_by_source_ids(self, chunk_ids: list[str]) -> dict[str, dict]:
+        """Get graph nodes whose source_id references any of the given chunk IDs."""
+
+        def _sync_get_nodes_by_source_ids():
+            from aperag.db.ops import db_ops
+
+            return db_ops.get_graph_nodes_by_source_ids(self.workspace, chunk_ids)
+
+        return await asyncio.to_thread(_sync_get_nodes_by_source_ids)
+
+    async def get_edges_by_source_ids(self, chunk_ids: list[str]) -> dict[tuple[str, str], dict]:
+        """Get graph edges whose source_id references any of the given chunk IDs."""
+
+        def _sync_get_edges_by_source_ids():
+            from aperag.db.ops import db_ops
+
+            return db_ops.get_graph_edges_by_source_ids(self.workspace, chunk_ids)
+
+        return await asyncio.to_thread(_sync_get_edges_by_source_ids)
+
     async def get_knowledge_graph(self, node_label: str, max_depth: int = 3, max_nodes: int = 1000) -> KnowledgeGraph:
         """
         Get a connected subgraph of nodes matching the specified label.

--- a/aperag/graph/lightrag/kg/pg_ops_sync_kv_storage.py
+++ b/aperag/graph/lightrag/kg/pg_ops_sync_kv_storage.py
@@ -83,6 +83,32 @@ class PGOpsSyncKVStorage(BaseKVStorage):
 
         return await asyncio.to_thread(_sync_get_all)
 
+    async def get_by_doc_id(self, doc_id: str) -> dict[str, Any]:
+        """Get all chunk records for a single document ID"""
+
+        def _sync_get_by_doc_id():
+            from aperag.db.ops import db_ops
+            from aperag.graph.lightrag.namespace import NameSpace, is_namespace
+
+            if is_namespace(self.namespace, NameSpace.KV_STORE_TEXT_CHUNKS):
+                models = db_ops.query_lightrag_doc_chunks_by_doc_id(self.workspace, doc_id)
+                return {
+                    chunk_id: {
+                        "id": chunk_id,
+                        "tokens": model.tokens,
+                        "content": model.content or "",
+                        "chunk_order_index": model.chunk_order_index,
+                        "full_doc_id": model.full_doc_id,
+                        "content_vector": model.content_vector,
+                        "file_path": model.file_path,
+                    }
+                    for chunk_id, model in models.items()
+                }
+            logger.error(f"Unknown namespace for get_by_doc_id: {self.namespace}")
+            return {}
+
+        return await asyncio.to_thread(_sync_get_by_doc_id)
+
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get data by id"""
 

--- a/aperag/graph/lightrag/kg/pg_ops_sync_vector_storage.py
+++ b/aperag/graph/lightrag/kg/pg_ops_sync_vector_storage.py
@@ -42,6 +42,7 @@ import numpy as np
 from ..base import (
     BaseVectorStorage,
 )
+from ..prompt import GRAPH_FIELD_SEP
 from ..utils import logger
 
 
@@ -125,38 +126,51 @@ class PGOpsSyncVectorStorage(BaseVectorStorage):
         from aperag.graph.lightrag.namespace import NameSpace, is_namespace
 
         if is_namespace(self.namespace, NameSpace.VECTOR_STORE_CHUNKS):
+            vector = item.get("__vector__", item.get("content_vector"))
+            if hasattr(vector, "tolist"):
+                vector = vector.tolist()
             return {
                 "tokens": item["tokens"],
                 "chunk_order_index": item["chunk_order_index"],
                 "full_doc_id": item["full_doc_id"],
                 "content": item["content"],
-                "content_vector": item["__vector__"].tolist()
-                if hasattr(item["__vector__"], "tolist")
-                else item["__vector__"],
+                "content_vector": vector,
                 "file_path": item.get("file_path"),
             }
         elif is_namespace(self.namespace, NameSpace.VECTOR_STORE_ENTITIES):
-            source_id = item["source_id"]
-            chunk_ids = source_id.split("<SEP>") if isinstance(source_id, str) and "<SEP>" in source_id else [source_id]
+            vector = item.get("__vector__", item.get("content_vector"))
+            if hasattr(vector, "tolist"):
+                vector = vector.tolist()
+            chunk_ids = item.get("chunk_ids")
+            if chunk_ids is None:
+                source_id = item.get("source_id")
+                if isinstance(source_id, str) and source_id:
+                    chunk_ids = source_id.split(GRAPH_FIELD_SEP) if GRAPH_FIELD_SEP in source_id else [source_id]
+                else:
+                    chunk_ids = []
             return {
                 "entity_name": item["entity_name"],
                 "content": item["content"],
-                "content_vector": item["__vector__"].tolist()
-                if hasattr(item["__vector__"], "tolist")
-                else item["__vector__"],
+                "content_vector": vector,
                 "chunk_ids": chunk_ids,
                 "file_path": item.get("file_path"),
             }
         elif is_namespace(self.namespace, NameSpace.VECTOR_STORE_RELATIONSHIPS):
-            source_id = item["source_id"]
-            chunk_ids = source_id.split("<SEP>") if isinstance(source_id, str) and "<SEP>" in source_id else [source_id]
+            vector = item.get("__vector__", item.get("content_vector"))
+            if hasattr(vector, "tolist"):
+                vector = vector.tolist()
+            chunk_ids = item.get("chunk_ids")
+            if chunk_ids is None:
+                source_id = item.get("source_id")
+                if isinstance(source_id, str) and source_id:
+                    chunk_ids = source_id.split(GRAPH_FIELD_SEP) if GRAPH_FIELD_SEP in source_id else [source_id]
+                else:
+                    chunk_ids = []
             return {
                 "source_id": item["src_id"],
                 "target_id": item["tgt_id"],
                 "content": item["content"],
-                "content_vector": item["__vector__"].tolist()
-                if hasattr(item["__vector__"], "tolist")
-                else item["__vector__"],
+                "content_vector": vector,
                 "chunk_ids": chunk_ids,
                 "file_path": item.get("file_path"),
             }
@@ -179,16 +193,26 @@ class PGOpsSyncVectorStorage(BaseVectorStorage):
             for k, v in data.items()
         ]
 
-        # Compute embeddings first (async)
-        contents = [v["content"] for v in data.values()]
-        batches = [contents[i : i + self._max_batch_size] for i in range(0, len(contents), self._max_batch_size)]
+        pending_embedding_items = []
+        pending_contents = []
+        for item in list_data:
+            existing_vector = item.get("content_vector")
+            if existing_vector is not None:
+                item["__vector__"] = existing_vector
+                continue
+            pending_embedding_items.append(item)
+            pending_contents.append(item["content"])
 
-        embedding_tasks = [self.embedding_func(batch) for batch in batches]
-        embeddings_list = await asyncio.gather(*embedding_tasks)
-        embeddings = np.concatenate(embeddings_list)
+        if pending_contents:
+            batches = [
+                pending_contents[i : i + self._max_batch_size] for i in range(0, len(pending_contents), self._max_batch_size)
+            ]
+            embedding_tasks = [self.embedding_func(batch) for batch in batches]
+            embeddings_list = await asyncio.gather(*embedding_tasks)
+            embeddings = np.concatenate(embeddings_list)
 
-        for i, d in enumerate(list_data):
-            d["__vector__"] = embeddings[i]
+            for item, embedding in zip(pending_embedding_items, embeddings):
+                item["__vector__"] = embedding
 
         def _sync_upsert_with_vectors():
             # Import here to avoid circular imports
@@ -213,6 +237,49 @@ class PGOpsSyncVectorStorage(BaseVectorStorage):
                 raise ValueError(f"{self.namespace} is not supported")
 
         await asyncio.to_thread(_sync_upsert_with_vectors)
+
+    async def get_by_chunk_ids(self, chunk_ids: list[str]) -> dict[str, Any]:
+        """Get vector records whose chunk_ids overlap with the provided chunk IDs."""
+
+        def _sync_get_by_chunk_ids():
+            from aperag.db.ops import db_ops
+            from aperag.graph.lightrag.namespace import NameSpace, is_namespace
+
+            if is_namespace(self.namespace, NameSpace.VECTOR_STORE_ENTITIES):
+                models = db_ops.query_lightrag_vdb_entity_by_chunk_ids(self.workspace, chunk_ids)
+                return {
+                    entity_id: {
+                        "id": entity_id,
+                        "entity_name": model.entity_name,
+                        "content": model.content or "",
+                        "content_vector": model.content_vector,
+                        "chunk_ids": model.chunk_ids or [],
+                        "file_path": model.file_path,
+                        "created_at": int(model.create_time.timestamp()) if model.create_time else None,
+                    }
+                    for entity_id, model in models.items()
+                }
+            if is_namespace(self.namespace, NameSpace.VECTOR_STORE_RELATIONSHIPS):
+                models = db_ops.query_lightrag_vdb_relation_by_chunk_ids(self.workspace, chunk_ids)
+                return {
+                    relation_id: {
+                        "id": relation_id,
+                        "source_id": model.source_id,
+                        "target_id": model.target_id,
+                        "content": model.content or "",
+                        "content_vector": model.content_vector,
+                        "chunk_ids": model.chunk_ids or [],
+                        "file_path": model.file_path,
+                        "created_at": int(model.create_time.timestamp()) if model.create_time else None,
+                        "src_id": model.source_id,
+                        "tgt_id": model.target_id,
+                    }
+                    for relation_id, model in models.items()
+                }
+            logger.error(f"Unknown namespace for get_by_chunk_ids: {self.namespace}")
+            return {}
+
+        return await asyncio.to_thread(_sync_get_by_chunk_ids)
 
     async def query(self, query: str, top_k: int, ids: list[str] | None = None) -> list[dict[str, Any]]:
         """Query vectors by similarity"""

--- a/aperag/graph/lightrag/kg/pg_ops_sync_vector_storage.py
+++ b/aperag/graph/lightrag/kg/pg_ops_sync_vector_storage.py
@@ -205,7 +205,8 @@ class PGOpsSyncVectorStorage(BaseVectorStorage):
 
         if pending_contents:
             batches = [
-                pending_contents[i : i + self._max_batch_size] for i in range(0, len(pending_contents), self._max_batch_size)
+                pending_contents[i : i + self._max_batch_size]
+                for i in range(0, len(pending_contents), self._max_batch_size)
             ]
             embedding_tasks = [self.embedding_func(batch) for batch in batches]
             embeddings_list = await asyncio.gather(*embedding_tasks)

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -1015,7 +1015,9 @@ class LightRAG:
                                 continue
                             sources = {
                                 source_id
-                                for source_id in split_string_by_multi_markers(edge_data["source_id"], [GRAPH_FIELD_SEP])
+                                for source_id in split_string_by_multi_markers(
+                                    edge_data["source_id"], [GRAPH_FIELD_SEP]
+                                )
                                 if source_id
                             }
                             if sources.intersection(chunk_ids):

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -881,139 +881,168 @@ class LightRAG:
             self.lightrag_logger.info(f"Starting deletion for document {doc_id}")
 
             # ========== STEP 1: Get all chunks related to this document ==========
-            all_chunks = await self.text_chunks.get_all()
-            related_chunks = {
-                chunk_id: chunk_data
-                for chunk_id, chunk_data in all_chunks.items()
-                if isinstance(chunk_data, dict) and chunk_data.get("full_doc_id") == doc_id
-            }
+            if hasattr(self.text_chunks, "get_by_doc_id"):
+                related_chunks = await self.text_chunks.get_by_doc_id(doc_id)
+            else:
+                all_chunks = await self.text_chunks.get_all()
+                related_chunks = {
+                    chunk_id: chunk_data
+                    for chunk_id, chunk_data in all_chunks.items()
+                    if isinstance(chunk_data, dict) and chunk_data.get("full_doc_id") == doc_id
+                }
 
             if not related_chunks:
                 logger.warning(f"No chunks found for document {doc_id}")
                 return
 
             chunk_ids = set(related_chunks.keys())
+            chunk_id_list = list(chunk_ids)
             self.lightrag_logger.info(f"Found {len(chunk_ids)} chunks to delete for document {doc_id}")
 
             # ========== STEP 2: Handle Vector Storage References (chunk_ids arrays) ==========
-            # Process entities in vector storage
             entities_to_delete_from_vdb = []
             entities_to_update_in_vdb = {}
-
-            if hasattr(self.entities_vdb, "get_all"):
-                all_entities = await self.entities_vdb.get_all()
-                for entity_id, entity_data in all_entities.items():
-                    if not isinstance(entity_data, dict) or "chunk_ids" not in entity_data:
-                        continue
-
-                    # Remove deleted chunks from entity's chunk_ids array
-                    old_chunk_ids = set(entity_data.get("chunk_ids", []))
-                    new_chunk_ids = old_chunk_ids - chunk_ids
-
-                    if not new_chunk_ids:
-                        # Entity has no remaining chunks, mark for deletion
-                        entity_name = entity_data.get("entity_name")
-                        if entity_name:
-                            entities_to_delete_from_vdb.append(entity_name)
-                            self.lightrag_logger.debug(
-                                f"Entity {entity_name} marked for deletion from VDB - no remaining chunks"
-                            )
-                    elif len(new_chunk_ids) != len(old_chunk_ids):
-                        # Entity has some remaining chunks, update chunk_ids array
-                        entity_data["chunk_ids"] = list(new_chunk_ids)
-                        entity_data["source_id"] = GRAPH_FIELD_SEP.join(new_chunk_ids)
-                        entities_to_update_in_vdb[entity_id] = entity_data
-                        self.lightrag_logger.debug(
-                            f"Entity {entity_data.get('entity_name')} chunk_ids updated: {len(old_chunk_ids)} -> {len(new_chunk_ids)}"
-                        )
-
-            # Process relationships in vector storage
             relationships_to_delete_from_vdb = []
             relationships_to_update_in_vdb = {}
 
-            if hasattr(self.relationships_vdb, "get_all"):
-                all_relationships = await self.relationships_vdb.get_all()
-                for rel_id, rel_data in all_relationships.items():
-                    if not isinstance(rel_data, dict) or "chunk_ids" not in rel_data:
-                        continue
+            if hasattr(self.entities_vdb, "get_by_chunk_ids"):
+                candidate_entities = await self.entities_vdb.get_by_chunk_ids(chunk_id_list)
+            elif hasattr(self.entities_vdb, "get_all"):
+                candidate_entities = await self.entities_vdb.get_all()
+            else:
+                candidate_entities = {}
 
-                    # Remove deleted chunks from relationship's chunk_ids array
-                    old_chunk_ids = set(rel_data.get("chunk_ids", []))
-                    new_chunk_ids = old_chunk_ids - chunk_ids
+            for entity_id, entity_data in candidate_entities.items():
+                if not isinstance(entity_data, dict) or "chunk_ids" not in entity_data:
+                    continue
 
-                    if not new_chunk_ids:
-                        # Relationship has no remaining chunks, mark for deletion by calculating IDs
-                        src_id = rel_data.get("src_id") or rel_data.get("source_id")
-                        tgt_id = rel_data.get("tgt_id") or rel_data.get("target_id")
-                        if src_id and tgt_id:
-                            relationships_to_delete_from_vdb.append((src_id, tgt_id))
-                            self.lightrag_logger.debug(
-                                f"Relationship {src_id}-{tgt_id} marked for deletion from VDB - no remaining chunks"
-                            )
-                    elif len(new_chunk_ids) != len(old_chunk_ids):
-                        # Relationship has some remaining chunks, update chunk_ids array
-                        rel_data["chunk_ids"] = list(new_chunk_ids)
-                        rel_data["source_id"] = GRAPH_FIELD_SEP.join(new_chunk_ids)
-                        relationships_to_update_in_vdb[rel_id] = rel_data
+                old_chunk_ids = {chunk_id for chunk_id in entity_data.get("chunk_ids", []) if chunk_id}
+                new_chunk_ids = old_chunk_ids - chunk_ids
+
+                if not new_chunk_ids:
+                    entity_name = entity_data.get("entity_name")
+                    if entity_name:
+                        entities_to_delete_from_vdb.append(entity_name)
                         self.lightrag_logger.debug(
-                            f"Relationship {rel_data.get('src_id')}-{rel_data.get('tgt_id')} chunk_ids updated: {len(old_chunk_ids)} -> {len(new_chunk_ids)}"
+                            f"Entity {entity_name} marked for deletion from VDB - no remaining chunks"
                         )
+                elif len(new_chunk_ids) != len(old_chunk_ids):
+                    updated_entity = dict(entity_data)
+                    updated_entity["chunk_ids"] = sorted(new_chunk_ids)
+                    entities_to_update_in_vdb[entity_id] = updated_entity
+                    self.lightrag_logger.debug(
+                        f"Entity {entity_data.get('entity_name')} chunk_ids updated: {len(old_chunk_ids)} -> {len(new_chunk_ids)}"
+                    )
+
+            if hasattr(self.relationships_vdb, "get_by_chunk_ids"):
+                candidate_relationships = await self.relationships_vdb.get_by_chunk_ids(chunk_id_list)
+            elif hasattr(self.relationships_vdb, "get_all"):
+                candidate_relationships = await self.relationships_vdb.get_all()
+            else:
+                candidate_relationships = {}
+
+            for rel_id, rel_data in candidate_relationships.items():
+                if not isinstance(rel_data, dict) or "chunk_ids" not in rel_data:
+                    continue
+
+                old_chunk_ids = {chunk_id for chunk_id in rel_data.get("chunk_ids", []) if chunk_id}
+                new_chunk_ids = old_chunk_ids - chunk_ids
+
+                if not new_chunk_ids:
+                    src_id = rel_data.get("src_id") or rel_data.get("source_id")
+                    tgt_id = rel_data.get("tgt_id") or rel_data.get("target_id")
+                    if src_id and tgt_id:
+                        relationships_to_delete_from_vdb.append((src_id, tgt_id))
+                        self.lightrag_logger.debug(
+                            f"Relationship {src_id}-{tgt_id} marked for deletion from VDB - no remaining chunks"
+                        )
+                elif len(new_chunk_ids) != len(old_chunk_ids):
+                    updated_relationship = dict(rel_data)
+                    updated_relationship["chunk_ids"] = sorted(new_chunk_ids)
+                    relationships_to_update_in_vdb[rel_id] = updated_relationship
+                    self.lightrag_logger.debug(
+                        f"Relationship {rel_data.get('src_id')}-{rel_data.get('tgt_id')} chunk_ids updated: {len(old_chunk_ids)} -> {len(new_chunk_ids)}"
+                    )
 
             # ========== STEP 3: Handle Graph Storage References (source_id strings) ==========
-            # Process entities in graph storage
             entities_to_delete_from_graph = set()
             entities_to_update_in_graph = {}
-
-            # Process relationships in graph storage
             relationships_to_delete_from_graph = set()
             relationships_to_update_in_graph = {}
 
-            # Get all labels from graph storage
-            all_labels = await self.chunk_entity_relation_graph.get_all_labels()
+            graph_nodes = {}
+            graph_edges = {}
 
-            # Process each entity node
-            for node_label in all_labels:
-                node_data = await self.chunk_entity_relation_graph.get_node(node_label)
-                if node_data and "source_id" in node_data:
-                    # Parse source_id string (format: chunk1|chunk2|chunk3)
-                    sources = set(node_data["source_id"].split(GRAPH_FIELD_SEP))
-                    sources.difference_update(chunk_ids)
+            if hasattr(self.chunk_entity_relation_graph, "get_nodes_by_source_ids"):
+                graph_nodes = await self.chunk_entity_relation_graph.get_nodes_by_source_ids(chunk_id_list)
+            if hasattr(self.chunk_entity_relation_graph, "get_edges_by_source_ids"):
+                graph_edges = await self.chunk_entity_relation_graph.get_edges_by_source_ids(chunk_id_list)
 
-                    if not sources:
-                        # Entity has no remaining source chunks
-                        entities_to_delete_from_graph.add(node_label)
-                        self.lightrag_logger.debug(
-                            f"Entity {node_label} marked for deletion from graph - no remaining sources"
-                        )
-                    else:
-                        # Entity has some remaining source chunks
-                        new_source_id = GRAPH_FIELD_SEP.join(sources)
-                        entities_to_update_in_graph[node_label] = new_source_id
-                        self.lightrag_logger.debug(f"Entity {node_label} source_id will be updated in graph")
+            if not graph_nodes:
+                all_labels = await self.chunk_entity_relation_graph.get_all_labels()
+                if all_labels:
+                    graph_nodes = await self.chunk_entity_relation_graph.get_nodes_batch(all_labels)
 
-                # Process relationships for this entity
-                node_edges = await self.chunk_entity_relation_graph.get_node_edges(node_label)
-                if node_edges:
-                    for src, tgt in node_edges:
-                        edge_data = await self.chunk_entity_relation_graph.get_edge(src, tgt)
-                        if edge_data and "source_id" in edge_data:
-                            # Parse source_id string (format: chunk1|chunk2|chunk3)
-                            sources = set(edge_data["source_id"].split(GRAPH_FIELD_SEP))
-                            sources.difference_update(chunk_ids)
+            if not graph_edges and graph_nodes:
+                node_edges_batch = await self.chunk_entity_relation_graph.get_nodes_edges_batch(list(graph_nodes.keys()))
+                edge_pairs = []
+                seen_edge_pairs = set()
+                for edge_list in node_edges_batch.values():
+                    for pair in edge_list:
+                        if pair not in seen_edge_pairs:
+                            edge_pairs.append({"src": pair[0], "tgt": pair[1]})
+                            seen_edge_pairs.add(pair)
+                if edge_pairs:
+                    graph_edges = await self.chunk_entity_relation_graph.get_edges_batch(edge_pairs)
 
-                            if not sources:
-                                # Relationship has no remaining source chunks
-                                relationships_to_delete_from_graph.add((src, tgt))
-                                self.lightrag_logger.debug(
-                                    f"Relationship {src}-{tgt} marked for deletion from graph - no remaining sources"
-                                )
-                            else:
-                                # Relationship has some remaining source chunks
-                                new_source_id = GRAPH_FIELD_SEP.join(sources)
-                                relationships_to_update_in_graph[(src, tgt)] = new_source_id
-                                self.lightrag_logger.debug(
-                                    f"Relationship {src}-{tgt} source_id will be updated in graph"
-                                )
+            for node_label, node_data in graph_nodes.items():
+                if not node_data or "source_id" not in node_data:
+                    continue
+
+                sources = {
+                    source_id
+                    for source_id in split_string_by_multi_markers(node_data["source_id"], [GRAPH_FIELD_SEP])
+                    if source_id
+                }
+                if not sources.intersection(chunk_ids):
+                    continue
+
+                sources.difference_update(chunk_ids)
+                if not sources:
+                    entities_to_delete_from_graph.add(node_label)
+                    self.lightrag_logger.debug(
+                        f"Entity {node_label} marked for deletion from graph - no remaining sources"
+                    )
+                else:
+                    updated_node = dict(node_data)
+                    updated_node["source_id"] = GRAPH_FIELD_SEP.join(sorted(sources))
+                    entities_to_update_in_graph[node_label] = updated_node
+                    self.lightrag_logger.debug(f"Entity {node_label} source_id will be updated in graph")
+
+            for edge_pair, edge_data in graph_edges.items():
+                if not edge_data or "source_id" not in edge_data:
+                    continue
+
+                sources = {
+                    source_id
+                    for source_id in split_string_by_multi_markers(edge_data["source_id"], [GRAPH_FIELD_SEP])
+                    if source_id
+                }
+                if not sources.intersection(chunk_ids):
+                    continue
+
+                sources.difference_update(chunk_ids)
+                src, tgt = edge_pair
+                if not sources:
+                    relationships_to_delete_from_graph.add((src, tgt))
+                    self.lightrag_logger.debug(
+                        f"Relationship {src}-{tgt} marked for deletion from graph - no remaining sources"
+                    )
+                else:
+                    updated_edge = dict(edge_data)
+                    updated_edge["source_id"] = GRAPH_FIELD_SEP.join(sorted(sources))
+                    relationships_to_update_in_graph[(src, tgt)] = updated_edge
+                    self.lightrag_logger.debug(f"Relationship {src}-{tgt} source_id will be updated in graph")
 
             # ========== STEP 4: Execute all deletions and updates ==========
 
@@ -1050,11 +1079,8 @@ class LightRAG:
                 await self.chunk_entity_relation_graph.remove_nodes(list(entities_to_delete_from_graph))
                 self.lightrag_logger.info(f"Deleted {len(entities_to_delete_from_graph)} entities from graph storage")
 
-            for entity_name, new_source_id in entities_to_update_in_graph.items():
-                node_data = await self.chunk_entity_relation_graph.get_node(entity_name)
-                if node_data:
-                    node_data["source_id"] = new_source_id
-                    await self.chunk_entity_relation_graph.upsert_node(entity_name, node_data)
+            for entity_name, node_data in entities_to_update_in_graph.items():
+                await self.chunk_entity_relation_graph.upsert_node(entity_name, node_data)
             if entities_to_update_in_graph:
                 self.lightrag_logger.info(f"Updated {len(entities_to_update_in_graph)} entities in graph storage")
 
@@ -1065,11 +1091,8 @@ class LightRAG:
                     f"Deleted {len(relationships_to_delete_from_graph)} relationships from graph storage"
                 )
 
-            for (src, tgt), new_source_id in relationships_to_update_in_graph.items():
-                edge_data = await self.chunk_entity_relation_graph.get_edge(src, tgt)
-                if edge_data:
-                    edge_data["source_id"] = new_source_id
-                    await self.chunk_entity_relation_graph.upsert_edge(src, tgt, edge_data)
+            for (src, tgt), edge_data in relationships_to_update_in_graph.items():
+                await self.chunk_entity_relation_graph.upsert_edge(src, tgt, edge_data)
             if relationships_to_update_in_graph:
                 self.lightrag_logger.info(
                     f"Updated {len(relationships_to_update_in_graph)} relationships in graph storage"
@@ -1082,12 +1105,15 @@ class LightRAG:
 
             # ========== STEP 5: Simple verification ==========
             # Verify chunks were actually deleted
-            remaining_chunks = await self.text_chunks.get_all()
-            remaining_related_chunks = {
-                chunk_id: chunk_data
-                for chunk_id, chunk_data in remaining_chunks.items()
-                if isinstance(chunk_data, dict) and chunk_data.get("full_doc_id") == doc_id
-            }
+            if hasattr(self.text_chunks, "get_by_doc_id"):
+                remaining_related_chunks = await self.text_chunks.get_by_doc_id(doc_id)
+            else:
+                remaining_chunks = await self.text_chunks.get_all()
+                remaining_related_chunks = {
+                    chunk_id: chunk_data
+                    for chunk_id, chunk_data in remaining_chunks.items()
+                    if isinstance(chunk_data, dict) and chunk_data.get("full_doc_id") == doc_id
+                }
 
             if remaining_related_chunks:
                 self.lightrag_logger.warning(

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -1352,12 +1352,10 @@ class LightRAG:
         }
 
         # Get all entities and check they exist
-        entities_data = {}
+        entities_data = await self.chunk_entity_relation_graph.get_nodes_batch(entity_ids)
         for entity_id in entity_ids:
-            node_data = await self.chunk_entity_relation_graph.get_node(entity_id)
-            if not node_data:
+            if entity_id not in entities_data:
                 raise ValueError(f"Entity '{entity_id}' does not exist")
-            entities_data[entity_id] = node_data
 
         # Determine target entity
         if target_entity_name is None:
@@ -1370,11 +1368,10 @@ class LightRAG:
         else:
             # Ensure target entity is in the list or exists
             if target_entity_name not in entity_ids:
-                target_exists = await self.chunk_entity_relation_graph.has_node(target_entity_name)
-                if target_exists:
+                target_nodes = await self.chunk_entity_relation_graph.get_nodes_batch([target_entity_name])
+                if target_entity_name in target_nodes:
                     # Target entity exists but not in merge list, add its data
-                    target_data = await self.chunk_entity_relation_graph.get_node(target_entity_name)
-                    entities_data[target_entity_name] = target_data
+                    entities_data[target_entity_name] = target_nodes[target_entity_name]
                     self.lightrag_logger.info(f"Target entity '{target_entity_name}' exists, merging into it")
                 else:
                     self.lightrag_logger.info(f"Target entity '{target_entity_name}' will be created as new")
@@ -1426,18 +1423,22 @@ class LightRAG:
         # Process relationships
         all_relations = []
         relations_to_delete_vdb = []
+        source_entity_ids = [entity_id for entity_id in entity_ids if entity_id != target_entity_name]
+        if source_entity_ids:
+            source_edges_batch = await self.chunk_entity_relation_graph.get_nodes_edges_batch(source_entity_ids)
+            edge_pairs = []
+            seen_edge_pairs = set()
+            for edge_list in source_edges_batch.values():
+                for pair in edge_list:
+                    if pair not in seen_edge_pairs:
+                        edge_pairs.append({"src": pair[0], "tgt": pair[1]})
+                        seen_edge_pairs.add(pair)
 
-        for entity_id in entity_ids:
-            if entity_id == target_entity_name:
-                continue  # Skip target entity to avoid self-processing
-
-            source_edges = await self.chunk_entity_relation_graph.get_node_edges(entity_id)
-            if source_edges:
-                for src, tgt in source_edges:
-                    edge_data = await self.chunk_entity_relation_graph.get_edge(src, tgt)
+            if edge_pairs:
+                edge_data_batch = await self.chunk_entity_relation_graph.get_edges_batch(edge_pairs)
+                for (src, tgt), edge_data in edge_data_batch.items():
                     if edge_data:
                         all_relations.append((src, tgt, edge_data))
-                        # Mark old relations for deletion from vector db
                         relations_to_delete_vdb.extend(
                             [
                                 compute_mdhash_id(src + tgt, prefix="rel-", workspace=self.workspace),
@@ -1546,9 +1547,10 @@ class LightRAG:
                 self.lightrag_logger.debug(f"Updated {len(new_rel_data)} relationship records in vector storage")
 
         # Delete source entities from graph storage
-        for entity_id in source_entities:
-            await self.chunk_entity_relation_graph.delete_node(entity_id)
-            self.lightrag_logger.debug(f"Deleted source entity {entity_id} from graph storage")
+        if source_entities:
+            await self.chunk_entity_relation_graph.remove_nodes(source_entities)
+            for entity_id in source_entities:
+                self.lightrag_logger.debug(f"Deleted source entity {entity_id} from graph storage")
 
         self.lightrag_logger.info(
             f"Multi-node merge completed: {source_entities} -> {target_entity_name}, redirected {redirected_edges} edges"

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -969,6 +969,7 @@ class LightRAG:
             entities_to_update_in_graph = {}
             relationships_to_delete_from_graph = set()
             relationships_to_update_in_graph = {}
+            graph_fallback_batch_size = 200
 
             graph_nodes = {}
             graph_edges = {}
@@ -980,20 +981,44 @@ class LightRAG:
 
             if not graph_nodes:
                 all_labels = await self.chunk_entity_relation_graph.get_all_labels()
-                if all_labels:
-                    graph_nodes = await self.chunk_entity_relation_graph.get_nodes_batch(all_labels)
+                for start in range(0, len(all_labels), graph_fallback_batch_size):
+                    batch_labels = all_labels[start : start + graph_fallback_batch_size]
+                    batch_nodes = await self.chunk_entity_relation_graph.get_nodes_batch(batch_labels)
+                    for node_label, node_data in batch_nodes.items():
+                        if not node_data or "source_id" not in node_data:
+                            continue
+                        sources = {
+                            source_id
+                            for source_id in split_string_by_multi_markers(node_data["source_id"], [GRAPH_FIELD_SEP])
+                            if source_id
+                        }
+                        if sources.intersection(chunk_ids):
+                            graph_nodes[node_label] = node_data
 
             if not graph_edges and graph_nodes:
-                node_edges_batch = await self.chunk_entity_relation_graph.get_nodes_edges_batch(list(graph_nodes.keys()))
-                edge_pairs = []
                 seen_edge_pairs = set()
-                for edge_list in node_edges_batch.values():
-                    for pair in edge_list:
-                        if pair not in seen_edge_pairs:
-                            edge_pairs.append({"src": pair[0], "tgt": pair[1]})
-                            seen_edge_pairs.add(pair)
-                if edge_pairs:
-                    graph_edges = await self.chunk_entity_relation_graph.get_edges_batch(edge_pairs)
+                graph_node_ids = list(graph_nodes.keys())
+                for start in range(0, len(graph_node_ids), graph_fallback_batch_size):
+                    batch_node_ids = graph_node_ids[start : start + graph_fallback_batch_size]
+                    node_edges_batch = await self.chunk_entity_relation_graph.get_nodes_edges_batch(batch_node_ids)
+                    edge_pairs = []
+                    for edge_list in node_edges_batch.values():
+                        for pair in edge_list:
+                            if pair not in seen_edge_pairs:
+                                edge_pairs.append({"src": pair[0], "tgt": pair[1]})
+                                seen_edge_pairs.add(pair)
+                    if edge_pairs:
+                        batch_edges = await self.chunk_entity_relation_graph.get_edges_batch(edge_pairs)
+                        for edge_pair, edge_data in batch_edges.items():
+                            if not edge_data or "source_id" not in edge_data:
+                                continue
+                            sources = {
+                                source_id
+                                for source_id in split_string_by_multi_markers(edge_data["source_id"], [GRAPH_FIELD_SEP])
+                                if source_id
+                            }
+                            if sources.intersection(chunk_ids):
+                                graph_edges[edge_pair] = edge_data
 
             for node_label, node_data in graph_nodes.items():
                 if not node_data or "source_id" not in node_data:

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -79,6 +79,7 @@ from .utils import (
     compute_mdhash_id,
     create_lightrag_logger,
     logger,
+    split_string_by_multi_markers,
 )
 
 

--- a/aperag/graph/lightrag/operate.py
+++ b/aperag/graph/lightrag/operate.py
@@ -386,28 +386,27 @@ async def _merge_edges_then_upsert(
     already_keywords = []
     already_file_paths = []
 
-    if await knowledge_graph_inst.has_edge(src_id, tgt_id):
-        already_edge = await knowledge_graph_inst.get_edge(src_id, tgt_id)
-        # Handle the case where get_edge returns None or missing fields
-        if already_edge:
-            # Get weight with default 0.0 if missing
-            already_weights.append(already_edge.get("weight", 0.0))
+    already_edge = await knowledge_graph_inst.get_edge(src_id, tgt_id)
+    # Handle the case where get_edge returns None or missing fields
+    if already_edge:
+        # Get weight with default 0.0 if missing
+        already_weights.append(already_edge.get("weight", 0.0))
 
-            # Get source_id with empty string default if missing or None
-            if already_edge.get("source_id") is not None:
-                already_source_ids.extend(split_string_by_multi_markers(already_edge["source_id"], [GRAPH_FIELD_SEP]))
+        # Get source_id with empty string default if missing or None
+        if already_edge.get("source_id") is not None:
+            already_source_ids.extend(split_string_by_multi_markers(already_edge["source_id"], [GRAPH_FIELD_SEP]))
 
-            # Get file_path with empty string default if missing or None
-            if already_edge.get("file_path") is not None:
-                already_file_paths.extend(split_string_by_multi_markers(already_edge["file_path"], [GRAPH_FIELD_SEP]))
+        # Get file_path with empty string default if missing or None
+        if already_edge.get("file_path") is not None:
+            already_file_paths.extend(split_string_by_multi_markers(already_edge["file_path"], [GRAPH_FIELD_SEP]))
 
-            # Get description with empty string default if missing or None
-            if already_edge.get("description") is not None:
-                already_description.append(already_edge["description"])
+        # Get description with empty string default if missing or None
+        if already_edge.get("description") is not None:
+            already_description.append(already_edge["description"])
 
-            # Get keywords with empty string default if missing or None
-            if already_edge.get("keywords") is not None:
-                already_keywords.extend(split_string_by_multi_markers(already_edge["keywords"], [GRAPH_FIELD_SEP]))
+        # Get keywords with empty string default if missing or None
+        if already_edge.get("keywords") is not None:
+            already_keywords.extend(split_string_by_multi_markers(already_edge["keywords"], [GRAPH_FIELD_SEP]))
 
     # Process edges_data with None checks
     weight = sum([dp["weight"] for dp in edges_data] + already_weights)
@@ -435,8 +434,9 @@ async def _merge_edges_then_upsert(
         set([dp["file_path"] for dp in edges_data if dp.get("file_path")] + already_file_paths)
     )
 
+    existing_nodes = await knowledge_graph_inst.get_nodes_batch([src_id, tgt_id])
     for need_insert_id in [src_id, tgt_id]:
-        if not (await knowledge_graph_inst.has_node(need_insert_id)):
+        if need_insert_id not in existing_nodes:
             await knowledge_graph_inst.upsert_node(
                 need_insert_id,
                 node_data={
@@ -543,6 +543,7 @@ async def _merge_nodes_and_edges_impl(
     lightrag_logger: LightRAGLogger,
 ) -> dict[str, int]:
     """Internal implementation of merge_nodes_and_edges with fine-grained locking"""
+    merge_concurrency = 8
 
     # Collect all nodes and edges from all chunks
     all_nodes = defaultdict(list)
@@ -558,86 +559,88 @@ async def _merge_nodes_and_edges_impl(
             sorted_edge_key = tuple(sorted(edge_key))
             all_edges[sorted_edge_key].extend(edges)
 
-    # Process entities with fine-grained locking
-    entity_count = 0
+    entity_semaphore = asyncio.Semaphore(merge_concurrency)
 
-    for entity_name, entities in all_nodes.items():
-        # Create lock for this specific entity
-        entity_lock = get_or_create_lock(f"entity:{entity_name}:{workspace}")
+    async def _process_entity(entity_name: str, entities: list[dict]) -> bool:
+        async with entity_semaphore:
+            entity_lock = get_or_create_lock(f"entity:{entity_name}:{workspace}")
 
-        async with entity_lock:
-            # Process and update entity in graph db
-            entity_data = await _merge_nodes_then_upsert(
-                entity_name,
-                entities,
-                knowledge_graph_inst,
-                llm_model_func,
-                tokenizer,
-                llm_model_max_token_size,
-                summary_to_max_tokens,
-                language,
-                force_llm_summary_on_merge,
-                lightrag_logger,
-                workspace,
+            async with entity_lock:
+                entity_data = await _merge_nodes_then_upsert(
+                    entity_name,
+                    entities,
+                    knowledge_graph_inst,
+                    llm_model_func,
+                    tokenizer,
+                    llm_model_max_token_size,
+                    summary_to_max_tokens,
+                    language,
+                    force_llm_summary_on_merge,
+                    lightrag_logger,
+                    workspace,
+                )
+
+                if entity_vdb is not None and entity_data:
+                    vdb_data = {
+                        compute_mdhash_id(entity_data["entity_name"], prefix="ent-", workspace=workspace): {
+                            "entity_name": entity_data["entity_name"],
+                            "entity_type": entity_data["entity_type"],
+                            "content": f"{entity_data['entity_name']}\n{entity_data['description']}",
+                            "source_id": entity_data["source_id"],
+                            "file_path": entity_data.get("file_path", "unknown_source"),
+                        }
+                    }
+                    await entity_vdb.upsert(vdb_data)
+
+                return entity_data is not None
+
+    entity_results = await asyncio.gather(*[_process_entity(entity_name, entities) for entity_name, entities in all_nodes.items()])
+    entity_count = sum(1 for result in entity_results if result)
+
+    relationship_semaphore = asyncio.Semaphore(merge_concurrency)
+
+    async def _process_relationship(edge_key: tuple[str, str], edges: list[dict]) -> bool:
+        async with relationship_semaphore:
+            sorted_edge_key = tuple(sorted(edge_key))
+            relationship_lock = get_or_create_lock(
+                f"relationship:{sorted_edge_key[0]}:{sorted_edge_key[1]}:{workspace}"
             )
 
-            # Update entity in vector db immediately under the same lock
-            if entity_vdb is not None and entity_data:
-                vdb_data = {
-                    compute_mdhash_id(entity_data["entity_name"], prefix="ent-", workspace=workspace): {
-                        "entity_name": entity_data["entity_name"],
-                        "entity_type": entity_data["entity_type"],
-                        "content": f"{entity_data['entity_name']}\n{entity_data['description']}",
-                        "source_id": entity_data["source_id"],
-                        "file_path": entity_data.get("file_path", "unknown_source"),
+            async with relationship_lock:
+                edge_data = await _merge_edges_then_upsert(
+                    edge_key[0],
+                    edge_key[1],
+                    edges,
+                    knowledge_graph_inst,
+                    llm_model_func,
+                    tokenizer,
+                    llm_model_max_token_size,
+                    summary_to_max_tokens,
+                    language,
+                    force_llm_summary_on_merge,
+                    lightrag_logger,
+                    workspace,
+                )
+
+                if relationships_vdb is not None and edge_data is not None:
+                    vdb_data = {
+                        compute_mdhash_id(edge_data["src_id"] + edge_data["tgt_id"], prefix="rel-", workspace=workspace): {
+                            "src_id": edge_data["src_id"],
+                            "tgt_id": edge_data["tgt_id"],
+                            "keywords": edge_data["keywords"],
+                            "content": f"{edge_data['src_id']}\t{edge_data['tgt_id']}\n{edge_data['keywords']}\n{edge_data['description']}",
+                            "source_id": edge_data["source_id"],
+                            "file_path": edge_data.get("file_path", "unknown_source"),
+                        }
                     }
-                }
-                await entity_vdb.upsert(vdb_data)
+                    await relationships_vdb.upsert(vdb_data)
 
-            entity_count += 1
+                return edge_data is not None
 
-    # Process relationships with fine-grained locking
-    relation_count = 0
-
-    for edge_key, edges in all_edges.items():
-        # Create lock for this specific relationship
-        # Sort edge key to ensure consistent lock naming
-        sorted_edge_key = tuple(sorted(edge_key))
-        relationship_lock = get_or_create_lock(f"relationship:{sorted_edge_key[0]}:{sorted_edge_key[1]}:{workspace}")
-
-        async with relationship_lock:
-            # Process and update relationship in graph db
-            edge_data = await _merge_edges_then_upsert(
-                edge_key[0],
-                edge_key[1],
-                edges,
-                knowledge_graph_inst,
-                llm_model_func,
-                tokenizer,
-                llm_model_max_token_size,
-                summary_to_max_tokens,
-                language,
-                force_llm_summary_on_merge,
-                lightrag_logger,
-                workspace,
-            )
-
-            # Update relationship in vector db immediately under the same lock
-            if relationships_vdb is not None and edge_data is not None:
-                vdb_data = {
-                    compute_mdhash_id(edge_data["src_id"] + edge_data["tgt_id"], prefix="rel-", workspace=workspace): {
-                        "src_id": edge_data["src_id"],
-                        "tgt_id": edge_data["tgt_id"],
-                        "keywords": edge_data["keywords"],
-                        "content": f"{edge_data['src_id']}\t{edge_data['tgt_id']}\n{edge_data['keywords']}\n{edge_data['description']}",
-                        "source_id": edge_data["source_id"],
-                        "file_path": edge_data.get("file_path", "unknown_source"),
-                    }
-                }
-                await relationships_vdb.upsert(vdb_data)
-
-            if edge_data is not None:
-                relation_count += 1
+    relationship_results = await asyncio.gather(
+        *[_process_relationship(edge_key, edges) for edge_key, edges in all_edges.items()]
+    )
+    relation_count = sum(1 for result in relationship_results if result)
 
     return {"entity_count": entity_count, "relation_count": relation_count}
 

--- a/aperag/graph/lightrag/operate.py
+++ b/aperag/graph/lightrag/operate.py
@@ -594,7 +594,9 @@ async def _merge_nodes_and_edges_impl(
 
                 return entity_data is not None
 
-    entity_results = await asyncio.gather(*[_process_entity(entity_name, entities) for entity_name, entities in all_nodes.items()])
+    entity_results = await asyncio.gather(
+        *[_process_entity(entity_name, entities) for entity_name, entities in all_nodes.items()]
+    )
     entity_count = sum(1 for result in entity_results if result)
 
     relationship_semaphore = asyncio.Semaphore(merge_concurrency)
@@ -624,7 +626,9 @@ async def _merge_nodes_and_edges_impl(
 
                 if relationships_vdb is not None and edge_data is not None:
                     vdb_data = {
-                        compute_mdhash_id(edge_data["src_id"] + edge_data["tgt_id"], prefix="rel-", workspace=workspace): {
+                        compute_mdhash_id(
+                            edge_data["src_id"] + edge_data["tgt_id"], prefix="rel-", workspace=workspace
+                        ): {
                             "src_id": edge_data["src_id"],
                             "tgt_id": edge_data["tgt_id"],
                             "keywords": edge_data["keywords"],

--- a/aperag/graph/lightrag/operate.py
+++ b/aperag/graph/lightrag/operate.py
@@ -1697,6 +1697,23 @@ async def get_high_degree_nodes(
         Input: Graph with 1000 nodes, max_analyze_nodes=300
         Output: (GraphNodeDataDict with 300 nodes, 1000)
     """
+    top_degree_nodes_result = await graph_storage.get_top_degree_nodes(max_analyze_nodes)
+    if top_degree_nodes_result is not None:
+        nodes_data_raw, total_nodes = top_degree_nodes_result
+        nodes_by_id = {}
+        for label, raw_data in nodes_data_raw.items():
+            raw_data = dict(raw_data)
+            raw_data.setdefault("entity_id", label)
+            raw_data["degree"] = raw_data.get("degree", 0)
+            nodes_by_id[label] = GraphNodeData(**raw_data)
+
+        if lightrag_logger:
+            lightrag_logger.debug(
+                f"Selected {len(nodes_by_id)} high-degree nodes directly from storage (total nodes: {total_nodes})"
+            )
+
+        return GraphNodeDataDict(nodes_by_id=nodes_by_id), total_nodes
+
     # Get all node labels
     all_labels = await graph_storage.get_all_labels()
     if not all_labels:

--- a/aperag/graph/lightrag/utils_graph.py
+++ b/aperag/graph/lightrag/utils_graph.py
@@ -41,6 +41,34 @@ from .prompt import GRAPH_FIELD_SEP
 from .utils import compute_mdhash_id, logger
 
 
+async def _get_nodes_by_id_batch(chunk_entity_relation_graph, node_ids: list[str]) -> dict[str, dict[str, Any]]:
+    unique_node_ids = list(dict.fromkeys(node_id for node_id in node_ids if node_id))
+    if not unique_node_ids:
+        return {}
+    return await chunk_entity_relation_graph.get_nodes_batch(unique_node_ids)
+
+
+async def _get_edges_for_nodes(
+    chunk_entity_relation_graph,
+    node_ids: list[str],
+) -> list[tuple[str, str, dict[str, Any]]]:
+    unique_node_ids = list(dict.fromkeys(node_id for node_id in node_ids if node_id))
+    if not unique_node_ids:
+        return []
+
+    node_edges_batch = await chunk_entity_relation_graph.get_incident_edges_with_data_batch(unique_node_ids)
+    seen_edge_pairs: set[tuple[str, str]] = set()
+    deduplicated_edges: list[tuple[str, str, dict[str, Any]]] = []
+    for node_id in unique_node_ids:
+        for source, target, edge_data in node_edges_batch.get(node_id, []) or []:
+            edge_pair = (source, target)
+            if edge_pair in seen_edge_pairs:
+                continue
+            seen_edge_pairs.add(edge_pair)
+            deduplicated_edges.append((source, target, edge_data))
+    return deduplicated_edges
+
+
 async def adelete_by_entity(
     chunk_entity_relation_graph, entities_vdb, relationships_vdb, entity_name: str, graph_db_lock: LockProtocol = None
 ) -> None:
@@ -85,9 +113,8 @@ async def adelete_by_relation(
     # Use graph database lock to ensure atomic graph and vector db operations
     async with graph_db_lock:
         try:
-            # Check if the relation exists
-            edge_exists = await chunk_entity_relation_graph.has_edge(source_entity, target_entity)
-            if not edge_exists:
+            edge_data = await chunk_entity_relation_graph.get_edge(source_entity, target_entity)
+            if edge_data is None:
                 logger.warning(f"Relation from '{source_entity}' to '{target_entity}' does not exist")
                 return
 
@@ -135,22 +162,24 @@ async def aedit_entity(
     async with graph_db_lock:
         try:
             # 1. Get current entity information
-            node_exists = await chunk_entity_relation_graph.has_node(entity_name)
-            if not node_exists:
-                raise ValueError(f"Entity '{entity_name}' does not exist")
-            node_data = await chunk_entity_relation_graph.get_node(entity_name)
-
-            # Check if entity is being renamed
+            entity_ids_to_fetch = [entity_name]
             new_entity_name = updated_data.get("entity_name", entity_name)
             is_renaming = new_entity_name != entity_name
+            if is_renaming:
+                entity_ids_to_fetch.append(new_entity_name)
 
+            existing_nodes = await _get_nodes_by_id_batch(chunk_entity_relation_graph, entity_ids_to_fetch)
+            node_data = existing_nodes.get(entity_name)
+            if node_data is None:
+                raise ValueError(f"Entity '{entity_name}' does not exist")
+
+            # Check if entity is being renamed
             # If renaming, check if new name already exists
             if is_renaming:
                 if not allow_rename:
                     raise ValueError("Entity renaming is not allowed. Set allow_rename=True to enable this feature")
 
-                existing_node = await chunk_entity_relation_graph.has_node(new_entity_name)
-                if existing_node:
+                if new_entity_name in existing_nodes:
                     raise ValueError(f"Entity name '{new_entity_name}' already exists, cannot rename")
 
             # 2. Update entity information in the graph
@@ -171,24 +200,20 @@ async def aedit_entity(
                 relations_to_update = []
                 relations_to_delete = []
                 # Get all edges related to the original entity
-                edges = await chunk_entity_relation_graph.get_node_edges(entity_name)
-                if edges:
-                    # Recreate edges for the new entity
-                    for source, target in edges:
-                        edge_data = await chunk_entity_relation_graph.get_edge(source, target)
-                        if edge_data:
-                            relations_to_delete.append(
-                                compute_mdhash_id(source + target, prefix="rel-", workspace=relationships_vdb.workspace)
-                            )
-                            relations_to_delete.append(
-                                compute_mdhash_id(target + source, prefix="rel-", workspace=relationships_vdb.workspace)
-                            )
-                            if source == entity_name:
-                                await chunk_entity_relation_graph.upsert_edge(new_entity_name, target, edge_data)
-                                relations_to_update.append((new_entity_name, target, edge_data))
-                            else:  # target == entity_name
-                                await chunk_entity_relation_graph.upsert_edge(source, new_entity_name, edge_data)
-                                relations_to_update.append((source, new_entity_name, edge_data))
+                related_edges = await _get_edges_for_nodes(chunk_entity_relation_graph, [entity_name])
+                for source, target, edge_data in related_edges:
+                    relations_to_delete.append(
+                        compute_mdhash_id(source + target, prefix="rel-", workspace=relationships_vdb.workspace)
+                    )
+                    relations_to_delete.append(
+                        compute_mdhash_id(target + source, prefix="rel-", workspace=relationships_vdb.workspace)
+                    )
+                    if source == entity_name:
+                        await chunk_entity_relation_graph.upsert_edge(new_entity_name, target, edge_data)
+                        relations_to_update.append((new_entity_name, target, edge_data))
+                    else:  # target == entity_name
+                        await chunk_entity_relation_graph.upsert_edge(source, new_entity_name, edge_data)
+                        relations_to_update.append((source, new_entity_name, edge_data))
 
                 # Delete old entity
                 await chunk_entity_relation_graph.delete_node(entity_name)
@@ -304,10 +329,9 @@ async def aedit_relation(
     async with graph_db_lock:
         try:
             # 1. Get current relation information
-            edge_exists = await chunk_entity_relation_graph.has_edge(source_entity, target_entity)
-            if not edge_exists:
-                raise ValueError(f"Relation from '{source_entity}' to '{target_entity}' does not exist")
             edge_data = await chunk_entity_relation_graph.get_edge(source_entity, target_entity)
+            if edge_data is None:
+                raise ValueError(f"Relation from '{source_entity}' to '{target_entity}' does not exist")
             # Important: First delete the old relation record from the vector database
             old_relation_id = compute_mdhash_id(
                 source_entity + target_entity, prefix="rel-", workspace=relationships_vdb.workspace
@@ -474,18 +498,16 @@ async def acreate_relation(
     # Use graph database lock to ensure atomic graph and vector db operations
     async with graph_db_lock:
         try:
-            # Check if both entities exist
-            source_exists = await chunk_entity_relation_graph.has_node(source_entity)
-            target_exists = await chunk_entity_relation_graph.has_node(target_entity)
+            existing_nodes = await _get_nodes_by_id_batch(chunk_entity_relation_graph, [source_entity, target_entity])
 
-            if not source_exists:
+            if source_entity not in existing_nodes:
                 raise ValueError(f"Source entity '{source_entity}' does not exist")
-            if not target_exists:
+            if target_entity not in existing_nodes:
                 raise ValueError(f"Target entity '{target_entity}' does not exist")
 
             # Check if relation already exists
-            existing_edge = await chunk_entity_relation_graph.has_edge(source_entity, target_entity)
-            if existing_edge:
+            existing_edge = await chunk_entity_relation_graph.get_edge(source_entity, target_entity)
+            if existing_edge is not None:
                 raise ValueError(f"Relation from '{source_entity}' to '{target_entity}' already exists")
 
             # Prepare edge data with defaults if missing
@@ -594,19 +616,20 @@ async def amerge_entities(
             target_entity_data = {} if target_entity_data is None else target_entity_data
 
             # 1. Check if all source entities exist
+            existing_nodes = await _get_nodes_by_id_batch(chunk_entity_relation_graph, source_entities + [target_entity])
+
             source_entities_data = {}
             for entity_name in source_entities:
-                node_exists = await chunk_entity_relation_graph.has_node(entity_name)
-                if not node_exists:
+                node_data = existing_nodes.get(entity_name)
+                if node_data is None:
                     raise ValueError(f"Source entity '{entity_name}' does not exist")
-                node_data = await chunk_entity_relation_graph.get_node(entity_name)
                 source_entities_data[entity_name] = node_data
 
             # 2. Check if target entity exists and get its data if it does
-            target_exists = await chunk_entity_relation_graph.has_node(target_entity)
+            target_exists = target_entity in existing_nodes
             existing_target_entity_data = {}
             if target_exists:
-                existing_target_entity_data = await chunk_entity_relation_graph.get_node(target_entity)
+                existing_target_entity_data = existing_nodes[target_entity]
                 logger.info(f"Target entity '{target_entity}' already exists, will merge data")
 
             # 3. Merge entity data
@@ -620,16 +643,7 @@ async def amerge_entities(
                 merged_entity_data[key] = value
 
             # 4. Get all relationships of the source entities
-            all_relations = []
-            for entity_name in source_entities:
-                # Get all relationships of the source entities
-                edges = await chunk_entity_relation_graph.get_node_edges(entity_name)
-                if edges:
-                    for src, tgt in edges:
-                        # Ensure src is the current entity
-                        if src == entity_name:
-                            edge_data = await chunk_entity_relation_graph.get_edge(src, tgt)
-                            all_relations.append((src, tgt, edge_data))
+            all_relations = await _get_edges_for_nodes(chunk_entity_relation_graph, source_entities)
 
             # 5. Create or update the target entity
             merged_entity_data["entity_id"] = target_entity
@@ -687,7 +701,7 @@ async def amerge_entities(
                 await chunk_entity_relation_graph.upsert_edge(rel_data["src"], rel_data["tgt"], rel_data["data"])
                 logger.info(f"Created or updated relationship: {rel_data['src']} -> {rel_data['tgt']}")
 
-                # Delete relationships records from vector database
+            if relations_to_delete:
                 await relationships_vdb.delete(relations_to_delete)
                 logger.info(f"Deleted {len(relations_to_delete)} relation records for entity from vector database")
 
@@ -739,19 +753,17 @@ async def amerge_entities(
                 await relationships_vdb.upsert(relation_data_for_vdb)
 
             # 9. Delete source entities
-            for entity_name in source_entities:
-                if entity_name == target_entity:
-                    logger.info(f"Skipping deletion of '{entity_name}' as it's also the target entity")
-                    continue
-
-                # Delete entity node from knowledge graph
-                await chunk_entity_relation_graph.delete_node(entity_name)
-
-                # Delete entity record from vector database
-                entity_id = compute_mdhash_id(entity_name, prefix="ent-", workspace=entities_vdb.workspace)
-                await entities_vdb.delete([entity_id])
-
-                logger.info(f"Deleted source entity '{entity_name}' and its vector embedding from database")
+            source_entities_to_delete = [entity_name for entity_name in source_entities if entity_name != target_entity]
+            if source_entities_to_delete:
+                await chunk_entity_relation_graph.remove_nodes(source_entities_to_delete)
+                entity_ids_to_delete = [
+                    compute_mdhash_id(entity_name, prefix="ent-", workspace=entities_vdb.workspace)
+                    for entity_name in source_entities_to_delete
+                ]
+                await entities_vdb.delete(entity_ids_to_delete)
+                logger.info(
+                    f"Deleted {len(source_entities_to_delete)} source entities and their vector embeddings from database"
+                )
 
             logger.info(f"Successfully merged {len(source_entities)} entities into '{target_entity}'")
             return await get_entity_info(

--- a/aperag/graph/lightrag/utils_graph.py
+++ b/aperag/graph/lightrag/utils_graph.py
@@ -616,7 +616,9 @@ async def amerge_entities(
             target_entity_data = {} if target_entity_data is None else target_entity_data
 
             # 1. Check if all source entities exist
-            existing_nodes = await _get_nodes_by_id_batch(chunk_entity_relation_graph, source_entities + [target_entity])
+            existing_nodes = await _get_nodes_by_id_batch(
+                chunk_entity_relation_graph, source_entities + [target_entity]
+            )
 
             source_entities_data = {}
             for entity_name in source_entities:

--- a/aperag/graph/lightrag_manager.py
+++ b/aperag/graph/lightrag_manager.py
@@ -166,6 +166,9 @@ async def _process_document_async(
                 "relations_extracted": 0,
             }
 
+        # Rebuild graph state from scratch for this document to avoid stale chunk/entity/edge references.
+        await rag.adelete_by_doc_id(str(doc_id))
+
         # Insert and chunk document
         chunk_result = await rag.ainsert_and_chunk_document(
             documents=[content], doc_ids=[doc_id], file_paths=[file_path]

--- a/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
+++ b/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.graph.lightrag.kg.pg_ops_sync_vector_storage import PGOpsSyncVectorStorage
+from aperag.graph.lightrag.namespace import NameSpace
+from aperag.graph.lightrag_manager import _process_document_async
+
+
+class _FakeRag:
+    def __init__(self):
+        self.calls = []
+
+    async def adelete_by_doc_id(self, doc_id: str):
+        self.calls.append(("delete", doc_id))
+
+    async def ainsert_and_chunk_document(self, documents, doc_ids, file_paths):
+        self.calls.append(("insert", list(doc_ids)))
+        return {
+            "results": [
+                {
+                    "doc_id": doc_ids[0],
+                    "chunks_data": {
+                        "chunk-1": {
+                            "content": documents[0],
+                            "full_doc_id": doc_ids[0],
+                            "file_path": file_paths[0],
+                        }
+                    },
+                    "chunk_count": 1,
+                }
+            ]
+        }
+
+    async def aprocess_graph_indexing(self, chunks, collection_id=None):
+        self.calls.append(("graph", sorted(chunks.keys()), collection_id))
+        return {"entities_extracted": 2, "relations_extracted": 1, "groups_processed": 1}
+
+    async def finalize_storages(self):
+        self.calls.append(("finalize",))
+
+
+@pytest.mark.asyncio
+async def test_process_document_async_deletes_existing_state_before_rebuild(monkeypatch):
+    fake_rag = _FakeRag()
+
+    async def _fake_create_lightrag_instance(collection):
+        return fake_rag
+
+    monkeypatch.setattr(
+        "aperag.graph.lightrag_manager.create_lightrag_instance",
+        _fake_create_lightrag_instance,
+    )
+
+    collection = SimpleNamespace(id="collection-1")
+    result = await _process_document_async(collection, "new content", "doc-1", "/tmp/doc.txt")
+
+    assert result["status"] == "success"
+    assert result["chunks_created"] == 1
+    assert fake_rag.calls[:3] == [
+        ("delete", "doc-1"),
+        ("insert", ["doc-1"]),
+        ("graph", ["chunk-1"], "collection-1"),
+    ]
+    assert fake_rag.calls[-1] == ("finalize",)
+
+
+@pytest.mark.asyncio
+async def test_pg_vector_upsert_reuses_existing_vector_for_metadata_only_update(monkeypatch):
+    captured = {}
+
+    async def _embedding_func(_batch):
+        raise AssertionError("embedding_func should not be called for metadata-only updates")
+
+    def _capture_upsert(_workspace, vector_data):
+        captured["vector_data"] = vector_data
+
+    monkeypatch.setattr(
+        "aperag.db.ops.db_ops.upsert_lightrag_vdb_entity",
+        _capture_upsert,
+    )
+
+    storage = PGOpsSyncVectorStorage(
+        namespace=NameSpace.VECTOR_STORE_ENTITIES,
+        workspace="workspace-1",
+        embedding_func=_embedding_func,
+    )
+
+    await storage.upsert(
+        {
+            "entity-1": {
+                "entity_name": "Alpha",
+                "content": "alpha content",
+                "content_vector": [0.1, 0.2, 0.3],
+                "chunk_ids": ["chunk-a", "chunk-b"],
+                "file_path": "/tmp/a.txt",
+            }
+        }
+    )
+
+    assert captured["vector_data"]["entity-1"]["content_vector"] == [0.1, 0.2, 0.3]
+    assert captured["vector_data"]["entity-1"]["chunk_ids"] == ["chunk-a", "chunk-b"]

--- a/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
+++ b/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from aperag.graph.lightrag import utils_graph
+from aperag.graph.lightrag.operate import get_high_degree_nodes
 from aperag.graph.lightrag.kg.pg_ops_sync_vector_storage import PGOpsSyncVectorStorage
 from aperag.graph.lightrag.namespace import NameSpace
 from aperag.graph.lightrag_manager import _process_document_async
@@ -174,6 +175,9 @@ class _FakeGraphStorage:
     async def get_node_edges(self, _node_id):
         raise AssertionError("legacy get_node_edges() should not be used")
 
+    async def get_top_degree_nodes(self, _limit):
+        return None
+
 
 class _FakeEntityVectorStorage:
     def __init__(self):
@@ -291,3 +295,39 @@ async def test_amerge_entities_uses_batch_graph_primitives_and_batch_delete():
     assert len(relationships_vdb.deleted) == 1
     assert any(node_id == "merged" for node_id, _ in graph_storage.upserted_nodes)
     assert result["entity_name"] == "merged"
+
+
+class _FakeHighDegreeGraphStorage:
+    async def get_top_degree_nodes(self, limit):
+        assert limit == 2
+        return (
+            {
+                "entity-1": {
+                    "entity_id": "entity-1",
+                    "entity_type": "ORG",
+                    "description": "node one",
+                    "source_id": "chunk-1",
+                    "degree": 7,
+                },
+                "entity-2": {
+                    "entity_id": "entity-2",
+                    "entity_type": "PERSON",
+                    "description": "node two",
+                    "source_id": "chunk-2",
+                    "degree": 5,
+                },
+            },
+            42,
+        )
+
+    async def get_all_labels(self):
+        raise AssertionError("get_all_labels() should not be used when top-degree primitive is available")
+
+
+@pytest.mark.asyncio
+async def test_get_high_degree_nodes_prefers_storage_top_degree_primitive():
+    selected_nodes, total_nodes = await get_high_degree_nodes(_FakeHighDegreeGraphStorage(), max_analyze_nodes=2)
+
+    assert total_nodes == 42
+    assert set(selected_nodes.nodes_by_id.keys()) == {"entity-1", "entity-2"}
+    assert selected_nodes.nodes_by_id["entity-1"].degree == 7

--- a/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
+++ b/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from aperag.graph.lightrag import utils_graph
 from aperag.graph.lightrag.kg.pg_ops_sync_vector_storage import PGOpsSyncVectorStorage
 from aperag.graph.lightrag.namespace import NameSpace
 from aperag.graph.lightrag_manager import _process_document_async
@@ -100,3 +101,193 @@ async def test_pg_vector_upsert_reuses_existing_vector_for_metadata_only_update(
 
     assert captured["vector_data"]["entity-1"]["content_vector"] == [0.1, 0.2, 0.3]
     assert captured["vector_data"]["entity-1"]["chunk_ids"] == ["chunk-a", "chunk-b"]
+
+
+class _FakeGraphStorage:
+    def __init__(self, nodes=None, edges_with_data_by_node=None):
+        self.nodes = dict(nodes or {})
+        self.edges_with_data_by_node = {
+            node_id: list(edges)
+            for node_id, edges in (edges_with_data_by_node or {}).items()
+        }
+        self.calls = []
+        self.upserted_nodes = []
+        self.upserted_edges = []
+        self.deleted_nodes = []
+        self.removed_nodes_batches = []
+        self.removed_edges_batches = []
+
+    async def get_nodes_batch(self, node_ids):
+        self.calls.append(("get_nodes_batch", tuple(node_ids)))
+        return {node_id: self.nodes[node_id] for node_id in node_ids if node_id in self.nodes}
+
+    async def get_nodes_edges_with_data_batch(self, node_ids):
+        self.calls.append(("get_nodes_edges_with_data_batch", tuple(node_ids)))
+        return {node_id: list(self.edges_with_data_by_node.get(node_id, [])) for node_id in node_ids}
+
+    async def get_incident_edges_with_data_batch(self, node_ids):
+        self.calls.append(("get_incident_edges_with_data_batch", tuple(node_ids)))
+        return await self.get_nodes_edges_with_data_batch(node_ids)
+
+    async def upsert_node(self, node_id, node_data):
+        self.calls.append(("upsert_node", node_id))
+        self.nodes[node_id] = dict(node_data)
+        self.upserted_nodes.append((node_id, dict(node_data)))
+
+    async def upsert_edge(self, source, target, edge_data):
+        self.calls.append(("upsert_edge", source, target))
+        self.upserted_edges.append((source, target, dict(edge_data)))
+
+    async def delete_node(self, node_id):
+        self.calls.append(("delete_node", node_id))
+        self.deleted_nodes.append(node_id)
+        self.nodes.pop(node_id, None)
+
+    async def remove_nodes(self, node_ids):
+        self.calls.append(("remove_nodes", tuple(node_ids)))
+        self.removed_nodes_batches.append(list(node_ids))
+        for node_id in node_ids:
+            self.nodes.pop(node_id, None)
+
+    async def remove_edges(self, edges):
+        self.calls.append(("remove_edges", tuple(edges)))
+        self.removed_edges_batches.append(list(edges))
+
+    async def get_node(self, node_id):
+        self.calls.append(("get_node", node_id))
+        return self.nodes.get(node_id)
+
+    async def get_edge(self, source, target):
+        self.calls.append(("get_edge", source, target))
+        for edges in self.edges_with_data_by_node.values():
+            for edge_source, edge_target, edge_data in edges:
+                if (edge_source, edge_target) == (source, target):
+                    return dict(edge_data)
+        return None
+
+    async def has_node(self, _node_id):
+        raise AssertionError("legacy has_node() should not be used")
+
+    async def has_edge(self, _source, _target):
+        raise AssertionError("legacy has_edge() should not be used")
+
+    async def get_node_edges(self, _node_id):
+        raise AssertionError("legacy get_node_edges() should not be used")
+
+
+class _FakeEntityVectorStorage:
+    def __init__(self):
+        self.workspace = "workspace-1"
+        self.deleted = []
+        self.upserts = []
+
+    async def delete(self, ids):
+        self.deleted.append(list(ids))
+
+    async def upsert(self, data):
+        self.upserts.append(data)
+
+    async def get_by_id(self, entity_id):
+        return {"id": entity_id}
+
+
+class _FakeRelationVectorStorage:
+    def __init__(self):
+        self.workspace = "workspace-1"
+        self.deleted = []
+        self.upserts = []
+
+    async def delete(self, ids):
+        self.deleted.append(list(ids))
+
+    async def upsert(self, data):
+        self.upserts.append(data)
+
+    async def get_by_id(self, relation_id):
+        return {"id": relation_id}
+
+
+class _FakeAsyncLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_aedit_entity_rename_uses_batch_graph_primitives():
+    graph_storage = _FakeGraphStorage(
+        nodes={
+            "old": {
+                "entity_id": "old",
+                "entity_type": "PERSON",
+                "description": "old desc",
+                "source_id": "chunk-1",
+            },
+            "neighbor": {
+                "entity_id": "neighbor",
+                "entity_type": "ORG",
+                "description": "neighbor desc",
+                "source_id": "chunk-2",
+            },
+        },
+        edges_with_data_by_node={
+            "old": [
+                ("old", "neighbor", {"description": "works at", "keywords": "job", "source_id": "chunk-1"}),
+            ],
+        },
+    )
+    entities_vdb = _FakeEntityVectorStorage()
+    relationships_vdb = _FakeRelationVectorStorage()
+
+    result = await utils_graph.aedit_entity(
+        graph_storage,
+        entities_vdb,
+        relationships_vdb,
+        "old",
+        {"entity_name": "new", "description": "new desc"},
+        graph_db_lock=_FakeAsyncLock(),
+    )
+
+    assert ("get_nodes_batch", ("old", "new")) in graph_storage.calls
+    assert ("get_incident_edges_with_data_batch", ("old",)) in graph_storage.calls
+    assert ("delete_node", "old") in graph_storage.calls
+    assert any(source == "new" and target == "neighbor" for source, target, _ in graph_storage.upserted_edges)
+    assert entities_vdb.deleted
+    assert relationships_vdb.deleted
+    assert result["entity_name"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_amerge_entities_uses_batch_graph_primitives_and_batch_delete():
+    graph_storage = _FakeGraphStorage(
+        nodes={
+            "A": {"entity_id": "A", "entity_type": "PERSON", "description": "desc A", "source_id": "chunk-a"},
+            "B": {"entity_id": "B", "entity_type": "PERSON", "description": "desc B", "source_id": "chunk-b"},
+            "X": {"entity_id": "X", "entity_type": "ORG", "description": "desc X", "source_id": "chunk-x"},
+            "Y": {"entity_id": "Y", "entity_type": "ORG", "description": "desc Y", "source_id": "chunk-y"},
+        },
+        edges_with_data_by_node={
+            "A": [("A", "X", {"description": "edge ax", "keywords": "k1", "source_id": "chunk-a", "weight": 1})],
+            "B": [("B", "Y", {"description": "edge by", "keywords": "k2", "source_id": "chunk-b", "weight": 2})],
+        },
+    )
+    entities_vdb = _FakeEntityVectorStorage()
+    relationships_vdb = _FakeRelationVectorStorage()
+
+    result = await utils_graph.amerge_entities(
+        graph_storage,
+        entities_vdb,
+        relationships_vdb,
+        ["A", "B"],
+        "merged",
+        graph_db_lock=_FakeAsyncLock(),
+    )
+
+    assert ("get_nodes_batch", ("A", "B", "merged")) in graph_storage.calls
+    assert ("get_incident_edges_with_data_batch", ("A", "B")) in graph_storage.calls
+    assert graph_storage.removed_nodes_batches == [["A", "B"]]
+    assert len(relationships_vdb.deleted) == 1
+    assert any(node_id == "merged" for node_id, _ in graph_storage.upserted_nodes)
+    assert result["entity_name"] == "merged"


### PR DESCRIPTION
## Summary
- delete the old document contribution path before rebuilding a document graph index
- narrow `adelete_by_doc_id` to doc/chunk/source scoped retrieval instead of whole-workspace scans
- reuse existing vectors for metadata-only VDB updates to avoid unnecessary embedding recomputation
- add storage primitives and utility-path batch fetches so graph edit/merge helpers stop doing `has_x + get_x` and per-edge round-trips
- add targeted unit tests for rebuild-before-delete, metadata-only vector updates, and the new utility-path batch primitives

## Correctness Semantics
This PR should **not** be read as “delete old entities by name before rebuild”.

The intended semantics are:
- remove the old document's **contribution** to entities / relationships
- keep nodes / edges alive if other chunks still contribute to them
- only delete a node / edge when it has no remaining sources

In other words, this is a **source-aware / contribution-aware** cleanup path, not a coarse entity-name delete.

## Problem
LightRAG graph update/delete paths had two correctness/performance issues:
1. graph rebuilds for a document did not clear the old document state first, so stale chunk/entity/edge references kept accumulating
2. delete/update/edit helpers still mixed whole-workspace scans, `has_x + get_x` double queries, and `get_node_edges() + get_edge()` N+1 patterns, which amplified DB round-trips and memory pressure

## What changed
- `aperag/graph/lightrag_manager.py`
  - call `adelete_by_doc_id(doc_id)` before rebuilding a document graph index
- `aperag/graph/lightrag/lightrag.py`
  - prefer scoped doc/chunk lookups during delete
  - prefer scoped graph node/edge lookups by source references
  - reuse already-loaded node/edge payloads during updates instead of extra point reads
  - batch multi-node merge fetches and use bounded concurrency in merge paths
- `aperag/graph/lightrag/operate.py`
  - remove merge-path `has_edge + get_edge` and `has_node` double queries
  - use batch graph primitives for node/edge merge flows
- `aperag/graph/lightrag/base.py`
  - add `get_incident_edges_with_data_batch(node_ids)` so callers can fetch incident edges and edge payloads without a second lookup pass
- `aperag/graph/lightrag/utils_graph.py`
  - switch entity/relation edit/create/merge helpers to batch node fetches and incident-edge-with-data fetches
  - remove helper-path `has_node + get_node`, `has_edge + get_edge`, and `get_node_edges + get_edge` patterns
  - use batch node deletion in helper merge flows
- `aperag/graph/lightrag/kg/pg_ops_sync_{kv,vector,graph}_storage.py`
  - add PG-specific scoped retrieval helpers
  - avoid recomputing embeddings when an upsert already carries `content_vector`
- `aperag/graph/lightrag/kg/neo4j_sync_impl.py`
  - make `remove_nodes()` and `remove_edges()` true batch operations instead of one-by-one loops
  - add source-aware node/edge lookups for delete/update paths
- `aperag/db/repositories/{lightrag,graph}.py`
  - add repository methods for doc-id, chunk-id and source-id scoped fetches
- `tests/unit_test/graphindex/test_lightrag_update_and_storage.py`
  - cover delete-before-rebuild behavior
  - cover metadata-only vector update path
  - cover utility-path migration to batch graph primitives

## Storage Primitive Changes
- `get_by_doc_id(doc_id)`
  - replaces whole-workspace chunk scans in delete/update paths
  - used by `LightRAG.adelete_by_doc_id()`
- `get_by_chunk_ids(chunk_ids)`
  - replaces broad VDB scans plus Python-side filtering
  - used by `LightRAG.adelete_by_doc_id()`
- `get_nodes_by_source_ids(chunk_ids)` / `get_edges_by_source_ids(chunk_ids)`
  - replace whole-graph label scans in delete/update flows where the backend can answer by source reference directly
  - used by `LightRAG.adelete_by_doc_id()`
- `get_incident_edges_with_data_batch(node_ids)`
  - replaces `get_node_edges()` followed by per-edge `get_edge()` loops
  - now used by `utils_graph.aedit_entity()` and `utils_graph.amerge_entities()`
- `get_top_degree_nodes(limit)`
  - replaces Python-side `get_all_labels()` + full-degree batching for supported backends
  - now used by `operate.get_high_degree_nodes()` on PG and Neo4j
- true batch `remove_nodes(nodes)` / `remove_edges(edges)` in Neo4j
  - replace API-level batch calls that still degraded into one-by-one deletes
  - now used by merge/helper delete flows

## What This PR Fixes
- shared entities / relationships are no longer deleted just because one document is removed or rebuilt
- stale state accumulation during document rebuild is stopped
- delete/update/helper-edit paths become much narrower and cheaper on PG and Neo4j-backed flows
- unnecessary embedding recomputation during metadata-only updates is removed
- graph utility helpers stop reissuing the same existence/fetch work as double queries or per-edge round-trips
- merge-suggestion/degree-analysis paths on PG and Neo4j no longer need to start by materializing all graph labels

## Known Limits / Not Solved Here
This PR is a correctness/performance stopgap, not the final semantic model.

It does **not** fully solve:
1. strict rollback of merged `description` / `keywords` / `weight`
   - current storage mostly keeps merged results, not per-chunk contribution records
   - without a contribution ledger / provenance table, merged fields cannot be perfectly recomputed by subtraction
2. transactional update atomicity
   - current rebuild is effectively “remove old document contribution, then write new contribution”
   - if rebuild fails in the middle, that document's graph contribution can be temporarily absent until retry succeeds
3. graph analysis paths that still start from whole-graph label enumeration
   - for example, merge-suggestion/high-degree analysis can still use `get_all_labels()` as an entry point
   - this PR prioritizes delete/update/edit/merge hot paths first

## Validation
- `python3 -m py_compile` on changed Python files and the new unit test
- no local pytest run; team convention is to use GitHub remote test runs by default

