### PR TITLE
docs: add agent runtime v3 design

### DIFF
--- a/docs/en-US/design/agent_runtime_v3.md
+++ b/docs/en-US/design/agent_runtime_v3.md
@@ -1,0 +1,524 @@
+---
+title: Agent Runtime V3 Design
+description: Detailed design for ApeRAG Agent Runtime V3, including the Turn, TimelineEvent, Artifact, SSE contract, and migration boundary
+keywords: Agent Runtime, SSE, Turn, TimelineEvent, Artifact, PydanticAI, MCP
+position: 4
+---
+
+# ApeRAG Agent Runtime V3 Design
+
+## 1. Background and Goal
+
+The current ApeRAG agent chat path is built on top of `mcp-agent`. It has proven that the system can work, but it is not a good long-term fit for ApeRAG's product and delivery goals.
+
+The unstable part is no longer the business API surface. The weakest layer is the runtime glue:
+
+- event dispatch
+- streaming output
+- frontend/backend message grammar
+- session cache shape
+- tool-result propagation
+
+These are coupled too tightly to third-party runtime internals, which directly turns into support cost, debugging cost, and deployment risk in private environments.
+
+This design therefore does **not** aim to find a more powerful agent framework. Its purpose is to rebuild ApeRAG's `agent product layer` around private deployment requirements:
+
+1. private-deployment friendly
+2. simple and reliable
+3. low maintenance cost
+4. minimal post-delivery support burden
+
+## 2. Final Decision
+
+Agent Runtime V3 makes the following decisions official:
+
+1. `mcp-agent` will not remain the long-term runtime core
+2. `FastAPI + FastMCP + existing business API/provider integrations` remain the stable business surface
+3. `SSE` becomes the only primary transport
+4. the product contract is rebuilt around `Turn + TimelineEvent + Artifact`
+5. `PydanticAI adapter` is used as the Phase 1 runtime implementation
+6. the system keeps a long-term path to collapse into a self-owned thin orchestration layer
+7. the main runtime will not be rebuilt around `Vercel AI SDK`, `OpenAI Agents SDK`, or `LangGraph`
+
+External libraries may help with implementation, but they do not define the product contract.
+
+## 3. Design Principles
+
+### 3.1 Private deployment first
+
+All decisions optimize for:
+
+- deterministic defaults
+- diagnosable failures
+- clear rollback boundaries
+- minimal hidden assumptions
+- minimal compatibility baggage
+
+### 3.2 ApeRAG owns the contract
+
+The following are owned by ApeRAG itself:
+
+- API entrypoints
+- SSE event protocol
+- user-visible status vocabulary
+- TimelineEvent schema
+- Artifact schema
+- history commit policy
+
+Third-party runtimes must adapt to this contract, not the other way around.
+
+### 3.3 Final answer and process events must be separated
+
+The final answer, process timeline, references, and tool results are no longer packed into one assistant message.
+
+The layering is:
+
+- `answer` is an answer artifact
+- `timeline` is a process-event stream
+- `references` are separate artifacts
+- `tool result` is surfaced via summary events and artifact references
+
+### 3.4 Phase 1 stays intentionally narrow
+
+Phase 1 supports only:
+
+- single agent
+- serial tool loop
+- single MCP server view
+- multiple internal loops inside a single turn
+
+Phase 1 explicitly does not support:
+
+- multi-agent
+- parallel tool fan-out
+- workflow/graph orchestration
+- long-running orchestration
+
+## 4. Core Object Model
+
+## 4.1 Turn
+
+A `Turn` is one complete agent execution for one user query.
+
+It is important to clarify that a turn is **not** a single-step answer. A turn may contain many rounds of:
+
+- thinking
+- web search
+- tool calls
+- result reading
+- internal reasoning
+
+The turn is the outer execution boundary.
+
+### 4.1.1 Suggested fields
+
+```text
+schema_version
+turn_id
+chat_id
+user_id
+request_id
+client_idempotency_key
+status
+input_text
+model_profile
+started_at
+finished_at
+error_code
+error_message
+answer_artifact_id
+reference_bundle_artifact_id
+timeline_cursor
+```
+
+### 4.1.2 State machine
+
+```text
+queued -> running -> completed
+queued -> running -> failed
+queued -> running -> cancelled
+```
+
+### 4.1.3 Hard rules
+
+1. one turn must have exactly one final answer artifact
+2. one turn must never execute twice
+3. one `chat_id + client_idempotency_key` must not create multiple valid turns
+
+## 4.2 TimelineEvent
+
+A `TimelineEvent` is the standardized event stream for one turn.
+
+It serves three roles:
+
+- frontend timeline rendering model
+- SSE transport model
+- replay and diagnosis model
+
+It is **not** a raw debug-log dump.
+
+### 4.2.1 Required fields
+
+```text
+schema_version
+event_id
+turn_id
+sequence
+timestamp
+type
+label
+status
+actor
+data
+```
+
+### 4.2.2 Hard rules
+
+1. `sequence` must be strictly monotonic inside one turn
+2. the frontend must not infer ordering from timestamps
+3. `actor` is limited to `agent | tool | system`
+4. `data` carries only the minimum payload
+5. the timeline must be replayable
+
+### 4.2.3 Event types
+
+Phase 1 event types are:
+
+- `turn.started`
+- `agent.state.changed`
+- `tool.started`
+- `tool.progress`
+- `tool.finished`
+- `external_action.started`
+- `external_action.finished`
+- `text.delta`
+- `artifact.created`
+- `turn.completed`
+- `turn.failed`
+- `turn.cancelled`
+- `heartbeat`
+
+### 4.2.4 Layering rules
+
+- `tool.*` is for the standard tool loop
+- `external_action.*` is only for user-visible external actions such as `web_search`
+- not every internal runtime step should appear in the timeline
+
+## 4.3 Artifact
+
+An `Artifact` is a persisted, re-readable, reusable object.
+
+### 4.3.1 Suggested artifact types
+
+- `answer`
+- `reference_bundle`
+- `tool_result_summary`
+- `search_result_summary`
+- `error_summary`
+
+### 4.3.2 Suggested fields
+
+```text
+schema_version
+artifact_id
+turn_id
+artifact_type
+created_at
+summary
+storage_ref | payload
+```
+
+### 4.3.3 Hard rules
+
+1. the stream must not carry large bodies
+2. the stream only carries summaries, artifact ids, and minimal metadata
+3. references must be materialized as a separate artifact
+
+## 5. User-visible status vocabulary
+
+The frontend must not expose raw runtime event names.
+
+Phase 1 user-facing status vocabulary is fixed to:
+
+- `Thinking`
+- `Searching`
+- `Calling Tool`
+- `Reading Result`
+- `Streaming Answer`
+- `Completed`
+- `Failed`
+
+This keeps the UI stable even if backend internals evolve later.
+
+## 6. API and Transport Design
+
+## 6.1 Primary transport
+
+The primary transport is `SSE` only.
+
+The system should not keep a long-lived `WebSocket + SSE` dual stack.
+
+## 6.2 API surface
+
+### 6.2.1 Create a turn
+
+```text
+POST /api/v2/agent/chats/{chat_id}/turns
+```
+
+Suggested request fields:
+
+- `query`
+- `context`
+- `model_profile`
+- `client_idempotency_key`
+
+Suggested response fields:
+
+- `turn_id`
+- `status`
+- `stream_url`
+
+### 6.2.2 Subscribe to turn events
+
+```text
+GET /api/v2/agent/chats/{chat_id}/turns/{turn_id}/events
+```
+
+Response type:
+
+```text
+Content-Type: text/event-stream
+```
+
+### 6.2.3 Get turn snapshot
+
+```text
+GET /api/v2/agent/chats/{chat_id}/turns/{turn_id}
+```
+
+Used for:
+
+- page refresh recovery
+- fallback after failed SSE reconnect
+- diagnosis
+
+### 6.2.4 Cancel a turn
+
+```text
+POST /api/v2/agent/chats/{chat_id}/turns/{turn_id}/cancel
+```
+
+### 6.2.5 Get an artifact
+
+```text
+GET /api/v2/agent/artifacts/{artifact_id}
+```
+
+## 6.3 Idempotency and reconnect
+
+### 6.3.1 Idempotency
+
+- `POST turn` must support a client idempotency key
+- repeated requests with the same `chat_id + client_idempotency_key` must not create multiple turns
+- one turn must never execute twice
+
+### 6.3.2 SSE reconnect
+
+- reconnect should use `Last-Event-ID` or an explicit offset
+- if the event buffer has expired:
+  1. the client fetches the turn snapshot
+  2. the client resumes from the newest available cursor
+
+## 6.4 Heartbeat, backpressure, and timeout
+
+The SSE layer must define:
+
+- heartbeat behavior
+- event buffer limits
+- delta merge policy
+- overload summarization/truncation behavior
+
+It must also distinguish:
+
+- single tool timeout
+- total runtime timeout for one turn
+- stream idle timeout
+
+## 7. Permission Boundary
+
+The new runtime entrypoint must re-check permissions explicitly. It must not inherit assumptions from the old WebSocket path.
+
+Every turn creation must validate:
+
+- chat ownership
+- collection/file context visibility
+- tool visibility scope
+
+Artifact retrieval endpoints must also enforce permissions.
+
+## 8. Storage Design
+
+## 8.1 Redis responsibility
+
+Redis handles only short-lived runtime and stream recovery state:
+
+- `turn runtime state`
+- `stream cursor`
+- `transient event buffer`
+- `in-flight text buffer`
+
+Redis no longer owns:
+
+- the old message grammar
+- the product-level message contract
+- the long-term history representation
+
+## 8.2 DB / persistent responsibility
+
+Persistent storage holds:
+
+- `conversation_turn`
+- `timeline_event` (at least key events)
+- `artifact`
+- `reference_bundle`
+- `error_summary`
+
+The timeline must be replayable after the stream ends.
+
+## 8.3 History commit policy
+
+The final history is not written token-by-token.
+
+Instead:
+
+1. only transient runtime state is updated during streaming
+2. the standardized turn record is committed only after `done` or explicit `error`
+
+This prevents half-written history after cancellation, reconnect, or rollback.
+
+## 9. Frontend Experience Model
+
+The frontend should no longer treat one assistant bubble as the carrier of everything.
+
+The recommended layout is:
+
+1. `Turn Header`
+2. `Timeline`
+3. `Final Answer Panel`
+4. `References Panel`
+5. `Diagnostics Drawer`
+
+Where:
+
+- Timeline shows process only
+- Final Answer Panel shows the final answer only
+- References Panel shows sources only
+- Diagnostics Drawer is expandable and opt-in
+
+## 10. Runtime Path
+
+## 10.1 Phase 1: PydanticAI adapter
+
+Phase 1 uses `PydanticAI` as the runtime implementation because it lowers implementation cost for:
+
+- single-turn internal loops
+- tool calling
+- provider calling
+- state mapping
+
+But it does not define:
+
+- public API
+- timeline schema
+- artifact schema
+- history commit policy
+
+## 10.2 Long-term path
+
+If the `PydanticAI adapter` stays stable and low-maintenance, it may remain.
+
+If its runtime behavior still constrains ApeRAG too much, the internals can later be replaced by a self-built thin orchestration layer.
+
+Because the contract is already separated, that later replacement changes the implementation only, not the product boundary.
+
+## 11. Replacement Boundary
+
+This rewrite:
+
+- keeps `FastAPI`, `FastMCP`, business APIs, provider integrations, and business entities
+- replaces `mcp-agent runtime glue`, the old WebSocket grammar, the old Redis message shape, the old frontend rendering model, and the old tool-result/event pushback mechanism
+
+That means business value is preserved while the most fragile product/runtime coupling is rebuilt cleanly.
+
+## 12. Migration and Rollback Principles
+
+### 12.1 Migration
+
+- a short-lived feature flag is allowed for migration safety
+- a long-lived dual stack is not allowed
+- once the new path is stable, the old WebSocket grammar and old runtime glue should be removed
+
+### 12.2 Rollback conditions
+
+Rollback is allowed if:
+
+- SSE is unstable behind enterprise proxies
+- timeline replay/reconnect is unreliable
+- turn/history/artifact compatibility is broken
+- provider/tool failures are not diagnosable
+
+### 12.3 Rollback requirements
+
+After rollback:
+
+- history must remain readable
+- turn records must not become orphaned
+- artifacts must remain traceable
+
+## 13. Phase 1 Task Outline
+
+Phase 1 should focus on the minimum viable end-to-end path rather than the final long-term shape.
+
+Suggested tasks:
+
+1. create `aperag/agent_runtime/`
+2. define `Turn / TimelineEvent / Artifact` schemas
+3. implement `TurnService`
+4. implement `EventService`
+5. implement `ArtifactService`
+6. implement `HistoryWriter`
+7. define `AgentRuntime`
+8. implement `PydanticAIRuntime`
+9. implement the MCP client adapter
+10. implement `SSE StreamEmitter`
+11. add v2 agent APIs
+12. build the new timeline frontend
+13. build answer/references/diagnostics panels
+14. implement snapshot recovery and cancel
+15. add contract-level E2E coverage
+
+## 14. Acceptance Criteria
+
+Phase 1 should satisfy:
+
+1. the new API can create turns, stream events, fetch snapshots, fetch artifacts, and cancel turns
+2. a single turn can complete multiple search/tool/thinking loops
+3. the timeline is reconnectable and replayable
+4. the final answer and process events are fully separated
+5. history commit policy leaves no half-written final records
+6. `mcp-agent` is no longer on the primary chat execution path
+
+## 15. Final Decision
+
+Agent Runtime V3 makes the following official:
+
+- stop patching `mcp-agent`
+- stop patching the old WebSocket grammar
+- rebuild the runtime contract around `Turn + TimelineEvent + Artifact + SSE`
+- use `PydanticAI adapter` for Phase 1
+- let implementation follow this document, while architecture remains responsible for the contract boundary and long-term direction
+
+In one sentence:
+
+This is not just a runtime swap. It is a product-layer rebuild of ApeRAG's agent runtime for private, low-support delivery.

