### PR TITLE
perf: optimize graph export and incident-edge fetches

### DIFF
--- a/aperag/db/repositories/graph.py
+++ b/aperag/db/repositories/graph.py
@@ -576,6 +576,23 @@ class GraphRepositoryMixin:
 
         return self._execute_query(_get_top_degree_graph_nodes)
 
+    def get_graph_node_ids(self, workspace: str, limit: Optional[int] = None) -> List[str]:
+        """Get graph node IDs directly, optionally with a limit."""
+
+        def _get_graph_node_ids(session):
+            stmt = (
+                select(LightRAGGraphNode.entity_id)
+                .where(LightRAGGraphNode.workspace == workspace)
+                .order_by(LightRAGGraphNode.entity_id)
+            )
+            if limit is not None:
+                stmt = stmt.limit(limit)
+
+            result = session.execute(stmt)
+            return [row[0] for row in result]
+
+        return self._execute_query(_get_graph_node_ids)
+
     def get_graph_edges_batch(
         self, workspace: str, edge_pairs: List[Tuple[str, str]]
     ) -> Dict[Tuple[str, str], Dict[str, Any]]:
@@ -670,6 +687,75 @@ class GraphRepositoryMixin:
             return edges_dict
 
         return self._execute_query(_get_nodes_edges_batch)
+
+    def get_graph_incident_edges_with_data_batch(
+        self, workspace: str, node_ids: List[str]
+    ) -> Dict[str, List[Tuple[str, str, Dict[str, Any]]]]:
+        """Get incident edges with edge payloads for multiple nodes in one query."""
+        if not node_ids:
+            return {}
+
+        def _get_incident_edges_with_data_batch(session):
+            query = text("""
+                WITH outgoing_edges AS (
+                    SELECT
+                        e.source_entity_id AS node_id,
+                        e.source_entity_id,
+                        e.target_entity_id,
+                        e.weight,
+                        e.keywords,
+                        e.description,
+                        e.source_id,
+                        e.file_path
+                    FROM lightrag_graph_edges e
+                    WHERE e.workspace = :workspace
+                      AND e.source_entity_id = ANY(:node_ids)
+                ),
+                incoming_edges AS (
+                    SELECT
+                        e.target_entity_id AS node_id,
+                        e.source_entity_id,
+                        e.target_entity_id,
+                        e.weight,
+                        e.keywords,
+                        e.description,
+                        e.source_id,
+                        e.file_path
+                    FROM lightrag_graph_edges e
+                    WHERE e.workspace = :workspace
+                      AND e.target_entity_id = ANY(:node_ids)
+                )
+                SELECT *
+                FROM outgoing_edges
+                UNION ALL
+                SELECT *
+                FROM incoming_edges
+                ORDER BY node_id, source_entity_id, target_entity_id
+            """)
+
+            result = session.execute(query, {"workspace": workspace, "node_ids": node_ids})
+            edges_dict = {node_id: [] for node_id in node_ids}
+
+            for row in result:
+                node_id = row.node_id
+                edge_data = {
+                    "weight": float(row.weight) if row.weight is not None else 0.0,
+                    "keywords": row.keywords,
+                    "description": row.description,
+                    "source_id": row.source_id,
+                    "file_path": row.file_path,
+                }
+                required_fields = {"weight", "keywords", "description", "source_id"}
+                filtered_edge_data = {}
+                for key, value in edge_data.items():
+                    if key in required_fields or value is not None:
+                        filtered_edge_data[key] = value
+
+                edges_dict[node_id].append((row.source_entity_id, row.target_entity_id, filtered_edge_data))
+
+            return edges_dict
+
+        return self._execute_query(_get_incident_edges_with_data_batch)
 
     def delete_graph_nodes_batch(self, workspace: str, node_ids: List[str]) -> None:
         """Delete multiple nodes and their edges in batch using efficient SQL"""

--- a/aperag/graph/lightrag/base.py
+++ b/aperag/graph/lightrag/base.py
@@ -494,7 +494,12 @@ class BaseGraphStorage(StorageNameSpace, ABC):
         return None
 
     async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
-        """Return node IDs without fetching full node payloads when backend supports it."""
+        """Return node IDs in stable ascending ID order without fetching full payloads.
+
+        Backends that implement this hook should return the same deterministic prefix
+        for a given workspace and limit so higher-level exports do not become
+        backend-dependent.
+        """
         return None
 
     @abstractmethod

--- a/aperag/graph/lightrag/base.py
+++ b/aperag/graph/lightrag/base.py
@@ -493,6 +493,10 @@ class BaseGraphStorage(StorageNameSpace, ABC):
         """Return top-degree nodes plus total node count when backend supports it."""
         return None
 
