### PR TITLE
chore: simplify make command surface

### DIFF
--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make install
+          make env-install
 
       - name: Run lint
         run: |
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run unit tests with coverage
         run: |
-          make unit-test
+          make test-unit
 
       - name: Upload unit coverage artifacts
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,52 @@ else
     LOCAL_PLATFORM = linux/amd64
 endif
 
+.PHONY: help
+help:
+	@printf "\nApeRAG Make Targets\n\n"
+	@printf "Recommended commands:\n\n"
+	@printf "Environment\n"
+	@printf "  make env-install          Install Python dependencies into .venv\n"
+	@printf "  make env-dev              Prepare the local development environment\n"
+	@printf "  make env-clean            Clean local development state\n\n"
+	@printf "Database / Infra\n"
+	@printf "  make db-migrate           Apply database migrations\n"
+	@printf "  make db-revision          Create a new alembic migration\n"
+	@printf "  make infra-up             Start infra dependencies only\n"
+	@printf "  make stack-up             Start the full local stack\n"
+	@printf "  make stack-down           Stop the local stack\n"
+	@printf "  make stack-logs           Tail stack logs\n\n"
+	@printf "Services\n"
+	@printf "  make serve-api            Run backend API locally\n"
+	@printf "  make serve-worker         Run celery worker locally\n"
+	@printf "  make serve-beat           Run celery beat locally\n"
+	@printf "  make serve-flower         Run flower locally\n"
+	@printf "  make serve-web            Run frontend locally\n\n"
+	@printf "Tests\n"
+	@printf "  make test-all             Run unit + integration + pytest E2E suites\n"
+	@printf "  make test-unit            Run unit tests\n"
+	@printf "  make test-integration     Run integration tests\n"
+	@printf "  make test-e2e             Run pytest-based residual E2E tests\n"
+	@printf "  make test-e2e-perf        Run pytest-based E2E performance tests\n"
+	@printf "  make test-http-bootstrap  Prepare HTTP E2E bootstrap state\n"
+	@printf "  make test-http-smoke      Run HTTP smoke suite against an existing target\n"
+	@printf "  make test-http-full       Run full HTTP suite against an existing target\n"
+	@printf "  make test-http-up-compose / test-http-down-compose\n"
+	@printf "  make test-http-smoke-compose / test-http-full-compose\n"
+	@printf "  make test-http-up-k8s / test-http-down-k8s\n"
+	@printf "  make test-http-smoke-k8s / test-http-full-k8s\n\n"
+	@printf "Build / API\n"
+	@printf "  make api-generate-models  Generate backend view models from OpenAPI\n"
+	@printf "  make api-generate-sdk     Generate frontend SDK\n"
+	@printf "  make build                Build production images\n"
+	@printf "  make release-version      Generate version metadata\n\n"
+
 ##################################################
 # Environment & Dependencies
 ##################################################
 
 # Python environment setup
-.PHONY: install-uv venv install clean
+.PHONY: install-uv venv env-install env-dev env-clean
 install-uv:
 	@if [ -z "$$(which uv)" ]; then \
 		echo "Installing uv..."; \
@@ -39,13 +79,13 @@ venv: install-uv
 		uv venv -p 3.11.12; \
 	fi
 
-install: venv
+env-install: venv
 	@echo "Installing Python dependencies..."
 	uv sync --all-groups --all-extras
 
 # Development environment setup
-.PHONY: dev install-hooks
-dev: install-uv venv install-addlicense install-hooks
+.PHONY: install-hooks
+env-dev: env-install install-addlicense install-hooks
 	@echo "Installing development tools..."
 	@command -v redocly >/dev/null || npm install @redocly/cli -g
 	@command -v openapi-generator-cli >/dev/null || npm install @openapitools/openapi-generator-cli -g
@@ -54,47 +94,46 @@ dev: install-uv venv install-addlicense install-hooks
 	@echo "✅ Development environment ready!"
 	@echo "📝 Next steps:"
 	@echo "   1. Activate virtual environment: source .venv/bin/activate"
-	@echo "   2. Install dependencies: make install"
-	@echo "   3. Start databases: make compose-infra"
-	@echo "   4. Apply migrations: make migrate"
-	@echo "   5. Run services: make run-backend, make run-celery"
+	@echo "   2. Start databases: make infra-up"
+	@echo "   3. Apply migrations: make db-migrate"
+	@echo "   4. Run services: make serve-api, make serve-worker"
 
 install-hooks:
 	@echo "Installing git hooks..."
 	@./scripts/install-hooks.sh
 
 # Environment cleanup
-clean:
+env-clean:
 	@echo "Cleaning development environment..."
 	@rm -f db.sqlite3
-	@$(MAKE) compose-down REMOVE_VOLUMES=1
+	@$(MAKE) stack-down REMOVE_VOLUMES=1
 
 ##################################################
 # Database & Infrastructure
 ##################################################
 
 # Database schema management
-.PHONY: makemigration migrate
-makemigration:
+.PHONY: db-revision db-migrate
+db-revision:
 	@uv run alembic -c aperag/alembic.ini revision --autogenerate
 
-migrate:
+db-migrate:
 	@uv run alembic -c aperag/alembic.ini upgrade head
 
 # Docker Compose infrastructure
 
 # Variables for compose command based on environment flags
 # Usage examples:
-#   make compose-up                              # Full application
-#   make compose-up WITH_NEO4J=1                 # Full application + Neo4j
-#   make compose-up WITH_NEBULA=1                # Full application + Nebula Graph
-#   make compose-up WITH_JAEGER=1                # Full application + Jaeger
-#   make compose-up WITH_JAEGER=1 WITH_NEO4J=1   # Full application + Jaeger + Neo4j
-#   make compose-infra                           # Infrastructure only (databases)
-#   make compose-infra WITH_NEO4J=1              # Infrastructure + Neo4j
-#   make compose-infra WITH_JAEGER=1             # Infrastructure + Jaeger
-#   make compose-down                            # Stop all services
-#   make compose-down REMOVE_VOLUMES=1           # Stop and remove volumes
+#   make stack-up                                # Full application
+#   make stack-up WITH_NEO4J=1                   # Full application + Neo4j
+#   make stack-up WITH_NEBULA=1                  # Full application + Nebula Graph
+#   make stack-up WITH_JAEGER=1                  # Full application + Jaeger
+#   make stack-up WITH_JAEGER=1 WITH_NEO4J=1     # Full application + Jaeger + Neo4j
+#   make infra-up                                # Infrastructure only (databases)
+#   make infra-up WITH_NEO4J=1                   # Infrastructure + Neo4j
+#   make infra-up WITH_JAEGER=1                  # Infrastructure + Jaeger
+#   make stack-down                              # Stop all services
+#   make stack-down REMOVE_VOLUMES=1             # Stop and remove volumes
 _PROFILES_TO_ACTIVATE :=
 _EXTRA_ENVS :=
 _COMPOSE_DOWN_FLAGS :=
@@ -117,26 +156,26 @@ ifeq ($(REMOVE_VOLUMES),1)
     _COMPOSE_DOWN_FLAGS += -v
 endif
 
-.PHONY: compose-up compose-down compose-logs compose-infra
+.PHONY: stack-up stack-down stack-logs infra-up
 # Full application startup
-compose-up:
+stack-up:
 	$(_EXTRA_ENVS) docker-compose $(_PROFILES_TO_ACTIVATE) -f docker-compose.yml up -d
 
 # Infrastructure only (databases + supporting services)
 # Optional services like Neo4j, Nebula, and Jaeger will ONLY start if explicitly enabled:
-#   make compose-infra WITH_NEO4J=1    # adds Neo4j
-#   make compose-infra WITH_NEBULA=1   # adds Nebula Graph
-#   make compose-infra WITH_JAEGER=1   # adds Jaeger
-compose-infra:
+#   make infra-up WITH_NEO4J=1    # adds Neo4j
+#   make infra-up WITH_NEBULA=1   # adds Nebula Graph
+#   make infra-up WITH_JAEGER=1   # adds Jaeger
+infra-up:
 	docker-compose $(_PROFILES_TO_ACTIVATE) -f docker-compose.yml up -d \
 		postgres redis qdrant es jaeger \
 		$(if $(filter 1,$(WITH_NEO4J)),neo4j,) \
 		$(if $(filter 1,$(WITH_NEBULA)),nebula-metad nebula-storaged nebula-graphd nebula-storage-activator,)
 
-compose-down:
+stack-down:
 	docker-compose --profile neo4j --profile nebula --profile jaeger -f docker-compose.yml down $(_COMPOSE_DOWN_FLAGS)
 
-compose-logs:
+stack-logs:
 	docker-compose -f docker-compose.yml logs -f
 
 ##################################################
@@ -144,20 +183,20 @@ compose-logs:
 ##################################################
 
 # Local development services
-.PHONY: run-backend run-frontend run-celery run-flower run-beat
-run-backend: migrate
+.PHONY: serve-api serve-web serve-worker serve-flower serve-beat
+serve-api: db-migrate
 	uvicorn aperag.app:app --host 0.0.0.0 --log-config scripts/uvicorn-log-config.yaml
 
