### PR TITLE
add parser health and diagnostics

### DIFF
--- a/aperag/api/components/schemas/settings.yaml
+++ b/aperag/api/components/schemas/settings.yaml
@@ -10,3 +10,111 @@ Settings:
     use_markitdown:
       type: boolean
       description: Whether to use MarkItDown
+
+ParserHealthItem:
+  type: object
+  properties:
+    key:
+      type: string
+    label:
+      type: string
+    status:
+      type: string
+      enum:
+        - ok
+        - warning
+        - error
+        - disabled
+    detail:
+      type: string
+  required:
+    - key
+    - label
+    - status
+    - detail
+
+ParserSupportTier:
+  type: object
+  properties:
+    key:
+      type: string
+    label:
+      type: string
+    category:
+      type: string
+      enum:
+        - official
+        - conditional
+        - enhanced
+        - optional
+    parser:
+      type: string
+    formats:
+      type: array
+      items:
+        type: string
+    status:
+      type: string
+      enum:
+        - available
+        - limited
+        - unavailable
+        - disabled
+    detail:
+      type: string
+    requirements:
+      type: array
+      items:
+        type: string
+  required:
+    - key
+    - label
+    - category
+    - parser
+    - formats
+    - status
+    - detail
+    - requirements
+
+ParserHealthReport:
+  type: object
+  properties:
+    default_parser:
+      type: string
+    parser_order:
+      type: array
+      items:
+        type: string
+    available_extensions:
+      type: array
+      items:
+        type: string
+    dependencies:
+      type: array
+      items:
+        $ref: '#/ParserHealthItem'
+    services:
+      type: array
+      items:
+        $ref: '#/ParserHealthItem'
+    support_tiers:
+      type: array
+      items:
+        $ref: '#/ParserSupportTier'
+    warnings:
+      type: array
+      items:
+        type: string
+    recommendations:
+      type: array
+      items:
+        type: string
+  required:
+    - default_parser
+    - parser_order
+    - available_extensions
+    - dependencies
+    - services
+    - support_tiers
+    - warnings
+    - recommendations

--- a/aperag/api/openapi.yaml
+++ b/aperag/api/openapi.yaml
@@ -85,6 +85,8 @@ paths:
   # settings
   /settings:
     $ref: './paths/settings.yaml#/settings'
+  /settings/parser_health:
+    $ref: './paths/misc.yaml#/parser_health'
   /settings/test_mineru_token:
     $ref: './paths/misc.yaml#/test_mineru_token'
 

--- a/aperag/api/paths/misc.yaml
+++ b/aperag/api/paths/misc.yaml
@@ -1,3 +1,23 @@
+parser_health:
+  get:
+    summary: Get parser health report
+    description: Returns parser preflight status, dependency readiness, external service reachability, and support tiers.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Parser health report
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/settings.yaml#/ParserHealthReport'
+      '401':
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/common.yaml#/failResponse'
+
 test_mineru_token:
   post:
     summary: Test MinerU API Token

--- a/aperag/docparser/audio_parser.py
+++ b/aperag/docparser/audio_parser.py
@@ -18,7 +18,7 @@ from typing import Any
 import requests
 
 from aperag.config import settings
-from aperag.docparser.base import BaseParser, FallbackError, Part, TextPart
+from aperag.docparser.base import BaseParser, FallbackError, ParserError, Part, TextPart
 
 SUPPORTED_EXTENSIONS = [
     ".mp3",
@@ -32,6 +32,8 @@ SUPPORTED_EXTENSIONS = [
     ".flac",
 ]
 
+REQUEST_TIMEOUT = 60
+
 
 class AudioParser(BaseParser):
     name = "audio"
@@ -41,7 +43,12 @@ class AudioParser(BaseParser):
 
     def parse_file(self, path: Path, metadata: dict[str, Any] = {}, **kwargs) -> list[Part]:
         if not settings.whisper_host:
-            raise FallbackError("WHISPER_HOST is not set")
+            raise FallbackError(
+                "Audio transcription is not configured",
+                parser_name=self.name,
+                code="service_not_configured",
+                detail="Set WHISPER_HOST to enable audio transcription.",
+            )
 
         content = self.recognize_speech(path)
         metadata = metadata.copy()
@@ -57,8 +64,6 @@ class AudioParser(BaseParser):
             "output": "txt",
         }
 
-        files = {"audio_file": open(str(path), "rb")}
-
         headers = {
             "Accept": "application/json",
         }
@@ -66,5 +71,21 @@ class AudioParser(BaseParser):
         # TODO: extract media metadata by using exiftool
 
         # Server: https://github.com/ahmetoner/whisper-asr-webservice
-        response = requests.post(settings.whisper_host + "/asr", params=params, files=files, headers=headers)
-        return response.text
+        try:
+            with open(str(path), "rb") as audio_file:
+                response = requests.post(
+                    settings.whisper_host + "/asr",
+                    params=params,
+                    files={"audio_file": audio_file},
+                    headers=headers,
+                    timeout=REQUEST_TIMEOUT,
+                )
+                response.raise_for_status()
+                return response.text
+        except requests.exceptions.RequestException as e:
+            raise ParserError(
+                "Audio transcription request failed",
+                parser_name=self.name,
+                code="service_unreachable",
+                detail=str(e),
+            ) from e

--- a/aperag/docparser/base.py
+++ b/aperag/docparser/base.py
@@ -19,8 +19,63 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 
-class FallbackError(Exception):
-    pass
+class ParserError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        parser_name: str | None = None,
+        code: str = "parser_error",
+        detail: str | None = None,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.parser_name = parser_name
+        self.code = code
+        self.detail = detail
+
+    def diagnostic_message(self) -> str:
+        parts = []
+        if self.parser_name:
+            parts.append(f"parser={self.parser_name}")
+        parts.append(f"code={self.code}")
+        parts.append(self.message)
+        if self.detail:
+            parts.append(f"detail={self.detail}")
+        return ", ".join(parts)
+
+
+class FallbackError(ParserError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        parser_name: str | None = None,
+        code: str = "fallback",
+        detail: str | None = None,
+    ):
+        super().__init__(message, parser_name=parser_name, code=code, detail=detail)
+
+
+class ParserAttempt(BaseModel):
+    parser_name: str
+    status: str
+    message: str
+    code: str | None = None
+    detail: str | None = None
+
+
+class ParserChainError(ParserError):
+    def __init__(self, extension: str, attempts: list[ParserAttempt], detail: str | None = None):
+        self.extension = extension
+        self.attempts = attempts
+        formatted_attempts = "; ".join(
+            f"{attempt.parser_name}[{attempt.status}] {attempt.message}" for attempt in attempts
+        )
+        message = f'No parser produced a usable result for extension "{extension}"'
+        if formatted_attempts:
+            message += f": {formatted_attempts}"
+        super().__init__(message, parser_name=None, code="parser_chain_failed", detail=detail)
 
 
 class Part(BaseModel):

--- a/aperag/docparser/doc_parser.py
+++ b/aperag/docparser/doc_parser.py
@@ -20,7 +20,7 @@ from typing import Any, List, Optional
 from pydantic import BaseModel, Field
 
 from aperag.docparser.audio_parser import AudioParser