+    async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
+        """Return node IDs without fetching full node payloads when backend supports it."""
+        return None
+
     @abstractmethod
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
         """Insert a new node or update an existing node in the graph.

--- a/aperag/graph/lightrag/kg/nebula_sync_impl.py
+++ b/aperag/graph/lightrag/kg/nebula_sync_impl.py
@@ -465,6 +465,55 @@ class NebulaSyncStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_nodes_edges_batch)
 
+    async def get_incident_edges_with_data_batch(self, node_ids: list[str]) -> dict[str, list[tuple[str, str, dict]]]:
+        """Retrieve incident edges with edge payloads for multiple nodes in batches."""
+
+        def _sync_get_incident_edges_with_data_batch():
+            with NebulaSyncConnectionManager.get_session(space=self._space_name) as session:
+                if not node_ids:
+                    return {}
+
+                edges_dict = {node_id: [] for node_id in node_ids}
+                batch_size = 100
+
+                for i in range(0, len(node_ids), batch_size):
+                    batch_ids = node_ids[i : i + batch_size]
+                    query = """
+                    UNWIND $node_ids AS node_id
+                    MATCH (v)-[r:DIRECTED]-(connected)
+                    WHERE id(v) == node_id
+                    RETURN node_id, id(v) as src, id(connected) as dst, properties(r) as props
+                    """
+                    result = session.execute_parameter(query, _prepare_nebula_params({"node_ids": batch_ids}))
+                    node_edges_sets = {node_id: set() for node_id in batch_ids}
+
+                    if result.is_succeeded():
+                        for row in result:
+                            source_node_id = row.values()[0].as_string()
+                            src = row.values()[1].as_string()
+                            dst = row.values()[2].as_string()
+                            props = row.values()[3].as_map()
+                            edge_pair = (src, dst)
+                            if edge_pair in node_edges_sets[source_node_id]:
+                                continue
+                            node_edges_sets[source_node_id].add(edge_pair)
+
+                            edge_data = self._convert_nebula_value_map(props)
+                            for key, default_value in {
+                                "weight": 0.0,
+                                "source_id": None,
+                                "description": None,
+                                "keywords": None,
+                            }.items():
+                                if key not in edge_data:
+                                    edge_data[key] = default_value
+
+                            edges_dict[source_node_id].append((src, dst, edge_data))
+
+                return edges_dict
+
+        return await asyncio.to_thread(_sync_get_incident_edges_with_data_batch)
+
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
         """Upsert a node in the database."""
 
@@ -549,6 +598,28 @@ class NebulaSyncStorage(BaseGraphStorage):
                 return list(set(labels))
 
         return await asyncio.to_thread(_sync_get_all_labels)
+
+    async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
+        """Get node IDs directly without fetching full node payloads."""
+
+        def _sync_get_node_ids():
+            with NebulaSyncConnectionManager.get_session(space=self._space_name) as session:
+                query = "MATCH (v:base) RETURN id(v) as vid ORDER BY vid"
+                if limit is not None:
+                    query += " LIMIT $limit"
+                    result = session.execute_parameter(query, _prepare_nebula_params({"limit": limit}))
+                else:
+                    result = session.execute(query)
+
+                node_ids = []
+                if result.is_succeeded():
+                    for row in result:
+                        node_id = row.values()[0].as_string()
+                        if node_id:
+                            node_ids.append(node_id)
+                return node_ids
+
+        return await asyncio.to_thread(_sync_get_node_ids)
 
     async def delete_node(self, node_id: str) -> None:
         """Delete a node and its incident edges."""

--- a/aperag/graph/lightrag/kg/neo4j_sync_impl.py
+++ b/aperag/graph/lightrag/kg/neo4j_sync_impl.py
@@ -376,6 +376,55 @@ class Neo4JSyncStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_nodes_edges_batch)
 
+    async def get_incident_edges_with_data_batch(self, node_ids: list[str]) -> dict[str, list[tuple[str, str, dict]]]:
+        """Batch retrieve incident edges together with edge payloads."""
+
+        def _sync_get_incident_edges_with_data_batch():
+            with Neo4jSyncConnectionManager.get_session(database=self._DATABASE) as session:
+                query = """
+                    UNWIND $node_ids AS id
+                    MATCH (n:base {entity_id: id})
+                    OPTIONAL MATCH (n)-[r]-(connected:base)
+                    RETURN id AS queried_id,
+                           startNode(r).entity_id AS source_entity_id,
+                           endNode(r).entity_id AS target_entity_id,
+                           properties(r) AS edge_properties
+                """
+                result = session.run(query, node_ids=node_ids)
+
+                edges_dict = {node_id: [] for node_id in node_ids}
+                seen_pairs = {node_id: set() for node_id in node_ids}
+
+                for record in result:
+                    queried_id = record["queried_id"]
+                    source_entity_id = record["source_entity_id"]
+                    target_entity_id = record["target_entity_id"]
+                    edge_properties = record["edge_properties"]
+
+                    if not source_entity_id or not target_entity_id or edge_properties is None:
+                        continue
+
+                    edge_pair = (source_entity_id, target_entity_id)
+                    if edge_pair in seen_pairs[queried_id]:
+                        continue
+                    seen_pairs[queried_id].add(edge_pair)
+
+                    edge_data = dict(edge_properties)
+                    for key, default_value in {
+                        "weight": 0.0,
+                        "source_id": None,
+                        "description": None,
+                        "keywords": None,
+                    }.items():
+                        if key not in edge_data:
+                            edge_data[key] = default_value
+
+                    edges_dict[queried_id].append((source_entity_id, target_entity_id, edge_data))
+
+                return edges_dict
+
+        return await asyncio.to_thread(_sync_get_incident_edges_with_data_batch)
+
     async def get_nodes_by_source_ids(self, chunk_ids: list[str]) -> dict[str, dict]:
         """Retrieve nodes whose source_id references any of the provided chunk IDs."""
 
@@ -685,6 +734,26 @@ class Neo4JSyncStorage(BaseGraphStorage):
                 return nodes, total_nodes
 
         return await asyncio.to_thread(_sync_get_top_degree_nodes)
+
+    async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
+        """Get node IDs directly from Neo4j without fetching full node payloads."""
+
+        def _sync_get_node_ids():
+            with Neo4jSyncConnectionManager.get_session(database=self._DATABASE) as session:
+                query = """
+                MATCH (n:base)
+                WHERE n.entity_id IS NOT NULL
+                RETURN DISTINCT n.entity_id AS entity_id
+                ORDER BY entity_id
+                """
+                if limit is not None:
+                    query += "\nLIMIT $limit"
+                    result = session.run(query, limit=limit)
+                else:
+                    result = session.run(query)
+                return [record["entity_id"] for record in result]
+
+        return await asyncio.to_thread(_sync_get_node_ids)
 
     @retry(
         stop=stop_after_attempt(3),

--- a/aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py
+++ b/aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py
@@ -235,6 +235,16 @@ class PGOpsSyncGraphStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_nodes_edges_batch)
 
+    async def get_incident_edges_with_data_batch(self, node_ids: list[str]) -> dict[str, list[tuple[str, str, dict]]]:
+        """Batch retrieve incident edges and edge payloads using optimized SQL."""
+
+        def _sync_get_incident_edges_with_data_batch():
+            from aperag.db.ops import db_ops
+
+            return db_ops.get_graph_incident_edges_with_data_batch(self.workspace, node_ids)
+
+        return await asyncio.to_thread(_sync_get_incident_edges_with_data_batch)
+
     async def delete_node(self, node_id: str) -> None:
         """Delete a node and all its related edges in a single transaction."""
 
@@ -311,6 +321,16 @@ class PGOpsSyncGraphStorage(BaseGraphStorage):
             return db_ops.get_top_degree_graph_nodes(self.workspace, limit)
 
         return await asyncio.to_thread(_sync_get_top_degree_nodes)
+
+    async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
+        """Get node IDs directly from PostgreSQL without fetching full node payloads."""
+
+        def _sync_get_node_ids():
+            from aperag.db.ops import db_ops
+
+            return db_ops.get_graph_node_ids(self.workspace, limit)
+
+        return await asyncio.to_thread(_sync_get_node_ids)
 
     async def get_knowledge_graph(self, node_label: str, max_depth: int = 3, max_nodes: int = 1000) -> KnowledgeGraph:
         """

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -1692,12 +1692,17 @@ class LightRAG:
         try:
             self.lightrag_logger.info(f"Starting KG-Eval export for workspace {self.workspace}")
 