-run-celery:
+serve-worker:
 	celery -A config.celery worker -B -l INFO --pool=threads --concurrency=16
 
-run-beat:
+serve-beat:
 	celery -A config.celery beat -l INFO
 
-run-flower:
+serve-flower:
 	celery -A config.celery flower --conf/flowerconfig.py
 
-run-frontend:
+serve-web:
 	cd ./web && yarn dev
 
 ##################################################
@@ -178,11 +217,13 @@ static-check:
 	uvx mypy ./aperag
 
 # Testing suite
-.PHONY: test unit-test integration-test e2e-test e2e-performance-test e2e-http-bootstrap e2e-http-smoke e2e-http-full e2e-http-compose-up e2e-http-compose-down e2e-http-compose-smoke e2e-http-compose-full e2e-http-k8s-up e2e-http-k8s-down e2e-http-k8s-smoke e2e-http-k8s-full
-test:
-	uv run pytest tests/ -v
+.PHONY: test-all test-unit test-integration test-e2e test-e2e-perf \
+	test-http-bootstrap test-http-smoke test-http-full \
+	test-http-up-compose test-http-down-compose test-http-smoke-compose test-http-full-compose \
+	test-http-up-k8s test-http-down-k8s test-http-smoke-k8s test-http-full-k8s
+test-all: test-unit test-integration test-e2e
 
-unit-test:
+test-unit:
 	@mkdir -p tests/report
 	uv run pytest tests/unit_test/ -v \
 		--cov=aperag \
@@ -190,13 +231,13 @@ unit-test:
 		--cov-report=xml:tests/report/unit-coverage.xml \
 		--cov-report=json:tests/report/unit-coverage.json
 
-integration-test:
+test-integration:
 	uv run pytest tests/integration/ -v
 
-e2e-test:
+test-e2e:
 	uv run pytest --benchmark-disable tests/e2e_pytest/ -v
 
-e2e-performance-test:
+test-e2e-perf:
 	@echo "Running E2E performance test..."
 	@uv run pytest -v \
 		--benchmark-enable \
@@ -207,37 +248,37 @@ e2e-performance-test:
 		--benchmark-save=benchmark-result-$$(date +%Y%m%d%H%M%S) \
 		tests/e2e_pytest/
 
-e2e-http-bootstrap:
+test-http-bootstrap:
 	@./tests/e2e_http/bootstrap/bootstrap.sh
 
-e2e-http-smoke:
+test-http-smoke:
 	@./tests/e2e_http/scripts/run_smoke.sh
 
-e2e-http-full:
+test-http-full:
 	@./tests/e2e_http/scripts/run_full.sh
 
-e2e-http-compose-up:
+test-http-up-compose:
 	@./tests/e2e_http/runners/compose/up.sh
 
-e2e-http-compose-down:
+test-http-down-compose:
 	@./tests/e2e_http/runners/compose/down.sh
 
-e2e-http-compose-smoke:
+test-http-smoke-compose:
 	@./tests/e2e_http/scripts/run_compose_smoke.sh
 
-e2e-http-compose-full:
+test-http-full-compose:
 	@./tests/e2e_http/scripts/run_compose_full.sh
 
-e2e-http-k8s-up:
+test-http-up-k8s:
 	@./tests/e2e_http/runners/k8s/up.sh
 
-e2e-http-k8s-down:
+test-http-down-k8s:
 	@./tests/e2e_http/runners/k8s/down.sh
 
-e2e-http-k8s-smoke:
+test-http-smoke-k8s:
 	@./tests/e2e_http/scripts/run_k8s_smoke.sh
 
-e2e-http-k8s-full:
+test-http-full-k8s:
 	@./tests/e2e_http/scripts/run_k8s_full.sh
 
 # RAG evaluation
@@ -251,11 +292,11 @@ evaluate:
 ##################################################
 
 # OpenAPI and model generation
-.PHONY: merge-openapi generate-models generate-frontend-sdk
+.PHONY: merge-openapi api-generate-models api-generate-sdk
 merge-openapi:
 	@cd aperag && npx --yes @redocly/cli bundle ./api/openapi.yaml > ./api/openapi.merged.yaml
 
-generate-models: merge-openapi
+api-generate-models: merge-openapi
 	@datamodel-codegen \
 		--input aperag/api/openapi.merged.yaml \
 		--input-file-type openapi \
@@ -268,7 +309,7 @@ generate-models: merge-openapi
 		--output-model-type pydantic_v2.BaseModel
 	@rm aperag/api/openapi.merged.yaml
 
-generate-frontend-sdk:
+api-generate-sdk:
 	cd ./web && yarn api:build
 
 # LLM configuration generation
@@ -277,8 +318,8 @@ llm_provider:
 	python ./models/generate_model_configs.py
 
 # Version management
-.PHONY: version
-version:
+.PHONY: release-version
+release-version:
 	@git rev-parse HEAD | cut -c1-7 > commit_id.txt
 	@echo "VERSION = \"$(VERSION)\"" > $(VERSION_FILE)
 	@echo "GIT_COMMIT_ID = \"$$(cat commit_id.txt)\"" >> $(VERSION_FILE)
@@ -309,7 +350,7 @@ build-aperag-frontend-assets:
 .PHONY: build build-aperag build-aperag-frontend
 build: build-aperag build-aperag-frontend
 
-build-aperag: setup-builder version
+build-aperag: setup-builder release-version
 	docker buildx build -t $(REGISTRY)/$(APERAG_IMAGE):$(VERSION) \
 		--platform $(BUILDX_PLATFORM) $(BUILDX_ARGS) --push \
 		-f ./Dockerfile .
@@ -323,7 +364,7 @@ build-aperag-frontend: setup-builder build-aperag-frontend-assets
 .PHONY: build-local build-aperag-local build-aperag-frontend-local
 build-local: build-aperag-local build-aperag-frontend-local
 
-build-aperag-local: setup-builder version
+build-aperag-local: setup-builder release-version
 	docker buildx build -t $(APERAG_IMAGE):$(VERSION) \
 		--platform $(LOCAL_PLATFORM) $(BUILDX_ARGS) --load \
 		-f ./Dockerfile .

--- a/docs/en-US/development/development-guide.md
+++ b/docs/en-US/development/development-guide.md
@@ -33,7 +33,7 @@ Use Docker Compose to start the essential database services:
 
 ```bash
 # Start core databases: PostgreSQL, Redis, Qdrant, Elasticsearch
-make compose-infra
+make infra-up
 ```
 
 This will start all required database services in the background. The default connection settings in your `.env` file are pre-configured to work with these services.
@@ -43,7 +43,7 @@ This will start all required database services in the background. The default co
 
 ```bash
 # Use Neo4j instead of PostgreSQL for graph storage
-make compose-infra WITH_NEO4J=1
+make infra-up WITH_NEO4J=1
 ```
 
 </details>
@@ -53,7 +53,7 @@ make compose-infra WITH_NEO4J=1
 Create Python virtual environment and setup development tools:
 
 ```bash
-make dev
+make env-dev
 ```
 
 This command will:
@@ -75,7 +75,7 @@ You'll know it's active when you see `(.venv)` in your terminal prompt.
 Install all backend and frontend dependencies:
 
 ```bash
-make install
+make env-install
 ```
 
 This command will:
@@ -87,7 +87,7 @@ This command will:
 Setup the database schema:
 
 ```bash
-make migrate
+make db-migrate
 ```
 
 ### 7. ▶️ Start Development Services
@@ -96,19 +96,19 @@ Now you can start the development services. Open separate terminal windows/tabs 
 
 **Terminal 1 - Backend API Server:**
 ```bash
-make run-backend
+make serve-api
 ```
 This starts the FastAPI development server at `http://localhost:8000` with auto-reload on code changes.
 
 **Terminal 2 - Celery Worker:**
 ```bash
-make run-celery
+make serve-worker
 ```
 This starts the Celery worker for processing asynchronous background tasks.
 
 **Terminal 3 - Frontend (Optional):**
 ```bash
-make run-frontend
+make serve-web
 ```
 This starts the frontend development server at `http://localhost:3000` with hot reload.
 
@@ -126,21 +126,21 @@ To stop the development environment:
 **Stop Database Services:**
 ```bash
 # Stop database services (data preserved)
-make compose-down
+make stack-down
 
 # Stop services and remove all data volumes
-make compose-down REMOVE_VOLUMES=1
+make stack-down REMOVE_VOLUMES=1
 ```
 
 **Stop Development Services:**
-- Backend API Server: Press `Ctrl+C` in the terminal running `make run-backend`
-- Celery Worker: Press `Ctrl+C` in the terminal running `make run-celery`  
-- Frontend Server: Press `Ctrl+C` in the terminal running `make run-frontend`
+- Backend API Server: Press `Ctrl+C` in the terminal running `make serve-api`
+- Celery Worker: Press `Ctrl+C` in the terminal running `make serve-worker`
+- Frontend Server: Press `Ctrl+C` in the terminal running `make serve-web`
 
 **Data Management:**