-from aperag.docparser.base import BaseParser, FallbackError, Part
+from aperag.docparser.base import BaseParser, FallbackError, ParserAttempt, ParserChainError, ParserError, Part
 from aperag.docparser.image_parser import ImageParser
 from aperag.docparser.markitdown_parser import MarkItDownParser
 from aperag.docparser.mineru_parser import MinerUParser
@@ -132,6 +132,7 @@ class DocParser(BaseParser):
     def parse_file(self, path: Path, metadata: dict[str, Any] = {}, **kwargs) -> list[Part]:
         extension = path.suffix
         last_err = None
+        attempts: list[ParserAttempt] = []
         for parser_name in self.parsing_order:
             parser = self.parsers[parser_name]
             if not self._parser_accept(parser_name, extension):
@@ -140,4 +141,37 @@ class DocParser(BaseParser):
                 return parser.parse_file(path, metadata, **kwargs)
             except FallbackError as e:
                 last_err = e
-        raise ValueError(f'No parser can handle file with extension "{extension}"') from last_err
+                attempts.append(
+                    ParserAttempt(
+                        parser_name=parser_name,
+                        status="fallback",
+                        message=e.message,
+                        code=e.code,
+                        detail=e.detail,
+                    )
+                )
+            except ParserError as e:
+                attempts.append(
+                    ParserAttempt(
+                        parser_name=parser_name,
+                        status="failed",
+                        message=e.message,
+                        code=e.code,
+                        detail=e.detail,
+                    )
+                )
+                raise ParserChainError(extension, attempts, detail=e.detail) from e
+            except Exception as e:
+                attempts.append(
+                    ParserAttempt(
+                        parser_name=parser_name,
+                        status="failed",
+                        message=f"Unexpected parser error: {type(e).__name__}",
+                        code="unexpected_error",
+                        detail=str(e),
+                    )
+                )
+                raise ParserChainError(extension, attempts, detail=str(e)) from e
+        if attempts:
+            raise ParserChainError(extension, attempts, detail=getattr(last_err, "detail", None)) from last_err
+        raise ValueError(f'No parser can handle file with extension "{extension}"')

--- a/aperag/docparser/health.py
+++ b/aperag/docparser/health.py
@@ -27,9 +27,7 @@ from aperag.docparser.mineru_parser import API_HOST as MINERU_API_HOST
 from aperag.docparser.mineru_parser import SUPPORTED_EXTENSIONS as MINERU_EXTENSIONS
 from aperag.docparser.utils import get_soffice_cmd
 
-OFFICIAL_FORMATS = [
-    ext for ext in MARKITDOWN_EXTENSIONS if ext not in [".doc", ".ppt"]
-]
+OFFICIAL_FORMATS = [ext for ext in MARKITDOWN_EXTENSIONS if ext not in [".doc", ".ppt"]]
 LEGACY_OFFICE_FORMATS = [".doc", ".ppt"]
 
 
@@ -135,7 +133,9 @@ async def get_parser_health_report(parser_settings: dict[str, Any] | None = None
         ),
     ]
 
-    mineru_status, mineru_detail = await _probe_mineru(mineru_token) if mineru_enabled else ("disabled", "MinerU is disabled.")
+    mineru_status, mineru_detail = (
+        await _probe_mineru(mineru_token) if mineru_enabled else ("disabled", "MinerU is disabled.")
+    )
     services = [
         ParserHealthItem(
             key="mineru",
@@ -215,11 +215,7 @@ async def get_parser_health_report(parser_settings: dict[str, Any] | None = None
             parser="mineru",
             formats=MINERU_EXTENSIONS,
             status=(
-                "available"
-                if mineru_enabled and mineru_status == "ok"
-                else "limited"
-                if mineru_enabled
-                else "disabled"
+                "available" if mineru_enabled and mineru_status == "ok" else "limited" if mineru_enabled else "disabled"
             ),
             detail="Optional enhancement path for complex PDFs and layout-heavy documents. Disabled by default.",
             requirements=["use_mineru=true", "mineru_api_token"],
@@ -270,7 +266,9 @@ async def get_parser_health_report(parser_settings: dict[str, Any] | None = None
         recommendations.append("Install LibreOffice/OpenOffice if customers need legacy Office support.")
 
     if mineru_enabled:
-        warnings.append("MinerU is enabled. Parsing results may differ from the default local parser for supported files.")
+        warnings.append(
+            "MinerU is enabled. Parsing results may differ from the default local parser for supported files."
+        )
         if mineru_status != "ok":
             warnings.append(f"MinerU enhancement is enabled but not healthy: {mineru_detail}")
         recommendations.append("Keep MinerU as an explicit enhancement path, not the default delivery path.")

--- a/aperag/docparser/health.py
+++ b/aperag/docparser/health.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import base64
+import io
+import wave
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Literal
 
@@ -73,13 +77,49 @@ def _service_url(base_url: str, suffix: str = "") -> str:
     return base_url.rstrip("/") + suffix
 
 
-async def _probe_url(url: str, method: str = "GET") -> tuple[bool, str]:
+def _sample_png_base64() -> str:
+    png_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wn7P9sAAAAASUVORK5CYII="
+    )
+    return base64.b64encode(png_bytes).decode("utf-8")
+
+
+def _sample_wav_file() -> tuple[str, bytes, str]:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16000)
+        wav_file.writeframes(b"\x00\x00" * 1600)
+    return ("health-check.wav", buffer.getvalue(), "audio/wav")
+
+
+async def _probe_http_endpoint(
+    url: str,
+    *,
+    method: str = "GET",
+    ok_statuses: set[int] | None = None,
+    json_body: dict[str, Any] | None = None,
+    files: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+) -> tuple[str, str]:
+    ok_statuses = ok_statuses or {200}
     try:
         async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-            response = await client.request(method, url)
-        return True, f"Reachable (HTTP {response.status_code})"
+            response = await client.request(
+                method,
+                url,
+                json=json_body,
+                files=files,
+                params=params,
+            )
+        if response.status_code in ok_statuses:
+            return "ok", f"Reachable (HTTP {response.status_code})"
+        if 400 <= response.status_code < 500:
+            return "error", f"Endpoint responded with HTTP {response.status_code}"
+        return "warning", f"Endpoint responded with HTTP {response.status_code}"
     except Exception as e:
-        return False, str(e)
+        return "warning", str(e)
 
 
 async def _probe_mineru(token: str | None) -> tuple[str, str]:
@@ -94,9 +134,38 @@ async def _probe_mineru(token: str | None) -> tuple[str, str]:
             )
         if response.status_code == 401:
             return "error", "Configured token is invalid."
-        return "ok", f"Reachable (HTTP {response.status_code})"
+        if 200 <= response.status_code < 300:
+            return "ok", f"Reachable (HTTP {response.status_code})"
+        if 400 <= response.status_code < 500:
+            return "error", f"MinerU responded with HTTP {response.status_code}"
+        return "warning", f"MinerU responded with HTTP {response.status_code}"
     except Exception as e:
         return "warning", f"Token configured but MinerU is unreachable: {e}"
+
+
+async def _probe_paddleocr(base_url: str) -> tuple[str, str]:
+    return await _probe_http_endpoint(
+        _service_url(base_url, "/predict/ocr_system"),
+        method="POST",
+        ok_statuses={200},
+        json_body={"images": [_sample_png_base64()]},
+    )
+
+
+async def _probe_whisper(base_url: str) -> tuple[str, str]:
+    return await _probe_http_endpoint(
+        _service_url(base_url, "/asr"),
+        method="POST",
+        ok_statuses={200},
+        params={
+            "encode": "true",
+            "task": "transcribe",
+            "vad_filter": "true",
+            "word_timestamps": "true",
+            "output": "txt",
+        },
+        files={"audio_file": _sample_wav_file()},
+    )
 
 
 def _package_status(package_name: str) -> tuple[str, str]:
@@ -133,59 +202,42 @@ async def get_parser_health_report(parser_settings: dict[str, Any] | None = None
         ),
     ]
 