--- a/docs/zh-CN/design/agent_runtime_v3.md
+++ b/docs/zh-CN/design/agent_runtime_v3.md
@@ -1,0 +1,546 @@
+---
+title: Agent Runtime V3 设计方案
+description: ApeRAG Agent Runtime V3 的详细设计文档，定义新的 Turn、TimelineEvent、Artifact、SSE 协议与迁移边界
+keywords: Agent Runtime, SSE, Turn, TimelineEvent, Artifact, PydanticAI, MCP
+position: 4
+---
+
+# ApeRAG Agent Runtime V3 设计方案
+
+## 1. 背景与目标
+
+当前 ApeRAG 的 agent chat 主链路基于 `mcp-agent` 运行。它已经证明“能工作”，但对 ApeRAG 的长期产品目标并不合适：
+
+- 当前最脆弱的部分不是业务 API，而是 runtime 胶水层
+- 事件分发、流式输出、前后端消息格式、会话缓存、工具结果回推都与第三方 runtime 的内部语义耦合过深
+- 这类耦合会直接转化成私有化交付后的维护成本、排障成本和答疑成本
+
+因此，这次设计的目标不是“换一个更强的 agent 框架”，而是：
+
+1. 重做 ApeRAG 的 `agent 产品层`
+2. 保持 ApeRAG 的 `业务能力面` 稳定
+3. 建立一个更适合 `私有化部署`、`简单可靠`、`低维护成本`、`低答疑成本` 的单 agent runtime
+
+本设计的约束前提如下：
+
+- 优先面向 `私有化交付`
+- 假设客户普遍缺乏强运维能力
+- 功能可以保守，但默认行为必须稳健
+- agent 层允许整体切换，不为旧 WebSocket grammar、旧 Redis message shape、旧 message part 语义做长期兼容
+
+## 2. 设计结论
+
+Agent Runtime V3 的正式结论如下：
+
+1. `mcp-agent` 不再作为 ApeRAG 的长期核心 runtime
+2. `FastAPI + FastMCP + 现有业务 API/provider` 继续作为稳定业务面保留
+3. 主传输协议统一为 `SSE`
+4. 核心产品契约统一为 `Turn + TimelineEvent + Artifact`
+5. 第一阶段 runtime 实现使用 `PydanticAI adapter`
+6. 长期保留进一步收敛到 `自研薄编排层` 的空间
+7. 不把核心 runtime 迁移到 `Vercel AI SDK`、`OpenAI Agents SDK` 或 `LangGraph`
+
+这意味着：外部库只负责帮助实现，不再定义 ApeRAG 的产品语义。
+
+## 3. 设计原则
+
+### 3.1 私有化优先
+
+所有设计优先满足以下诉求：
+
+- 默认配置可运行
+- 失败行为可诊断
+- 升级和回退边界清晰
+- 少依赖隐式前提
+- 少引入双栈和兼容包袱
+
+### 3.2 产品契约归 ApeRAG 自己拥有
+
+新的对外契约由 ApeRAG 自己定义，包括：
+
+- API 入口
+- SSE 事件流
+- 前端可见状态词表
+- TimelineEvent schema
+- Artifact schema
+- History commit policy
+
+第三方 runtime 只能适配这套契约，不能反向决定它。
+
+### 3.3 最终回答与过程事件彻底分离
+
+最终 answer、运行过程、references、tool result 不再混塞进一条 assistant message。
+
+分层原则如下：
+
+- `answer` 是 answer artifact
+- `timeline` 是过程事件流
+- `references` 是独立 artifact
+- `tool result` 通过摘要事件 + artifact 引用暴露
+
+### 3.4 明确缩小 Phase 1 能力边界
+
+Phase 1 只支持：
+
+- 单 agent
+- 串行 tool loop
+- 单 MCP server 视图
+- 单个 turn 内多轮 internal loop
+
+Phase 1 不支持：
+
+- 多 agent
+- 并发 tool fan-out
+- workflow/graph orchestration
+- 长任务编排
+
+## 4. 核心对象模型
+
+## 4.1 Turn
+
+`Turn` 表示一次用户 query 对应的一次完整 agent execution。
+
+需要特别澄清的是：
+
+- 一个 turn 不是“一步回答”
+- 一个 turn 内允许多次 thinking、多次 web search、多次 tool call、多次读取结果和多轮内部推理
+- turn 是外层执行边界，不是内部 loop 次数的限制器
+
+### 4.1.1 设计目标
+
+Turn 统一承担以下职责：
+
+- 幂等边界
+- 取消边界
+- 超时边界
+- 恢复边界
+- 最终历史提交边界
+- 回放与评测边界
+
+### 4.1.2 建议字段
+
+```text
+schema_version
+turn_id
+chat_id
+user_id
+request_id
+client_idempotency_key
+status
+input_text
+model_profile
+started_at
+finished_at
+error_code
+error_message
+answer_artifact_id
+reference_bundle_artifact_id
+timeline_cursor
+```
+
+### 4.1.3 状态机
+
+```text
+queued -> running -> completed
+queued -> running -> failed
+queued -> running -> cancelled
+```
+
+### 4.1.4 硬约束
+
+1. 一个 turn 只允许一个最终 `answer_artifact_id`
+2. 同一个 turn 不允许被执行两次
+3. 同一个 `chat_id + client_idempotency_key` 只能创建一个有效 turn
+
+## 4.2 TimelineEvent
+
+`TimelineEvent` 表示 turn 执行过程中的标准化事件流。
+
+它既是：
+
+- 前端时间线展示模型
+- SSE 传输模型
+- 诊断与回放模型
+
+但它不是：
+
+- runtime 原始内部日志 dump
+- debug event 任意透出层
+
+### 4.2.1 必备字段
+
+```text
+schema_version
+event_id
+turn_id
+sequence
+timestamp
+type
+label
+status
+actor
+data
+```
+
+### 4.2.2 硬约束
+
+1. `sequence` 在 turn 内必须严格单调递增
+2. 不允许前端按时间戳猜顺序
+3. `actor` 只允许：`agent | tool | system`
+4. `data` 只携带最小必要 payload
+5. timeline 必须支持重放
+
+### 4.2.3 事件类型
+
+Phase 1 标准事件类型定义如下：
+
+- `turn.started`
+- `agent.state.changed`
+- `tool.started`
+- `tool.progress`
+- `tool.finished`
+- `external_action.started`
+- `external_action.finished`
+- `text.delta`
+- `artifact.created`
+- `turn.completed`
+- `turn.failed`
+- `turn.cancelled`
+- `heartbeat`
+
+### 4.2.4 事件分层约束
+
+- `tool.*` 用于标准 tool loop
+- `external_action.*` 只用于少数用户可感知外部动作，例如 `web_search`
+- 不允许把所有内部小步骤都提升到 timeline 层
+
+## 4.3 Artifact
+
+`Artifact` 表示需要持久化、可重读、可复用、可排障的大对象。
+
+### 4.3.1 建议类型
+
+- `answer`
+- `reference_bundle`
+- `tool_result_summary`
+- `search_result_summary`
+- `error_summary`
+
+### 4.3.2 建议字段
+
+```text
+schema_version
+artifact_id
+turn_id
+artifact_type
+created_at
+summary
+storage_ref | payload
+```
+
+### 4.3.3 硬约束
+
+1. stream 中不直接推送大正文
+2. stream 只推送摘要、artifact id 和必要元数据
+3. references 必须 materialize 成独立 artifact
+
+## 5. 用户可见状态词表
+
+前端不直接显示 runtime 原始事件名，而是统一映射成稳定的用户可见状态词表。
+
+Phase 1 固定为：
+
+- `Thinking`
+- `Searching`
+- `Calling Tool`
+- `Reading Result`
+- `Streaming Answer`
+- `Completed`
+- `Failed`
+
+这样做的目的有两个：
+
+1. 避免后端内部状态演进反复影响前端展示
+2. 降低用户理解成本与答疑成本
+
+## 6. 前后端协议设计
+
+## 6.1 主传输协议
+
+主链路只保留 `SSE`。
+
+不长期保留 `WebSocket + SSE` 双栈共存。
+
+## 6.2 API 设计
+
+### 6.2.1 创建 turn
+
+```text
+POST /api/v2/agent/chats/{chat_id}/turns
+```
+
+请求体建议包含：
+
+- `query`
+- `context`
+- `model_profile`
+- `client_idempotency_key`
+
+响应建议包含：
+
+- `turn_id`
+- `status`
+- `stream_url`
+
+### 6.2.2 订阅 turn 事件流
+
+```text
+GET /api/v2/agent/chats/{chat_id}/turns/{turn_id}/events
+```
+
+返回类型：
+
+```text
+Content-Type: text/event-stream
+```
+
+### 6.2.3 获取 turn snapshot
+
+```text
+GET /api/v2/agent/chats/{chat_id}/turns/{turn_id}
+```
+
+用于：
+
+- 刷新页面恢复
+- SSE 重连失败时兜底
+- 调试和诊断
+
+### 6.2.4 取消 turn
+
+```text
+POST /api/v2/agent/chats/{chat_id}/turns/{turn_id}/cancel
+```
+
+### 6.2.5 获取 artifact
+
+```text
+GET /api/v2/agent/artifacts/{artifact_id}
+```
+
+## 6.3 幂等与重连
+
+### 6.3.1 幂等策略
+
+- `POST turn` 必须支持客户端幂等键
+- 同一 `chat_id + client_idempotency_key` 下重复请求不得创建多个 turn
+- 同一个 turn 一旦创建成功，就不允许重复执行
+
+### 6.3.2 SSE 重连策略
+
+- 默认支持 `Last-Event-ID` 或 offset 续传
+- 如果服务端 event buffer 已过期，则：
+  1. 客户端先拉 `turn snapshot`
+  2. 再从当前最新游标继续订阅
+
+## 6.4 心跳、背压与超时
+
+SSE 层必须定义以下行为：
+
+- heartbeat 事件
+- event buffer 上限
+- delta 合并策略
+- 过载时摘要/截断策略
+
+同时区分以下超时：
+
+- 单 tool timeout
+- 单轮 total runtime timeout
+- stream idle timeout
+
+## 7. 权限与安全边界
+
+新 runtime 入口必须重新做完整鉴权，不能依赖旧 WebSocket 路径中的隐式前提。
+
+每个 turn 创建时必须重新校验：
+
+- `chat_id` ownership
+- collection/file context visibility
+- tool 可见范围
+
+artifact 读取接口也必须重新做权限校验，防止通过 artifact id 越权读取。
+
+## 8. 存储设计
+
+## 8.1 Redis 职责
+
+Redis 只负责短期运行态与流式恢复：
+
+- `turn runtime state`
+- `stream cursor`
+- `transient event buffer`
+- `in-flight text buffer`
+
+Redis 不再承担：
+
+- 旧 message grammar 兼容
+- 最终产品层消息协议
+- 长期历史表达
+
+## 8.2 DB / Persistent Store 职责
+
+持久化层负责保存：
+
+- `conversation_turn`
+- `timeline_event`（至少关键事件）
+- `artifact`
+- `reference_bundle`
+- `error_summary`
+
+Timeline 必须可重放，不能只存在于流式阶段。
+
+## 8.3 History Commit Policy
+
+最终 history 不按 token 流实时写入。
+
+策略如下：
+
+1. stream 期间只写运行态/缓存态
+2. 只有在 `done` 或明确 `error` 后，才一次性提交标准化 turn 记录
+
+这样可以避免：
+
+- 半截输出污染 history
+- 取消后残留脏记录
+- 重连或回退留下不可解释状态
+
+## 9. 前端体验模型
+
+新的前端展示不再以“一个 assistant bubble 包含一切”为核心。
+
+建议拆成五个视图层：
+
+1. `Turn Header`
+2. `Timeline`
+3. `Final Answer Panel`
+4. `References Panel`
+5. `Diagnostics Drawer`
+
+其中：
+
+- Timeline 只展示过程
+- Final Answer Panel 只展示最终 answer
+- References Panel 只展示引用和来源
+- Diagnostics Drawer 只在需要时展开
+
+## 10. Runtime 路线
+
+## 10.1 Phase 1：PydanticAI Adapter
+
+第一阶段 runtime 实现采用 `PydanticAI`，原因不是它定义契约，而是它能降低第一阶段实现成本。
+
+它适合用来实现：
+
+- 单 turn 内部 loop
+- tool 调用
+- provider 调用
+- 状态映射
+
+但不负责定义：
+
+- 对外 API
+- TimelineEvent schema
+- Artifact schema
+- History commit policy
+
+## 10.2 长期路线
+
+如果 `PydanticAI adapter` 运行稳定、维护成本可接受，可以继续保留。
+
+如果后续仍发现第三方 runtime 对行为边界约束太多，则继续把底层收成完全自研薄编排层。
+
+由于契约层已经独立，届时只替换 runtime 实现，不需要再次重写前后端协议。
+
+## 11. 替换边界
+
+本次重写：
+
+- 保留：`FastAPI`、`FastMCP`、业务 API、provider 接入、业务数据实体
+- 替换：`mcp-agent runtime glue`、旧 WebSocket grammar、旧 Redis message shape、旧前端消息渲染模型、旧事件回推机制
+
+这意味着：
+
+- 业务价值复用
+- 产品层和运行时耦合重做
+
+## 12. 迁移与回退原则
+
+### 12.1 迁移原则
+
+- 可以保留短期 feature flag 灰度
+- 不允许长期双栈共存
+- 一旦新链路稳定，旧 WebSocket grammar 和旧 runtime glue 直接下线
+
+### 12.2 回退条件
+
+以下情况允许回退：
+
+- SSE 在企业代理环境中明显不稳定
+- timeline 重放和恢复不可靠
+- turn/history/artifact 兼容性不成立
+- tool/provider 错误不可诊断
+
+### 12.3 回退要求
+
+回退后必须保证：
+
+- 历史记录可读
+- turn 记录不变成孤儿
+- artifact 不变成不可追踪残留
+
+## 13. Phase 1 实施清单
+
+Phase 1 的实施目标是跑通新的最小主链路，而不是一次性追求最终形态。
+
+建议的 Phase 1 任务：
+
+1. 新建 `aperag/agent_runtime/` 模块
+2. 定义 `Turn / TimelineEvent / Artifact` schema
+3. 实现 `TurnService`
+4. 实现 `EventService`
+5. 实现 `ArtifactService`
+6. 实现 `HistoryWriter`
+7. 定义 `AgentRuntime` 抽象
+8. 实现 `PydanticAIRuntime`
+9. 实现 MCP client adapter
+10. 实现 `SSE StreamEmitter`
+11. 新增 v2 agent API
+12. 新增前端 timeline 组件
+13. 新增 answer/references/diagnostics 分层面板
+14. 实现 snapshot 恢复与 cancel
+15. 补充契约级 E2E 覆盖
+
+## 14. 验收标准
+
+Phase 1 完成时，至少应满足：
+
+1. 新 API 可以创建 turn、订阅 SSE、拉 snapshot、读取 artifact、取消 turn
+2. 单 turn 内部可以完成多轮 search/tool/thinking loop
+3. Timeline 可重连、可重放
+4. 最终 answer 与过程事件完全分离
+5. 历史提交策略不产生半截脏记录
+6. `mcp-agent` 已退出主 chat 运行路径
+
+## 15. 正式拍板
+
+Agent Runtime V3 的正式拍板如下：
+
+- 不再继续修补 `mcp-agent`
+- 不再继续修补旧 WebSocket grammar
+- 新 runtime 契约统一为 `Turn + TimelineEvent + Artifact + SSE`
+- 第一阶段采用 `PydanticAI adapter`
+- 后续由实现同学按本设计文档推进，架构侧负责监督契约边界与长期方向
+
+一句话总结：
+
+这次不是“把某个 agent 库换掉”，而是为 ApeRAG 重建一个更适合私有化交付的 agent runtime 产品层。


### PR DESCRIPTION
## Summary
- add a detailed Chinese design document for ApeRAG Agent Runtime V3
- add the matching English design document
- formalize the agreed V3 contract around Turn, TimelineEvent, Artifact, and SSE

## Scope
- docs only
- no implementation changes
- implementation will be handled by follow-up owners; this PR only freezes the architecture contract

## Highlights
- private-deployment-first design goals
- clear runtime replacement boundary
- explicit Turn / TimelineEvent / Artifact model
- SSE-only primary transport
- Phase 1 migration outline with PydanticAI adapter
- explicit rollback and capability boundaries

## Validation
- docs paths verified under `docs/zh-CN/design/` and `docs/en-US/design/`
- `git diff --check` passed
