### PR TITLE
test: expand document status and search Hurl coverage

### DIFF
--- a/tests/COVERAGE_MATRIX.md
+++ b/tests/COVERAGE_MATRIX.md
@@ -16,6 +16,8 @@ This matrix is the working contract for converging the test tree toward:
 | collection CRUD | partial | yes | no | no | no | fully owned by Hurl |
 | document upload/detail/delete | partial | yes | no | no | no | fully owned by Hurl |
 | document staged/confirm/download/rebuild | no | no | yes | `test_document_download.py` | no | move the primary path to Hurl; keep pytest edge cases until stable |
+| document status visibility and list search by name | no | no | yes | no | no | Hurl owns the stable HTTP contract for status fields and document-name search |
+| collection search API and search history contract | no | no | yes | no | no | Hurl owns stable search/history HTTP behavior; result quality stays provider-sensitive |
 | api key | no | yes | no | no | no | fully owned by Hurl |
 | available models | no | no | yes | `test_available_models.py` | no | migrate to Hurl and delete pytest duplicate |
 | llm provider config and model CRUD | no | no | yes | `test_llm_provider.py` | no | migrate to Hurl and delete pytest duplicate |
@@ -38,6 +40,7 @@ This matrix is the working contract for converging the test tree toward:
 | `tests/e2e_pytest/test_bot.py` | delete after this phase | replaced by `tests/e2e_http/hurl/full/12_bot.hurl` |
 | `tests/e2e_pytest/test_chat.py` | trim later | keep only streaming / websocket / openai-compatible supplements once Hurl parity is validated |
 | `tests/e2e_pytest/test_document_download.py` | keep for now | Hurl now covers the main download path, while pytest still carries extra negative cases |
+| document status/search residual pytest | no extra pytest to delete in this phase | current delta is Hurl contract expansion rather than duplicate pytest removal |
 | `tests/integration/cache/*` | keep | not product-level E2E |
 | `tests/integration/graphstorage/*` | keep | backend oracle and contract verification, not product HTTP behavior |
 | `tests/e2e_http/hurl/smoke/*` | keep | PR gate for provider-independent deployment contract |

--- a/tests/e2e_http/README.md
+++ b/tests/e2e_http/README.md
@@ -30,6 +30,7 @@ Current v1 scope:
   - query `/api/v1/available_models`
   - call `/api/v1/embeddings` and `/api/v1/rerank` through real external providers
   - cover document staged/confirm/download/rebuild paths
+  - cover document status visibility, list search by name, and collection search/history HTTP contracts
   - cover bot CRUD + flow get/update
   - cover chat create/list/get/update plus a non-streaming frontend completion envelope path
   - cover graph labels + graph overview endpoints
@@ -42,6 +43,7 @@ Non-goals for v1:
 Important behavior notes from the current implementation:
 - Smoke tests create and clean up their own business resources.
 - `document` smoke intentionally validates upload and basic lifecycle only; it does not require provider-backed indexing to complete.
+- `document` full validates stable document/search HTTP contracts without hard-coding async index completion or search relevance guarantees.
 - API key smoke explicitly logs out before bearer-only checks so cookie auth does not mask key behavior.
 - Full Hurl tests are intentionally separated from smoke so provider/API-key failures do not dilute the minimal deployment contract.
 

--- a/tests/e2e_http/hurl/full/11_document_full.hurl
+++ b/tests/e2e_http/hurl/full/11_document_full.hurl
@@ -72,6 +72,8 @@ HTTP 200
 [Asserts]
 jsonpath "$.items[0].id" == "{{document_id}}"
 jsonpath "$.items[0].name" == "tests/e2e_http/testdata/full-document.txt"
+jsonpath "$.items[0].status" exists
+jsonpath "$.items[0].fulltext_index_status" exists
 jsonpath "$.total" == 1
 
 GET {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}
@@ -79,6 +81,50 @@ HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{document_id}}"
 jsonpath "$.name" == "tests/e2e_http/testdata/full-document.txt"
+jsonpath "$.status" exists
+jsonpath "$.vector_index_status" exists
+jsonpath "$.fulltext_index_status" exists
+jsonpath "$.graph_index_status" == "SKIPPED"
+jsonpath "$.summary_index_status" == "SKIPPED"
+jsonpath "$.vision_index_status" == "SKIPPED"
+
+GET {{base_url}}/api/v1/collections/{{collection_id}}/documents?search=full-document&sort_by=status&sort_order=asc
+HTTP 200
+[Asserts]
+jsonpath "$.items[0].id" == "{{document_id}}"
+jsonpath "$.items[0].name" == "tests/e2e_http/testdata/full-document.txt"
+jsonpath "$.items[0].status" exists
+jsonpath "$.items[0].fulltext_index_status" exists
+jsonpath "$.total" == 1
+
+POST {{base_url}}/api/v1/collections/{{collection_id}}/searches
+Content-Type: application/json
+{
+  "query": "Hurl full document coverage",
+  "fulltext_search": {
+    "topk": 3
+  },
+  "save_to_history": true
+}
+HTTP 200
+[Captures]
+search_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" == "{{search_id}}"
+jsonpath "$.query" == "Hurl full document coverage"
+jsonpath "$.fulltext_search.topk" == 3
+jsonpath "$.items" exists
+jsonpath "$.created" exists
+
+GET {{base_url}}/api/v1/collections/{{collection_id}}/searches
+HTTP 200
+[Asserts]
+jsonpath "$.items[0].id" == "{{search_id}}"
+jsonpath "$.items[0].query" == "Hurl full document coverage"
+jsonpath "$.items[0].items" exists
+
+DELETE {{base_url}}/api/v1/collections/{{collection_id}}/searches/{{search_id}}
+HTTP 200
 
 GET {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}/download
 HTTP 200


### PR DESCRIPTION
## Summary
- extend `11_document_full.hurl` with document status-field visibility assertions
- add document list name-search coverage plus collection search/history HTTP contract coverage
- update the test coverage matrix and Hurl README to match the new scope

## Scope Boundary
- this PR only covers `P0 document status/search`
- it does not expand into `P1 chat happy-path`
- it does not delete residual pytest E2E in this phase because no duplicate module reached stable Hurl parity yet

## Validation
- `git diff --check`
- GitHub remote checks are the source of truth for broader validation