-    mineru_status, mineru_detail = (
-        await _probe_mineru(mineru_token) if mineru_enabled else ("disabled", "MinerU is disabled.")
+    paddle_host = settings.paddleocr_host
+    whisper_host = settings.whisper_host
+    mineru_result, paddle_result, whisper_result = await asyncio.gather(
+        _probe_mineru(mineru_token) if mineru_enabled else asyncio.sleep(0, result=("disabled", "MinerU is disabled.")),
+        _probe_paddleocr(paddle_host)
+        if paddle_host
+        else asyncio.sleep(0, result=("disabled", "Not configured. Image OCR is disabled.")),
+        _probe_whisper(whisper_host)
+        if whisper_host
+        else asyncio.sleep(0, result=("disabled", "Not configured. Audio transcription is disabled.")),
     )
+
+    mineru_status, mineru_detail = mineru_result
+    paddle_status, paddle_detail = paddle_result
+    whisper_status, whisper_detail = whisper_result
+
     services = [
         ParserHealthItem(
             key="mineru",
             label="MinerU enhancement service",
             status=mineru_status,
             detail=mineru_detail,
-        )
+        ),
+        ParserHealthItem(
+            key="paddleocr",
+            label="PaddleOCR service",
+            status=paddle_status,
+            detail=paddle_detail,
+        ),
+        ParserHealthItem(
+            key="whisper",
+            label="Whisper ASR service",
+            status=whisper_status,
+            detail=whisper_detail,
+        ),
     ]
