### PR TITLE
[codex] fix celery worker stability and workflow tracking

### DIFF
--- a/aperag/llm/litellm_logging.py
+++ b/aperag/llm/litellm_logging.py
@@ -13,6 +13,24 @@
 # limitations under the License.
 
 
+def disable_litellm_async_logging_callbacks():
+    """
+    Disable LiteLLM's async callback path in process types that spin up many short-lived
+    event loops, such as Celery tasks using ``asyncio.run()`` or custom loop wrappers.
+    """
+    import logging
+
+    import litellm
+
+    litellm.turn_off_message_logging = True
+    litellm.callbacks = []
+    litellm._async_success_callback = []
+    litellm._async_failure_callback = []
+    litellm._async_input_callback = []
+
+    logging.info("LiteLLM async logging callbacks are disabled for this process.")
+
+
 def setup_litellm_logging():
     import logging
 

--- a/aperag/service/evaluation_service.py
+++ b/aperag/service/evaluation_service.py
@@ -364,6 +364,7 @@ class EvaluationExecutor:
         """Calls the internal agent chat API via HTTP."""
 
         db_ops = AsyncDatabaseOps(session)
+        aperag_api_key = None
         aperag_api_keys = await db_ops.query_api_keys(user_id, is_system=True)
         for item in aperag_api_keys:
             aperag_api_key = item.key

--- a/aperag/tasks/scheduler.py
+++ b/aperag/tasks/scheduler.py
@@ -106,6 +106,33 @@ def create_task_scheduler(scheduler_type: str):
 class CeleryTaskScheduler(TaskScheduler):
     """Celery implementation of TaskScheduler - Direct workflow execution"""
 
+    @staticmethod
+    def _build_status_result(task_id: str, async_result, nested_workflow_id: str = None) -> TaskResult:
+        """Normalize Celery AsyncResult states, optionally following a dispatched child workflow."""
+        if async_result.state == "PENDING":
+            return TaskResult(task_id, success=False, error="Workflow is pending")
+        elif async_result.state in {"STARTED", "RETRY"}:
+            return TaskResult(task_id, success=False, error="Workflow is running")
+        elif async_result.state == "FAILURE":
+            return TaskResult(task_id, success=False, error=str(async_result.info))
+        elif async_result.state != "SUCCESS":
+            return TaskResult(task_id, success=False, error=f"Unknown state: {async_result.state}")
+
+        result_data = async_result.result
+        if isinstance(result_data, dict):
+            child_workflow_id = result_data.get("workflow_id")
+            if child_workflow_id and child_workflow_id != nested_workflow_id:
+                from celery.result import AsyncResult
+
+                from config.celery import app
+
+                nested_result = AsyncResult(child_workflow_id, app=app)
+                return CeleryTaskScheduler._build_status_result(
+                    task_id, nested_result, nested_workflow_id=child_workflow_id
+                )
+
+        return TaskResult(task_id, success=True, data=result_data)
+
     def schedule_create_index(self, document_id: str, index_types: List[str], context: dict = None, **kwargs) -> str:
         """Schedule index creation workflow"""
         from config.celery_tasks import create_document_indexes_workflow
@@ -164,17 +191,7 @@ class CeleryTaskScheduler(TaskScheduler):
             # Get AsyncResult without calling .get()
             workflow_result = AsyncResult(task_id, app=app)
 
-            # Check status without blocking
-            if workflow_result.state == "PENDING":
-                return TaskResult(task_id, success=False, error="Workflow is pending")
-            elif workflow_result.state == "STARTED":
-                return TaskResult(task_id, success=False, error="Workflow is running")
-            elif workflow_result.state == "SUCCESS":
-                return TaskResult(task_id, success=True, data=workflow_result.result)
-            elif workflow_result.state == "FAILURE":
-                return TaskResult(task_id, success=False, error=str(workflow_result.info))
-            else:
-                return TaskResult(task_id, success=False, error=f"Unknown state: {workflow_result.state}")
+            return self._build_status_result(task_id, workflow_result)
 
         except Exception as e:
             logger.error(f"Failed to get workflow status for {task_id}: {str(e)}")

--- a/config/celery.py
+++ b/config/celery.py
@@ -62,13 +62,6 @@ app.conf.beat_schedule = {
     },
 }
 