-            # Get all node labels (entity names) - single call
-            all_labels = await self.chunk_entity_relation_graph.get_all_labels()
-            self.lightrag_logger.debug(f"Found {len(all_labels)} entities in workspace {self.workspace}")
+            sampled_labels = await self.chunk_entity_relation_graph.get_node_ids(limit=sample_size)
+            if sampled_labels is None:
+                # Fallback for backends that have not implemented the lighter-weight primitive yet.
+                all_labels = await self.chunk_entity_relation_graph.get_all_labels()
+                self.lightrag_logger.debug(f"Found {len(all_labels)} entities in workspace {self.workspace}")
+                sampled_labels = all_labels[:sample_size] if len(all_labels) > sample_size else all_labels
+            else:
+                self.lightrag_logger.debug(
+                    f"Fetched {len(sampled_labels)} entity ids directly from storage for workspace {self.workspace}"
+                )
 
-            # Sample nodes for export (take first N)
-            sampled_labels = all_labels[:sample_size] if len(all_labels) > sample_size else all_labels
             self.lightrag_logger.debug(f"Sampling {len(sampled_labels)} entities for export")
 
             # Early return if no entities
@@ -1706,10 +1711,10 @@ class LightRAG:
 
             # Batch get all node data and edges in parallel
             nodes_data_task = self.chunk_entity_relation_graph.get_nodes_batch(sampled_labels)
-            nodes_edges_task = self.chunk_entity_relation_graph.get_nodes_edges_batch(sampled_labels)
+            incident_edges_task = self.chunk_entity_relation_graph.get_incident_edges_with_data_batch(sampled_labels)
 
             # Execute both tasks concurrently
-            nodes_data, nodes_edges = await asyncio.gather(nodes_data_task, nodes_edges_task)
+            nodes_data, incident_edges = await asyncio.gather(nodes_data_task, incident_edges_task)
 
             # Prepare entities list in KG-Eval format (direct iteration, no redundant operations)
             entities = [
@@ -1723,23 +1728,18 @@ class LightRAG:
 
             # Collect edge pairs that connect our sampled nodes (optimized filtering)
             sampled_labels_set = set(sampled_labels)  # O(1) lookup
-            edge_pairs_to_query = {
-                (source_entity_id, target_entity_id)
-                for edges in nodes_edges.values()
-                for source_entity_id, target_entity_id in edges
-                if source_entity_id in sampled_labels_set and target_entity_id in sampled_labels_set
-            }
+            deduped_edges = {}
+            for edge_list in incident_edges.values():
+                for source_entity_id, target_entity_id, edge_data in edge_list:
+                    if source_entity_id in sampled_labels_set and target_entity_id in sampled_labels_set:
+                        deduped_edges.setdefault((source_entity_id, target_entity_id), edge_data)
 
-            self.lightrag_logger.debug(f"Found {len(edge_pairs_to_query)} edges between sampled entities")
+            self.lightrag_logger.debug(f"Found {len(deduped_edges)} edges between sampled entities")
 
-            # Batch get edge details (single call)
+            # Process relationships from already-fetched incident edge payloads
             relationships = []
-            edges_data = {}
-            if edge_pairs_to_query:
-                edge_pairs_list = [{"src": src, "tgt": tgt} for src, tgt in edge_pairs_to_query]
-                edges_data = await self.chunk_entity_relation_graph.get_edges_batch(edge_pairs_list)
-
-                # Process relationships efficiently
+            edges_data = deduped_edges
+            if deduped_edges:
                 relationships = [
                     {
                         "source_entity_name": nodes_data.get(source_entity_id, {}).get("entity_name", source_entity_id),
@@ -1748,7 +1748,7 @@ class LightRAG:
                         "keywords": [kw.strip() for kw in edge_data.get("keywords", "").split(",") if kw.strip()],
                         "weight": float(edge_data.get("weight", 0.0)),
                     }
-                    for (source_entity_id, target_entity_id), edge_data in edges_data.items()
+                    for (source_entity_id, target_entity_id), edge_data in deduped_edges.items()
                 ]
 
             # Initialize result

--- a/aperag/graph/lightrag/operate.py
+++ b/aperag/graph/lightrag/operate.py
@@ -1292,9 +1292,22 @@ async def _find_most_related_text_unit_from_entities(
     ]
 
     node_names = [dp["entity_name"] for dp in node_datas]
-    batch_edges_dict = await knowledge_graph_inst.get_nodes_edges_batch(node_names)
+    incident_edges_dict = await knowledge_graph_inst.get_incident_edges_with_data_batch(node_names)
+
+    def _normalize_incident_edges(node_name: str, incident_edges: list[tuple[str, str, dict]]) -> list[tuple[str, str]]:
+        normalized_edges = []
+        seen = set()
+        for src_id, tgt_id, _edge_data in incident_edges or []:
+            other_node = tgt_id if src_id == node_name else src_id
+            normalized_edge = (node_name, other_node)
+            if normalized_edge in seen:
+                continue
+            seen.add(normalized_edge)
+            normalized_edges.append(normalized_edge)
+        return normalized_edges
+
     # Build the edges list in the same order as node_datas.
-    edges = [batch_edges_dict.get(name, []) for name in node_names]
+    edges = [_normalize_incident_edges(name, incident_edges_dict.get(name, [])) for name in node_names]
 
     all_one_hop_nodes = set()
     for this_edges in edges:
@@ -1379,35 +1392,29 @@ async def _find_most_related_edges_from_entities(
     tokenizer: Tokenizer,
 ):
     node_names = [dp["entity_name"] for dp in node_datas]
-    batch_edges_dict = await knowledge_graph_inst.get_nodes_edges_batch(node_names)
+    incident_edges_dict = await knowledge_graph_inst.get_incident_edges_with_data_batch(node_names)
 
     all_edges = []
     seen = set()
+    deduped_edge_data = {}
 
     for node_name in node_names:
-        this_edges = batch_edges_dict.get(node_name, [])
-        for e in this_edges:
-            sorted_edge = tuple(sorted(e))
+        for src_id, tgt_id, edge_data in incident_edges_dict.get(node_name, []):
+            sorted_edge = tuple(sorted((src_id, tgt_id)))
             if sorted_edge not in seen:
                 seen.add(sorted_edge)
                 all_edges.append(sorted_edge)
+                deduped_edge_data[sorted_edge] = edge_data
 
-    # Prepare edge pairs in two forms:
-    # For the batch edge properties function, use dicts.
-    edge_pairs_dicts = [{"src": e[0], "tgt": e[1]} for e in all_edges]
     # For edge degrees, use tuples.
     edge_pairs_tuples = list(all_edges)  # all_edges is already a list of tuples
 
-    # Call the batched functions concurrently.
-    edge_data_dict, edge_degrees_dict = await asyncio.gather(
-        knowledge_graph_inst.get_edges_batch(edge_pairs_dicts),
-        knowledge_graph_inst.edge_degrees_batch(edge_pairs_tuples),
-    )
+    edge_degrees_dict = await knowledge_graph_inst.edge_degrees_batch(edge_pairs_tuples)
 
     # Reconstruct edge_datas list in the same order as the deduplicated results.
     all_edges_data = []
     for pair in all_edges:
-        edge_props = edge_data_dict.get(pair)
+        edge_props = deduped_edge_data.get(pair)
         if edge_props is not None:
             if "weight" not in edge_props:
                 logger.warning(f"Edge {pair} missing 'weight' attribute, using default value 0.0")

--- a/tests/integration/graphstorage/graph_storage_oracle.py
+++ b/tests/integration/graphstorage/graph_storage_oracle.py
@@ -674,7 +674,7 @@ class GraphStorageOracle(BaseGraphStorage):
             raise
 
     async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
-        """Get node IDs while allowing backend-specific ordering differences."""
+        """Get node IDs with deterministic ordering comparison."""
         self._operation_count += 1
         operation_id = f"get_node_ids#{self._operation_count}"
 
@@ -692,14 +692,14 @@ class GraphStorageOracle(BaseGraphStorage):
                     f"  Baseline: {baseline_result}"
                 )
 