-
-    paddle_host = settings.paddleocr_host
-    if paddle_host:
-        paddle_ok, paddle_detail = await _probe_url(_service_url(paddle_host))
-        services.append(
-            ParserHealthItem(
-                key="paddleocr",
-                label="PaddleOCR service",
-                status="ok" if paddle_ok else "warning",
-                detail=paddle_detail if paddle_ok else f"Configured but unreachable: {paddle_detail}",
-            )
-        )
-    else:
-        services.append(
-            ParserHealthItem(
-                key="paddleocr",
-                label="PaddleOCR service",
-                status="disabled",
-                detail="Not configured. Image OCR is disabled.",
-            )
-        )
-
-    whisper_host = settings.whisper_host
-    if whisper_host:
-        whisper_ok, whisper_detail = await _probe_url(_service_url(whisper_host))
-        services.append(
-            ParserHealthItem(
-                key="whisper",
-                label="Whisper ASR service",
-                status="ok" if whisper_ok else "warning",
-                detail=whisper_detail if whisper_ok else f"Configured but unreachable: {whisper_detail}",
-            )
-        )
-    else:
-        services.append(
-            ParserHealthItem(
-                key="whisper",
-                label="Whisper ASR service",
-                status="disabled",
-                detail="Not configured. Audio transcription is disabled.",
-            )
-        )
 
     support_tiers = [
         ParserSupportTier(
@@ -226,13 +278,7 @@ async def get_parser_health_report(parser_settings: dict[str, Any] | None = None
             category="optional",
             parser="image",
             formats=IMAGE_EXTENSIONS,
-            status=(
-                "available"
-                if paddle_host and any(item.key == "paddleocr" and item.status == "ok" for item in services)
-                else "disabled"
-                if not paddle_host
-                else "limited"
-            ),
+            status="available" if paddle_status == "ok" else "disabled" if not paddle_host else "limited",
             detail="Optional OCR path for standalone images.",
             requirements=["PADDLEOCR_HOST"],
         ),
@@ -242,13 +288,7 @@ async def get_parser_health_report(parser_settings: dict[str, Any] | None = None
             category="optional",
             parser="audio",
             formats=AUDIO_EXTENSIONS,
-            status=(
-                "available"
-                if whisper_host and any(item.key == "whisper" and item.status == "ok" for item in services)
-                else "disabled"
-                if not whisper_host
-                else "limited"
-            ),
+            status="available" if whisper_status == "ok" else "disabled" if not whisper_host else "limited",
             detail="Optional speech-to-text path for uploaded audio files.",
             requirements=["WHISPER_HOST"],
         ),
@@ -273,10 +313,10 @@ async def get_parser_health_report(parser_settings: dict[str, Any] | None = None
             warnings.append(f"MinerU enhancement is enabled but not healthy: {mineru_detail}")
         recommendations.append("Keep MinerU as an explicit enhancement path, not the default delivery path.")
 
-    if paddle_host and not any(item.key == "paddleocr" and item.status == "ok" for item in services):
-        warnings.append("PaddleOCR is configured but currently unreachable.")
-    if whisper_host and not any(item.key == "whisper" and item.status == "ok" for item in services):
-        warnings.append("Whisper ASR is configured but currently unreachable.")
+    if paddle_host and paddle_status != "ok":
+        warnings.append("PaddleOCR is configured but currently unreachable or unhealthy.")
+    if whisper_host and whisper_status != "ok":
+        warnings.append("Whisper ASR is configured but currently unreachable or unhealthy.")
 
     recommendations.append("Use the support tiers below as the customer-facing parser support matrix.")
     recommendations.append("Prefer deployment-time parser preflight over upload-time trial and error.")

--- a/aperag/docparser/health.py
+++ b/aperag/docparser/health.py
@@ -1,0 +1,295 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Literal
+
+import httpx
+from pydantic import BaseModel, Field
+
+from aperag.config import settings
+from aperag.docparser.audio_parser import SUPPORTED_EXTENSIONS as AUDIO_EXTENSIONS
+from aperag.docparser.doc_parser import DocParser
+from aperag.docparser.image_parser import SUPPORTED_EXTENSIONS as IMAGE_EXTENSIONS
+from aperag.docparser.markitdown_parser import SUPPORTED_EXTENSIONS as MARKITDOWN_EXTENSIONS
+from aperag.docparser.mineru_parser import API_HOST as MINERU_API_HOST
+from aperag.docparser.mineru_parser import SUPPORTED_EXTENSIONS as MINERU_EXTENSIONS
+from aperag.docparser.utils import get_soffice_cmd
+
+OFFICIAL_FORMATS = [
+    ext for ext in MARKITDOWN_EXTENSIONS if ext not in [".doc", ".ppt"]
+]
+LEGACY_OFFICE_FORMATS = [".doc", ".ppt"]
+
+
+class ParserHealthItem(BaseModel):
+    key: str
+    label: str
+    status: Literal["ok", "warning", "error", "disabled"]
+    detail: str
+
+
+class ParserSupportTier(BaseModel):
+    key: str
+    label: str
+    category: Literal["official", "conditional", "enhanced", "optional"]
+    parser: str
+    formats: list[str] = Field(default_factory=list)
+    status: Literal["available", "limited", "unavailable", "disabled"]
+    detail: str
+    requirements: list[str] = Field(default_factory=list)
+
+
+class ParserHealthReport(BaseModel):
+    default_parser: str
+    parser_order: list[str] = Field(default_factory=list)
+    available_extensions: list[str] = Field(default_factory=list)
+    dependencies: list[ParserHealthItem] = Field(default_factory=list)
+    services: list[ParserHealthItem] = Field(default_factory=list)
+    support_tiers: list[ParserSupportTier] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    recommendations: list[str] = Field(default_factory=list)
+
+
+def _normalize_parser_settings(parser_settings: dict[str, Any] | None) -> dict[str, Any]:
+    parser_settings = parser_settings or {}
+    return {
+        "use_mineru": parser_settings.get("use_mineru", False),
+        "mineru_api_token": parser_settings.get("mineru_api_token") or None,
+        "use_markitdown": parser_settings.get("use_markitdown", True),
+    }
+
+
+def _service_url(base_url: str, suffix: str = "") -> str:
+    return base_url.rstrip("/") + suffix
+
+
+async def _probe_url(url: str, method: str = "GET") -> tuple[bool, str]:
+    try:
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+            response = await client.request(method, url)
+        return True, f"Reachable (HTTP {response.status_code})"
+    except Exception as e:
+        return False, str(e)
+
+
+async def _probe_mineru(token: str | None) -> tuple[str, str]:
+    if not token:
+        return "disabled", "MinerU token is not configured."
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                f"{MINERU_API_HOST}/api/v4/extract-results/batch/test-token",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        if response.status_code == 401:
+            return "error", "Configured token is invalid."
+        return "ok", f"Reachable (HTTP {response.status_code})"
+    except Exception as e:
+        return "warning", f"Token configured but MinerU is unreachable: {e}"
+
+
+def _package_status(package_name: str) -> tuple[str, str]:
+    try:
+        return "ok", f"Installed ({version(package_name)})"
+    except PackageNotFoundError:
+        return "error", "Not installed"
+
+
+async def get_parser_health_report(parser_settings: dict[str, Any] | None = None) -> ParserHealthReport:
+    parser_settings = _normalize_parser_settings(parser_settings)
+    parser = DocParser(parser_config=parser_settings)
+    parser_order = parser.parsing_order
+    available_extensions = parser.supported_extensions()
+
+    markitdown_enabled = parser_settings["use_markitdown"]
+    mineru_enabled = parser_settings["use_mineru"]
+    mineru_token = parser_settings["mineru_api_token"]
+    soffice_cmd = get_soffice_cmd()
+
+    markitdown_status, markitdown_detail = _package_status("markitdown")
+    dependencies = [
+        ParserHealthItem(
+            key="markitdown",
+            label="MarkItDown package",
+            status=markitdown_status,
+            detail=markitdown_detail,
+        ),
+        ParserHealthItem(
+            key="soffice",
+            label="LibreOffice soffice",
+            status="ok" if soffice_cmd else "warning",
+            detail=soffice_cmd or "Not found. Legacy .doc/.ppt parsing will be unavailable.",
+        ),
+    ]
+
+    mineru_status, mineru_detail = await _probe_mineru(mineru_token) if mineru_enabled else ("disabled", "MinerU is disabled.")
+    services = [
+        ParserHealthItem(
+            key="mineru",
+            label="MinerU enhancement service",
+            status=mineru_status,
+            detail=mineru_detail,
+        )
+    ]
+
+    paddle_host = settings.paddleocr_host
+    if paddle_host:
+        paddle_ok, paddle_detail = await _probe_url(_service_url(paddle_host))
+        services.append(
+            ParserHealthItem(
+                key="paddleocr",
+                label="PaddleOCR service",
+                status="ok" if paddle_ok else "warning",
+                detail=paddle_detail if paddle_ok else f"Configured but unreachable: {paddle_detail}",
+            )
+        )
+    else:
+        services.append(
+            ParserHealthItem(
+                key="paddleocr",
+                label="PaddleOCR service",
+                status="disabled",
+                detail="Not configured. Image OCR is disabled.",
+            )
+        )
+
+    whisper_host = settings.whisper_host
+    if whisper_host:
+        whisper_ok, whisper_detail = await _probe_url(_service_url(whisper_host))
+        services.append(
+            ParserHealthItem(
+                key="whisper",
+                label="Whisper ASR service",
+                status="ok" if whisper_ok else "warning",
+                detail=whisper_detail if whisper_ok else f"Configured but unreachable: {whisper_detail}",
+            )
+        )
+    else:
+        services.append(
+            ParserHealthItem(
+                key="whisper",
+                label="Whisper ASR service",
+                status="disabled",
+                detail="Not configured. Audio transcription is disabled.",
+            )
+        )
+
+    support_tiers = [
+        ParserSupportTier(
+            key="default_local",
+            label="Default local parsing",
+            category="official",
+            parser="markitdown",
+            formats=OFFICIAL_FORMATS,
+            status="available" if markitdown_enabled and markitdown_status == "ok" else "unavailable",
+            detail="Default private-deployment parser path. Uses local MarkItDown without cloud dependency.",
+            requirements=["markitdown"],
+        ),
+        ParserSupportTier(
+            key="legacy_office",
+            label="Legacy Office conversion",
+            category="conditional",
+            parser="markitdown+soffice",
+            formats=LEGACY_OFFICE_FORMATS,
+            status="available" if markitdown_enabled and bool(soffice_cmd) else "limited",
+            detail="Legacy .doc/.ppt support requires the soffice binary to convert files before parsing.",
+            requirements=["markitdown", "soffice"],
+        ),
+        ParserSupportTier(
+            key="mineru_enhancement",
+            label="Complex document enhancement",
+            category="enhanced",
+            parser="mineru",
+            formats=MINERU_EXTENSIONS,
+            status=(
+                "available"
+                if mineru_enabled and mineru_status == "ok"
+                else "limited"
+                if mineru_enabled
+                else "disabled"
+            ),
+            detail="Optional enhancement path for complex PDFs and layout-heavy documents. Disabled by default.",
+            requirements=["use_mineru=true", "mineru_api_token"],
+        ),
+        ParserSupportTier(
+            key="image_ocr",
+            label="Image OCR",
+            category="optional",
+            parser="image",
+            formats=IMAGE_EXTENSIONS,
+            status=(
+                "available"
+                if paddle_host and any(item.key == "paddleocr" and item.status == "ok" for item in services)
+                else "disabled"
+                if not paddle_host
+                else "limited"
+            ),
+            detail="Optional OCR path for standalone images.",
+            requirements=["PADDLEOCR_HOST"],
+        ),
+        ParserSupportTier(
+            key="audio_asr",
+            label="Audio transcription",
+            category="optional",
+            parser="audio",
+            formats=AUDIO_EXTENSIONS,
+            status=(
+                "available"
+                if whisper_host and any(item.key == "whisper" and item.status == "ok" for item in services)
+                else "disabled"
+                if not whisper_host
+                else "limited"
+            ),
+            detail="Optional speech-to-text path for uploaded audio files.",
+            requirements=["WHISPER_HOST"],
+        ),
+    ]
+
+    warnings: list[str] = []
+    recommendations: list[str] = []
+
+    if not markitdown_enabled:
+        warnings.append("MarkItDown is disabled. The default parser path is unavailable for most document formats.")
+        recommendations.append("Keep MarkItDown enabled for the default private-deployment parser path.")
+
+    if not soffice_cmd:
+        warnings.append("Legacy Office files (.doc/.ppt) are not available because soffice is missing.")
+        recommendations.append("Install LibreOffice/OpenOffice if customers need legacy Office support.")
+
+    if mineru_enabled:
+        warnings.append("MinerU is enabled. Parsing results may differ from the default local parser for supported files.")
+        if mineru_status != "ok":
+            warnings.append(f"MinerU enhancement is enabled but not healthy: {mineru_detail}")
+        recommendations.append("Keep MinerU as an explicit enhancement path, not the default delivery path.")
+
+    if paddle_host and not any(item.key == "paddleocr" and item.status == "ok" for item in services):
+        warnings.append("PaddleOCR is configured but currently unreachable.")
+    if whisper_host and not any(item.key == "whisper" and item.status == "ok" for item in services):
+        warnings.append("Whisper ASR is configured but currently unreachable.")
+
+    recommendations.append("Use the support tiers below as the customer-facing parser support matrix.")
+    recommendations.append("Prefer deployment-time parser preflight over upload-time trial and error.")
+
+    return ParserHealthReport(
+        default_parser="markitdown" if markitdown_enabled else "none",
+        parser_order=parser_order,
+        available_extensions=available_extensions,
+        dependencies=dependencies,
+        services=services,
+        support_tiers=support_tiers,
+        warnings=warnings,
+        recommendations=recommendations,
+    )

--- a/aperag/docparser/image_parser.py
+++ b/aperag/docparser/image_parser.py
@@ -22,7 +22,7 @@ import requests
 from PIL import Image
 
 from aperag.config import settings
-from aperag.docparser.base import BaseParser, FallbackError, Part, TextPart
+from aperag.docparser.base import BaseParser, FallbackError, ParserError, Part, TextPart
 
 SUPPORTED_EXTENSIONS = [
     ".jpg",
@@ -33,6 +33,8 @@ SUPPORTED_EXTENSIONS = [
     ".tif",
 ]
 
+REQUEST_TIMEOUT = 15
+
 
 class ImageParser(BaseParser):
     name = "image"
@@ -42,7 +44,12 @@ class ImageParser(BaseParser):
 
     def parse_file(self, path: Path, metadata: dict[str, Any] = {}, **kwargs) -> list[Part]:
         if not settings.paddleocr_host:
-            raise FallbackError("PADDLEOCR_HOST is not set")
+            raise FallbackError(
+                "Image OCR is not configured",
+                parser_name=self.name,
+                code="service_not_configured",
+                detail="Set PADDLEOCR_HOST to enable image OCR.",
+            )
 
         content = self.read_image_text(path)
         metadata = metadata.copy()
@@ -63,8 +70,24 @@ class ImageParser(BaseParser):
         data = {"images": [image_to_base64(str(path))]}
         headers = {"Content-type": "application/json"}
         url = settings.paddleocr_host + "/predict/ocr_system"
-        r = requests.post(url=url, headers=headers, data=json.dumps(data))
-        data = json.loads(r.text)
+        try:
+            r = requests.post(url=url, headers=headers, data=json.dumps(data), timeout=REQUEST_TIMEOUT)
+            r.raise_for_status()
+            data = json.loads(r.text)
+        except requests.exceptions.RequestException as e:
+            raise ParserError(
+                "Image OCR request failed",
+                parser_name=self.name,
+                code="service_unreachable",
+                detail=str(e),
+            ) from e
+        except json.JSONDecodeError as e:
+            raise ParserError(
+                "Image OCR returned invalid JSON",
+                parser_name=self.name,
+                code="invalid_response",
+                detail=str(e),
+            ) from e
 
         # TODO: extract image metadata by using exiftool
 

--- a/aperag/docparser/markitdown_parser.py
+++ b/aperag/docparser/markitdown_parser.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from markitdown import MarkItDown
 
-from aperag.docparser.base import BaseParser, FallbackError, Part
+from aperag.docparser.base import BaseParser, FallbackError, ParserError, Part
 from aperag.docparser.parse_md import parse_md
 from aperag.docparser.utils import convert_office_doc, get_soffice_cmd
 
@@ -56,13 +56,28 @@ class MarkItDownParser(BaseParser):
             target_format = ".pptx"
         if target_format:
             if get_soffice_cmd() is None:
-                raise FallbackError("soffice command not found")
+                raise FallbackError(
+                    "Legacy Office conversion requires soffice",
+                    parser_name=self.name,
+                    code="missing_dependency",
+                    detail="Install LibreOffice/OpenOffice or upload .docx/.pptx instead.",
+                )
             with tempfile.TemporaryDirectory() as temp_dir:
                 converted = convert_office_doc(path, Path(temp_dir), target_format)
                 return self._parse_file(converted, metadata, **kwargs)
         return self._parse_file(path, metadata, **kwargs)
 
     def _parse_file(self, path: Path, metadata: dict[str, Any] = {}, **kwargs) -> list[Part]:
-        mid = MarkItDown()
-        result = mid.convert_local(path, keep_data_uris=True)
-        return parse_md(result.markdown, metadata)
+        try:
+            mid = MarkItDown()
+            result = mid.convert_local(path, keep_data_uris=True)
+            return parse_md(result.markdown, metadata)
+        except ParserError:
+            raise
+        except Exception as e:
+            raise ParserError(
+                f"MarkItDown failed to parse {path.suffix.lower() or 'unknown'} file",
+                parser_name=self.name,
+                code="parse_failed",
+                detail=str(e),
+            ) from e

--- a/aperag/docparser/mineru_parser.py
+++ b/aperag/docparser/mineru_parser.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import requests
 
-from aperag.docparser.base import BaseParser, FallbackError, Part, PdfPart
+from aperag.docparser.base import BaseParser, FallbackError, ParserError, Part, PdfPart
 from aperag.docparser.mineru_common import middle_json_to_parts, to_md_part
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,8 @@ SUPPORTED_EXTENSIONS = [
 ]
 
 API_HOST = "https://mineru.net"
+REQUEST_TIMEOUT = 30
+MAX_POLL_SECONDS = 300
 
 
 class MinerUParser(BaseParser):
@@ -53,7 +55,12 @@ class MinerUParser(BaseParser):
 
     def parse_file(self, path: Path, metadata: dict[str, Any], **kwargs) -> list[Part]:
         if not self.api_token:
-            raise RuntimeError("MinerU API token is not set")
+            raise FallbackError(
+                "MinerU is enabled but no API token is configured",
+                parser_name=self.name,
+                code="missing_configuration",
+                detail="Set mineru_api_token to enable MinerU enhancement.",
+            )
 
         headers = {
             "Authorization": f"Bearer {self.api_token}",
@@ -71,11 +78,17 @@ class MinerUParser(BaseParser):
                 f"{API_HOST}/api/v4/file-urls/batch",
                 headers=headers,
                 json=upload_url_payload,
+                timeout=REQUEST_TIMEOUT,
             )
             resp.raise_for_status()
             upload_data = resp.json()
             if upload_data.get("code") != 0:
-                raise RuntimeError(f"Failed to get upload URL: {upload_data.get('msg')}")
+                raise FallbackError(
+                    "MinerU could not allocate an upload slot",
+                    parser_name=self.name,
+                    code="service_rejected_request",
+                    detail=upload_data.get("msg"),
+                )
 
             batch_id = upload_data["data"]["batch_id"]
             file_url = upload_data["data"]["file_urls"][0]
@@ -83,25 +96,44 @@ class MinerUParser(BaseParser):
 
         except requests.exceptions.RequestException as e:
             logger.exception("Failed to get Mineru upload URL")
-            raise RuntimeError("Failed to get Mineru upload URL") from e
+            raise FallbackError(
+                "MinerU upload initialization failed",
+                parser_name=self.name,
+                code="service_unreachable",
+                detail=str(e),
+            ) from e
 
         # 2. Upload file
         try:
             with open(path, "rb") as f:
-                upload_resp = requests.put(file_url, data=f)
+                upload_resp = requests.put(file_url, data=f, timeout=REQUEST_TIMEOUT)
                 upload_resp.raise_for_status()
             logger.info(f"Successfully uploaded {path.name} to Mineru.")
         except requests.exceptions.RequestException as e:
             logger.exception(f"Failed to upload file to Mineru: {path.name}")
-            raise RuntimeError("Failed to upload file to Mineru") from e
+            raise FallbackError(
+                "MinerU file upload failed",
+                parser_name=self.name,
+                code="service_unreachable",
+                detail=str(e),
+            ) from e
 
         # 3. Poll for result
+        start_time = time.monotonic()
         while True:
+            if time.monotonic() - start_time > MAX_POLL_SECONDS:
+                raise FallbackError(
+                    "MinerU parsing timed out",
+                    parser_name=self.name,
+                    code="timeout",
+                    detail=f"Timed out after {MAX_POLL_SECONDS} seconds. Falling back to local parser.",
+                )
             try:
                 time.sleep(5)  # Poll every 5 seconds
                 status_resp = requests.get(
                     f"{API_HOST}/api/v4/extract-results/batch/{batch_id}",
                     headers={"Authorization": f"Bearer {self.api_token}"},
+                    timeout=REQUEST_TIMEOUT,
                 )
                 status_resp.raise_for_status()
                 status_data = status_resp.json()
@@ -129,17 +161,32 @@ class MinerUParser(BaseParser):
                     error_message = task_status.get("err_msg", "Unknown error")
                     # "number of pages exceeds limit" or "file size exceeds limit"
                     if "exceeds limit" in error_message:
-                        raise FallbackError(error_message)
-                    raise RuntimeError(f"Mineru parsing failed for batch {batch_id}: {error_message}")
+                        raise FallbackError(
+                            "MinerU rejected the file because it exceeds service limits",
+                            parser_name=self.name,
+                            code="service_limit_exceeded",
+                            detail=error_message,
+                        )
+                    raise FallbackError(
+                        "MinerU parsing failed and the system will fall back to the local parser",
+                        parser_name=self.name,
+                        code="service_failed",
+                        detail=error_message,
+                    )
 
             except requests.exceptions.RequestException as e:
                 logger.warning(f"Polling request failed for batch {batch_id}: {e}")
-                # Continue polling even if one request fails
+                raise FallbackError(
+                    "MinerU status polling failed",
+                    parser_name=self.name,
+                    code="service_unreachable",
+                    detail=str(e),
+                ) from e
 
     def _download_and_process_zip(self, zip_url: str, metadata: dict[str, Any], is_pdf_input: bool) -> list[Part]:
         temp_dir_obj = None
         try:
-            response = requests.get(zip_url)
+            response = requests.get(zip_url, timeout=REQUEST_TIMEOUT)
             response.raise_for_status()
 
             temp_dir_obj = tempfile.TemporaryDirectory()
@@ -161,7 +208,12 @@ class MinerUParser(BaseParser):
                         pdf_part = PdfPart(data=pdf_data, metadata=metadata.copy())
 
             if not middle_json_content:
-                raise RuntimeError("layout.json not found in the result zip.")
+                raise FallbackError(
+                    "MinerU response did not contain layout.json",
+                    parser_name=self.name,
+                    code="invalid_response",
+                    detail="Falling back to the local parser.",
+                )
 
             parts = middle_json_to_parts(image_dir, middle_json_content, metadata.copy())
             if not parts:
@@ -175,7 +227,21 @@ class MinerUParser(BaseParser):
 
         except requests.exceptions.RequestException as e:
             logger.exception(f"Failed to download result zip from {zip_url}")
-            raise RuntimeError(f"Failed to download result zip from {zip_url}") from e
+            raise FallbackError(
+                "MinerU result download failed",
+                parser_name=self.name,
+                code="service_unreachable",
+                detail=str(e),
+            ) from e
+        except FallbackError:
+            raise
+        except Exception as e:
+            raise ParserError(
+                "MinerU returned an invalid parsing result",
+                parser_name=self.name,
+                code="invalid_response",
+                detail=str(e),
+            ) from e
         finally:
             if temp_dir_obj:
                 temp_dir_obj.cleanup()

--- a/aperag/index/document_parser.py
+++ b/aperag/index/document_parser.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 import pikepdf
 import pypdfium2 as pdfium
 
-from aperag.docparser.base import AssetBinPart, MarkdownPart, PdfPart
+from aperag.docparser.base import AssetBinPart, MarkdownPart, ParserError, PdfPart
 from aperag.docparser.doc_parser import DocParser
 from aperag.objectstore.base import get_object_store
 
@@ -263,8 +263,10 @@ class DocumentParser:
 
             return DocumentParsingResult(doc_parts=doc_parts, content=content, metadata={"parts_count": len(doc_parts)})
 
+        except ParserError as e:
+            raise Exception(f"Document parsing failed for {filepath}: {e.diagnostic_message()}") from e
         except Exception as e:
-            raise Exception(f"Document parsing failed for {filepath}: {str(e)}")
+            raise Exception(f"Document parsing failed for {filepath}: {str(e)}") from e
 
 
 # Global parser instance

--- a/aperag/views/settings.py
+++ b/aperag/views/settings.py
@@ -17,6 +17,7 @@ from typing import Optional
 from fastapi import APIRouter, Body, Depends, Response
 from fastapi.responses import JSONResponse
 
+from aperag.docparser.health import ParserHealthReport, get_parser_health_report
 from aperag.schema.view_models import Settings
 from aperag.service.setting_service import setting_service
 from aperag.views.auth import required_user
@@ -37,6 +38,12 @@ async def update_settings(
 ):
     await setting_service.update_settings(settings.model_dump())
     return Response(status_code=204)
+
+
+@router.get("/settings/parser_health", tags=["Settings"], response_model=ParserHealthReport)
+async def get_parser_health(user: dict = Depends(required_user)):
+    current_settings = await setting_service.get_all_settings()
+    return await get_parser_health_report(current_settings)
 
 
 @router.post("/settings/test_mineru_token", tags=["Settings"])

--- a/web/src/app/admin/configuration/parser-settings.tsx
+++ b/web/src/app/admin/configuration/parser-settings.tsx
@@ -2,6 +2,7 @@
 
 import { Settings } from '@/api';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import {
   Card,
   CardContent,
@@ -14,7 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { apiClient } from '@/lib/api/client';
 import { cn } from '@/lib/utils';
-import { LaptopMinimalCheck, LoaderCircle } from 'lucide-react';
+import { LaptopMinimalCheck, LoaderCircle, RefreshCcw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
@@ -24,6 +25,63 @@ const defaultValue = {
   mineru_api_token: '',
   use_markitdown: true,
 };
+
+type HealthStatus = 'ok' | 'warning' | 'error' | 'disabled';
+type SupportStatus = 'available' | 'limited' | 'unavailable' | 'disabled';
+
+type ParserHealthItem = {
+  key: string;
+  label: string;
+  status: HealthStatus;
+  detail: string;
+};
+
+type ParserSupportTier = {
+  key: string;
+  label: string;
+  category: 'official' | 'conditional' | 'enhanced' | 'optional';
+  parser: string;
+  formats: string[];
+  status: SupportStatus;
+  detail: string;
+  requirements: string[];
+};
+
+type ParserHealthReport = {
+  default_parser: string;
+  parser_order: string[];
+  available_extensions: string[];
+  dependencies: ParserHealthItem[];
+  services: ParserHealthItem[];
+  support_tiers: ParserSupportTier[];
+  warnings: string[];
+  recommendations: string[];
+};
+
+const getHealthBadgeClassName = (status: HealthStatus | SupportStatus) => {
+  switch (status) {
+    case 'ok':
+    case 'available':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+    case 'warning':
+    case 'limited':
+      return 'border-amber-200 bg-amber-50 text-amber-700';
+    case 'error':
+    case 'unavailable':
+      return 'border-red-200 bg-red-50 text-red-700';
+    case 'disabled':
+      return 'border-slate-200 bg-slate-50 text-slate-600';
+  }
+  return 'border-slate-200 bg-slate-50 text-slate-600';
+};
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+
+const StatusBadge = ({ status }: { status: HealthStatus | SupportStatus }) => (
+  <Badge variant="outline" className={getHealthBadgeClassName(status)}>
+    {capitalize(status)}
+  </Badge>
+);
 
 export const ParserSettings = ({
   data: initData = defaultValue,
@@ -39,13 +97,39 @@ export const ParserSettings = ({
   const common_tips = useTranslations('common.tips');
   const [checked, setChecked] = useState<boolean>(false);
   const [checking, setChecking] = useState<boolean>(false);
+  const [health, setHealth] = useState<ParserHealthReport | null>(null);
+  const [healthLoading, setHealthLoading] = useState<boolean>(true);
+
+  const fetchParserHealth = useCallback(async () => {
+    setHealthLoading(true);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v1/settings/parser_health`,
+        {
+          credentials: 'include',
+          cache: 'no-store',
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const result = (await response.json()) as ParserHealthReport;
+      setHealth(result);
+    } catch (error) {
+      toast.error(admin_config('parser_health_load_failed'));
+      console.error(error);
+    } finally {
+      setHealthLoading(false);
+    }
+  }, [admin_config]);
 
   const handleSave = useCallback(async () => {
     await apiClient.defaultApi.settingsPut({
       settings: data,
     });
     toast.success('Saved successfully');
-  }, [data]);
+    await fetchParserHealth();
+  }, [data, fetchParserHealth]);
 
   const handleSwitchChange = useCallback(
     async (key: keyof Settings, checked: boolean) => {
@@ -54,8 +138,9 @@ export const ParserSettings = ({
       await apiClient.defaultApi.settingsPut({
         settings,
       });
+      await fetchParserHealth();
     },
-    [data],
+    [data, fetchParserHealth],
   );
 
   const handleCheckMineruToken = useCallback(async () => {
@@ -77,7 +162,8 @@ export const ParserSettings = ({
       toast.success(common_tips('save_success'));
     }
     setChecking(false);
-  }, [admin_config, common_tips, data.mineru_api_token]);
+    await fetchParserHealth();
+  }, [admin_config, common_tips, data.mineru_api_token, fetchParserHealth]);
 
   useEffect(() => {
     setData({
@@ -86,8 +172,181 @@ export const ParserSettings = ({
     });
   }, [initData]);
 
+  useEffect(() => {
+    void fetchParserHealth();
+  }, [fetchParserHealth]);
+
   return (
     <>
+      <Card>
+        <CardHeader>
+          <div className="flex flex-row items-center justify-between gap-4">
+            <div>
+              <CardTitle>{admin_config('parser_health_title')}</CardTitle>
+              <CardDescription>
+                {admin_config('parser_health_description')}
+              </CardDescription>
+            </div>
+            <Button
+              variant="outline"
+              disabled={healthLoading}
+              onClick={() => void fetchParserHealth()}
+            >
+              <RefreshCcw className={cn(healthLoading ? 'animate-spin' : '')} />
+              {admin_config('parser_health_refresh')}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {healthLoading && !health ? (
+            <div className="text-muted-foreground flex items-center gap-2 text-sm">
+              <LoaderCircle className="animate-spin" />
+              {admin_config('parser_health_loading')}
+            </div>
+          ) : null}
+
+          {health ? (
+            <>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-lg border p-4">
+                  <div className="mb-2 text-sm font-medium">
+                    {admin_config('parser_health_default_parser')}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="border-blue-200 bg-blue-50 text-blue-700">
+                      {health.default_parser}
+                    </Badge>
+                  </div>
+                </div>
+                <div className="rounded-lg border p-4">
+                  <div className="mb-2 text-sm font-medium">
+                    {admin_config('parser_health_parser_order')}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {health.parser_order.map((parserName) => (
+                      <Badge key={parserName} variant="outline">
+                        {parserName}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-lg border p-4">
+                  <div className="mb-3 text-sm font-medium">
+                    {admin_config('parser_health_dependencies')}
+                  </div>
+                  <div className="space-y-3">
+                    {health.dependencies.map((item) => (
+                      <div key={item.key} className="space-y-1">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="text-sm font-medium">{item.label}</div>
+                          <StatusBadge status={item.status} />
+                        </div>
+                        <div className="text-muted-foreground text-sm">
+                          {item.detail}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-lg border p-4">
+                  <div className="mb-3 text-sm font-medium">
+                    {admin_config('parser_health_services')}
+                  </div>
+                  <div className="space-y-3">
+                    {health.services.map((item) => (
+                      <div key={item.key} className="space-y-1">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="text-sm font-medium">{item.label}</div>
+                          <StatusBadge status={item.status} />
+                        </div>
+                        <div className="text-muted-foreground text-sm">
+                          {item.detail}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-lg border p-4">
+                <div className="mb-3 text-sm font-medium">
+                  {admin_config('parser_health_support_matrix')}
+                </div>
+                <div className="space-y-4">
+                  {health.support_tiers.map((tier) => (
+                    <div key={tier.key} className="rounded-md border p-3">
+                      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <div className="font-medium">{tier.label}</div>
+                          <Badge variant="outline">{tier.category}</Badge>
+                          <Badge variant="outline">{tier.parser}</Badge>
+                        </div>
+                        <StatusBadge status={tier.status} />
+                      </div>
+                      <div className="text-muted-foreground mb-2 text-sm">
+                        {tier.detail}
+                      </div>
+                      <div className="mb-2 flex flex-wrap gap-2">
+                        {tier.formats.map((format) => (
+                          <Badge key={`${tier.key}-${format}`} variant="outline">
+                            {format}
+                          </Badge>
+                        ))}
+                      </div>
+                      {tier.requirements.length > 0 ? (
+                        <div className="text-xs text-slate-600">
+                          {admin_config('parser_health_requirements')}:{' '}
+                          {tier.requirements.join(', ')}
+                        </div>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-lg border p-4">
+                  <div className="mb-3 text-sm font-medium">
+                    {admin_config('parser_health_warnings')}
+                  </div>
+                  {health.warnings.length > 0 ? (
+                    <ul className="list-disc space-y-2 pl-5 text-sm">
+                      {health.warnings.map((warning) => (
+                        <li key={warning}>{warning}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="text-muted-foreground text-sm">
+                      {admin_config('parser_health_none')}
+                    </div>
+                  )}
+                </div>
+
+                <div className="rounded-lg border p-4">
+                  <div className="mb-3 text-sm font-medium">
+                    {admin_config('parser_health_recommendations')}
+                  </div>
+                  {health.recommendations.length > 0 ? (
+                    <ul className="list-disc space-y-2 pl-5 text-sm">
+                      {health.recommendations.map((recommendation) => (
+                        <li key={recommendation}>{recommendation}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="text-muted-foreground text-sm">
+                      {admin_config('parser_health_none')}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          ) : null}
+        </CardContent>
+      </Card>
       <Card>
         <CardHeader>
           <div className="flex flex-row items-center justify-between">

--- a/web/src/i18n/en-US/admin_config.json
+++ b/web/src/i18n/en-US/admin_config.json
@@ -13,6 +13,20 @@
 
   "use_markitdown": "Use markitdown",
   "use_markitdown_description": "When enabled, the system will use markitdown for document parsing.",
+  "parser_health_title": "Parser health",
+  "parser_health_description": "Shows the current parser path, dependency readiness, external service reachability, and customer-facing support tiers.",
+  "parser_health_refresh": "Refresh",
+  "parser_health_loading": "Loading parser health...",
+  "parser_health_load_failed": "Failed to load parser health.",
+  "parser_health_default_parser": "Default parser",
+  "parser_health_parser_order": "Enabled parser order",
+  "parser_health_dependencies": "Dependencies",
+  "parser_health_services": "External services",
+  "parser_health_support_matrix": "Support matrix",
+  "parser_health_requirements": "Requirements",
+  "parser_health_warnings": "Warnings",
+  "parser_health_recommendations": "Recommendations",
+  "parser_health_none": "None",
 
   "system_default_quota": "User default quotas",
   "system_default_quota_description": "These default quotas help maintain system stability, prevent resource abuse, and ensure fair allocation across users or applications."

--- a/web/src/i18n/zh-CN/admin_config.json
+++ b/web/src/i18n/zh-CN/admin_config.json
@@ -13,6 +13,20 @@
 
   "use_markitdown": "启用 markitdown",
   "use_markitdown_description": "启用后，系统将使用 markitdown 进行文档解析。",
+  "parser_health_title": "解析服务健康状态",
+  "parser_health_description": "展示当前默认解析路径、依赖是否齐全、外部服务是否可达，以及客户可见的支持矩阵。",
+  "parser_health_refresh": "刷新",
+  "parser_health_loading": "正在加载解析服务状态...",
+  "parser_health_load_failed": "加载解析服务状态失败。",
+  "parser_health_default_parser": "默认解析器",
+  "parser_health_parser_order": "当前启用的解析顺序",
+  "parser_health_dependencies": "依赖检查",
+  "parser_health_services": "外部服务",
+  "parser_health_support_matrix": "支持矩阵",
+  "parser_health_requirements": "前置条件",
+  "parser_health_warnings": "风险提示",
+  "parser_health_recommendations": "建议",
+  "parser_health_none": "无",
 
   "system_default_quota": "用户默认配额",
   "system_default_quota_description": "默认配额有助于维护系统稳定性，防止资源滥用，并确保用户或应用间的公平分配"


### PR DESCRIPTION
## What Changed
- add a parser preflight / health endpoint at `GET /settings/parser_health`
- expose parser dependency readiness, external-service reachability, and a support-tier matrix for admin visibility
- add parser health UI to the admin configuration page so operators can see the default parser path, support tiers, warnings, and recommendations without trial-and-error uploads
- improve parser diagnostics by introducing structured parser errors and clearer parser-chain failure messages
- make MinerU a safer enhancement path by bounding request timeouts and falling back to the local parser for service-side failures instead of failing the whole parsing chain immediately
- tighten OCR / ASR request errors so they produce clearer operational diagnostics
- document the new endpoint in the source OpenAPI files

## Why
The parsing service is being optimized for private deployment, weak customer ops capability, and minimal post-delivery support burden.

This PR is intended to move the parser stack toward that goal by:
- making the default path easier to understand
- moving parser/environment issues from upload-time to deployment-time
- turning vague parsing failures into clearer diagnostics
- making optional enhancement paths safer when they are enabled

## Behavior Notes
- `MarkItDown` remains the default parser path.
- `MinerU` remains optional and default-off, but now degrades more safely when the external service is unhealthy.
- the new health endpoint reports official, conditional, enhanced, and optional support tiers so support boundaries are explicit.

## Validation
Backend/local checks:
- `uv run python -m compileall aperag/docparser aperag/views/settings.py aperag/index/document_parser.py`
- `uv run` smoke check for `get_parser_health_report({})`
- `uv run` smoke check for `get_parser_health_report({... use_mineru ...})`
- `uv run` smoke check showing parser-chain diagnostics for a PNG upload without OCR configured
- `uv run` import check confirming `/api/v1/settings/parser_health` is registered on the FastAPI app
- `git diff --check`

Frontend/local checks:
- attempted to run `yarn lint`, but this checkout does not currently have a usable local `next` executable (`next: command not found`), so frontend lint could not be completed locally in this environment
- per team convention, additional verification can run in GitHub CI / remote checks