-- `make compose-down` - Stops services but preserves all data (PostgreSQL, Redis, Qdrant, etc.)
-- `make compose-down REMOVE_VOLUMES=1` - Stops services and **⚠️ permanently deletes all data**
-- You can run `make compose-down REMOVE_VOLUMES=1` even after already running `make compose-down`
+- `make stack-down` - Stops services but preserves all data (PostgreSQL, Redis, Qdrant, etc.)
+- `make stack-down REMOVE_VOLUMES=1` - Stops services and **⚠️ permanently deletes all data**
+- You can run `make stack-down REMOVE_VOLUMES=1` even after already running `make stack-down`
 
 **Verify Data Removal:**
 ```bash
@@ -160,16 +160,16 @@ Now you have ApeRAG running locally from source code, ready for development! �
 1. Edit OpenAPI specification: `aperag/api/paths/[endpoint-name].yaml`
 2. Regenerate backend models: 
    ```bash
-   make generate-models  # This runs merge-openapi internally
+   make api-generate-models  # This runs merge-openapi internally
    ```
 3. Implement backend view: `aperag/views/[module].py`
 4. Generate frontend TypeScript client:
    ```bash
-   make generate-frontend-sdk  # Updates frontend/src/api/
+   make api-generate-sdk  # Updates frontend/src/api/
    ```
 5. Test the API:
    ```bash
-   make test
+   make test-all
    # ✅ Check live docs: http://localhost:8000/docs
    ```
 
@@ -179,16 +179,16 @@ Now you have ApeRAG running locally from source code, ready for development! �
 1. Edit SQLModel classes in `aperag/db/models.py`
 2. Generate migration file:
    ```bash
-   make makemigration  # Creates new migration in migration/versions/
+   make db-revision  # Creates new migration in migration/versions/
    ```
 3. Apply migration to database:
    ```bash
-   make migrate  # Updates database schema
+   make db-migrate  # Updates database schema
    ```
 4. Update related code (repositories in `aperag/db/repositories/`, services in `aperag/service/`)
 5. Verify changes:
    ```bash
-   make test  # ✅ Ensure everything works
+   make test-all  # ✅ Ensure everything works
    ```
 
 ### Q: ⚡ How do I add a new feature with background processing?
@@ -200,14 +200,14 @@ Now you have ApeRAG running locally from source code, ready for development! �
    - Database models: `aperag/db/models.py`
 2. Update API and generate code:
    ```bash
-   make makemigration      # Generate migration files
-   make migrate           # Apply database changes
-   make generate-models   # Update Pydantic models
-   make generate-frontend-sdk  # Update TypeScript client
+   make db-revision      # Generate migration files
+   make db-migrate           # Apply database changes
+   make api-generate-models   # Update Pydantic models
+   make api-generate-sdk  # Update TypeScript client
    ```
 3. Quality assurance:
    ```bash
-   make format && make lint && make test
+   make format && make lint && make test-all
    ```
 
 ### Q: 🧪 How do I run unit tests and e2e tests?
@@ -215,7 +215,7 @@ Now you have ApeRAG running locally from source code, ready for development! �
 **Unit Tests (Fast, No External Dependencies):**
 ```bash
 # Run all unit tests
-make unit-test
+make test-unit
 
 # Run specific test file
 uv run pytest tests/unit_test/test_model_service.py -v
@@ -224,23 +224,23 @@ uv run pytest tests/unit_test/test_model_service.py -v
 uv run pytest tests/unit_test/test_model_service.py::TestModelService::test_get_models -v
 
 # Run tests with coverage
-make unit-test
+make test-unit
 ```
 
 **E2E Tests (Require Running Services):**
 ```bash
 # Setup: Start required services first
-make compose-infra      # 🗄️ Start databases
-make run-backend       # 🚀 Start API server (separate terminal)
+make infra-up      # 🗄️ Start databases
+make serve-api       # 🚀 Start API server (separate terminal)
 
 # Run the remaining pytest-based product e2e tests
-make e2e-test
+make test-e2e
 
 # Run HTTP black-box smoke against a running service
-make e2e-http-smoke
+make test-http-smoke
 
 # Run backend integration tests
-make integration-test
+make test-integration
 
 # Run specific pytest e2e modules
 uv run pytest tests/e2e_pytest/test_chat.py -v
@@ -252,17 +252,17 @@ uv run pytest tests/integration/graphstorage/ -v
 uv run pytest tests/e2e_pytest/test_chat.py -v -s
 
 # Performance benchmarks (with timing)
-make e2e-performance-test
+make test-e2e-perf
 ```
 
 **Complete Test Suite:**
 ```bash
 # Run everything (unit + e2e)
-make test
+make test-all
 
 # Test with different configurations
-make compose-infra WITH_NEO4J=1  # Test with Neo4j instead of PostgreSQL
-make test
+make infra-up WITH_NEO4J=1  # Test with Neo4j instead of PostgreSQL
+make test-all
 ```
 
 ### Q: 🐛 How do I debug failing tests?
@@ -278,9 +278,9 @@ make test
    ```
 2. For e2e test failures, ensure services are running:
    ```bash
-   make compose-infra       # Database services
-   make run-backend         # API server
-   make run-celery         # Background workers (if testing async tasks)
+   make infra-up       # Database services
+   make serve-api         # API server
+   make serve-worker         # Background workers (if testing async tasks)
    ```
 3. Use debugging tools:
    ```bash
@@ -302,9 +302,9 @@ make test
 **Evaluation workflow:**
 ```bash
 # Ensure environment is ready
-make compose-infra WITH_NEO4J=1  # Use Neo4j for better graph performance
-make run-backend
-make run-celery
+make infra-up WITH_NEO4J=1  # Use Neo4j for better graph performance
+make serve-api
+make serve-worker
 
 # Run comprehensive RAG evaluation
 make evaluate               # 📊 Runs aperag.evaluation.run module
@@ -318,8 +318,8 @@ make evaluate               # 📊 Runs aperag.evaluation.run module
 1. Edit `pyproject.toml` (add/update packages)
 2. Update virtual environment:
    ```bash
-   make install            # Syncs all groups and extras with uv
-   make test              # Verify compatibility
+   make env-install            # Syncs all groups and extras with uv
+   make test-all              # Verify compatibility
    ```
 
 **Frontend dependencies:**
@@ -327,8 +327,8 @@ make evaluate               # 📊 Runs aperag.evaluation.run module
 2. Update and test:
    ```bash
    cd frontend && yarn install
-   make run-frontend      # Test frontend compilation
-   make generate-frontend-sdk  # Ensure API client still works
+   make serve-web      # Test frontend compilation
+   make api-generate-sdk  # Ensure API client still works
    ```
 
 ### Q: 🚀 How do I prepare code for production deployment?
@@ -342,49 +342,49 @@ make evaluate               # 📊 Runs aperag.evaluation.run module
    ```
 2. Comprehensive testing:
    ```bash
-   make test             # All unit + e2e tests
-   make e2e-performance-test  # Performance benchmarks
+   make test-all             # All unit + e2e tests
+   make test-e2e-perf  # Performance benchmarks
    ```
 3. API consistency:
    ```bash
-   make generate-models         # Ensure models match OpenAPI spec
-   make generate-frontend-sdk   # Update frontend client
+   make api-generate-models         # Ensure models match OpenAPI spec
+   make api-generate-sdk   # Update frontend client
    ```
 4. Database migrations:
    ```bash
-   make makemigration    # Generate any pending migrations
+   make db-revision    # Generate any pending migrations
    ```
 5. Full-stack integration test:
    ```bash
-   make compose-up WITH_NEO4J=1 WITH_DOCRAY=1  # Production-like setup
+   make stack-up WITH_NEO4J=1 WITH_DOCRAY=1  # Production-like setup
    # Manual testing at http://localhost:3000/web/
-   make compose-down
+   make stack-down
    ```
 
 ### Q: 🔄 How do I completely reset my development environment?
 
 **Nuclear reset (destroys all data):**
 ```bash
-make compose-down REMOVE_VOLUMES=1  # ⚠️ Stop services + delete ALL data
-make clean                         # 🧹 Clean temporary files
+make stack-down REMOVE_VOLUMES=1  # ⚠️ Stop services + delete ALL data
+make env-clean                         # 🧹 Clean temporary files
 
 # Restart fresh
-make compose-infra                 # 🗄️ Fresh databases
-make migrate                      # 🔄 Apply all migrations
-make run-backend                  # 🚀 Start API server
-make run-celery                   # ⚡ Start background workers
+make infra-up                 # 🗄️ Fresh databases
+make db-migrate                      # 🔄 Apply all migrations
+make serve-api                  # 🚀 Start API server
+make serve-worker                   # ⚡ Start background workers
 ```
 
 **Soft reset (preserve data):**
 ```bash
-make compose-down                 # ⏹️ Stop services, keep data
-make compose-infra               # 🗄️ Restart databases
-make migrate                    # 🔄 Apply any new migrations
+make stack-down                 # ⏹️ Stop services, keep data
+make infra-up               # 🗄️ Restart databases
+make db-migrate                    # 🔄 Apply any new migrations
 ```
 
 **Reset just Python environment:**
 ```bash
 rm -rf .venv/                   # 🗑️ Remove virtual environment