-            baseline_all_labels = set(await self.baseline.get_all_labels())
-            storage_all_labels = set(await self.storage.get_all_labels())
+            baseline_all_labels = sorted(await self.baseline.get_all_labels())
+            storage_all_labels = sorted(await self.storage.get_all_labels())
 
             if baseline_all_labels != storage_all_labels:
                 raise AssertionError(
                     f"Oracle mismatch (label universe) in '{operation_id}':\n"
-                    f"  Storage labels:  {sorted(storage_all_labels)}\n"
-                    f"  Baseline labels: {sorted(baseline_all_labels)}"
+                    f"  Storage labels:  {storage_all_labels}\n"
+                    f"  Baseline labels: {baseline_all_labels}"
                 )
 
             if len(storage_result) != len(set(storage_result)):
@@ -708,16 +708,21 @@ class GraphStorageOracle(BaseGraphStorage):
             if len(baseline_result) != len(set(baseline_result)):
                 raise AssertionError(f"Oracle mismatch in '{operation_id}': baseline returned duplicate node IDs")
 
-            if not set(storage_result).issubset(storage_all_labels):
+            if not set(storage_result).issubset(set(storage_all_labels)):
                 raise AssertionError(f"Oracle mismatch in '{operation_id}': storage returned unknown node IDs")
 
-            if not set(baseline_result).issubset(baseline_all_labels):
+            if not set(baseline_result).issubset(set(baseline_all_labels)):
                 raise AssertionError(f"Oracle mismatch in '{operation_id}': baseline returned unknown node IDs")
 
+            expected_result = baseline_all_labels[:limit] if limit is not None else baseline_all_labels
+
             if limit is None:
-                if set(storage_result) != baseline_all_labels or set(baseline_result) != baseline_all_labels:
+                if baseline_result != expected_result or storage_result != expected_result:
                     raise AssertionError(
-                        f"Oracle mismatch in '{operation_id}': full node-id results do not cover the graph"
+                        f"Oracle mismatch in '{operation_id}': full node-id results are not deterministically ordered\n"
+                        f"  Storage:  {storage_result}\n"
+                        f"  Baseline: {baseline_result}\n"
+                        f"  Expected: {expected_result}"
                     )
             else:
                 expected_len = min(limit, len(storage_all_labels))
@@ -725,6 +730,13 @@ class GraphStorageOracle(BaseGraphStorage):
                     raise AssertionError(
                         f"Oracle mismatch in '{operation_id}': expected {expected_len} node IDs when limit={limit}, "
                         f"got storage={len(storage_result)} baseline={len(baseline_result)}"
+                    )
+                if baseline_result != expected_result or storage_result != expected_result:
+                    raise AssertionError(
+                        f"Oracle mismatch in '{operation_id}': node-id prefix is not deterministic for limit={limit}\n"
+                        f"  Storage:  {storage_result}\n"
+                        f"  Baseline: {baseline_result}\n"
+                        f"  Expected: {expected_result}"
                     )
 
             print(f"✅ Oracle match for '{operation_id}' ({len(storage_result)} node ids)")

--- a/tests/integration/graphstorage/graph_storage_oracle.py
+++ b/tests/integration/graphstorage/graph_storage_oracle.py
@@ -351,6 +351,23 @@ class GraphStorageOracle(BaseGraphStorage):
         """Normalize a list of edges to a set of normalized edge tuples"""
         return {self._normalize_edge(edge) for edge in edges}
 
+    def _normalize_incident_edge_payloads(
+        self,
+        edges: list[tuple[str, str, dict]],
+        operation_id: str,
+        node_id: str,
+    ) -> dict[tuple[str, str], dict]:
+        """Normalize incident-edge payloads for order- and direction-insensitive comparison."""
+        normalized = {}
+        for src_id, tgt_id, edge_data in edges:
+            edge_key = self._normalize_edge((src_id, tgt_id))
+            if edge_key in normalized:
+                raise AssertionError(
+                    f"Oracle mismatch (duplicate incident edge) in '{operation_id}' for node {node_id}: {edge_key}"
+                )
+            normalized[edge_key] = edge_data
+        return normalized
+
     async def get_node_edges(self, source_node_id: str) -> list[tuple[str, str]] | None:
         """Get node edges with unordered comparison and edge direction normalization"""
         self._operation_count += 1
@@ -589,6 +606,128 @@ class GraphStorageOracle(BaseGraphStorage):
                     )
 
             print(f"✅ Oracle match for '{operation_id}' (unordered node edges batch with direction normalization)")