-# Set up task routes if local queue is specified
-if settings.local_queue_name:
-    app.conf.task_routes = {
-        "aperag.tasks.index.add_index_for_local_document": {"queue": f"{settings.local_queue_name}"},
-    }
-
-
 # Simple logging configuration for Celery workers
 CELERY_LOGGING_CONFIG = {
     'version': 1,
@@ -126,6 +119,12 @@ def setup_worker(**kwargs):
     """Setup logging and other worker initialization"""
     # Configure logging for this worker process
     dictConfig(CELERY_LOGGING_CONFIG)
+    # Celery tasks create isolated event loops (`asyncio.run()` / manual loop wrappers).
+    # LiteLLM's async callback worker keeps a process-global asyncio.Queue, which can become
+    # bound to the wrong loop and crash the worker process.
+    from aperag.llm.litellm_logging import disable_litellm_async_logging_callbacks
+
+    disable_litellm_async_logging_callbacks()
 
 @worker_process_shutdown.connect
 def shutdown_worker(**kwargs):

--- a/config/celery_tasks.py
+++ b/config/celery_tasks.py
@@ -142,15 +142,30 @@ def _validate_task_relevance(document_id: str, index_type: str, target_version: 
 
         if not db_index:
             logger.info(f"Index record not found for {document_id}:{index_type}, skipping task.")
-            return {"status": "skipped", "reason": "index_record_not_found"}
+            return {
+                "status": "skipped",
+                "reason": "index_record_not_found",
+                "document_id": document_id,
+                "index_type": index_type,
+            }
 
         if db_index.status != expected_status:
             logger.info(f"Index status for {document_id}:{index_type} changed to {db_index.status} (expected {expected_status}), skipping task.")
-            return {"status": "skipped", "reason": f"status_changed_to_{db_index.status}"}
+            return {
+                "status": "skipped",
+                "reason": f"status_changed_to_{db_index.status}",
+                "document_id": document_id,
+                "index_type": index_type,
+            }
 
         if target_version and db_index.version != target_version:
             logger.info(f"Version mismatch for {document_id}:{index_type}, expected: {target_version}, current: {db_index.version}, skipping task.")
-            return {"status": "skipped", "reason": f"version_mismatch_expected_{target_version}_current_{db_index.version}"}
+            return {
+                "status": "skipped",
+                "reason": f"version_mismatch_expected_{target_version}_current_{db_index.version}",
+                "document_id": document_id,
+                "index_type": index_type,
+            }
 
         # Check document status - if document is UPLOADED or EXPIRED, task should be skipped
         doc_stmt = select(Document).where(Document.id == document_id)
@@ -159,13 +174,31 @@ def _validate_task_relevance(document_id: str, index_type: str, target_version: 
 
         if not document:
             logger.info(f"Document {document_id} not found, skipping task.")
-            return {"status": "skipped", "reason": "document_not_found"}
+            return {
+                "status": "skipped",
+                "reason": "document_not_found",
+                "document_id": document_id,
+                "index_type": index_type,
+            }
 
         if document.status in [DocumentStatus.UPLOADED, DocumentStatus.EXPIRED]:
             logger.info(f"Document {document_id} status is {document.status}, skipping task.")
-            return {"status": "skipped", "reason": f"document_status_{document.status}"}
+            return {
+                "status": "skipped",
+                "reason": f"document_status_{document.status}",
+                "document_id": document_id,
+                "index_type": index_type,
+            }
 
         return None  # Task is still relevant
+
+
+def _build_dispatched_workflow_result(async_result) -> dict:
+    """Return a small, JSON-serializable handoff payload for downstream workflow tracking."""
+    return {
+        "status": "dispatched",
+        "workflow_id": async_result.id,
+    }
 
 class BaseIndexTask(Task):
     """
@@ -322,11 +355,21 @@ def delete_index_task(self, document_id: str, index_type: str) -> dict:
             # Validate task is still relevant
             if not db_index:
                 logger.info(f"Index record not found for {document_id}:{index_type}, already deleted")
-                return {"status": "skipped", "reason": "index_record_not_found"}
+                return {
+                    "status": "skipped",
+                    "reason": "index_record_not_found",
+                    "document_id": document_id,
+                    "index_type": index_type,
+                }
 
             if db_index.status != DocumentIndexStatus.DELETION_IN_PROGRESS:
                 logger.info(f"Index status changed for {document_id}:{index_type}, current: {db_index.status}, skipping task")
-                return {"status": "skipped", "reason": f"status_changed_to_{db_index.status}"}
+                return {
+                    "status": "skipped",
+                    "reason": f"status_changed_to_{db_index.status}",
+                    "document_id": document_id,
+                    "index_type": index_type,
+                }
 
             break
 
@@ -449,9 +492,9 @@ def trigger_create_indexes_workflow(self, parsed_data_dict: dict, document_id: s
         )
 
         # Execute the chord
-        workflow_chord.apply_async()
+        chord_async_result = workflow_chord.apply_async()
 
-        return workflow_chord
+        return _build_dispatched_workflow_result(chord_async_result)
 
     except Exception as e:
         error_msg = f"Failed to trigger create indexes workflow: {str(e)}"
@@ -487,9 +530,9 @@ def trigger_delete_indexes_workflow(self, document_id: str, index_types: List[st
         )
 
         # Execute the chord
-        workflow_chord.apply_async()
+        chord_async_result = workflow_chord.apply_async()
 
-        return workflow_chord
+        return _build_dispatched_workflow_result(chord_async_result)
 
     except Exception as e:
         error_msg = f"Failed to trigger delete indexes workflow: {str(e)}"
@@ -527,7 +570,7 @@ def trigger_update_indexes_workflow(self, parsed_data_dict: dict, document_id: s
 
         chord_async_result = workflow_chord.apply_async()
 
-        return chord_async_result
+        return _build_dispatched_workflow_result(chord_async_result)
 
     except Exception as e:
         error_msg = f"Failed to trigger update indexes workflow: {str(e)}"
@@ -559,10 +602,16 @@ def notify_workflow_complete(self, index_results: List[dict], document_id: str, 
         # Analyze results
         successful_tasks = []
         failed_tasks = []
+        skipped_tasks = []
+        normalized_results = []
 
         for result_dict in index_results:
+            if isinstance(result_dict, dict) and result_dict.get("status") == "skipped":
+                skipped_tasks.append(result_dict.get("index_type", "unknown"))
+                continue
             try:
                 result = IndexTaskResult.from_dict(result_dict)
+                normalized_results.append(result)
                 if result.success:
                     successful_tasks.append(result.index_type)
                 else:
@@ -573,11 +622,22 @@ def notify_workflow_complete(self, index_results: List[dict], document_id: str, 
         # Determine overall status
         if not failed_tasks:
             status = TaskStatus.SUCCESS
-            status_message = f"Document {document_id} {operation} COMPLETED SUCCESSFULLY! All indexes processed: {', '.join(successful_tasks)}"
+            processed_indexes = successful_tasks if successful_tasks else skipped_tasks
+            status_message = (
+                f"Document {document_id} {operation} COMPLETED SUCCESSFULLY! "
+                f"Processed indexes: {', '.join(processed_indexes)}"
+            )
+            if skipped_tasks:
+                status_message += f". Skipped: {', '.join(skipped_tasks)}"
             logger.info(status_message)
         elif successful_tasks:
             status = TaskStatus.PARTIAL_SUCCESS
-            status_message = f"Document {document_id} {operation} COMPLETED with WARNINGS. Success: {', '.join(successful_tasks)}. Failures: {'; '.join(failed_tasks)}"
+            status_message = (
+                f"Document {document_id} {operation} COMPLETED with WARNINGS. "
+                f"Success: {', '.join(successful_tasks)}. Failures: {'; '.join(failed_tasks)}"
+            )
+            if skipped_tasks:
+                status_message += f". Skipped: {', '.join(skipped_tasks)}"
             logger.warning(status_message)
         else:
             status = TaskStatus.FAILED
@@ -594,7 +654,7 @@ def notify_workflow_complete(self, index_results: List[dict], document_id: str, 
             successful_indexes=successful_tasks,
             failed_indexes=[f.split(':')[0] for f in failed_tasks],
             total_indexes=len(index_types),
-            index_results=[IndexTaskResult.from_dict(r) for r in index_results]
+            index_results=normalized_results,
         )
 
         return workflow_result.to_dict()


### PR DESCRIPTION
## What Changed
- disable LiteLLM async logging callbacks during Celery worker initialization to avoid cross-event-loop crashes in worker processes
- follow the real child chord workflow when reporting Celery workflow status instead of reporting success as soon as fan-out is dispatched
- treat skipped index tasks as skipped in workflow aggregation instead of misclassifying them as failures
- initialize the evaluation system API key state safely when no key exists yet
- remove a stale Celery task route that points at a task name no longer present in the repo

## Why
The Celery review found both correctness issues and a likely worker-stability issue.

On the live cluster, the last `celeryworker` restart exited with code `133`, and the previous worker logs showed LiteLLM `Queue ... is bound to a different event loop` errors before process termination. The worker currently runs threaded Celery tasks while some task paths create fresh event loops via `asyncio.run()` / manual loop wrappers. LiteLLM's process-global async logging worker is not safe under that pattern, so this change disables that async callback path inside Celery worker processes.

Separately, workflow status tracking was reporting the outer trigger task rather than the terminal chord result, and skipped tasks could be misreported as failures.

## Impact
- reduces the chance of Celery worker crashes caused by LiteLLM async logging worker loop affinity issues
- makes workflow status and workflow result summaries match real execution much more closely
- fixes a latent evaluation API key bootstrap bug
- removes stale config that could mislead future Celery routing/debugging work

## Validation
- `python3 -m py_compile config/celery.py config/celery_tasks.py aperag/tasks/scheduler.py aperag/service/evaluation_service.py aperag/llm/litellm_logging.py`
- inspected live Kubernetes pod state and previous `celeryworker` logs to confirm the restart signature and LiteLLM event-loop errors