-make dev                       # ⚙️ Recreate everything
+make env-dev                       # ⚙️ Recreate everything
 source .venv/bin/activate      # ✅ Reactivate
 ``` 

--- a/docs/en-US/jaeger-tracing.md
+++ b/docs/en-US/jaeger-tracing.md
@@ -10,10 +10,10 @@ To start ApeRAG with Jaeger enabled:
 
 ```bash
 # Start infrastructure with Jaeger
-make compose-infra WITH_JAEGER=1
+make infra-up WITH_JAEGER=1
 
 # Or start the full application stack with Jaeger
-make compose-up WITH_JAEGER=1
+make stack-up WITH_JAEGER=1
 ```
 
 Alternatively, you can use docker-compose directly:
@@ -136,7 +136,7 @@ export JAEGER_ENABLED=True
 export JAEGER_ENDPOINT=http://localhost:14268/api/traces
 
 # Start your application
-make run-backend
+make serve-api
 ```
 
 ### Custom Tracing

--- a/docs/zh-CN/design/collection_knowledge_export_design.md
+++ b/docs/zh-CN/design/collection_knowledge_export_design.md
@@ -192,8 +192,8 @@ API 定义的源文件：
 
 修改 API 后需运行：
 ```bash
-make generate-models          # 重新生成 aperag/schema/view_models.py
-make generate-frontend-sdk    # 重新生成 web/src/api/**
+make api-generate-models          # 重新生成 aperag/schema/view_models.py
+make api-generate-sdk    # 重新生成 web/src/api/**
 ```
 
 ### 接口列表

--- a/docs/zh-CN/design/collection_marketplace_design.md
+++ b/docs/zh-CN/design/collection_marketplace_design.md
@@ -381,7 +381,7 @@ ORDER BY ucs.gmt_subscribed DESC;
 
 **4.1.2 新增视图模型 (aperag/schema/view_models.py):**
 > 在aperag/api/components/schemas/marketplace.yaml中定义
-> 注意需要用make generate-models和make generate-frontend-sdk生成前后端代码
+> 注意需要用make api-generate-models和make api-generate-sdk生成前后端代码
 
 - **`SharedCollection`**: 共享的 Collection 信息（视图模型）
     - `id: str`: Collection ID