+            return storage_result
+
+        except Exception as e:
+            print(f"❌ Oracle operation '{operation_id}' failed: {e}")
+            raise
+
+    async def get_incident_edges_with_data_batch(
+        self,
+        node_ids: list[str],
+    ) -> dict[str, list[tuple[str, str, dict]]]:
+        """Get incident edges with payloads using unordered comparison and direction normalization."""
+        self._operation_count += 1
+        operation_id = f"get_incident_edges_with_data_batch#{self._operation_count}"
+
+        try:
+            baseline_result = await self.baseline.get_incident_edges_with_data_batch(node_ids)
+            storage_result = await self.storage.get_incident_edges_with_data_batch(node_ids)
+
+            if set(baseline_result.keys()) != set(storage_result.keys()):
+                raise AssertionError(
+                    f"Oracle mismatch (incident-edge batch keys) in '{operation_id}':\n"
+                    f"  Storage keys:  {sorted(storage_result.keys())}\n"
+                    f"  Baseline keys: {sorted(baseline_result.keys())}"
+                )
+
+            for node_id in baseline_result.keys():
+                baseline_edges = baseline_result[node_id]
+                storage_edges = storage_result[node_id]
+
+                if len(baseline_edges) != len(storage_edges):
+                    raise AssertionError(
+                        f"Oracle mismatch (incident-edge count for {node_id}) in '{operation_id}':\n"
+                        f"  Storage:  {len(storage_edges)} edges\n"
+                        f"  Baseline: {len(baseline_edges)} edges"
+                    )
+
+                baseline_normalized = self._normalize_incident_edge_payloads(baseline_edges, operation_id, node_id)
+                storage_normalized = self._normalize_incident_edge_payloads(storage_edges, operation_id, node_id)
+
+                if set(baseline_normalized.keys()) != set(storage_normalized.keys()):
+                    raise AssertionError(
+                        f"Oracle mismatch (incident-edge keys for {node_id}) in '{operation_id}':\n"
+                        f"  Storage:  {sorted(storage_normalized.keys())}\n"
+                        f"  Baseline: {sorted(baseline_normalized.keys())}"
+                    )
+
+                for edge_key in baseline_normalized.keys():
+                    baseline_edge = baseline_normalized[edge_key]
+                    storage_edge = storage_normalized[edge_key]
+                    if not self._flexible_dict_compare(
+                        baseline_edge,
+                        storage_edge,
+                        f"{operation_id}_edge_{node_id}_{edge_key}",
+                    ):
+                        raise AssertionError(
+                            f"Oracle mismatch (incident-edge payload for {node_id} {edge_key}) in '{operation_id}':\n"
+                            f"  Storage:  {storage_edge}\n"
+                            f"  Baseline: {baseline_edge}"
+                        )
+
+            print(f"✅ Oracle match for '{operation_id}' (incident-edge payload batch)")
+            return storage_result
+
+        except Exception as e:
+            print(f"❌ Oracle operation '{operation_id}' failed: {e}")
+            raise
+
+    async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
+        """Get node IDs while allowing backend-specific ordering differences."""
+        self._operation_count += 1
+        operation_id = f"get_node_ids#{self._operation_count}"
+
+        try:
+            baseline_result = await self.baseline.get_node_ids(limit)
+            storage_result = await self.storage.get_node_ids(limit)
+
+            if baseline_result is None and storage_result is None:
+                print(f"✅ Oracle match for '{operation_id}' (both unsupported)")
+                return storage_result
+            if baseline_result is None or storage_result is None:
+                raise AssertionError(
+                    f"Oracle mismatch in '{operation_id}' (None vs non-None):\n"
+                    f"  Storage:  {storage_result}\n"
+                    f"  Baseline: {baseline_result}"
+                )
+
+            baseline_all_labels = set(await self.baseline.get_all_labels())
+            storage_all_labels = set(await self.storage.get_all_labels())
+
+            if baseline_all_labels != storage_all_labels:
+                raise AssertionError(
+                    f"Oracle mismatch (label universe) in '{operation_id}':\n"
+                    f"  Storage labels:  {sorted(storage_all_labels)}\n"
+                    f"  Baseline labels: {sorted(baseline_all_labels)}"
+                )
+
+            if len(storage_result) != len(set(storage_result)):
+                raise AssertionError(f"Oracle mismatch in '{operation_id}': storage returned duplicate node IDs")
+
+            if len(baseline_result) != len(set(baseline_result)):
+                raise AssertionError(f"Oracle mismatch in '{operation_id}': baseline returned duplicate node IDs")
+
+            if not set(storage_result).issubset(storage_all_labels):
+                raise AssertionError(f"Oracle mismatch in '{operation_id}': storage returned unknown node IDs")
+
+            if not set(baseline_result).issubset(baseline_all_labels):
+                raise AssertionError(f"Oracle mismatch in '{operation_id}': baseline returned unknown node IDs")
+
+            if limit is None:
+                if set(storage_result) != baseline_all_labels or set(baseline_result) != baseline_all_labels:
+                    raise AssertionError(
+                        f"Oracle mismatch in '{operation_id}': full node-id results do not cover the graph"
+                    )
+            else:
+                expected_len = min(limit, len(storage_all_labels))
+                if len(storage_result) != expected_len or len(baseline_result) != expected_len:
+                    raise AssertionError(
+                        f"Oracle mismatch in '{operation_id}': expected {expected_len} node IDs when limit={limit}, "
+                        f"got storage={len(storage_result)} baseline={len(baseline_result)}"
+                    )
+
+            print(f"✅ Oracle match for '{operation_id}' ({len(storage_result)} node ids)")
             return storage_result
 
         except Exception as e:

--- a/tests/integration/graphstorage/networkx_baseline_storage.py
+++ b/tests/integration/graphstorage/networkx_baseline_storage.py
@@ -227,8 +227,8 @@ class NetworkXBaselineStorage(BaseGraphStorage):
         return list(self.graph.nodes())
 
     async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