@@ -1110,9 +1110,9 @@ const CollectionDetail: React.FC = () => {
         - 包含所有必要字段、约束和索引（特别注意 `gmt_deleted` 的索引优化）
         - 注意：`status` 字段使用 `Column(String(20))` 而非 `EnumColumn`，确保数据库层使用VARCHAR
         - 重点：UserCollectionSubscription表关联collection_marketplace_id而不是collection_id
-    - [x] 运行 `make makemigration` 生成新的数据库迁移脚本
+    - [x] 运行 `make db-revision` 生成新的数据库迁移脚本
     - [x] 检查生成的迁移脚本（位于 `aperag/migration/versions/`）确保 SQL 语法正确性和索引创建
-    - [x] 运行 `make migrate` 将数据库 schema 变更应用到开发环境
+    - [x] 运行 `make db-migrate` 将数据库 schema 变更应用到开发环境
     - [x] 验证新表创建成功，检查约束和索引是否正确建立
 
 - [x] **1.2. OpenAPI Schema 定义**
@@ -1132,7 +1132,7 @@ const CollectionDetail: React.FC = () => {
         - `DELETE /api/v1/collections/{collection_id}/sharing`
 
     - [x] 修改 `aperag/api/components/schemas/collection.yaml`，在 Collection schema 中添加 `is_published` 和 `published_at` 字段
-    - [x] 运行 `make generate-models` 生成更新后的 `aperag/schema/view_models.py`
+    - [x] 运行 `make api-generate-models` 生成更新后的 `aperag/schema/view_models.py`
     - [x] 验证生成的 Pydantic 模型类型注解正确
 
 - [x] **1.3. 服务层 - Marketplace Service**
@@ -1221,7 +1221,7 @@ const CollectionDetail: React.FC = () => {
         - 为每个端点添加订阅权限验证和异常错误处理
 
 - [x] **2.2. 前端 - 生成 SDK 与状态管理**
-    - [x] 运行 `make generate-frontend-sdk` 更新前端 API client
+    - [x] 运行 `make api-generate-sdk` 更新前端 API client
     - [x] 验证 `frontend/src/api/` 目录中的新增内容：
         - 检查 `apis/` 目录下是否生成了 marketplace 相关的 API 函数
         - 检查 `models/` 目录下是否生成了新的 TypeScript 接口

--- a/docs/zh-CN/design/url_and_text_import_design.md
+++ b/docs/zh-CN/design/url_and_text_import_design.md
@@ -543,14 +543,14 @@ URL 导入的文档在 `doc_metadata` 中记录来源信息，便于追溯和未
 
 1. 在 `document.yaml` schema 中新增 `fetchUrlRequest/Response`
 2. 在 `collections.yaml` paths 中注册 `/fetch-url` 路由
-3. 运行 `make generate-models`
+3. 运行 `make api-generate-models`
 4. 将 `web.py` 中的 `_read_with_jina_fallback` / `_read_with_trafilatura_only` 提取为 `ReaderService` 的公共方法
 5. 在 `views/collections.py` 中实现 `fetch_url_document_view` 路由函数
 6. 编写单元测试
 
 ### Phase 2：前端（约 2 天）
 
-1. 运行 `make generate-frontend-sdk`
+1. 运行 `make api-generate-sdk`
 2. 实现 `import-dialog.tsx`（来源选择入口）
 3. 实现 `url-import.tsx`（URL 输入 + 调用 `/fetch-url`）
 4. 实现 `text-import.tsx`（文本粘贴 + 创建 File 对象 + 调用现有上传接口）

--- a/docs/zh-CN/design/web-search-design.md
+++ b/docs/zh-CN/design/web-search-design.md
@@ -557,7 +557,7 @@ lxml>=5.0.0                   # 解析器（可选）
 
 ```bash
 # 通过项目Makefile安装
-make install
+make env-install
 
 # 或直接pip安装
 pip install duckduckgo-search trafilatura markdownify aiohttp

--- a/docs/zh-CN/development/development-guide.md
+++ b/docs/zh-CN/development/development-guide.md
@@ -38,7 +38,7 @@ cp envs/env.template .env
 
 ```bash
 # 启动核心数据库：PostgreSQL、Redis、Qdrant、Elasticsearch
-make compose-infra
+make infra-up
 ```
 
 这将在后台启动所有必需的数据库服务。您的 `.env` 文件中的默认连接设置已预配置为与这些服务一起工作。
@@ -48,7 +48,7 @@ make compose-infra
 
 ```bash
 # 使用 Neo4j 而不是 PostgreSQL 进行图存储
-make compose-infra WITH_NEO4J=1
+make infra-up WITH_NEO4J=1
 ```
 
 </details>
@@ -58,7 +58,7 @@ make compose-infra WITH_NEO4J=1
 创建 Python 虚拟环境并设置开发工具：
 
 ```bash
-make dev
+make env-dev
 ```
 
 此命令将：
@@ -80,7 +80,7 @@ source .venv/bin/activate
 安装所有后端和前端依赖项：
 
 ```bash
-make install
+make env-install
 ```
 
 此命令将：
@@ -92,7 +92,7 @@ make install
 设置数据库架构：
 
 ```bash
-make migrate
+make db-migrate
 ```
 
 ### 7. ▶️ 启动开发服务
@@ -101,19 +101,19 @@ make migrate
 
 **终端 1 - 后端 API 服务器：**
 ```bash
-make run-backend
+make serve-api
 ```
 这将在 `http://localhost:8000` 启动 FastAPI 开发服务器，代码更改时自动重新加载。
 
 **终端 2 - Celery Worker：**
 ```bash
-make run-celery
+make serve-worker
 ```
 这将启动 Celery worker 以处理异步后台任务。
 
 **终端 3 - 前端（可选）：**
 ```bash
-make run-frontend
+make serve-web
 ```
 这将在 `http://localhost:3000` 启动前端开发服务器，支持热重载。
 
@@ -131,21 +131,21 @@ make run-frontend
 **停止数据库服务：**
 ```bash
 # 停止数据库服务（保留数据）
-make compose-down
+make stack-down
 
 # 停止服务并移除所有数据卷
-make compose-down REMOVE_VOLUMES=1
+make stack-down REMOVE_VOLUMES=1
 ```
 
 **停止开发服务：**
-- 后端 API 服务器：在运行 `make run-backend` 的终端中按 `Ctrl+C`
-- Celery Worker：在运行 `make run-celery` 的终端中按 `Ctrl+C`
-- 前端服务器：在运行 `make run-frontend` 的终端中按 `Ctrl+C`
+- 后端 API 服务器：在运行 `make serve-api` 的终端中按 `Ctrl+C`
+- Celery Worker：在运行 `make serve-worker` 的终端中按 `Ctrl+C`
+- 前端服务器：在运行 `make serve-web` 的终端中按 `Ctrl+C`
 
 **数据管理：**
-- `make compose-down` - 停止服务但保留所有数据（PostgreSQL、Redis、Qdrant 等）
-- `make compose-down REMOVE_VOLUMES=1` - 停止服务并**⚠️ 永久删除所有数据**
-- 即使已经运行过 `make compose-down`，您也可以运行 `make compose-down REMOVE_VOLUMES=1`
+- `make stack-down` - 停止服务但保留所有数据（PostgreSQL、Redis、Qdrant 等）
+- `make stack-down REMOVE_VOLUMES=1` - 停止服务并**⚠️ 永久删除所有数据**
+- 即使已经运行过 `make stack-down`，您也可以运行 `make stack-down REMOVE_VOLUMES=1`
 
 **验证数据移除：**
 ```bash
@@ -165,16 +165,16 @@ docker volume ls | grep aperag
 1. 编辑 OpenAPI 规范：`aperag/api/paths/[endpoint-name].yaml`
 2. 重新生成后端模型：
    ```bash
-   make generate-models  # 这会在内部运行 merge-openapi
+   make api-generate-models  # 这会在内部运行 merge-openapi
    ```
 3. 实现后端视图：`aperag/views/[module].py`
 4. 生成前端 TypeScript 客户端：
    ```bash
-   make generate-frontend-sdk  # 更新 frontend/src/api/
+   make api-generate-sdk  # 更新 frontend/src/api/
    ```
 5. 测试 API：
    ```bash
-   make test
+   make test-all
    # ✅ 检查实时文档：http://localhost:8000/docs
    ```
 
@@ -184,16 +184,16 @@ docker volume ls | grep aperag
 1. 编辑 `aperag/db/models.py` 中的 SQLModel 类
 2. 生成迁移文件：
    ```bash
-   make makemigration  # 在 migration/versions/ 中创建新迁移
+   make db-revision  # 在 migration/versions/ 中创建新迁移
    ```
 3. 将迁移应用到数据库：
    ```bash
-   make migrate  # 更新数据库架构
+   make db-migrate  # 更新数据库架构
    ```
 4. 更新相关代码（`aperag/db/repositories/` 中的仓库，`aperag/service/` 中的服务）
 5. 验证更改：
    ```bash
-   make test  # ✅ 确保一切正常工作
+   make test-all  # ✅ 确保一切正常工作
    ```
 
 ### Q: ⚡ 如何添加具有后台处理的新功能？
@@ -205,14 +205,14 @@ docker volume ls | grep aperag
    - 数据库模型：`aperag/db/models.py`
 2. 更新 API 并生成代码：
    ```bash
-   make makemigration      # 生成迁移文件
-   make migrate           # 应用数据库更改
-   make generate-models   # 更新 Pydantic 模型
-   make generate-frontend-sdk  # 更新 TypeScript 客户端
+   make db-revision      # 生成迁移文件
+   make db-migrate           # 应用数据库更改
+   make api-generate-models   # 更新 Pydantic 模型
+   make api-generate-sdk  # 更新 TypeScript 客户端
    ```
 3. 质量保证：
    ```bash
-   make format && make lint && make test
+   make format && make lint && make test-all
    ```
 
 ### Q: 🧪 如何运行单元测试和 e2e 测试？
@@ -220,7 +220,7 @@ docker volume ls | grep aperag
 **单元测试（快速，无外部依赖）：**
 ```bash
 # 运行所有单元测试
-make unit-test
+make test-unit
 
 # 运行特定测试文件
 uv run pytest tests/unit_test/test_model_service.py -v
@@ -229,23 +229,23 @@ uv run pytest tests/unit_test/test_model_service.py -v
 uv run pytest tests/unit_test/test_model_service.py::TestModelService::test_get_models -v
 
 # 运行带覆盖率的测试
-make unit-test
+make test-unit
 ```
 
 **E2E 测试（需要运行服务）：**
 ```bash
 # 设置：首先启动所需服务
-make compose-infra      # 🗄️ 启动数据库
-make run-backend       # 🚀 启动 API 服务器（单独终端）
+make infra-up      # 🗄️ 启动数据库
+make serve-api       # 🚀 启动 API 服务器（单独终端）
 
 # 运行剩余的 pytest 版产品级 e2e
-make e2e-test
+make test-e2e
 
 # 对运行中的服务执行 HTTP 黑盒 smoke
-make e2e-http-smoke
+make test-http-smoke
 
 # 运行后端集成测试
-make integration-test
+make test-integration
 
 # 运行特定 pytest e2e 模块
 uv run pytest tests/e2e_pytest/test_chat.py -v
@@ -257,17 +257,17 @@ uv run pytest tests/integration/graphstorage/ -v
 uv run pytest tests/e2e_pytest/test_chat.py -v -s
 
 # 性能基准测试（带计时）
-make e2e-performance-test
+make test-e2e-perf
 ```
 
 **完整测试套件：**
 ```bash
 # 运行所有内容（单元 + e2e）
-make test
+make test-all
 
 # 使用不同配置进行测试
-make compose-infra WITH_NEO4J=1  # 使用 Neo4j 而不是 PostgreSQL 进行测试
-make test
+make infra-up WITH_NEO4J=1  # 使用 Neo4j 而不是 PostgreSQL 进行测试
+make test-all
 ```
 
 ### Q: 🐛 如何调试失败的测试？
@@ -283,9 +283,9 @@ make test
    ```
 2. 对于 e2e 测试失败，确保服务正在运行：
    ```bash
-   make compose-infra       # 数据库服务
-   make run-backend         # API 服务器
-   make run-celery         # 后台 workers（如果测试异步任务）
+   make infra-up       # 数据库服务
+   make serve-api         # API 服务器
+   make serve-worker         # 后台 workers（如果测试异步任务）
    ```
 3. 使用调试工具：
    ```bash
@@ -307,9 +307,9 @@ make test
 **评估工作流程：**
 ```bash
 # 确保环境准备就绪
-make compose-infra WITH_NEO4J=1  # 使用 Neo4j 获得更好的图性能
-make run-backend
-make run-celery
+make infra-up WITH_NEO4J=1  # 使用 Neo4j 获得更好的图性能
+make serve-api
+make serve-worker
 
 # 运行全面的 RAG 评估
 make evaluate               # 📊 运行 aperag.evaluation.run 模块
@@ -323,8 +323,8 @@ make evaluate               # 📊 运行 aperag.evaluation.run 模块
 1. 编辑 `pyproject.toml`（添加/更新包）
 2. 更新虚拟环境：
    ```bash
-   make install            # 使用 uv 同步所有组和额外内容
-   make test              # 验证兼容性
+   make env-install            # 使用 uv 同步所有组和额外内容
+   make test-all              # 验证兼容性
    ```
 
 **前端依赖项：**
@@ -332,8 +332,8 @@ make evaluate               # 📊 运行 aperag.evaluation.run 模块
 2. 更新并测试：
    ```bash
    cd frontend && yarn install
-   make run-frontend      # 测试前端编译
-   make generate-frontend-sdk  # 确保 API 客户端仍然工作
+   make serve-web      # 测试前端编译
+   make api-generate-sdk  # 确保 API 客户端仍然工作
    ```
 
 ### Q: 🚀 如何准备代码进行生产部署？
@@ -347,49 +347,49 @@ make evaluate               # 📊 运行 aperag.evaluation.run 模块
    ```
 2. 全面测试：
    ```bash
-   make test             # 所有单元 + e2e 测试
-   make e2e-performance-test  # 性能基准测试
+   make test-all             # 所有单元 + e2e 测试
+   make test-e2e-perf  # 性能基准测试
    ```
 3. API 一致性：
    ```bash
-   make generate-models         # 确保模型与 OpenAPI 规范匹配
-   make generate-frontend-sdk   # 更新前端客户端
+   make api-generate-models         # 确保模型与 OpenAPI 规范匹配
+   make api-generate-sdk   # 更新前端客户端
    ```
 4. 数据库迁移：
    ```bash
-   make makemigration    # 生成任何待处理的迁移
+   make db-revision    # 生成任何待处理的迁移
    ```
 5. 全栈集成测试：
    ```bash
-   make compose-up WITH_NEO4J=1 WITH_DOCRAY=1  # 类似生产的设置
+   make stack-up WITH_NEO4J=1 WITH_DOCRAY=1  # 类似生产的设置
    # 在 http://localhost:3000/web/ 手动测试
-   make compose-down
+   make stack-down
    ```
 
 ### Q: 🔄 如何完全重置我的开发环境？
 
 **核选项重置（销毁所有数据）：**
 ```bash
-make compose-down REMOVE_VOLUMES=1  # ⚠️ 停止服务 + 删除所有数据
-make clean                         # 🧹 清理临时文件
+make stack-down REMOVE_VOLUMES=1  # ⚠️ 停止服务 + 删除所有数据
+make env-clean                         # 🧹 清理临时文件
 
 # 重新开始
-make compose-infra                 # 🗄️ 新的数据库
-make migrate                      # 🔄 应用所有迁移
-make run-backend                  # 🚀 启动 API 服务器
-make run-celery                   # ⚡ 启动后台 workers
+make infra-up                 # 🗄️ 新的数据库
+make db-migrate                      # 🔄 应用所有迁移
+make serve-api                  # 🚀 启动 API 服务器
+make serve-worker                   # ⚡ 启动后台 workers
 ```
 
 **软重置（保留数据）：**
 ```bash
-make compose-down                 # ⏹️ 停止服务，保留数据
-make compose-infra               # 🗄️ 重启数据库
-make migrate                    # 🔄 应用任何新迁移
+make stack-down                 # ⏹️ 停止服务，保留数据
+make infra-up               # 🗄️ 重启数据库
+make db-migrate                    # 🔄 应用任何新迁移
 ```
 
 **仅重置 Python 环境：**
 ```bash
 rm -rf .venv/                   # 🗑️ 移除虚拟环境
-make dev                       # ⚙️ 重新创建所有内容
+make env-dev                       # ⚙️ 重新创建所有内容
 source .venv/bin/activate      # ✅ 重新激活
 ``` 

--- a/tests/e2e_pytest/README.md
+++ b/tests/e2e_pytest/README.md
@@ -42,8 +42,8 @@ Ensure ApeRAG services are running:
 ```bash
 # Start ApeRAG services
 cd /path/to/ApeRAG
-make run-backend
-make run-celery
+make serve-api
+make serve-worker
 ```
 
 ### 2. Create Environment Configuration File
@@ -91,7 +91,7 @@ RERANK_MODEL_NAME=BAAI/bge-large-zh-1.5
 
 ```bash
 # Run all e2e tests
-make e2e-test
+make test-e2e
 
 # Run specific test file
 pytest tests/e2e_pytest/test_chat.py

--- a/tests/e2e_pytest/README_zh.md
+++ b/tests/e2e_pytest/README_zh.md
@@ -42,8 +42,8 @@ tests/e2e_pytest/
 ```bash
 # 启动 ApeRAG 服务
 cd /path/to/ApeRAG
-make run-backend
-make run-celery
+make serve-api
+make serve-worker
 ```
 
 ### 2. 创建环境配置文件
@@ -91,7 +91,7 @@ RERANK_MODEL_NAME=BAAI/bge-large-zh-1.5
 
 ```bash
 # 运行所有 e2e 测试
-make e2e-test
+make test-e2e
 
 # 运行特定测试文件
 pytest tests/e2e_pytest/test_chat.py

--- a/web/docs/en-US/development/development-guide.md
+++ b/web/docs/en-US/development/development-guide.md
@@ -33,7 +33,7 @@ Use Docker Compose to start the essential database services:
 
 ```bash
 # Start core databases: PostgreSQL, Redis, Qdrant, Elasticsearch
-make compose-infra
+make infra-up
 ```
 
 This will start all required database services in the background. The default connection settings in your `.env` file are pre-configured to work with these services.
@@ -43,7 +43,7 @@ This will start all required database services in the background. The default co
 
 ```bash
 # Use Neo4j instead of PostgreSQL for graph storage
-make compose-infra WITH_NEO4J=1
+make infra-up WITH_NEO4J=1
 ```
 
 </details>
@@ -53,7 +53,7 @@ make compose-infra WITH_NEO4J=1
 Create Python virtual environment and setup development tools:
 
 ```bash
-make dev
+make env-dev
 ```
 
 This command will:
@@ -75,7 +75,7 @@ You'll know it's active when you see `(.venv)` in your terminal prompt.
 Install all backend and frontend dependencies:
 
 ```bash
-make install
+make env-install
 ```
 
 This command will:
@@ -87,7 +87,7 @@ This command will:
 Setup the database schema:
 
 ```bash
-make migrate
+make db-migrate
 ```
 
 ### 7. ▶️ Start Development Services
@@ -96,19 +96,19 @@ Now you can start the development services. Open separate terminal windows/tabs 
 
 **Terminal 1 - Backend API Server:**
 ```bash
-make run-backend
+make serve-api
 ```
 This starts the FastAPI development server at `http://localhost:8000` with auto-reload on code changes.
 
 **Terminal 2 - Celery Worker:**
 ```bash
-make run-celery
+make serve-worker
 ```
 This starts the Celery worker for processing asynchronous background tasks.
 
 **Terminal 3 - Frontend (Optional):**
 ```bash
-make run-frontend
+make serve-web
 ```
 This starts the frontend development server at `http://localhost:3000` with hot reload.
 
@@ -126,21 +126,21 @@ To stop the development environment:
 **Stop Database Services:**
 ```bash
 # Stop database services (data preserved)
-make compose-down
+make stack-down
 
 # Stop services and remove all data volumes
-make compose-down REMOVE_VOLUMES=1
+make stack-down REMOVE_VOLUMES=1
 ```
 
 **Stop Development Services:**
-- Backend API Server: Press `Ctrl+C` in the terminal running `make run-backend`
-- Celery Worker: Press `Ctrl+C` in the terminal running `make run-celery`
-- Frontend Server: Press `Ctrl+C` in the terminal running `make run-frontend`
+- Backend API Server: Press `Ctrl+C` in the terminal running `make serve-api`
+- Celery Worker: Press `Ctrl+C` in the terminal running `make serve-worker`
+- Frontend Server: Press `Ctrl+C` in the terminal running `make serve-web`
 
 **Data Management:**
-- `make compose-down` - Stops services but preserves all data (PostgreSQL, Redis, Qdrant, etc.)
-- `make compose-down REMOVE_VOLUMES=1` - Stops services and **⚠️ permanently deletes all data**
-- You can run `make compose-down REMOVE_VOLUMES=1` even after already running `make compose-down`
+- `make stack-down` - Stops services but preserves all data (PostgreSQL, Redis, Qdrant, etc.)
+- `make stack-down REMOVE_VOLUMES=1` - Stops services and **⚠️ permanently deletes all data**
+- You can run `make stack-down REMOVE_VOLUMES=1` even after already running `make stack-down`
 
 **Verify Data Removal:**
 ```bash
@@ -160,16 +160,16 @@ Now you have ApeRAG running locally from source code, ready for development! �
 1. Edit OpenAPI specification: `aperag/api/paths/[endpoint-name].yaml`
 2. Regenerate backend models:
    ```bash
-   make generate-models  # This runs merge-openapi internally
+   make api-generate-models  # This runs merge-openapi internally
    ```
 3. Implement backend view: `aperag/views/[module].py`
 4. Generate frontend TypeScript client:
    ```bash
-   make generate-frontend-sdk  # Updates frontend/src/api/
+   make api-generate-sdk  # Updates frontend/src/api/
    ```
 5. Test the API:
    ```bash
-   make test
+   make test-all
    # ✅ Check live docs: http://localhost:8000/docs
    ```
 
@@ -179,16 +179,16 @@ Now you have ApeRAG running locally from source code, ready for development! �
 1. Edit SQLModel classes in `aperag/db/models.py`
 2. Generate migration file:
    ```bash
-   make makemigration  # Creates new migration in migration/versions/
+   make db-revision  # Creates new migration in migration/versions/
    ```
 3. Apply migration to database:
    ```bash
-   make migrate  # Updates database schema
+   make db-migrate  # Updates database schema
    ```
 4. Update related code (repositories in `aperag/db/repositories/`, services in `aperag/service/`)
 5. Verify changes:
    ```bash
-   make test  # ✅ Ensure everything works
+   make test-all  # ✅ Ensure everything works
    ```
 
 ### Q: ⚡ How do I add a new feature with background processing?
@@ -200,14 +200,14 @@ Now you have ApeRAG running locally from source code, ready for development! �
    - Database models: `aperag/db/models.py`
 2. Update API and generate code:
    ```bash
-   make makemigration      # Generate migration files
-   make migrate           # Apply database changes
-   make generate-models   # Update Pydantic models
-   make generate-frontend-sdk  # Update TypeScript client
+   make db-revision      # Generate migration files
+   make db-migrate           # Apply database changes
+   make api-generate-models   # Update Pydantic models
+   make api-generate-sdk  # Update TypeScript client
    ```
 3. Quality assurance:
    ```bash
-   make format && make lint && make test
+   make format && make lint && make test-all
    ```
 
 ### Q: 🧪 How do I run unit tests and e2e tests?
@@ -215,7 +215,7 @@ Now you have ApeRAG running locally from source code, ready for development! �
 **Unit Tests (Fast, No External Dependencies):**
 ```bash
 # Run all unit tests
-make unit-test
+make test-unit
 
 # Run specific test file
 uv run pytest tests/unit_test/test_model_service.py -v
@@ -230,11 +230,11 @@ uv run pytest tests/unit_test/ --cov=aperag --cov-report=html
 **E2E Tests (Require Running Services):**
 ```bash
 # Setup: Start required services first
-make compose-infra      # 🗄️ Start databases
-make run-backend       # 🚀 Start API server (separate terminal)
+make infra-up      # 🗄️ Start databases
+make serve-api       # 🚀 Start API server (separate terminal)
 
 # Run all e2e tests
-make e2e-test
+make test-e2e
 
 # Run specific e2e test modules
 uv run pytest tests/e2e_test/test_chat/ -v
@@ -244,17 +244,17 @@ uv run pytest tests/e2e_test/graphstorage/ -v
 uv run pytest tests/e2e_test/test_specific.py -v -s
 
 # Performance benchmarks (with timing)
-make e2e-performance-test
+make test-e2e-perf
 ```
 
 **Complete Test Suite:**
 ```bash
 # Run everything (unit + e2e)
-make test
+make test-all
 
 # Test with different configurations
-make compose-infra WITH_NEO4J=1  # Test with Neo4j instead of PostgreSQL
-make test
+make infra-up WITH_NEO4J=1  # Test with Neo4j instead of PostgreSQL
+make test-all
 ```
 
 ### Q: 🐛 How do I debug failing tests?
@@ -270,9 +270,9 @@ make test
    ```
 2. For e2e test failures, ensure services are running:
    ```bash
-   make compose-infra       # Database services
-   make run-backend         # API server
-   make run-celery         # Background workers (if testing async tasks)
+   make infra-up       # Database services
+   make serve-api         # API server
+   make serve-worker         # Background workers (if testing async tasks)
    ```
 3. Use debugging tools:
    ```bash
@@ -294,9 +294,9 @@ make test
 **Evaluation workflow:**
 ```bash
 # Ensure environment is ready
-make compose-infra WITH_NEO4J=1  # Use Neo4j for better graph performance
-make run-backend
-make run-celery
+make infra-up WITH_NEO4J=1  # Use Neo4j for better graph performance
+make serve-api
+make serve-worker
 
 # Run comprehensive RAG evaluation
 make evaluate               # 📊 Runs aperag.evaluation.run module
@@ -310,8 +310,8 @@ make evaluate               # 📊 Runs aperag.evaluation.run module
 1. Edit `pyproject.toml` (add/update packages)
 2. Update virtual environment:
    ```bash
-   make install            # Syncs all groups and extras with uv
-   make test              # Verify compatibility
+   make env-install            # Syncs all groups and extras with uv
+   make test-all              # Verify compatibility
    ```
 
 **Frontend dependencies:**
@@ -319,8 +319,8 @@ make evaluate               # 📊 Runs aperag.evaluation.run module
 2. Update and test:
    ```bash
    cd frontend && yarn install
-   make run-frontend      # Test frontend compilation
-   make generate-frontend-sdk  # Ensure API client still works
+   make serve-web      # Test frontend compilation
+   make api-generate-sdk  # Ensure API client still works
    ```
 
 ### Q: 🚀 How do I prepare code for production deployment?
@@ -334,49 +334,49 @@ make evaluate               # 📊 Runs aperag.evaluation.run module
    ```
 2. Comprehensive testing:
    ```bash
-   make test             # All unit + e2e tests
-   make e2e-performance-test  # Performance benchmarks
+   make test-all             # All unit + e2e tests
+   make test-e2e-perf  # Performance benchmarks
    ```
 3. API consistency:
    ```bash
-   make generate-models         # Ensure models match OpenAPI spec
-   make generate-frontend-sdk   # Update frontend client
+   make api-generate-models         # Ensure models match OpenAPI spec
+   make api-generate-sdk   # Update frontend client
    ```
 4. Database migrations:
    ```bash
-   make makemigration    # Generate any pending migrations
+   make db-revision    # Generate any pending migrations
    ```
 5. Full-stack integration test:
    ```bash
-   make compose-up WITH_NEO4J=1 WITH_DOCRAY=1  # Production-like setup
+   make stack-up WITH_NEO4J=1 WITH_DOCRAY=1  # Production-like setup
    # Manual testing at http://localhost:3000/web/
-   make compose-down
+   make stack-down
    ```
 
 ### Q: 🔄 How do I completely reset my development environment?
 
 **Nuclear reset (destroys all data):**
 ```bash
-make compose-down REMOVE_VOLUMES=1  # ⚠️ Stop services + delete ALL data
-make clean                         # 🧹 Clean temporary files
+make stack-down REMOVE_VOLUMES=1  # ⚠️ Stop services + delete ALL data
+make env-clean                         # 🧹 Clean temporary files
 
 # Restart fresh
-make compose-infra                 # 🗄️ Fresh databases
-make migrate                      # 🔄 Apply all migrations
-make run-backend                  # 🚀 Start API server
-make run-celery                   # ⚡ Start background workers
+make infra-up                 # 🗄️ Fresh databases
+make db-migrate                      # 🔄 Apply all migrations
+make serve-api                  # 🚀 Start API server
+make serve-worker                   # ⚡ Start background workers
 ```
 
 **Soft reset (preserve data):**
 ```bash
-make compose-down                 # ⏹️ Stop services, keep data
-make compose-infra               # 🗄️ Restart databases
-make migrate                    # 🔄 Apply any new migrations
+make stack-down                 # ⏹️ Stop services, keep data
+make infra-up               # 🗄️ Restart databases
+make db-migrate                    # 🔄 Apply any new migrations
 ```
 
 **Reset just Python environment:**
 ```bash
 rm -rf .venv/                   # 🗑️ Remove virtual environment
-make dev                       # ⚙️ Recreate everything
+make env-dev                       # ⚙️ Recreate everything
 source .venv/bin/activate      # ✅ Reactivate
 ```

--- a/web/docs/zh-CN/development/development-guide.md
+++ b/web/docs/zh-CN/development/development-guide.md
@@ -38,7 +38,7 @@ cp envs/env.template .env
 
 ```bash
 # 启动核心数据库：PostgreSQL、Redis、Qdrant、Elasticsearch
-make compose-infra
+make infra-up
 ```
 
 这将在后台启动所有必需的数据库服务。您的 `.env` 文件中的默认连接设置已预配置为与这些服务一起工作。
@@ -48,7 +48,7 @@ make compose-infra
 
 ```bash
 # 使用 Neo4j 而不是 PostgreSQL 进行图存储
-make compose-infra WITH_NEO4J=1
+make infra-up WITH_NEO4J=1
 ```
 
 </details>
@@ -58,7 +58,7 @@ make compose-infra WITH_NEO4J=1
 创建 Python 虚拟环境并设置开发工具：
 
 ```bash
-make dev
+make env-dev
 ```
 
 此命令将：
@@ -80,7 +80,7 @@ source .venv/bin/activate
 安装所有后端和前端依赖项：
 
 ```bash
-make install
+make env-install
 ```
 
 此命令将：
@@ -92,7 +92,7 @@ make install
 设置数据库架构：
 
 ```bash
-make migrate
+make db-migrate
 ```
 
 ### 7. ▶️ 启动开发服务
@@ -101,19 +101,19 @@ make migrate
 
 **终端 1 - 后端 API 服务器：**
 ```bash
-make run-backend
+make serve-api
 ```
 这将在 `http://localhost:8000` 启动 FastAPI 开发服务器，代码更改时自动重新加载。
 
 **终端 2 - Celery Worker：**
 ```bash
-make run-celery
+make serve-worker
 ```
 这将启动 Celery worker 以处理异步后台任务。
 
 **终端 3 - 前端（可选）：**
 ```bash
-make run-frontend
+make serve-web
 ```
 这将在 `http://localhost:3000` 启动前端开发服务器，支持热重载。
 
@@ -131,21 +131,21 @@ make run-frontend
 **停止数据库服务：**
 ```bash
 # 停止数据库服务（保留数据）
-make compose-down
+make stack-down
 
 # 停止服务并移除所有数据卷
-make compose-down REMOVE_VOLUMES=1
+make stack-down REMOVE_VOLUMES=1
 ```
 
 **停止开发服务：**
-- 后端 API 服务器：在运行 `make run-backend` 的终端中按 `Ctrl+C`
-- Celery Worker：在运行 `make run-celery` 的终端中按 `Ctrl+C`
-- 前端服务器：在运行 `make run-frontend` 的终端中按 `Ctrl+C`
+- 后端 API 服务器：在运行 `make serve-api` 的终端中按 `Ctrl+C`
+- Celery Worker：在运行 `make serve-worker` 的终端中按 `Ctrl+C`
+- 前端服务器：在运行 `make serve-web` 的终端中按 `Ctrl+C`
 
 **数据管理：**
-- `make compose-down` - 停止服务但保留所有数据（PostgreSQL、Redis、Qdrant 等）
-- `make compose-down REMOVE_VOLUMES=1` - 停止服务并**⚠️ 永久删除所有数据**
-- 即使已经运行过 `make compose-down`，您也可以运行 `make compose-down REMOVE_VOLUMES=1`
+- `make stack-down` - 停止服务但保留所有数据（PostgreSQL、Redis、Qdrant 等）
+- `make stack-down REMOVE_VOLUMES=1` - 停止服务并**⚠️ 永久删除所有数据**
+- 即使已经运行过 `make stack-down`，您也可以运行 `make stack-down REMOVE_VOLUMES=1`
 
 **验证数据移除：**
 ```bash
@@ -165,16 +165,16 @@ docker volume ls | grep aperag
 1. 编辑 OpenAPI 规范：`aperag/api/paths/[endpoint-name].yaml`
 2. 重新生成后端模型：
    ```bash
-   make generate-models  # 这会在内部运行 merge-openapi
+   make api-generate-models  # 这会在内部运行 merge-openapi
    ```
 3. 实现后端视图：`aperag/views/[module].py`
 4. 生成前端 TypeScript 客户端：
    ```bash
-   make generate-frontend-sdk  # 更新 frontend/src/api/
+   make api-generate-sdk  # 更新 frontend/src/api/
    ```
 5. 测试 API：
    ```bash
-   make test
+   make test-all
    # ✅ 检查实时文档：http://localhost:8000/docs
    ```
 
@@ -184,16 +184,16 @@ docker volume ls | grep aperag
 1. 编辑 `aperag/db/models.py` 中的 SQLModel 类
 2. 生成迁移文件：
    ```bash
-   make makemigration  # 在 migration/versions/ 中创建新迁移
+   make db-revision  # 在 migration/versions/ 中创建新迁移
    ```
 3. 将迁移应用到数据库：
    ```bash
-   make migrate  # 更新数据库架构
+   make db-migrate  # 更新数据库架构
    ```
 4. 更新相关代码（`aperag/db/repositories/` 中的仓库，`aperag/service/` 中的服务）
 5. 验证更改：
    ```bash
-   make test  # ✅ 确保一切正常工作
+   make test-all  # ✅ 确保一切正常工作
    ```
 
 ### Q: ⚡ 如何添加具有后台处理的新功能？
@@ -205,14 +205,14 @@ docker volume ls | grep aperag
    - 数据库模型：`aperag/db/models.py`
 2. 更新 API 并生成代码：
    ```bash
-   make makemigration      # 生成迁移文件
-   make migrate           # 应用数据库更改
-   make generate-models   # 更新 Pydantic 模型
-   make generate-frontend-sdk  # 更新 TypeScript 客户端
+   make db-revision      # 生成迁移文件
+   make db-migrate           # 应用数据库更改
+   make api-generate-models   # 更新 Pydantic 模型
+   make api-generate-sdk  # 更新 TypeScript 客户端
    ```
 3. 质量保证：
    ```bash
-   make format && make lint && make test
+   make format && make lint && make test-all
    ```
 
 ### Q: 🧪 如何运行单元测试和 e2e 测试？
@@ -220,7 +220,7 @@ docker volume ls | grep aperag
 **单元测试（快速，无外部依赖）：**
 ```bash
 # 运行所有单元测试
-make unit-test
+make test-unit
 
 # 运行特定测试文件
 uv run pytest tests/unit_test/test_model_service.py -v
@@ -235,11 +235,11 @@ uv run pytest tests/unit_test/ --cov=aperag --cov-report=html
 **E2E 测试（需要运行服务）：**
 ```bash
 # 设置：首先启动所需服务
-make compose-infra      # 🗄️ 启动数据库
-make run-backend       # 🚀 启动 API 服务器（单独终端）
+make infra-up      # 🗄️ 启动数据库
+make serve-api       # 🚀 启动 API 服务器（单独终端）
 
 # 运行所有 e2e 测试
-make e2e-test
+make test-e2e
 
 # 运行特定 e2e 测试模块
 uv run pytest tests/e2e_test/test_chat/ -v
@@ -249,17 +249,17 @@ uv run pytest tests/e2e_test/graphstorage/ -v
 uv run pytest tests/e2e_test/test_specific.py -v -s
 
 # 性能基准测试（带计时）
-make e2e-performance-test
+make test-e2e-perf
 ```
 
 **完整测试套件：**
 ```bash
 # 运行所有内容（单元 + e2e）
-make test
+make test-all
 
 # 使用不同配置进行测试
-make compose-infra WITH_NEO4J=1  # 使用 Neo4j 而不是 PostgreSQL 进行测试
-make test
+make infra-up WITH_NEO4J=1  # 使用 Neo4j 而不是 PostgreSQL 进行测试
+make test-all
 ```
 
 ### Q: 🐛 如何调试失败的测试？
@@ -275,9 +275,9 @@ make test
    ```
 2. 对于 e2e 测试失败，确保服务正在运行：
    ```bash
-   make compose-infra       # 数据库服务
-   make run-backend         # API 服务器
-   make run-celery         # 后台 workers（如果测试异步任务）
+   make infra-up       # 数据库服务
+   make serve-api         # API 服务器
+   make serve-worker         # 后台 workers（如果测试异步任务）
    ```
 3. 使用调试工具：
    ```bash
@@ -299,9 +299,9 @@ make test
 **评估工作流程：**
 ```bash
 # 确保环境准备就绪
-make compose-infra WITH_NEO4J=1  # 使用 Neo4j 获得更好的图性能
-make run-backend
-make run-celery
+make infra-up WITH_NEO4J=1  # 使用 Neo4j 获得更好的图性能
+make serve-api
+make serve-worker
 
 # 运行全面的 RAG 评估
 make evaluate               # 📊 运行 aperag.evaluation.run 模块
@@ -315,8 +315,8 @@ make evaluate               # 📊 运行 aperag.evaluation.run 模块
 1. 编辑 `pyproject.toml`（添加/更新包）
 2. 更新虚拟环境：
    ```bash
-   make install            # 使用 uv 同步所有组和额外内容
-   make test              # 验证兼容性
+   make env-install            # 使用 uv 同步所有组和额外内容
+   make test-all              # 验证兼容性
    ```
 
 **前端依赖项：**
@@ -324,8 +324,8 @@ make evaluate               # 📊 运行 aperag.evaluation.run 模块
 2. 更新并测试：
    ```bash
    cd frontend && yarn install
-   make run-frontend      # 测试前端编译
-   make generate-frontend-sdk  # 确保 API 客户端仍然工作
+   make serve-web      # 测试前端编译
+   make api-generate-sdk  # 确保 API 客户端仍然工作
    ```
 
 ### Q: 🚀 如何准备代码进行生产部署？
@@ -339,49 +339,49 @@ make evaluate               # 📊 运行 aperag.evaluation.run 模块
    ```
 2. 全面测试：
    ```bash
-   make test             # 所有单元 + e2e 测试
-   make e2e-performance-test  # 性能基准测试
+   make test-all             # 所有单元 + e2e 测试
+   make test-e2e-perf  # 性能基准测试
    ```
 3. API 一致性：
    ```bash
-   make generate-models         # 确保模型与 OpenAPI 规范匹配
-   make generate-frontend-sdk   # 更新前端客户端
+   make api-generate-models         # 确保模型与 OpenAPI 规范匹配
+   make api-generate-sdk   # 更新前端客户端
    ```
 4. 数据库迁移：
    ```bash
-   make makemigration    # 生成任何待处理的迁移
+   make db-revision    # 生成任何待处理的迁移
    ```
 5. 全栈集成测试：
    ```bash
-   make compose-up WITH_NEO4J=1 WITH_DOCRAY=1  # 类似生产的设置
+   make stack-up WITH_NEO4J=1 WITH_DOCRAY=1  # 类似生产的设置
    # 在 http://localhost:3000/web/ 手动测试
-   make compose-down
+   make stack-down
    ```
 
 ### Q: 🔄 如何完全重置我的开发环境？
 
 **核选项重置（销毁所有数据）：**
 ```bash
-make compose-down REMOVE_VOLUMES=1  # ⚠️ 停止服务 + 删除所有数据
-make clean                         # 🧹 清理临时文件
+make stack-down REMOVE_VOLUMES=1  # ⚠️ 停止服务 + 删除所有数据
+make env-clean                         # 🧹 清理临时文件
 
 # 重新开始
-make compose-infra                 # 🗄️ 新的数据库
-make migrate                      # 🔄 应用所有迁移
-make run-backend                  # 🚀 启动 API 服务器
-make run-celery                   # ⚡ 启动后台 workers
+make infra-up                 # 🗄️ 新的数据库
+make db-migrate                      # 🔄 应用所有迁移
+make serve-api                  # 🚀 启动 API 服务器
+make serve-worker                   # ⚡ 启动后台 workers
 ```
 
 **软重置（保留数据）：**
 ```bash
-make compose-down                 # ⏹️ 停止服务，保留数据
-make compose-infra               # 🗄️ 重启数据库
-make migrate                    # 🔄 应用任何新迁移
+make stack-down                 # ⏹️ 停止服务，保留数据
+make infra-up               # 🗄️ 重启数据库
+make db-migrate                    # 🔄 应用任何新迁移
 ```
 
 **仅重置 Python 环境：**
 ```bash
 rm -rf .venv/                   # 🗑️ 移除虚拟环境
-make dev                       # ⚙️ 重新创建所有内容
+make env-dev                       # ⚙️ 重新创建所有内容
 source .venv/bin/activate      # ✅ 重新激活
 ```


### PR DESCRIPTION
## Summary
- rename public Make targets into clearer env/db/stack/serve/test/api groups
- remove legacy command aliases instead of keeping compatibility wrappers
- update docs, pytest e2e READMEs, and CI references to the new command surface

## Validation
- `git diff --check`
- `make help`
- `make -n env-install env-dev env-clean db-migrate db-revision infra-up stack-up stack-down stack-logs serve-api serve-worker serve-beat serve-flower serve-web test-all test-unit test-integration test-e2e test-e2e-perf test-http-bootstrap test-http-smoke test-http-full test-http-up-compose test-http-down-compose test-http-smoke-compose test-http-full-compose test-http-up-k8s test-http-down-k8s test-http-smoke-k8s test-http-full-k8s api-generate-models api-generate-sdk release-version`
- repo scan confirms removed old command names are no longer referenced