-        """Return node IDs without materializing full node payloads."""
-        node_ids = list(self.graph.nodes())
+        """Return node IDs in stable ascending order."""
+        node_ids = sorted(self.graph.nodes())
         return node_ids[:limit] if limit is not None else node_ids
 
     async def get_knowledge_graph(

--- a/tests/integration/graphstorage/networkx_baseline_storage.py
+++ b/tests/integration/graphstorage/networkx_baseline_storage.py
@@ -226,6 +226,11 @@ class NetworkXBaselineStorage(BaseGraphStorage):
         """Get all node labels (node IDs in this case)."""
         return list(self.graph.nodes())
 
+    async def get_node_ids(self, limit: int | None = None) -> list[str] | None:
+        """Return node IDs without materializing full node payloads."""
+        node_ids = list(self.graph.nodes())
+        return node_ids[:limit] if limit is not None else node_ids
+
     async def get_knowledge_graph(
         self,
         node_label: str,

--- a/tests/integration/graphstorage/test_graph_storage.py
+++ b/tests/integration/graphstorage/test_graph_storage.py
@@ -814,20 +814,22 @@ class GraphStorageTestSuite:
 
     @staticmethod
     async def test_get_node_ids(oracle, graph_data: Dict[str, Any]):
-        """Test lightweight node-id retrieval semantics via oracle."""
+        """Test deterministic lightweight node-id retrieval semantics via oracle."""
         print("🔍 Testing get_node_ids via oracle")
 
+        expected_all_node_ids = sorted(graph_data["nodes"].keys())
         all_node_ids = await oracle.get_node_ids()
         assert isinstance(all_node_ids, list)
         assert len(all_node_ids) == len(graph_data["nodes"])
-        assert set(all_node_ids) == set(graph_data["nodes"].keys())
+        assert all_node_ids == expected_all_node_ids
 
         limit = min(10, len(graph_data["nodes"]))
+        expected_limited_node_ids = expected_all_node_ids[:limit]
         limited_node_ids = await oracle.get_node_ids(limit=limit)
         assert isinstance(limited_node_ids, list)
         assert len(limited_node_ids) == limit
         assert len(limited_node_ids) == len(set(limited_node_ids)), "Node IDs should be unique"
-        assert set(limited_node_ids).issubset(graph_data["nodes"].keys())
+        assert limited_node_ids == expected_limited_node_ids
 
         print(f"✓ Verified full and limited node-id retrieval (limit={limit})")
 

--- a/tests/integration/graphstorage/test_graph_storage.py
+++ b/tests/integration/graphstorage/test_graph_storage.py
@@ -499,6 +499,31 @@ class GraphStorageTestSuite:
         print(f"✓ Verified batch node edges for {len(batch_result)} nodes")
 
     @staticmethod
+    async def test_get_incident_edges_with_data_batch(oracle, graph_data: Dict[str, Any]):
+        """Test get_incident_edges_with_data_batch function via oracle."""
+        print("🔍 Testing get_incident_edges_with_data_batch via oracle")
+
+        node_ids = get_high_degree_nodes(graph_data, max_count=8)
+        if not node_ids:
+            node_ids = get_random_sample(graph_data["nodes"], max_size=8, min_size=3)
+
+        batch_result = await oracle.get_incident_edges_with_data_batch(node_ids)
+
+        assert isinstance(batch_result, dict)
+        assert len(batch_result) == len(node_ids), f"Expected {len(node_ids)} nodes, got {len(batch_result)}"
+
+        for node_id, edges in batch_result.items():
+            assert isinstance(edges, list)
+            assert node_id in node_ids, "Returned node should be in requested list"
+            for src, tgt, edge_data in edges:
+                assert node_id in {src, tgt}, f"Incident edge ({src}, {tgt}) should include node {node_id}"
+                assert isinstance(src, str)
+                assert isinstance(tgt, str)
+                assert isinstance(edge_data, dict)
+
+        print(f"✓ Verified incident-edge payloads for {len(batch_result)} nodes")
+
+    @staticmethod
     async def test_edge_degree(oracle, graph_data: Dict[str, Any]):
         """Test edge_degree function via oracle"""
         print("🔍 Testing edge_degree via oracle")
@@ -787,6 +812,25 @@ class GraphStorageTestSuite:
         assert len(all_labels) > 0
         print(f"✓ Total labels found: {len(all_labels)}")
 
+    @staticmethod
+    async def test_get_node_ids(oracle, graph_data: Dict[str, Any]):
+        """Test lightweight node-id retrieval semantics via oracle."""
+        print("🔍 Testing get_node_ids via oracle")
+
+        all_node_ids = await oracle.get_node_ids()
+        assert isinstance(all_node_ids, list)
+        assert len(all_node_ids) == len(graph_data["nodes"])
+        assert set(all_node_ids) == set(graph_data["nodes"].keys())
+
+        limit = min(10, len(graph_data["nodes"]))
+        limited_node_ids = await oracle.get_node_ids(limit=limit)
+        assert isinstance(limited_node_ids, list)
+        assert len(limited_node_ids) == limit
+        assert len(limited_node_ids) == len(set(limited_node_ids)), "Node IDs should be unique"
+        assert set(limited_node_ids).issubset(graph_data["nodes"].keys())
+
+        print(f"✓ Verified full and limited node-id retrieval (limit={limit})")
+
     # ===== Summary Test =====
 
     @staticmethod
@@ -806,6 +850,9 @@ class GraphStorageTestSuite:
             "edge_degrees_batch",
             "get_edges_batch",
             "get_nodes_edges_batch",
+            "get_nodes_edges_with_data_batch",
+            "get_incident_edges_with_data_batch",
+            "get_node_ids",
             "upsert_node",
             "upsert_edge",
             "delete_node",

--- a/tests/integration/graphstorage/test_nebula_storage.py
+++ b/tests/integration/graphstorage/test_nebula_storage.py
@@ -133,6 +133,10 @@ class TestNebulaStorage:
         oracle, graph_data = nebula_oracle_storage
         await GraphStorageTestSuite.test_get_nodes_edges_batch(oracle, graph_data)
 
+    async def test_get_incident_edges_with_data_batch(self, nebula_oracle_storage):
+        oracle, graph_data = nebula_oracle_storage
+        await GraphStorageTestSuite.test_get_incident_edges_with_data_batch(oracle, graph_data)
+
     async def test_edge_degree(self, nebula_oracle_storage):
         oracle, graph_data = nebula_oracle_storage
         await GraphStorageTestSuite.test_edge_degree(oracle, graph_data)
@@ -164,6 +168,10 @@ class TestNebulaStorage:
     async def test_get_all_labels(self, nebula_oracle_storage):
         oracle, graph_data = nebula_oracle_storage
         await GraphStorageTestSuite.test_get_all_labels(oracle, graph_data)
+
+    async def test_get_node_ids(self, nebula_oracle_storage):
+        oracle, graph_data = nebula_oracle_storage
+        await GraphStorageTestSuite.test_get_node_ids(oracle, graph_data)
 
     async def test_interface_coverage_summary(self, nebula_oracle_storage):
         oracle, _ = nebula_oracle_storage

--- a/tests/integration/graphstorage/test_neo4j_storage.py
+++ b/tests/integration/graphstorage/test_neo4j_storage.py
@@ -180,6 +180,10 @@ class TestNeo4jStorage:
         oracle, graph_data = neo4j_oracle_storage
         await GraphStorageTestSuite.test_get_nodes_edges_batch(oracle, graph_data)
 
+    async def test_get_incident_edges_with_data_batch(self, neo4j_oracle_storage):
+        oracle, graph_data = neo4j_oracle_storage
+        await GraphStorageTestSuite.test_get_incident_edges_with_data_batch(oracle, graph_data)
+
     async def test_edge_degree(self, neo4j_oracle_storage):
         oracle, graph_data = neo4j_oracle_storage
         await GraphStorageTestSuite.test_edge_degree(oracle, graph_data)
@@ -212,6 +216,10 @@ class TestNeo4jStorage:
     async def test_get_all_labels(self, neo4j_oracle_storage):
         oracle, graph_data = neo4j_oracle_storage
         await GraphStorageTestSuite.test_get_all_labels(oracle, graph_data)
+
+    async def test_get_node_ids(self, neo4j_oracle_storage):
+        oracle, graph_data = neo4j_oracle_storage
+        await GraphStorageTestSuite.test_get_node_ids(oracle, graph_data)
 
     async def test_interface_coverage_summary(self, neo4j_oracle_storage):
         oracle, graph_data = neo4j_oracle_storage

--- a/tests/integration/graphstorage/test_postgres_graph_storage.py
+++ b/tests/integration/graphstorage/test_postgres_graph_storage.py
@@ -182,6 +182,10 @@ class TestPostgresGraphStorage:
         oracle, graph_data = postgres_graph_oracle_storage
         await GraphStorageTestSuite.test_get_nodes_edges_batch(oracle, graph_data)
 
+    async def test_get_incident_edges_with_data_batch(self, postgres_graph_oracle_storage):
+        oracle, graph_data = postgres_graph_oracle_storage
+        await GraphStorageTestSuite.test_get_incident_edges_with_data_batch(oracle, graph_data)
+
     async def test_edge_degree(self, postgres_graph_oracle_storage):
         oracle, graph_data = postgres_graph_oracle_storage
         await GraphStorageTestSuite.test_edge_degree(oracle, graph_data)
@@ -214,6 +218,10 @@ class TestPostgresGraphStorage:
     async def test_get_all_labels(self, postgres_graph_oracle_storage):
         oracle, graph_data = postgres_graph_oracle_storage
         await GraphStorageTestSuite.test_get_all_labels(oracle, graph_data)
+
+    async def test_get_node_ids(self, postgres_graph_oracle_storage):
+        oracle, graph_data = postgres_graph_oracle_storage
+        await GraphStorageTestSuite.test_get_node_ids(oracle, graph_data)
 
     async def test_interface_coverage_summary(self, postgres_graph_oracle_storage):
         oracle, graph_data = postgres_graph_oracle_storage

--- a/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
+++ b/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from aperag.graph.lightrag import utils_graph
+from aperag.graph.lightrag.lightrag import LightRAG
 from aperag.graph.lightrag.operate import get_high_degree_nodes
 from aperag.graph.lightrag.kg.pg_ops_sync_vector_storage import PGOpsSyncVectorStorage
 from aperag.graph.lightrag.namespace import NameSpace
@@ -178,6 +179,10 @@ class _FakeGraphStorage:
     async def get_top_degree_nodes(self, _limit):
         return None
 
+    async def get_node_ids(self, limit=None):
+        self.calls.append(("get_node_ids", limit))
+        return list(self.nodes.keys())[:limit] if limit is not None else list(self.nodes.keys())
+
 
 class _FakeEntityVectorStorage:
     def __init__(self):
@@ -331,3 +336,71 @@ async def test_get_high_degree_nodes_prefers_storage_top_degree_primitive():
     assert total_nodes == 42
     assert set(selected_nodes.nodes_by_id.keys()) == {"entity-1", "entity-2"}
     assert selected_nodes.nodes_by_id["entity-1"].degree == 7
+
+
+class _FakeExportGraphStorage:
+    def __init__(self):
+        self.calls = []
+
+    async def get_node_ids(self, limit=None):
+        self.calls.append(("get_node_ids", limit))
+        return ["entity-1", "entity-2"][:limit] if limit is not None else ["entity-1", "entity-2"]
+
+    async def get_all_labels(self):
+        raise AssertionError("get_all_labels() should not be used when get_node_ids() is available")
+
+    async def get_nodes_batch(self, node_ids):
+        self.calls.append(("get_nodes_batch", tuple(node_ids)))
+        return {
+            "entity-1": {
+                "entity_id": "entity-1",
+                "entity_name": "Alpha",
+                "entity_type": "ORG",
+                "description": "alpha desc",
+                "source_id": "chunk-1",
+            },
+            "entity-2": {
+                "entity_id": "entity-2",
+                "entity_name": "Beta",
+                "entity_type": "PERSON",
+                "description": "beta desc",
+                "source_id": "chunk-2",
+            },
+        }
+
+    async def get_incident_edges_with_data_batch(self, node_ids):
+        self.calls.append(("get_incident_edges_with_data_batch", tuple(node_ids)))
+        return {
+            "entity-1": [
+                ("entity-1", "entity-2", {"description": "rel", "keywords": "kw", "weight": 3.0, "source_id": "chunk-1"})
+            ],
+            "entity-2": [
+                ("entity-1", "entity-2", {"description": "rel", "keywords": "kw", "weight": 3.0, "source_id": "chunk-1"})
+            ],
+        }
+
+
+class _FakeLogger:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def debug(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_export_for_kg_eval_prefers_node_ids_and_incident_edges_primitive():
+    rag = LightRAG.__new__(LightRAG)
+    rag.workspace = "workspace-1"
+    rag.lightrag_logger = _FakeLogger()
+    rag.chunk_entity_relation_graph = _FakeExportGraphStorage()
+
+    result = await LightRAG.export_for_kg_eval(rag, sample_size=2, include_source_texts=False)
+
+    assert result["entities"][0]["entity_name"] == "Alpha"
+    assert result["relationships"][0]["source_entity_name"] == "Alpha"
+    assert ("get_node_ids", 2) in rag.chunk_entity_relation_graph.calls
+    assert ("get_incident_edges_with_data_batch", ("entity-1", "entity-2")) in rag.chunk_entity_relation_graph.calls

--- a/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
+++ b/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
@@ -3,8 +3,9 @@ from types import SimpleNamespace
 import pytest
 
 from aperag.graph.lightrag import utils_graph
+from aperag.graph.lightrag.base import QueryParam
 from aperag.graph.lightrag.lightrag import LightRAG
-from aperag.graph.lightrag.operate import get_high_degree_nodes
+from aperag.graph.lightrag.operate import _find_most_related_edges_from_entities, get_high_degree_nodes
 from aperag.graph.lightrag.kg.pg_ops_sync_vector_storage import PGOpsSyncVectorStorage
 from aperag.graph.lightrag.namespace import NameSpace
 from aperag.graph.lightrag_manager import _process_document_async
@@ -391,6 +392,11 @@ class _FakeLogger:
         return None
 
 
+class _FakeTokenizer:
+    def encode(self, text):
+        return list(text or "")
+
+
 @pytest.mark.asyncio
 async def test_export_for_kg_eval_prefers_node_ids_and_incident_edges_primitive():
     rag = LightRAG.__new__(LightRAG)
@@ -404,3 +410,43 @@ async def test_export_for_kg_eval_prefers_node_ids_and_incident_edges_primitive(
     assert result["relationships"][0]["source_entity_name"] == "Alpha"
     assert ("get_node_ids", 2) in rag.chunk_entity_relation_graph.calls
     assert ("get_incident_edges_with_data_batch", ("entity-1", "entity-2")) in rag.chunk_entity_relation_graph.calls
+
+
+class _FakeOperateGraphStorage:
+    def __init__(self):
+        self.calls = []
+
+    async def get_incident_edges_with_data_batch(self, node_ids):
+        self.calls.append(("get_incident_edges_with_data_batch", tuple(node_ids)))
+        return {
+            "entity-1": [
+                ("entity-1", "entity-2", {"description": "edge desc", "keywords": "kw", "weight": 2.0, "source_id": "chunk-1"})
+            ]
+        }
+
+    async def edge_degrees_batch(self, edge_pairs):
+        self.calls.append(("edge_degrees_batch", tuple(edge_pairs)))
+        return {("entity-1", "entity-2"): 9}
+
+    async def get_nodes_edges_batch(self, _node_ids):
+        raise AssertionError("legacy get_nodes_edges_batch() should not be used")
+
+    async def get_edges_batch(self, _pairs):
+        raise AssertionError("legacy get_edges_batch() should not be used")
+
+
+@pytest.mark.asyncio
+async def test_find_most_related_edges_from_entities_prefers_incident_edge_primitive():
+    graph_storage = _FakeOperateGraphStorage()
+    node_datas = [{"entity_name": "entity-1"}]
+
+    result = await _find_most_related_edges_from_entities(
+        node_datas,
+        QueryParam(max_token_for_global_context=1000),
+        graph_storage,
+        _FakeTokenizer(),
+    )
+
+    assert result[0]["src_tgt"] == ("entity-1", "entity-2")
+    assert result[0]["rank"] == 9
+    assert ("get_incident_edges_with_data_batch", ("entity-1",)) in graph_storage.calls


### PR DESCRIPTION
## Summary
- avoid remaining full-label scans in KG export by fetching limited node IDs directly from storage
- add backend incident-edge primitives for PG, Neo4j, and Nebula so edge payloads can be fetched in one hop
- switch `LightRAG.export_for_kg_eval()` and remaining `operate.py` relation hotspots to consume `get_incident_edges_with_data_batch()` directly
- add multi-backend integration coverage so the new storage primitives are constrained consistently across PG / Neo4j / Nebula

## Why
This is the next small batch after #1472.

The previous PR introduced storage primitives for helper/edit/merge paths and for high-degree analysis. This batch continues the same direction for:
- `analysis/export` paths that still started from `get_all_labels()`
- `operate.py` hotspots that still composed `get_nodes_edges_batch()` plus per-edge fetches
- new storage primitives that needed explicit cross-database consistency coverage before wider adoption

## What Changed
- `aperag/graph/lightrag/base.py`
  - add `get_node_ids(limit=None)` capability hook for lighter-weight node-id retrieval
- `aperag/db/repositories/graph.py`
  - add PG repository methods for direct node-id fetches and incident-edge-with-data batch fetches
- `aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py`
  - implement direct PG `get_node_ids()` and `get_incident_edges_with_data_batch()`
- `aperag/graph/lightrag/kg/neo4j_sync_impl.py`
  - implement direct Neo4j `get_node_ids()` and `get_incident_edges_with_data_batch()`
- `aperag/graph/lightrag/kg/nebula_sync_impl.py`
  - implement direct Nebula `get_node_ids()` and `get_incident_edges_with_data_batch()`
- `aperag/graph/lightrag/lightrag.py`
  - update `export_for_kg_eval()` to prefer `get_node_ids(limit)` over `get_all_labels()`
  - update export edge collection to consume incident edges with payloads directly instead of a second edge lookup pass
- `aperag/graph/lightrag/operate.py`
  - update `_find_most_related_text_unit_from_entities()` to derive one-hop neighbors from incident-edge payloads directly
  - update `_find_most_related_edges_from_entities()` to reuse incident-edge payloads instead of a follow-up `get_edges_batch()` pass
- `tests/unit_test/graphindex/test_lightrag_update_and_storage.py`
  - add targeted coverage proving the `operate.py` relation path prefers `get_incident_edges_with_data_batch()`
- `tests/integration/graphstorage/*`
  - add oracle-backed integration coverage for `get_node_ids()` and `get_incident_edges_with_data_batch()`
  - wire the new suite methods into PG / Neo4j / Nebula test classes so backend behavior stays aligned

## Primitive Migration
- `get_node_ids(limit)`
  - replaces export-time `get_all_labels()` scans when the backend can answer with a limited node-id query directly
  - now used by `LightRAG.export_for_kg_eval()`
- `get_incident_edges_with_data_batch(node_ids)` backend overrides
  - replace composed `get_nodes_edges_batch()` + `get_edges_batch()` fetch chains for supported backends
  - now used by `LightRAG.export_for_kg_eval()`
  - now used by `_find_most_related_text_unit_from_entities()`
  - now used by `_find_most_related_edges_from_entities()`

## Validation
- `python3 -m py_compile` on changed Python files and the targeted unit/integration test files
- no local pytest run; remote CI remains the primary test signal by team convention

## Base
- stacked on top of `bryce/fix-lightrag-delete-update-path` / PR #1472
- both stacked branches have been rebased onto latest `main`
