### PR TITLE
[codex] implement safe celery reclaim recovery

### DIFF
--- a/aperag/db/models.py
+++ b/aperag/db/models.py
@@ -237,7 +237,10 @@ class Collection(Base):
 
 class CollectionSummary(Base):
     __tablename__ = "collection_summary"
-    __table_args__ = (UniqueConstraint("collection_id", name="uq_collection_summary"),)
+    __table_args__ = (
+        UniqueConstraint("collection_id", name="uq_collection_summary"),
+        Index("idx_collection_summary_status_lease", "status", "lease_expires_at"),
+    )
 
     id = Column(String(24), primary_key=True, default=lambda: "cs" + random_id())
     collection_id = Column(String(24), nullable=False, index=True)
@@ -252,6 +255,8 @@ class CollectionSummary(Base):
     # Summary content and metadata
     summary = Column(Text, nullable=True)
     error_message = Column(Text, nullable=True)
+    processing_token = Column(String(64), nullable=True)
+    lease_expires_at = Column(DateTime(timezone=True), nullable=True)
 
     # Timestamps
     gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
@@ -767,7 +772,10 @@ class DocumentIndex(Base):
     """Document index - single status model"""
 
     __tablename__ = "document_index"
-    __table_args__ = (UniqueConstraint("document_id", "index_type", name="uq_document_index"),)
+    __table_args__ = (
+        UniqueConstraint("document_id", "index_type", name="uq_document_index"),
+        Index("idx_document_index_status_lease", "status", "lease_expires_at"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     document_id = Column(String(24), nullable=False, index=True)
@@ -780,6 +788,8 @@ class DocumentIndex(Base):
     # Index data and task tracking
     index_data = Column(Text, nullable=True)  # JSON string for index-specific data
     error_message = Column(Text, nullable=True)
+    processing_token = Column(String(64), nullable=True)
+    lease_expires_at = Column(DateTime(timezone=True), nullable=True)
 
     # Timestamps
     gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)

--- a/aperag/migration/versions/20260420191500-9f3c2d7b1a4e.py
+++ b/aperag/migration/versions/20260420191500-9f3c2d7b1a4e.py
@@ -1,0 +1,46 @@
+"""add celery processing lease fields
+
+Revision ID: 9f3c2d7b1a4e
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-20 19:15:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "9f3c2d7b1a4e"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("document_index", sa.Column("processing_token", sa.String(length=64), nullable=True))
+    op.add_column("document_index", sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True))
+    op.create_index(
+        "idx_document_index_status_lease", "document_index", ["status", "lease_expires_at"], unique=False
+    )
+
+    op.add_column("collection_summary", sa.Column("processing_token", sa.String(length=64), nullable=True))
+    op.add_column("collection_summary", sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True))
+    op.create_index(
+        "idx_collection_summary_status_lease",
+        "collection_summary",
+        ["status", "lease_expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("idx_collection_summary_status_lease", table_name="collection_summary")
+    op.drop_column("collection_summary", "lease_expires_at")
+    op.drop_column("collection_summary", "processing_token")
+
+    op.drop_index("idx_document_index_status_lease", table_name="document_index")
+    op.drop_column("document_index", "lease_expires_at")
+    op.drop_column("document_index", "processing_token")

--- a/aperag/service/collection_summary_service.py
+++ b/aperag/service/collection_summary_service.py
@@ -14,7 +14,7 @@
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -93,8 +93,27 @@ class CollectionSummaryService:
         )
         return result.scalar_one_or_none()
 
-    def generate_collection_summary_task(self, summary_id: str, collection_id: str, target_version: int):
+    def generate_collection_summary_task(
+        self,
+        summary_id: str,
+        collection_id: str,
+        target_version: int,
+        processing_token: str,
+        callback_allowed: Optional[Callable[[], bool]] = None,
+    ):
         """Background task to generate collection summary using map-reduce strategy"""
+        callback_allowed = callback_allowed or (lambda: True)
+
+        def can_emit_callback(callback_type: str) -> bool:
+            if callback_allowed():
+                return True
+            logger.warning(
+                "Skipping collection summary %s callback for %s because ownership was lost",
+                callback_type,
+                summary_id,
+            )
+            return False
+
         try:
             logger.info(
                 f"Starting collection summary generation for summary {summary_id} (collection: {collection_id}, v{target_version})"
@@ -112,46 +131,79 @@ class CollectionSummaryService:
 
             if not collection:
                 logger.error(f"Collection {collection_id} not found during summary generation")
-                CollectionSummaryCallbacks.on_summary_failed(summary_id, "Collection not found", target_version)
+                if can_emit_callback("failure"):
+                    CollectionSummaryCallbacks.on_summary_failed(
+                        summary_id,
+                        "Collection not found",
+                        target_version,
+                        processing_token,
+                    )
                 return
 
             if not summary:
                 logger.error(f"CollectionSummary {summary_id} not found during summary generation")
                 return
 
-            if summary.status != CollectionSummaryStatus.GENERATING or summary.version != target_version:
+            if (
+                summary.status != CollectionSummaryStatus.GENERATING
+                or summary.version != target_version
+                or summary.processing_token != processing_token
+            ):
                 raise Exception(
-                    f"CollectionSummary {summary_id} status/version mismatch, Status: {summary.status}, Version: {summary.version}, Target: {target_version}, retry... "
+                    "CollectionSummary "
+                    f"{summary_id} state mismatch, Status: {summary.status}, "
+                    f"Version: {summary.version}, Token: {summary.processing_token}, "
+                    f"Target: {target_version}, retry... "
                 )
 
             completion_service = get_collection_completion_service_sync(collection)
 
             if not completion_service:
                 logger.warning(f"No completion service available for collection {collection_id}")
-                CollectionSummaryCallbacks.on_summary_failed(
-                    summary_id, "No completion service available", target_version
-                )
+                if can_emit_callback("failure"):
+                    CollectionSummaryCallbacks.on_summary_failed(
+                        summary_id,
+                        "No completion service available",
+                        target_version,
+                        processing_token,
+                    )
                 return
 
             document_summaries = self._get_all_document_summaries(collection_id)
 
             if not document_summaries:
                 logger.info(f"No document summaries found for collection {collection_id}")
-                CollectionSummaryCallbacks.on_summary_generated(
-                    summary_id, "", target_version
-                )  # TODO: should we return empty string?
+                if can_emit_callback("success"):
+                    CollectionSummaryCallbacks.on_summary_generated(
+                        summary_id,
+                        "",
+                        target_version,
+                        processing_token,
+                    )  # TODO: should we return empty string?
                 return
 
             collection_summary_text = self._reduce_document_summaries(
                 completion_service, document_summaries, collection.title
             )
 
-            CollectionSummaryCallbacks.on_summary_generated(summary_id, collection_summary_text, target_version)
+            if can_emit_callback("success"):
+                CollectionSummaryCallbacks.on_summary_generated(
+                    summary_id,
+                    collection_summary_text,
+                    target_version,
+                    processing_token,
+                )
             logger.info(f"Collection summary generated successfully for summary {summary_id} (v{target_version})")
 
         except Exception as e:
             logger.error(f"Error generating collection summary for {summary_id}: {e}", exc_info=True)
-            CollectionSummaryCallbacks.on_summary_failed(summary_id, str(e), target_version)
+            if can_emit_callback("failure"):
+                CollectionSummaryCallbacks.on_summary_failed(
+                    summary_id,
+                    str(e),
+                    target_version,
+                    processing_token,
+                )
 
     def _get_all_document_summaries(self, collection_id: str) -> List[Dict[str, Any]]:
         """Get all document summaries for the collection (Map phase)"""

--- a/aperag/tasks/processing_lease.py
+++ b/aperag/tasks/processing_lease.py
@@ -1,0 +1,84 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import threading
+import uuid
+from datetime import timedelta
+from typing import Callable, Optional
+
+from aperag.utils.utils import utc_now
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROCESSING_LEASE_TTL_SECONDS = int(os.getenv("APERAG_PROCESSING_LEASE_TTL_SECONDS", "900"))
+DEFAULT_PROCESSING_LEASE_RENEW_INTERVAL_SECONDS = int(os.getenv("APERAG_PROCESSING_LEASE_RENEW_INTERVAL_SECONDS", "60"))
+
+
+def generate_processing_token() -> str:
+    return uuid.uuid4().hex
+
+
+def build_lease_expires_at(ttl_seconds: int = DEFAULT_PROCESSING_LEASE_TTL_SECONDS):
+    return utc_now() + timedelta(seconds=ttl_seconds)
+
+
+class ProcessingLeaseRenewer:
+    """Background helper that periodically renews the current processing lease."""
+
+    def __init__(
+        self,
+        renew_fn: Callable[[], bool],
+        *,
+        interval_seconds: int = DEFAULT_PROCESSING_LEASE_RENEW_INTERVAL_SECONDS,
+        description: str,
+    ):
+        self._renew_fn = renew_fn
+        self._interval_seconds = max(interval_seconds, 1)
+        self._description = description
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.ownership_lost = False
+
+    def start(self):
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"lease-renewer:{self._description}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._interval_seconds + 1)
+
+    def _run(self):
+        while not self._stop_event.wait(self._interval_seconds):
+            try:
+                renewed = self._renew_fn()
+            except Exception:
+                logger.exception("Processing lease renewer failed for %s", self._description)
+                continue
+
+            if renewed:
+                continue
+
+            self.ownership_lost = True
+            logger.warning("Processing lease ownership lost for %s", self._description)
+            self._stop_event.set()
+            return

--- a/aperag/tasks/reconciler.py
+++ b/aperag/tasks/reconciler.py
@@ -31,6 +31,7 @@ from aperag.db.models import (
     DocumentStatus,
 )
 from aperag.schema.utils import parseCollectionConfig
+from aperag.tasks.processing_lease import build_lease_expires_at, generate_processing_token
 from aperag.tasks.scheduler import TaskScheduler, create_task_scheduler
 from aperag.utils.constant import IndexAction
 from aperag.utils.utils import utc_now
@@ -55,6 +56,10 @@ class DocumentIndexReconciler:
         """
         # Get all indexes that need reconciliation
         for session in get_sync_session():
+            reclaimed_count = self._reclaim_stale_indexes(session)
+            if reclaimed_count > 0:
+                session.commit()
+                logger.warning("Reclaimed %s stale document-index tasks back to retryable states", reclaimed_count)
             operations = self._get_indexes_needing_reconciliation(session)
 
         logger.info(f"Found {len(operations)} documents need to be reconciled")
@@ -184,11 +189,19 @@ class DocumentIndexReconciler:
                         DocumentIndex.status == DocumentIndexStatus.DELETING,
                     ]
 
+                processing_token = generate_processing_token()
+
                 # Try to claim this specific index
                 update_stmt = (
                     update(DocumentIndex)
                     .where(and_(*claiming_conditions))
-                    .values(status=target_state, gmt_updated=utc_now(), gmt_last_reconciled=utc_now())
+                    .values(
+                        status=target_state,
+                        processing_token=processing_token,
+                        lease_expires_at=build_lease_expires_at(),
+                        gmt_updated=utc_now(),
+                        gmt_last_reconciled=utc_now(),
+                    )
                 )
 
                 result = session.execute(update_stmt)
@@ -203,6 +216,7 @@ class DocumentIndexReconciler:
                             "target_version": current_index.version
                             if action in [IndexAction.CREATE, IndexAction.UPDATE]
                             else None,
+                            "processing_token": processing_token,
                         }
                     )
                     logger.debug(f"Claimed index {index_id} for document {document_id} ({action})")
@@ -215,6 +229,53 @@ class DocumentIndexReconciler:
             logger.error(f"Failed to claim indexes for document {document_id}: {e}")
             return []
 
+    def _reclaim_stale_indexes(self, session: Session) -> int:
+        current_time = utc_now()
+
+        create_update_stmt = (
+            update(DocumentIndex)
+            .where(
+                and_(
+                    DocumentIndex.status == DocumentIndexStatus.CREATING,
+                    DocumentIndex.processing_token.is_not(None),
+                    DocumentIndex.lease_expires_at.is_not(None),
+                    DocumentIndex.lease_expires_at < current_time,
+                )
+            )
+            .values(
+                status=DocumentIndexStatus.PENDING,
+                error_message="stale lease reclaimed",
+                processing_token=None,
+                lease_expires_at=None,
+                gmt_updated=current_time,
+                gmt_last_reconciled=current_time,
+            )
+        )
+        create_update_result = session.execute(create_update_stmt)
+
+        delete_stmt = (
+            update(DocumentIndex)
+            .where(
+                and_(
+                    DocumentIndex.status == DocumentIndexStatus.DELETION_IN_PROGRESS,
+                    DocumentIndex.processing_token.is_not(None),
+                    DocumentIndex.lease_expires_at.is_not(None),
+                    DocumentIndex.lease_expires_at < current_time,
+                )
+            )
+            .values(
+                status=DocumentIndexStatus.DELETING,
+                error_message="stale lease reclaimed",
+                processing_token=None,
+                lease_expires_at=None,
+                gmt_updated=current_time,
+                gmt_last_reconciled=current_time,
+            )
+        )
+        delete_result = session.execute(delete_stmt)
+
+        return create_update_result.rowcount + delete_result.rowcount
+
     def _dispatch_claimed_indexes(self, document_id: str, action: str, claimed_indexes: List[dict]):
         """Dispatch a single claimed action group after its claim has already been committed."""
         index_types = [claimed_index["index_type"] for claimed_index in claimed_indexes]
@@ -225,6 +286,8 @@ class DocumentIndexReconciler:
                 target_version = claimed_index.get("target_version")
                 if target_version is not None:
                     context[f"{claimed_index['index_type']}_version"] = target_version
+                context[f"{claimed_index['index_type']}_processing_token"] = claimed_index["processing_token"]
+                context[f"{claimed_index['index_type']}_index_id"] = claimed_index["index_id"]
 
             self.task_scheduler.schedule_create_index(document_id=document_id, index_types=index_types, context=context)
             logger.info(f"Scheduled create task for document {document_id}, types: {index_types}")
@@ -236,13 +299,20 @@ class DocumentIndexReconciler:
                 target_version = claimed_index.get("target_version")
                 if target_version is not None:
                     context[f"{claimed_index['index_type']}_version"] = target_version
+                context[f"{claimed_index['index_type']}_processing_token"] = claimed_index["processing_token"]
+                context[f"{claimed_index['index_type']}_index_id"] = claimed_index["index_id"]
 
             self.task_scheduler.schedule_update_index(document_id=document_id, index_types=index_types, context=context)
             logger.info(f"Scheduled update task for document {document_id}, types: {index_types}")
             return
 
         if action == IndexAction.DELETE:
-            self.task_scheduler.schedule_delete_index(document_id=document_id, index_types=index_types)
+            context = {}
+            for claimed_index in claimed_indexes:
+                context[f"{claimed_index['index_type']}_processing_token"] = claimed_index["processing_token"]
+                context[f"{claimed_index['index_type']}_index_id"] = claimed_index["index_id"]
+
+            self.task_scheduler.schedule_delete_index(document_id=document_id, index_types=index_types, context=context)
             logger.info(f"Scheduled delete task for document {document_id}, types: {index_types}")
             return
 
@@ -268,11 +338,14 @@ class DocumentIndexReconciler:
                                 DocumentIndex.id == claimed_index["index_id"],
                                 DocumentIndex.status == DocumentIndexStatus.CREATING,
                                 DocumentIndex.version == target_version,
+                                DocumentIndex.processing_token == claimed_index["processing_token"],
                             )
                         )
                         .values(
                             status=DocumentIndexStatus.PENDING,
                             error_message=rollback_error_message,
+                            processing_token=None,
+                            lease_expires_at=None,
                             gmt_updated=current_time,
                             gmt_last_reconciled=current_time,
                         )
@@ -284,11 +357,14 @@ class DocumentIndexReconciler:
                             and_(
                                 DocumentIndex.id == claimed_index["index_id"],
                                 DocumentIndex.status == DocumentIndexStatus.DELETION_IN_PROGRESS,
+                                DocumentIndex.processing_token == claimed_index["processing_token"],
                             )
                         )
                         .values(
                             status=DocumentIndexStatus.DELETING,
                             error_message=rollback_error_message,
+                            processing_token=None,
+                            lease_expires_at=None,
                             gmt_updated=current_time,
                             gmt_last_reconciled=current_time,
                         )
@@ -330,7 +406,41 @@ class IndexTaskCallbacks:
         session.add(document)
 
     @staticmethod
-    def on_index_created(document_id: str, index_type: str, target_version: int, index_data: str = None):
+    def _describe_index_callback_mismatch(
+        document_id: str,
+        index_type: str,
+        processing_token: str,
+        expected_status: DocumentIndexStatus,
+        target_version: Optional[int] = None,
+    ) -> str:
+        for session in get_sync_session():
+            stmt = select(DocumentIndex).where(
+                and_(
+                    DocumentIndex.document_id == document_id,
+                    DocumentIndex.index_type == DocumentIndexType(index_type),
+                )
+            )
+            result = session.execute(stmt)
+            record = result.scalar_one_or_none()
+            if not record:
+                return "index_record_not_found"
+            if record.processing_token != processing_token:
+                return "token_mismatch"
+            if record.status != expected_status:
+                return f"status_changed_to_{record.status}"
+            if target_version is not None and record.version != target_version:
+                return f"version_mismatch_expected_{target_version}_current_{record.version}"
+            return "unknown_mismatch"
+        return "unknown_mismatch"
+
+    @staticmethod
+    def on_index_created(
+        document_id: str,
+        index_type: str,
+        target_version: int,
+        processing_token: str,
+        index_data: str = None,
+    ):
         """Called when index creation/update succeeds"""
         for session in get_sync_session():
             # Use atomic update with version validation
@@ -342,6 +452,7 @@ class IndexTaskCallbacks:
                         DocumentIndex.index_type == DocumentIndexType(index_type),
                         DocumentIndex.status == DocumentIndexStatus.CREATING,
                         DocumentIndex.version == target_version,  # Critical: validate version
+                        DocumentIndex.processing_token == processing_token,
                     )
                 )
                 .values(
@@ -349,6 +460,8 @@ class IndexTaskCallbacks:
                     observed_version=target_version,  # Mark this version as processed
                     index_data=index_data,
                     error_message=None,
+                    processing_token=None,
+                    lease_expires_at=None,
                     gmt_updated=utc_now(),
                     gmt_last_reconciled=utc_now(),
                 )
@@ -360,31 +473,52 @@ class IndexTaskCallbacks:
                 logger.info(f"{index_type} index creation completed for document {document_id} (v{target_version})")
                 session.commit()
             else:
+                reason = IndexTaskCallbacks._describe_index_callback_mismatch(
+                    document_id,
+                    index_type,
+                    processing_token,
+                    DocumentIndexStatus.CREATING,
+                    target_version,
+                )
                 logger.warning(
-                    f"Index creation callback ignored for document {document_id} type {index_type} v{target_version} - not in expected state"
+                    "Index creation callback ignored for document %s type %s v%s - %s",
+                    document_id,
+                    index_type,
+                    target_version,
+                    reason,
                 )
                 session.rollback()
 
     @staticmethod
-    def on_index_failed(document_id: str, index_type: str, error_message: str):
+    def on_index_failed(
+        document_id: str,
+        index_type: str,
+        error_message: str,
+        processing_token: str,
+        target_version: Optional[int] = None,
+        expected_status: Optional[DocumentIndexStatus] = None,
+    ):
         """Called when index operation fails"""
+        expected_status = expected_status or DocumentIndexStatus.CREATING
         for session in get_sync_session():
             # Use atomic update with state validation
+            conditions = [
+                DocumentIndex.document_id == document_id,
+                DocumentIndex.index_type == DocumentIndexType(index_type),
+                DocumentIndex.status == expected_status,
+                DocumentIndex.processing_token == processing_token,
+            ]
+            if target_version is not None:
+                conditions.append(DocumentIndex.version == target_version)
+
             update_stmt = (
                 update(DocumentIndex)
-                .where(
-                    and_(
-                        DocumentIndex.document_id == document_id,
-                        DocumentIndex.index_type == DocumentIndexType(index_type),
-                        # Allow transition from any in-progress state
-                        DocumentIndex.status.in_(
-                            [DocumentIndexStatus.CREATING, DocumentIndexStatus.DELETION_IN_PROGRESS]
-                        ),
-                    )
-                )
+                .where(and_(*conditions))
                 .values(
                     status=DocumentIndexStatus.FAILED,
                     error_message=error_message,
+                    processing_token=None,
+                    lease_expires_at=None,
                     gmt_updated=utc_now(),
                     gmt_last_reconciled=utc_now(),
                 )
@@ -396,13 +530,23 @@ class IndexTaskCallbacks:
                 logger.error(f"{index_type} index operation failed for document {document_id}: {error_message}")
                 session.commit()
             else:
+                reason = IndexTaskCallbacks._describe_index_callback_mismatch(
+                    document_id,
+                    index_type,
+                    processing_token,
+                    expected_status,
+                    target_version,
+                )
                 logger.warning(
-                    f"Index failure callback ignored for document {document_id} type {index_type} - not in expected state"
+                    "Index failure callback ignored for document %s type %s - %s",
+                    document_id,
+                    index_type,
+                    reason,
                 )
                 session.rollback()
 
     @staticmethod
-    def on_index_deleted(document_id: str, index_type: str):
+    def on_index_deleted(document_id: str, index_type: str, processing_token: str):
         """Called when index deletion succeeds - hard delete the record"""
         for session in get_sync_session():
             # Delete the record entirely
@@ -413,6 +557,7 @@ class IndexTaskCallbacks:
                     DocumentIndex.document_id == document_id,
                     DocumentIndex.index_type == DocumentIndexType(index_type),
                     DocumentIndex.status == DocumentIndexStatus.DELETION_IN_PROGRESS,
+                    DocumentIndex.processing_token == processing_token,
                 )
             )
 
@@ -422,8 +567,17 @@ class IndexTaskCallbacks:
                 logger.info(f"{index_type} index deleted for document {document_id}")
                 session.commit()
             else:
+                reason = IndexTaskCallbacks._describe_index_callback_mismatch(
+                    document_id,
+                    index_type,
+                    processing_token,
+                    DocumentIndexStatus.DELETION_IN_PROGRESS,
+                )
                 logger.warning(
-                    f"Index deletion callback ignored for document {document_id} type {index_type} - not in expected state"
+                    "Index deletion callback ignored for document %s type %s - %s",
+                    document_id,
+                    index_type,
+                    reason,
                 )
                 session.rollback()
 
@@ -439,6 +593,13 @@ class CollectionSummaryReconciler:
         Main reconciliation loop - scan collections and reconcile summary differences
         """
         for session in get_sync_session():
+            reclaimed_count = self._reclaim_stale_summaries(session)
+            if reclaimed_count > 0:
+                session.commit()
+                logger.warning(
+                    "Reclaimed %s stale collection-summary tasks back to retryable states",
+                    reclaimed_count,
+                )
             summaries_to_reconcile = self._get_summaries_needing_reconciliation(session)
             logger.info(f"Found {len(summaries_to_reconcile)} collection summaries need reconciliation")
 
@@ -475,23 +636,48 @@ class CollectionSummaryReconciler:
         """
         Reconcile summary generation for a single collection summary
         """
-        claimed = self._claim_summary_for_processing(session, summary.id, summary.version)
+        processing_token = self._claim_summary_for_processing(session, summary.id, summary.version)
 
-        if claimed:
+        if processing_token:
             session.commit()
             try:
-                self._schedule_summary_generation(summary.id, summary.collection_id, summary.version)
+                self._schedule_summary_generation(summary.id, summary.collection_id, summary.version, processing_token)
             except Exception as e:
-                self._rollback_summary_claim(summary.id, summary.version, str(e))
+                self._rollback_summary_claim(summary.id, summary.version, processing_token, str(e))
                 raise
         else:
             logger.debug(
                 f"Skipping summary {summary.id} - could not be claimed (likely already processing or version mismatch)"
             )
 
-    def _claim_summary_for_processing(self, session: Session, summary_id: str, version: int) -> bool:
+    def _reclaim_stale_summaries(self, session: Session) -> int:
+        current_time = utc_now()
+        reclaim_stmt = (
+            update(CollectionSummary)
+            .where(
+                and_(
+                    CollectionSummary.status == CollectionSummaryStatus.GENERATING,
+                    CollectionSummary.processing_token.is_not(None),
+                    CollectionSummary.lease_expires_at.is_not(None),
+                    CollectionSummary.lease_expires_at < current_time,
+                )
+            )
+            .values(
+                status=CollectionSummaryStatus.PENDING,
+                error_message="stale lease reclaimed",
+                processing_token=None,
+                lease_expires_at=None,
+                gmt_updated=current_time,
+                gmt_last_reconciled=current_time,
+            )
+        )
+        result = session.execute(reclaim_stmt)
+        return result.rowcount
+
+    def _claim_summary_for_processing(self, session: Session, summary_id: str, version: int) -> Optional[str]:
         """Atomically claim a summary for processing by updating its state and observed_version"""
         try:
+            processing_token = generate_processing_token()
             update_stmt = (
                 update(CollectionSummary)
                 .where(
@@ -503,6 +689,8 @@ class CollectionSummaryReconciler:
                 )
                 .values(
                     status=CollectionSummaryStatus.GENERATING,
+                    processing_token=processing_token,
+                    lease_expires_at=build_lease_expires_at(),
                     gmt_last_reconciled=utc_now(),
                     gmt_updated=utc_now(),
                 )
@@ -511,14 +699,14 @@ class CollectionSummaryReconciler:
             if result.rowcount > 0:
                 logger.debug(f"Claimed summary {summary_id} (v{version}) for processing")
                 session.flush()
-                return True
-            return False
+                return processing_token
+            return None
         except Exception as e:
             logger.error(f"Failed to claim summary {summary_id}: {e}")
             session.rollback()
-            return False
+            return None
 
-    def _rollback_summary_claim(self, summary_id: str, target_version: int, error_message: str):
+    def _rollback_summary_claim(self, summary_id: str, target_version: int, processing_token: str, error_message: str):
         """Return a summary claim to PENDING when Celery dispatch fails before work starts."""
         rollback_error_message = f"Task dispatch failed: {error_message}"
 
@@ -530,11 +718,14 @@ class CollectionSummaryReconciler:
                         CollectionSummary.id == summary_id,
                         CollectionSummary.status == CollectionSummaryStatus.GENERATING,
                         CollectionSummary.version == target_version,
+                        CollectionSummary.processing_token == processing_token,
                     )
                 )
                 .values(
                     status=CollectionSummaryStatus.PENDING,
                     error_message=rollback_error_message,
+                    processing_token=None,
+                    lease_expires_at=None,
                     gmt_updated=utc_now(),
                     gmt_last_reconciled=utc_now(),
                 )
@@ -552,14 +743,20 @@ class CollectionSummaryReconciler:
                 )
             return
 
-    def _schedule_summary_generation(self, summary_id: str, collection_id: str, target_version: int):
+    def _schedule_summary_generation(
+        self,
+        summary_id: str,
+        collection_id: str,
+        target_version: int,
+        processing_token: str,
+    ):
         """
         Schedule summary generation task
         """
         try:
             from config.celery_tasks import collection_summary_task
 
-            task_result = collection_summary_task.delay(summary_id, collection_id, target_version)
+            task_result = collection_summary_task.delay(summary_id, collection_id, target_version, processing_token)
             logger.info(
                 f"Collection summary generation task scheduled for summary {summary_id} "
                 f"(collection: {collection_id}, version: {target_version}), task ID: {task_result.id}"
@@ -573,7 +770,32 @@ class CollectionSummaryCallbacks:
     """Callbacks for collection summary task completion"""
 
     @staticmethod
-    def on_summary_generated(summary_id: str, summary_content: str, target_version: int):
+    def _describe_summary_callback_mismatch(
+        summary_id: str,
+        processing_token: str,
+        expected_status: CollectionSummaryStatus,
+        target_version: int,
+    ) -> str:
+        try:
+            for session in get_sync_session():
+                summary_query = select(CollectionSummary).where(CollectionSummary.id == summary_id)
+                summary_result = session.execute(summary_query)
+                summary_record = summary_result.scalar_one_or_none()
+                if not summary_record:
+                    return "summary_record_not_found"
+                if summary_record.processing_token != processing_token:
+                    return "token_mismatch"
+                if summary_record.status != expected_status:
+                    return f"status_changed_to_{summary_record.status}"
+                if summary_record.version != target_version:
+                    return f"version_mismatch_expected_{target_version}_current_{summary_record.version}"
+                return "unknown_mismatch"
+        except Exception:
+            logger.exception("Failed to inspect collection summary callback mismatch for %s", summary_id)
+        return "unknown_mismatch"
+
+    @staticmethod
+    def on_summary_generated(summary_id: str, summary_content: str, target_version: int, processing_token: str):
         """Called when summary generation succeeds"""
         try:
             for session in get_sync_session():
@@ -583,14 +805,24 @@ class CollectionSummaryCallbacks:
                         CollectionSummary.id == summary_id,
                         CollectionSummary.status == CollectionSummaryStatus.GENERATING,
                         CollectionSummary.version == target_version,
+                        CollectionSummary.processing_token == processing_token,
                     )
                 )
                 summary_result = session.execute(summary_query)
                 summary_record = summary_result.scalar_one_or_none()
 
                 if not summary_record:
+                    reason = CollectionSummaryCallbacks._describe_summary_callback_mismatch(
+                        summary_id,
+                        processing_token,
+                        CollectionSummaryStatus.GENERATING,
+                        target_version,
+                    )
                     logger.warning(
-                        f"Summary completion callback ignored for {summary_id} (v{target_version}) - not in expected state"
+                        "Summary completion callback ignored for %s (v%s) - %s",
+                        summary_id,
+                        target_version,
+                        reason,
                     )
                     return
 
@@ -626,6 +858,7 @@ class CollectionSummaryCallbacks:
                             CollectionSummary.id == summary_id,
                             CollectionSummary.status == CollectionSummaryStatus.GENERATING,
                             CollectionSummary.version == target_version,
+                            CollectionSummary.processing_token == processing_token,
                         )
                     )
                     .values(
@@ -633,6 +866,8 @@ class CollectionSummaryCallbacks:
                         summary=summary_content,
                         error_message=None,
                         observed_version=target_version,
+                        processing_token=None,
+                        lease_expires_at=None,
                         gmt_updated=current_time,
                     )
                 )
@@ -640,8 +875,17 @@ class CollectionSummaryCallbacks:
 
                 if summary_update_result.rowcount == 0:
                     session.rollback()
+                    reason = CollectionSummaryCallbacks._describe_summary_callback_mismatch(
+                        summary_id,
+                        processing_token,
+                        CollectionSummaryStatus.GENERATING,
+                        target_version,
+                    )
                     logger.warning(
-                        f"Summary completion callback ignored for {summary_id} (v{target_version}) - summary not in expected state"
+                        "Summary completion callback ignored for %s (v%s) - %s",
+                        summary_id,
+                        target_version,
+                        reason,
                     )
                     return
 
@@ -681,7 +925,7 @@ class CollectionSummaryCallbacks:
                 pass
 
     @staticmethod
-    def on_summary_failed(summary_id: str, error_message: str, target_version: int):
+    def on_summary_failed(summary_id: str, error_message: str, target_version: int, processing_token: str):
         """Called when summary generation fails"""
         try:
             for session in get_sync_session():
@@ -692,11 +936,14 @@ class CollectionSummaryCallbacks:
                             CollectionSummary.id == summary_id,
                             CollectionSummary.status == CollectionSummaryStatus.GENERATING,
                             CollectionSummary.version == target_version,
+                            CollectionSummary.processing_token == processing_token,
                         )
                     )
                     .values(
                         status=CollectionSummaryStatus.FAILED,
                         error_message=error_message,
+                        processing_token=None,
+                        lease_expires_at=None,
                         gmt_updated=utc_now(),
                     )
                 )
@@ -708,8 +955,17 @@ class CollectionSummaryCallbacks:
                     )
                 else:
                     session.rollback()
+                    reason = CollectionSummaryCallbacks._describe_summary_callback_mismatch(
+                        summary_id,
+                        processing_token,
+                        CollectionSummaryStatus.GENERATING,
+                        target_version,
+                    )
                     logger.warning(
-                        f"Summary failure callback ignored for {summary_id} (v{target_version}) - not in expected state"
+                        "Summary failure callback ignored for %s (v%s) - %s",
+                        summary_id,
+                        target_version,
+                        reason,
                     )
         except Exception as e:
             logger.error(f"Failed to update collection summary failure for {summary_id}: {e}")

--- a/aperag/tasks/scheduler.py
+++ b/aperag/tasks/scheduler.py
@@ -165,13 +165,13 @@ class CeleryTaskScheduler(TaskScheduler):
             logger.error(f"Failed to schedule update indexes workflow for document {document_id}: {str(e)}")
             raise
 
-    def schedule_delete_index(self, document_id: str, index_types: List[str], **kwargs) -> str:
+    def schedule_delete_index(self, document_id: str, index_types: List[str], context: dict = None, **kwargs) -> str:
         """Schedule index deletion workflow"""
         from config.celery_tasks import delete_document_indexes_workflow
 
         try:
             # Execute workflow and return AsyncResult ID
-            workflow_result = delete_document_indexes_workflow(document_id, index_types)
+            workflow_result = delete_document_indexes_workflow(document_id, index_types, context)
             workflow_id = workflow_result.id
             logger.debug(
                 f"Scheduled delete indexes workflow {workflow_id} for document {document_id} with types {index_types}"

--- a/config/celery.py
+++ b/config/celery.py
@@ -46,7 +46,7 @@ app.conf.update(
 app.conf.beat_schedule = {
     'reconcile-indexes': {
         'task': 'config.celery_tasks.reconcile_indexes_task',
-        'schedule': 3600.0, # Run every 1 hour
+        'schedule': 300.0,  # Run every 5 minutes
     },
     'reconcile-collection-summaries': {
         'task': 'config.celery_tasks.reconcile_collection_summaries_task',

--- a/config/celery_tasks.py
+++ b/config/celery_tasks.py
@@ -100,7 +100,7 @@ Each task has built-in retry mechanisms:
 import json
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, List
+from typing import Any, Callable, List
 
 from celery import Task, chain, chord, current_app, group
 
@@ -113,14 +113,40 @@ from aperag.tasks.models import (
     TaskStatus,
     WorkflowResult,
 )
+from aperag.tasks.processing_lease import (
+    DEFAULT_PROCESSING_LEASE_RENEW_INTERVAL_SECONDS,
+    DEFAULT_PROCESSING_LEASE_TTL_SECONDS,
+    ProcessingLeaseRenewer,
+    build_lease_expires_at,
+)
 from aperag.tasks.utils import TaskConfig
 from aperag.utils.constant import IndexAction
+from aperag.utils.utils import utc_now
 from config.celery import app
 
 logger = logging.getLogger()
 
 
-def _validate_task_relevance(document_id: str, index_type: str, target_version: int, expected_status):
+def _build_skipped_payload(reason: str, **payload) -> dict:
+    payload.update({"status": "skipped", "reason": reason})
+    return payload
+
+
+def _build_skipped_task_result(document_id: str, index_type: str, reason: str) -> dict:
+    return _build_skipped_payload(reason, document_id=document_id, index_type=index_type)
+
+
+def _is_skipped_payload(payload: Any) -> bool:
+    return isinstance(payload, dict) and payload.get("status") == "skipped"
+
+
+def _validate_task_relevance(
+    document_id: str,
+    index_type: str,
+    target_version: int,
+    expected_status,
+    processing_token: str = None,
+):
     """
     Double-check the database to ensure the task is still valid.
 
@@ -135,40 +161,38 @@ def _validate_task_relevance(document_id: str, index_type: str, target_version: 
     for session in get_sync_session():
         # Check document index status
         stmt = select(DocumentIndex).where(
-            and_(
-                DocumentIndex.document_id == document_id,
-                DocumentIndex.index_type == DocumentIndexType(index_type)
-            )
+            and_(DocumentIndex.document_id == document_id, DocumentIndex.index_type == DocumentIndexType(index_type))
         )
         result = session.execute(stmt)
         db_index = result.scalar_one_or_none()
 
         if not db_index:
             logger.info(f"Index record not found for {document_id}:{index_type}, skipping task.")
-            return {
-                "status": "skipped",
-                "reason": "index_record_not_found",
-                "document_id": document_id,
-                "index_type": index_type,
-            }
+            return _build_skipped_task_result(document_id, index_type, "index_record_not_found")
 
         if db_index.status != expected_status:
-            logger.info(f"Index status for {document_id}:{index_type} changed to {db_index.status} (expected {expected_status}), skipping task.")
-            return {
-                "status": "skipped",
-                "reason": f"status_changed_to_{db_index.status}",
-                "document_id": document_id,
-                "index_type": index_type,
-            }
+            logger.info(
+                f"Index status for {document_id}:{index_type} changed to {db_index.status} (expected {expected_status}), skipping task."
+            )
+            return _build_skipped_task_result(document_id, index_type, f"status_changed_to_{db_index.status}")
 
         if target_version and db_index.version != target_version:
-            logger.info(f"Version mismatch for {document_id}:{index_type}, expected: {target_version}, current: {db_index.version}, skipping task.")
-            return {
-                "status": "skipped",
-                "reason": f"version_mismatch_expected_{target_version}_current_{db_index.version}",
-                "document_id": document_id,
-                "index_type": index_type,
-            }
+            logger.info(
+                f"Version mismatch for {document_id}:{index_type}, expected: {target_version}, current: {db_index.version}, skipping task."
+            )
+            return _build_skipped_task_result(
+                document_id, index_type, f"version_mismatch_expected_{target_version}_current_{db_index.version}"
+            )
+
+        if processing_token and db_index.processing_token != processing_token:
+            logger.info(
+                "Processing token mismatch for %s:%s, expected: %s, current: %s, skipping task.",
+                document_id,
+                index_type,
+                processing_token,
+                db_index.processing_token,
+            )
+            return _build_skipped_task_result(document_id, index_type, "token_mismatch")
 
         # Check document status - if document is UPLOADED or EXPIRED, task should be skipped
         doc_stmt = select(Document).where(Document.id == document_id)
@@ -177,23 +201,172 @@ def _validate_task_relevance(document_id: str, index_type: str, target_version: 
 
         if not document:
             logger.info(f"Document {document_id} not found, skipping task.")
-            return {
-                "status": "skipped",
-                "reason": "document_not_found",
-                "document_id": document_id,
-                "index_type": index_type,
-            }
+            return _build_skipped_task_result(document_id, index_type, "document_not_found")
 
         if document.status in [DocumentStatus.UPLOADED, DocumentStatus.EXPIRED]:
             logger.info(f"Document {document_id} status is {document.status}, skipping task.")
-            return {
-                "status": "skipped",
-                "reason": f"document_status_{document.status}",
-                "document_id": document_id,
-                "index_type": index_type,
-            }
+            return _build_skipped_task_result(document_id, index_type, f"document_status_{document.status}")
 
         return None  # Task is still relevant
+
+
+def _get_index_context_value(context: dict, index_type: str, key_suffix: str):
+    context = context or {}
+    return context.get(f"{index_type}_{key_suffix}")
+
+
+def _require_index_processing_context(index_type: str, context: dict, *, require_version: bool = True) -> dict:
+    target_version = _get_index_context_value(context, index_type, "version")
+    processing_token = _get_index_context_value(context, index_type, "processing_token")
+    index_id = _get_index_context_value(context, index_type, "index_id")
+
+    missing_fields = []
+    if require_version and target_version is None:
+        missing_fields.append("version")
+    if not processing_token:
+        missing_fields.append("processing_token")
+    if index_id is None:
+        missing_fields.append("index_id")
+
+    if missing_fields:
+        raise ValueError(f"Missing processing context for {index_type}: {', '.join(missing_fields)}")
+
+    return {
+        "target_version": target_version,
+        "processing_token": processing_token,
+        "index_id": index_id,
+    }
+
+
+def _build_document_index_lease_targets(index_types: List[str], context: dict, expected_status) -> List[dict]:
+    targets = []
+    for index_type in index_types:
+        target_context = _require_index_processing_context(
+            index_type,
+            context,
+            require_version=expected_status.name != "DELETION_IN_PROGRESS",
+        )
+        target = {
+            "index_type": index_type,
+            "index_id": target_context["index_id"],
+            "processing_token": target_context["processing_token"],
+            "target_version": target_context["target_version"],
+            "expected_status": expected_status,
+        }
+        targets.append(target)
+    return targets
+
+
+def _validate_index_batch_relevance(document_id: str, index_types: List[str], context: dict, expected_status):
+    for index_type in index_types:
+        target_context = _require_index_processing_context(
+            index_type,
+            context,
+            require_version=expected_status.name != "DELETION_IN_PROGRESS",
+        )
+        skip_reason = _validate_task_relevance(
+            document_id,
+            index_type,
+            target_context["target_version"],
+            expected_status,
+            processing_token=target_context["processing_token"],
+        )
+        if skip_reason:
+            return skip_reason
+    return None
+
+
+def _renew_document_index_leases(targets: List[dict]) -> bool:
+    from sqlalchemy import and_, update
+
+    from aperag.config import get_sync_session
+    from aperag.db.models import DocumentIndex
+
+    if not targets:
+        return False
+
+    current_time = utc_now()
+    next_expiry = build_lease_expires_at(DEFAULT_PROCESSING_LEASE_TTL_SECONDS)
+
+    for session in get_sync_session():
+        for target in targets:
+            conditions = [
+                DocumentIndex.id == target["index_id"],
+                DocumentIndex.status == target["expected_status"],
+                DocumentIndex.processing_token == target["processing_token"],
+            ]
+            if target.get("target_version") is not None:
+                conditions.append(DocumentIndex.version == target["target_version"])
+
+            renew_stmt = (
+                update(DocumentIndex)
+                .where(and_(*conditions))
+                .values(
+                    lease_expires_at=next_expiry,
+                    gmt_updated=current_time,
+                )
+            )
+            result = session.execute(renew_stmt)
+            if result.rowcount == 0:
+                session.rollback()
+                return False
+
+        session.commit()
+        return True
+    return False
+
+
+def _renew_collection_summary_lease(summary_id: str, target_version: int, processing_token: str) -> bool:
+    from sqlalchemy import and_, update
+
+    from aperag.config import get_sync_session
+    from aperag.db.models import CollectionSummary, CollectionSummaryStatus
+
+    current_time = utc_now()
+    next_expiry = build_lease_expires_at(DEFAULT_PROCESSING_LEASE_TTL_SECONDS)
+
+    for session in get_sync_session():
+        renew_stmt = (
+            update(CollectionSummary)
+            .where(
+                and_(
+                    CollectionSummary.id == summary_id,
+                    CollectionSummary.status == CollectionSummaryStatus.GENERATING,
+                    CollectionSummary.version == target_version,
+                    CollectionSummary.processing_token == processing_token,
+                )
+            )
+            .values(
+                lease_expires_at=next_expiry,
+                gmt_updated=current_time,
+            )
+        )
+        result = session.execute(renew_stmt)
+        if result.rowcount == 0:
+            session.rollback()
+            return False
+
+        session.commit()
+        return True
+    return False
+
+
+def _make_document_index_lease_renewer(targets: List[dict], description: str) -> ProcessingLeaseRenewer:
+    return ProcessingLeaseRenewer(
+        lambda: _renew_document_index_leases(targets),
+        interval_seconds=DEFAULT_PROCESSING_LEASE_RENEW_INTERVAL_SECONDS,
+        description=description,
+    )
+
+
+def _make_collection_summary_lease_renewer(
+    summary_id: str, target_version: int, processing_token: str
+) -> ProcessingLeaseRenewer:
+    return ProcessingLeaseRenewer(
+        lambda: _renew_collection_summary_lease(summary_id, target_version, processing_token),
+        interval_seconds=DEFAULT_PROCESSING_LEASE_RENEW_INTERVAL_SECONDS,
+        description=f"collection-summary:{summary_id}",
+    )
 
 
 def _build_dispatched_workflow_result(async_result) -> dict:
@@ -203,6 +376,60 @@ def _build_dispatched_workflow_result(async_result) -> dict:
         "workflow_id": async_result.id,
     }
 
+
+def _validate_collection_summary_relevance(summary_id: str, target_version: int, processing_token: str):
+    from sqlalchemy import select
+
+    from aperag.config import get_sync_session
+    from aperag.db.models import CollectionSummary, CollectionSummaryStatus
+
+    for session in get_sync_session():
+        stmt = select(CollectionSummary).where(CollectionSummary.id == summary_id)
+        result = session.execute(stmt)
+        summary = result.scalar_one_or_none()
+
+        if not summary:
+            logger.info("Collection summary %s not found, skipping task.", summary_id)
+            return _build_skipped_payload("summary_record_not_found", summary_id=summary_id)
+
+        if summary.status != CollectionSummaryStatus.GENERATING:
+            logger.info(
+                "Collection summary %s status changed to %s (expected %s), skipping task.",
+                summary_id,
+                summary.status,
+                CollectionSummaryStatus.GENERATING,
+            )
+            return _build_skipped_payload(f"status_changed_to_{summary.status}", summary_id=summary_id)
+
+        if summary.version != target_version:
+            logger.info(
+                "Collection summary %s version mismatch, expected %s current %s, skipping task.",
+                summary_id,
+                target_version,
+                summary.version,
+            )
+            return _build_skipped_payload(
+                f"version_mismatch_expected_{target_version}_current_{summary.version}",
+                summary_id=summary_id,
+            )
+
+        if summary.processing_token != processing_token:
+            logger.info(
+                "Collection summary %s token mismatch, expected %s current %s, skipping task.",
+                summary_id,
+                processing_token,
+                summary.processing_token,
+            )
+            return _build_skipped_payload("token_mismatch", summary_id=summary_id)
+
+        return None
+
+
+def _handle_ownership_lost(*, payload_factory: Callable[[], dict], log_message: str):
+    logger.warning("%s", log_message)
+    return payload_factory()
+
+
 class BaseIndexTask(Task):
     """
     Base class for all index tasks
@@ -210,37 +437,92 @@ class BaseIndexTask(Task):
 
     abstract = True
 
-    def _handle_index_success(self, document_id: str, index_type: str, target_version: int, index_data: dict = None):
+    def _handle_index_success(
+        self,
+        document_id: str,
+        index_type: str,
+        target_version: int,
+        processing_token: str,
+        index_data: dict = None,
+    ):
         try:
             from aperag.tasks.reconciler import index_task_callbacks
-            index_data_json = json.dumps(index_data) if index_data else None
-            index_task_callbacks.on_index_created(document_id, index_type, target_version, index_data_json)
-            logger.info(f"Index success callback executed for {index_type} index of document {document_id} (v{target_version})")
-        except Exception as e:
-            logger.warning(f"Failed to execute index success callback for {index_type} of {document_id} v{target_version}: {e}", exc_info=True)
 
-    def _handle_index_deletion_success(self, document_id: str, index_type: str):
+            index_data_json = json.dumps(index_data) if index_data else None
+            index_task_callbacks.on_index_created(
+                document_id,
+                index_type,
+                target_version,
+                processing_token,
+                index_data_json,
+            )
+            logger.info(
+                "Index success callback executed for %s index of document %s (v%s)",
+                index_type,
+                document_id,
+                target_version,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to execute index success callback for %s of %s v%s: %s",
+                index_type,
+                document_id,
+                target_version,
+                e,
+                exc_info=True,
+            )
+
+    def _handle_index_deletion_success(self, document_id: str, index_type: str, processing_token: str):
         try:
             from aperag.tasks.reconciler import index_task_callbacks
-            index_task_callbacks.on_index_deleted(document_id, index_type)
+
+            index_task_callbacks.on_index_deleted(document_id, index_type, processing_token)
             logger.info(f"Index deletion callback executed for {index_type} index of document {document_id}")
         except Exception as e:
-            logger.warning(f"Failed to execute index deletion callback for {index_type} of {document_id}: {e}", exc_info=True)
+            logger.warning(
+                f"Failed to execute index deletion callback for {index_type} of {document_id}: {e}", exc_info=True
+            )
 
-    def _handle_index_failure(self, document_id: str, index_types: List[str], error_msg: str):
+    def _handle_index_failure(
+        self,
+        document_id: str,
+        index_types: List[str],
+        error_msg: str,
+        *,
+        context: dict = None,
+        expected_status=None,
+    ):
         try:
+            from aperag.db.models import DocumentIndexStatus
             from aperag.tasks.reconciler import index_task_callbacks
 
+            expected_status = expected_status or DocumentIndexStatus.CREATING
             for index_type in index_types:
-                index_task_callbacks.on_index_failed(document_id, index_type, error_msg)
+                target_context = _require_index_processing_context(
+                    index_type,
+                    context,
+                    require_version=expected_status != DocumentIndexStatus.DELETION_IN_PROGRESS,
+                )
+                index_task_callbacks.on_index_failed(
+                    document_id,
+                    index_type,
+                    error_msg,
+                    target_context["processing_token"],
+                    target_version=target_context["target_version"],
+                    expected_status=expected_status,
+                )
             logger.info(f"Index failure callback executed for {index_types} indexes of document {document_id}")
         except Exception as e:
             logger.warning(f"Failed to execute index failure callback for {document_id}: {e}", exc_info=True)
 
+
 # ========== Core Document Processing Tasks ==========
 
-@current_app.task(bind=True, base=BaseIndexTask, autoretry_for=(Exception,), retry_kwargs={'max_retries': 3, 'countdown': 60})
-def parse_document_task(self, document_id: str, index_types: List[str]) -> dict:
+
+@current_app.task(
+    bind=True, base=BaseIndexTask, autoretry_for=(Exception,), retry_kwargs={"max_retries": 3, "countdown": 60}
+)
+def parse_document_task(self, document_id: str, index_types: List[str], context: dict = None) -> dict:
     """
     Parse document content task
 
@@ -250,9 +532,38 @@ def parse_document_task(self, document_id: str, index_types: List[str]) -> dict:
     Returns:
         Serialized ParsedDocumentData
     """
+    from aperag.db.models import DocumentIndexStatus
+
+    context = context or {}
+    renewer = None
+
     try:
+        skip_reason = _validate_index_batch_relevance(
+            document_id,
+            index_types,
+            context,
+            DocumentIndexStatus.CREATING,
+        )
+        if skip_reason:
+            return skip_reason
+
+        renewer = _make_document_index_lease_renewer(
+            _build_document_index_lease_targets(index_types, context, DocumentIndexStatus.CREATING),
+            f"parse-document:{document_id}",
+        )
+        renewer.start()
+
         logger.info(f"Starting to parse document {document_id}")
         parsed_data = document_index_task.parse_document(document_id)
+
+        if renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_payload("ownership_lost", document_id=document_id),
+                log_message=(
+                    f"Processing ownership lost while parsing document {document_id}; " "dropping downstream callbacks"
+                ),
+            )
+
         logger.info(f"Successfully parsed document {document_id}")
         return parsed_data.to_dict()
     except ParserError as e:
@@ -265,17 +576,31 @@ def parse_document_task(self, document_id: str, index_types: List[str]) -> dict:
 
         raise
     except Exception as e:
+        if renewer and renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_payload("ownership_lost", document_id=document_id),
+                log_message=(
+                    f"Processing ownership lost while parsing document {document_id}; "
+                    "suppressing parse failure callback"
+                ),
+            )
+
         error_msg = f"Failed to parse document {document_id}: source=runtime, code=parse_failed, detail={str(e)}"
         logger.error(error_msg, exc_info=True)
 
         # Only mark as failed if all retries are exhausted
         if self.request.retries >= self.max_retries:
-            self._handle_index_failure(document_id, index_types, error_msg)
+            self._handle_index_failure(document_id, index_types, error_msg, context=context)
 
         raise
+    finally:
+        if renewer:
+            renewer.stop()
 
 
-@current_app.task(bind=True, base=BaseIndexTask, autoretry_for=(Exception,), retry_kwargs={'max_retries': 3, 'countdown': 60})
+@current_app.task(
+    bind=True, base=BaseIndexTask, autoretry_for=(Exception,), retry_kwargs={"max_retries": 3, "countdown": 60}
+)
 def create_index_task(self, document_id: str, index_type: str, parsed_data_dict: dict, context: dict = None) -> dict:
     """
     Create a single index for a document with distributed locking
@@ -289,20 +614,33 @@ def create_index_task(self, document_id: str, index_type: str, parsed_data_dict:
     Returns:
         Serialized IndexTaskResult
     """
-
     from aperag.db.models import DocumentIndexStatus
 
-    # Extract target version from context
     context = context or {}
-    target_version = context.get(f'{index_type}_version')
+    target_context = _require_index_processing_context(index_type, context)
+    target_version = target_context["target_version"]
+    processing_token = target_context["processing_token"]
+    renewer = None
 
     try:
         logger.info(f"Starting to create {index_type} index for document {document_id} (v{target_version})")
 
         # Double-check: verify task is still valid
-        skip_reason = _validate_task_relevance(document_id, index_type, target_version, DocumentIndexStatus.CREATING)
+        skip_reason = _validate_task_relevance(
+            document_id,
+            index_type,
+            target_version,
+            DocumentIndexStatus.CREATING,
+            processing_token=processing_token,
+        )
         if skip_reason:
             return skip_reason
+
+        renewer = _make_document_index_lease_renewer(
+            _build_document_index_lease_targets([index_type], context, DocumentIndexStatus.CREATING),
+            f"create-index:{document_id}:{index_type}",
+        )
+        renewer.start()
 
         # Convert dict back to structured data
         parsed_data = ParsedDocumentData.from_dict(parsed_data_dict)
@@ -316,25 +654,48 @@ def create_index_task(self, document_id: str, index_type: str, parsed_data_dict:
             logger.error(error_msg)
             raise Exception(error_msg)
 
+        if renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_task_result(document_id, index_type, "ownership_lost"),
+                log_message=(
+                    f"Processing ownership lost for create {index_type} index on document {document_id}; "
+                    "dropping success callback"
+                ),
+            )
+
         # Handle success callback with version validation
         logger.info(f"Successfully created {index_type} index for document {document_id} (v{target_version})")
-        self._handle_index_success(document_id, index_type, target_version, result.data)
+        self._handle_index_success(document_id, index_type, target_version, processing_token, result.data)
 
         return result.to_dict()
 
     except Exception as e:
+        if renewer and renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_task_result(document_id, index_type, "ownership_lost"),
+                log_message=(
+                    f"Processing ownership lost for create {index_type} index on document {document_id}; "
+                    "suppressing failure callback"
+                ),
+            )
+
         error_msg = f"Failed to create {index_type} index for document {document_id}: {str(e)}"
         logger.error(error_msg, exc_info=True)
 
         # Only mark as failed if all retries are exhausted
         if self.request.retries >= self.max_retries:
-            self._handle_index_failure(document_id, [index_type], error_msg)
+            self._handle_index_failure(document_id, [index_type], error_msg, context=context)
 
         raise
+    finally:
+        if renewer:
+            renewer.stop()
 
 
-@current_app.task(bind=True, base=BaseIndexTask, autoretry_for=(Exception,), retry_kwargs={'max_retries': 3, 'countdown': 60})
-def delete_index_task(self, document_id: str, index_type: str) -> dict:
+@current_app.task(
+    bind=True, base=BaseIndexTask, autoretry_for=(Exception,), retry_kwargs={"max_retries": 3, "countdown": 60}
+)
+def delete_index_task(self, document_id: str, index_type: str, context: dict = None) -> dict:
     """
     Delete a single index for a document
 
@@ -345,45 +706,31 @@ def delete_index_task(self, document_id: str, index_type: str) -> dict:
     Returns:
         Serialized IndexTaskResult
     """
-    from sqlalchemy import and_, select
+    from aperag.db.models import DocumentIndexStatus
 
-    from aperag.config import get_sync_session
-    from aperag.db.models import DocumentIndex, DocumentIndexStatus, DocumentIndexType
+    context = context or {}
+    target_context = _require_index_processing_context(index_type, context, require_version=False)
+    processing_token = target_context["processing_token"]
+    renewer = None
 
     try:
         logger.info(f"Starting to delete {index_type} index for document {document_id}")
 
-        # Double-check: verify task is still valid
-        for session in get_sync_session():
-            stmt = select(DocumentIndex).where(
-                and_(
-                    DocumentIndex.document_id == document_id,
-                    DocumentIndex.index_type == DocumentIndexType(index_type)
-                )
-            )
-            result = session.execute(stmt)
-            db_index = result.scalar_one_or_none()
+        skip_reason = _validate_task_relevance(
+            document_id,
+            index_type,
+            None,
+            DocumentIndexStatus.DELETION_IN_PROGRESS,
+            processing_token=processing_token,
+        )
+        if skip_reason:
+            return skip_reason
 
-            # Validate task is still relevant
-            if not db_index:
-                logger.info(f"Index record not found for {document_id}:{index_type}, already deleted")
-                return {
-                    "status": "skipped",
-                    "reason": "index_record_not_found",
-                    "document_id": document_id,
-                    "index_type": index_type,
-                }
-
-            if db_index.status != DocumentIndexStatus.DELETION_IN_PROGRESS:
-                logger.info(f"Index status changed for {document_id}:{index_type}, current: {db_index.status}, skipping task")
-                return {
-                    "status": "skipped",
-                    "reason": f"status_changed_to_{db_index.status}",
-                    "document_id": document_id,
-                    "index_type": index_type,
-                }
-
-            break
+        renewer = _make_document_index_lease_renewer(
+            _build_document_index_lease_targets([index_type], context, DocumentIndexStatus.DELETION_IN_PROGRESS),
+            f"delete-index:{document_id}:{index_type}",
+        )
+        renewer.start()
 
         # Execute index deletion
         result = document_index_task.delete_index(document_id, index_type)
@@ -394,24 +741,53 @@ def delete_index_task(self, document_id: str, index_type: str) -> dict:
             logger.error(error_msg)
             raise Exception(error_msg)
 
+        if renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_task_result(document_id, index_type, "ownership_lost"),
+                log_message=(
+                    f"Processing ownership lost for delete {index_type} index on document {document_id}; "
+                    "dropping success callback"
+                ),
+            )
+
         # Handle success callback
         logger.info(f"Successfully deleted {index_type} index for document {document_id}")
-        self._handle_index_deletion_success(document_id, index_type)
+        self._handle_index_deletion_success(document_id, index_type, processing_token)
 
         return result.to_dict()
 
     except Exception as e:
+        if renewer and renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_task_result(document_id, index_type, "ownership_lost"),
+                log_message=(
+                    f"Processing ownership lost for delete {index_type} index on document {document_id}; "
+                    "suppressing failure callback"
+                ),
+            )
+
         error_msg = f"Failed to delete {index_type} index for document {document_id}: {str(e)}"
         logger.error(error_msg, exc_info=True)
 
         # Only mark as failed if all retries are exhausted
         if self.request.retries >= self.max_retries:
-            self._handle_index_failure(document_id, [index_type], error_msg)
+            self._handle_index_failure(
+                document_id,
+                [index_type],
+                error_msg,
+                context=context,
+                expected_status=DocumentIndexStatus.DELETION_IN_PROGRESS,
+            )
 
         raise
+    finally:
+        if renewer:
+            renewer.stop()
 
 
-@current_app.task(bind=True, base=BaseIndexTask, autoretry_for=(Exception,), retry_kwargs={'max_retries': 3, 'countdown': 60})
+@current_app.task(
+    bind=True, base=BaseIndexTask, autoretry_for=(Exception,), retry_kwargs={"max_retries": 3, "countdown": 60}
+)
 def update_index_task(self, document_id: str, index_type: str, parsed_data_dict: dict, context: dict = None) -> dict:
     """
     Update a single index for a document with distributed locking
@@ -425,20 +801,33 @@ def update_index_task(self, document_id: str, index_type: str, parsed_data_dict:
     Returns:
         Serialized IndexTaskResult
     """
-
     from aperag.db.models import DocumentIndexStatus
 
-    # Extract target version from context
     context = context or {}
-    target_version = context.get(f'{index_type}_version')
+    target_context = _require_index_processing_context(index_type, context)
+    target_version = target_context["target_version"]
+    processing_token = target_context["processing_token"]
+    renewer = None
 
     try:
         logger.info(f"Starting to update {index_type} index for document {document_id} (v{target_version})")
 
         # Double-check: verify task is still valid
-        skip_reason = _validate_task_relevance(document_id, index_type, target_version, DocumentIndexStatus.CREATING)
+        skip_reason = _validate_task_relevance(
+            document_id,
+            index_type,
+            target_version,
+            DocumentIndexStatus.CREATING,
+            processing_token=processing_token,
+        )
         if skip_reason:
             return skip_reason
+
+        renewer = _make_document_index_lease_renewer(
+            _build_document_index_lease_targets([index_type], context, DocumentIndexStatus.CREATING),
+            f"update-index:{document_id}:{index_type}",
+        )
+        renewer.start()
 
         # Convert dict back to structured data
         parsed_data = ParsedDocumentData.from_dict(parsed_data_dict)
@@ -452,27 +841,51 @@ def update_index_task(self, document_id: str, index_type: str, parsed_data_dict:
             logger.error(error_msg)
             raise Exception(error_msg)
 
+        if renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_task_result(document_id, index_type, "ownership_lost"),
+                log_message=(
+                    f"Processing ownership lost for update {index_type} index on document {document_id}; "
+                    "dropping success callback"
+                ),
+            )
+
         # Handle success callback with version validation
         logger.info(f"Successfully updated {index_type} index for document {document_id} (v{target_version})")
-        self._handle_index_success(document_id, index_type, target_version, result.data)
+        self._handle_index_success(document_id, index_type, target_version, processing_token, result.data)
 
         return result.to_dict()
 
     except Exception as e:
+        if renewer and renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_task_result(document_id, index_type, "ownership_lost"),
+                log_message=(
+                    f"Processing ownership lost for update {index_type} index on document {document_id}; "
+                    "suppressing failure callback"
+                ),
+            )
+
         error_msg = f"Failed to update {index_type} index for document {document_id}: {str(e)}"
         logger.error(error_msg, exc_info=True)
 
         # Only mark as failed if all retries are exhausted
         if self.request.retries >= self.max_retries:
-            self._handle_index_failure(document_id, [index_type], error_msg)
+            self._handle_index_failure(document_id, [index_type], error_msg, context=context)
 
         raise
+    finally:
+        if renewer:
+            renewer.stop()
 
 
 # ========== Dynamic Workflow Orchestration Tasks ==========
 
+
 @current_app.task(bind=True)
-def trigger_create_indexes_workflow(self, parsed_data_dict: dict, document_id: str, index_types: List[str], context: dict = None) -> Any:
+def trigger_create_indexes_workflow(
+    self, parsed_data_dict: dict, document_id: str, index_types: List[str], context: dict = None
+) -> Any:
     """
     Dynamic orchestration task for index creation workflow.
 
@@ -488,18 +901,24 @@ def trigger_create_indexes_workflow(self, parsed_data_dict: dict, document_id: s
         Chord signature for parallel index creation + completion notification
     """
     try:
+        if _is_skipped_payload(parsed_data_dict):
+            logger.warning(
+                "Skipping create-index workflow fan-out for document %s because parse stage returned %s",
+                document_id,
+                parsed_data_dict.get("reason"),
+            )
+            return parsed_data_dict
+
         logger.info(f"Triggering parallel index creation for document {document_id} with types: {index_types}")
 
         # Dynamically create parallel index creation tasks
-        parallel_index_tasks = group([
-            create_index_task.s(document_id, index_type, parsed_data_dict, context)
-            for index_type in index_types
-        ])
+        parallel_index_tasks = group(
+            [create_index_task.s(document_id, index_type, parsed_data_dict, context) for index_type in index_types]
+        )
 
         # Create a chord that executes the completion notification after all create tasks are done
         workflow_chord = chord(
-            parallel_index_tasks,
-            notify_workflow_complete.s(document_id, IndexAction.CREATE, index_types)
+            parallel_index_tasks, notify_workflow_complete.s(document_id, IndexAction.CREATE, index_types)
         )
 
         # Execute the chord
@@ -514,7 +933,7 @@ def trigger_create_indexes_workflow(self, parsed_data_dict: dict, document_id: s
 
 
 @current_app.task(bind=True)
-def trigger_delete_indexes_workflow(self, document_id: str, index_types: List[str]) -> Any:
+def trigger_delete_indexes_workflow(self, document_id: str, index_types: List[str], context: dict = None) -> Any:
     """
     Dynamic orchestration task for index deletion workflow.
 
@@ -529,15 +948,13 @@ def trigger_delete_indexes_workflow(self, document_id: str, index_types: List[st
         logger.info(f"Triggering parallel index deletion for document {document_id} with types: {index_types}")
 
         # Create parallel index deletion tasks
-        parallel_delete_tasks = group([
-            delete_index_task.s(document_id, index_type)
-            for index_type in index_types
-        ])
+        parallel_delete_tasks = group(
+            [delete_index_task.s(document_id, index_type, context) for index_type in index_types]
+        )
 
         # Create a chord that executes the completion notification after all delete tasks are done
         workflow_chord = chord(
-            parallel_delete_tasks,
-            notify_workflow_complete.s(document_id, IndexAction.DELETE, index_types)
+            parallel_delete_tasks, notify_workflow_complete.s(document_id, IndexAction.DELETE, index_types)
         )
 
         # Execute the chord
@@ -552,7 +969,9 @@ def trigger_delete_indexes_workflow(self, document_id: str, index_types: List[st
 
 
 @current_app.task(bind=True)
-def trigger_update_indexes_workflow(self, parsed_data_dict: dict, document_id: str, index_types: List[str], context: dict = None) -> Any:
+def trigger_update_indexes_workflow(
+    self, parsed_data_dict: dict, document_id: str, index_types: List[str], context: dict = None
+) -> Any:
     """
     Dynamic orchestration task for index update workflow.
 
@@ -565,18 +984,24 @@ def trigger_update_indexes_workflow(self, parsed_data_dict: dict, document_id: s
         Chord signature for parallel index update + completion notification
     """
     try:
+        if _is_skipped_payload(parsed_data_dict):
+            logger.warning(
+                "Skipping update-index workflow fan-out for document %s because parse stage returned %s",
+                document_id,
+                parsed_data_dict.get("reason"),
+            )
+            return parsed_data_dict
+
         logger.info(f"Triggering parallel index update for document {document_id} with types: {index_types}")
 
         # Create parallel index update tasks
-        parallel_update_tasks = group([
-            update_index_task.s(document_id, index_type, parsed_data_dict, context)
-            for index_type in index_types
-        ])
+        parallel_update_tasks = group(
+            [update_index_task.s(document_id, index_type, parsed_data_dict, context) for index_type in index_types]
+        )
 
         # Create chord: parallel tasks + completion notification
         workflow_chord = chord(
-            parallel_update_tasks,
-            notify_workflow_complete.s(document_id, IndexAction.UPDATE, index_types)
+            parallel_update_tasks, notify_workflow_complete.s(document_id, IndexAction.UPDATE, index_types)
         )
 
         chord_async_result = workflow_chord.apply_async()
@@ -590,7 +1015,9 @@ def trigger_update_indexes_workflow(self, parsed_data_dict: dict, document_id: s
 
 
 @current_app.task(bind=True, base=BaseIndexTask)
-def notify_workflow_complete(self, index_results: List[dict], document_id: str, operation: str, index_types: List[str]) -> dict:
+def notify_workflow_complete(
+    self, index_results: List[dict], document_id: str, operation: str, index_types: List[str]
+) -> dict:
     """
     Workflow completion notification task.
 
@@ -663,7 +1090,7 @@ def notify_workflow_complete(self, index_results: List[dict], document_id: str, 
             status=status,
             message=status_message,
             successful_indexes=successful_tasks,
-            failed_indexes=[f.split(':')[0] for f in failed_tasks],
+            failed_indexes=[f.split(":")[0] for f in failed_tasks],
             total_indexes=len(index_types),
             index_results=normalized_results,
         )
@@ -684,13 +1111,14 @@ def notify_workflow_complete(self, index_results: List[dict], document_id: str, 
             successful_indexes=[],
             failed_indexes=index_types,
             total_indexes=len(index_types),
-            index_results=[]
+            index_results=[],
         )
 
         return workflow_result.to_dict()
 
 
 # ========== Workflow Entry Point Functions ==========
+
 
 def create_document_indexes_workflow(document_id: str, index_types: List[str], context: dict = None):
     """
@@ -711,8 +1139,8 @@ def create_document_indexes_workflow(document_id: str, index_types: List[str], c
     logger.info(f"Starting create indexes workflow for document {document_id} with types: {index_types}")
     # Create the workflow chain: parse -> dynamic trigger
     workflow_chain = chain(
-        parse_document_task.s(document_id, index_types),
-        trigger_create_indexes_workflow.s(document_id, index_types, context)
+        parse_document_task.s(document_id, index_types, context),
+        trigger_create_indexes_workflow.s(document_id, index_types, context),
     )
 
     # Submit the workflow
@@ -722,7 +1150,7 @@ def create_document_indexes_workflow(document_id: str, index_types: List[str], c
     return workflow_result
 
 
-def delete_document_indexes_workflow(document_id: str, index_types: List[str]):
+def delete_document_indexes_workflow(document_id: str, index_types: List[str], context: dict = None):
     """
     Delete indexes for a document using dynamic workflow orchestration.
 
@@ -736,7 +1164,7 @@ def delete_document_indexes_workflow(document_id: str, index_types: List[str]):
     logger.info(f"Starting delete indexes workflow for document {document_id} with types: {index_types}")
 
     # For deletion, we don't need parsing, so we directly trigger the delete workflow
-    workflow_result = trigger_delete_indexes_workflow.delay(document_id, index_types)
+    workflow_result = trigger_delete_indexes_workflow.delay(document_id, index_types, context)
     logger.info(f"Delete indexes workflow submitted for document {document_id}, workflow ID: {workflow_result.id}")
 
     return workflow_result
@@ -762,8 +1190,8 @@ def update_document_indexes_workflow(document_id: str, index_types: List[str], c
 
     # Create the workflow chain: parse -> dynamic trigger
     workflow_chain = chain(
-        parse_document_task.s(document_id, index_types),
-        trigger_update_indexes_workflow.s(document_id, index_types, context)
+        parse_document_task.s(document_id, index_types, context),
+        trigger_update_indexes_workflow.s(document_id, index_types, context),
     )
 
     # Submit the workflow
@@ -774,6 +1202,7 @@ def update_document_indexes_workflow(document_id: str, index_types: List[str], c
 
 
 # ========== Collection Tasks ==========
+
 
 @current_app.task
 def reconcile_indexes_task():
@@ -866,8 +1295,10 @@ def collection_init_task(self, collection_id: str, document_user_quota: int) -> 
         )
 
 
-@app.task(bind=True, autoretry_for=(Exception,), retry_kwargs={'max_retries': 3, 'countdown': 60})
-def collection_summary_task(self, summary_id: str, collection_id: str, target_version: int) -> Any:
+@app.task(bind=True, autoretry_for=(Exception,), retry_kwargs={"max_retries": 3, "countdown": 60})
+def collection_summary_task(
+    self, summary_id: str, collection_id: str, target_version: int, processing_token: str
+) -> Any:
     """
     Generate collection summary task entry point
 
@@ -875,27 +1306,70 @@ def collection_summary_task(self, summary_id: str, collection_id: str, target_ve
         summary_id: Summary ID to generate
         collection_id: Collection ID to generate summary for
     """
+    renewer = None
+
     try:
         from aperag.service.collection_summary_service import collection_summary_service
 
-        collection_summary_service.generate_collection_summary_task(summary_id, collection_id, target_version)
+        skip_reason = _validate_collection_summary_relevance(summary_id, target_version, processing_token)
+        if skip_reason:
+            return skip_reason
+
+        renewer = _make_collection_summary_lease_renewer(summary_id, target_version, processing_token)
+        renewer.start()
+
+        collection_summary_service.generate_collection_summary_task(
+            summary_id,
+            collection_id,
+            target_version,
+            processing_token,
+            callback_allowed=lambda: not renewer.ownership_lost,
+        )
+
+        if renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_payload(
+                    "ownership_lost",
+                    summary_id=summary_id,
+                    collection_id=collection_id,
+                ),
+                log_message=(
+                    f"Processing ownership lost for collection summary {summary_id}; " "suppressing success handling"
+                ),
+            )
 
         logger.info(f"Collection summary task completed for {collection_id}")
         return {"success": True, "collection_id": collection_id}
 
     except Exception as e:
+        if renewer and renewer.ownership_lost:
+            return _handle_ownership_lost(
+                payload_factory=lambda: _build_skipped_payload(
+                    "ownership_lost",
+                    summary_id=summary_id,
+                    collection_id=collection_id,
+                ),
+                log_message=(
+                    f"Processing ownership lost for collection summary {summary_id}; " "suppressing failure callback"
+                ),
+            )
+
         logger.error(f"Collection summary generation failed for {collection_id}: {str(e)}")
 
         # Mark as failed using callback if we've exhausted retries
         if self.request.retries >= self.max_retries:
             from aperag.tasks.reconciler import collection_summary_callbacks
-            collection_summary_callbacks.on_summary_failed(summary_id, str(e), target_version)
+
+            collection_summary_callbacks.on_summary_failed(summary_id, str(e), target_version, processing_token)
 
         raise self.retry(
             exc=e,
             countdown=TaskConfig.RETRY_COUNTDOWN_COLLECTION,
             max_retries=TaskConfig.RETRY_MAX_RETRIES_COLLECTION,
         )
+    finally:
+        if renewer:
+            renewer.stop()
 
 
 @current_app.task
@@ -914,7 +1388,9 @@ def cleanup_expired_documents_task():
     logger.info(f"Celery task completed with result: {result}")
     return result
 
+
 # ========== Evaluation Tasks ==========
+
 
 # By default, get_async_session() uses a global AsyncEngine object.
 # Since we also use asyncio.run() to execute async functions, old connections
@@ -936,6 +1412,7 @@ async def _new_async_engine():
 def reconcile_evaluations_task():
     """Periodic task to reconcile evaluations."""
     try:
+
         async def execute():
             from aperag.service.evaluation_service import EvaluationExecutor
 
@@ -944,6 +1421,7 @@ def reconcile_evaluations_task():
                 await executor.schedule_evaluations()
 
         import asyncio
+
         asyncio.run(execute())
 
         return {"success": True}
@@ -956,6 +1434,7 @@ def reconcile_evaluations_task():
 def initialize_evaluation_task(self, evaluation_id: str) -> Any:
     """Task to initialize a specific evaluation."""
     try:
+
         async def execute():
             from aperag.service.evaluation_service import EvaluationExecutor
 
@@ -964,6 +1443,7 @@ def initialize_evaluation_task(self, evaluation_id: str) -> Any:
                 await executor.initialize_evaluation(evaluation_id)
 
         import asyncio
+
         asyncio.run(execute())
 
         return {"success": True, "evaluation_id": evaluation_id}
@@ -976,6 +1456,7 @@ def initialize_evaluation_task(self, evaluation_id: str) -> Any:
 def process_evaluation_batch_task(self, evaluation_id: str) -> Any:
     """Task to process a batch of items for an evaluation."""
     try:
+
         async def execute():
             from aperag.service.evaluation_service import EvaluationExecutor
 
@@ -984,6 +1465,7 @@ def process_evaluation_batch_task(self, evaluation_id: str) -> Any:
                 await executor.process_evaluation_batch(evaluation_id)
 
         import asyncio
+
         asyncio.run(execute())
 
         return {"success": True, "evaluation_id": evaluation_id}
@@ -996,6 +1478,7 @@ def process_evaluation_batch_task(self, evaluation_id: str) -> Any:
 def process_evaluation_item_task(self, evaluation_id: str, item_id: str) -> Any:
     """Task to process a single evaluation item."""
     try:
+
         async def execute():
             from aperag.service.evaluation_service import EvaluationExecutor
 
@@ -1004,6 +1487,7 @@ def process_evaluation_item_task(self, evaluation_id: str, item_id: str) -> Any:
                 await executor.process_evaluation_item(evaluation_id, item_id)
 
         import asyncio
+
         asyncio.run(execute())
 
         return {"success": True, "item_id": item_id}

--- a/tests/unit_test/tasks/test_reconciler.py
+++ b/tests/unit_test/tasks/test_reconciler.py
@@ -1,19 +1,29 @@
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from aperag.db.models import (
     CollectionSummary,
+    CollectionSummaryStatus,
     DocumentIndex,
+    DocumentIndexStatus,
     DocumentIndexType,
 )
 from aperag.tasks import reconciler as reconciler_module
-from aperag.tasks.reconciler import CollectionSummaryReconciler, DocumentIndexReconciler
+from aperag.tasks.models import LocalDocumentInfo, ParsedDocumentData
+from aperag.tasks.reconciler import (
+    CollectionSummaryReconciler,
+    DocumentIndexReconciler,
+    collection_summary_callbacks,
+    index_task_callbacks,
+)
 from aperag.utils.constant import IndexAction
-from config.celery_tasks import collection_summary_task
+from aperag.utils.utils import utc_now
+from config.celery_tasks import collection_summary_task, create_index_task
 
 
 class FakeSession:
@@ -30,6 +40,19 @@ class FakeSession:
         self.rollback_called = True
 
 
+class FakeRenewer:
+    def __init__(self, ownership_lost=False):
+        self.ownership_lost = ownership_lost
+        self.started = False
+        self.stopped = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+
 @pytest.fixture
 def sqlite_session():
     engine = create_engine("sqlite:///:memory:")
@@ -39,6 +62,19 @@ def sqlite_session():
 
     with session_factory() as session:
         yield session
+
+
+@pytest.fixture
+def parsed_document_payload():
+    parsed_data = ParsedDocumentData(
+        document_id="doc1",
+        collection_id="col1",
+        content="hello",
+        doc_parts=[],
+        file_path="/tmp/doc1.txt",
+        local_doc_info=LocalDocumentInfo(path="/tmp/doc1.txt"),
+    )
+    return parsed_data.to_dict()
 
 
 class TestDocumentIndexReconciler:
@@ -52,6 +88,7 @@ class TestDocumentIndexReconciler:
                 "index_type": DocumentIndexType.VECTOR.value,
                 "action": IndexAction.CREATE,
                 "target_version": 1,
+                "processing_token": "tok-1",
             }
         ]
 
@@ -96,6 +133,7 @@ class TestDocumentIndexReconciler:
                 "index_type": DocumentIndexType.VECTOR.value,
                 "action": IndexAction.CREATE,
                 "target_version": 1,
+                "processing_token": "tok-1",
             }
         ]
 
@@ -130,6 +168,106 @@ class TestDocumentIndexReconciler:
         assert fake_session.commit_count == 1
         assert rollback_calls == [("doc1", claimed_indexes, "broker unavailable")]
 
+    def test_stale_reclaim_only_reclaims_expired_tokenized_rows(self, sqlite_session, monkeypatch):
+        now = utc_now()
+        expired = now - timedelta(minutes=5)
+        future = now + timedelta(minutes=5)
+
+        expired_create = DocumentIndex(
+            id=1,
+            document_id="doc1",
+            index_type=DocumentIndexType.VECTOR,
+            status=DocumentIndexStatus.CREATING,
+            version=1,
+            observed_version=0,
+            processing_token="tok-expired-create",
+            lease_expires_at=expired,
+        )
+        live_create = DocumentIndex(
+            id=2,
+            document_id="doc2",
+            index_type=DocumentIndexType.FULLTEXT,
+            status=DocumentIndexStatus.CREATING,
+            version=1,
+            observed_version=0,
+            processing_token="tok-live-create",
+            lease_expires_at=future,
+        )
+        missing_token = DocumentIndex(
+            id=3,
+            document_id="doc3",
+            index_type=DocumentIndexType.GRAPH,
+            status=DocumentIndexStatus.CREATING,
+            version=1,
+            observed_version=0,
+            processing_token=None,
+            lease_expires_at=expired,
+        )
+        expired_delete = DocumentIndex(
+            id=4,
+            document_id="doc4",
+            index_type=DocumentIndexType.VECTOR,
+            status=DocumentIndexStatus.DELETION_IN_PROGRESS,
+            version=2,
+            observed_version=1,
+            processing_token="tok-expired-delete",
+            lease_expires_at=expired,
+        )
+        sqlite_session.add_all([expired_create, live_create, missing_token, expired_delete])
+        sqlite_session.commit()
+
+        reconciler = DocumentIndexReconciler(task_scheduler=MagicMock())
+        reclaimed = reconciler._reclaim_stale_indexes(sqlite_session)
+        sqlite_session.commit()
+
+        assert reclaimed == 2
+
+        refreshed = {
+            row.id: row
+            for row in sqlite_session.execute(select(DocumentIndex).order_by(DocumentIndex.id)).scalars().all()
+        }
+
+        assert refreshed[1].status == DocumentIndexStatus.PENDING
+        assert refreshed[1].processing_token is None
+        assert refreshed[1].lease_expires_at is None
+        assert refreshed[1].error_message == "stale lease reclaimed"
+
+        assert refreshed[2].status == DocumentIndexStatus.CREATING
+        assert refreshed[2].processing_token == "tok-live-create"
+        assert refreshed[2].lease_expires_at == future
+
+        assert refreshed[3].status == DocumentIndexStatus.CREATING
+        assert refreshed[3].processing_token is None
+        assert refreshed[3].lease_expires_at == expired
+
+        assert refreshed[4].status == DocumentIndexStatus.DELETING
+        assert refreshed[4].processing_token is None
+        assert refreshed[4].lease_expires_at is None
+
+    def test_old_index_callback_token_is_ignored(self, sqlite_session, monkeypatch):
+        sqlite_session.add(
+            DocumentIndex(
+                id=1,
+                document_id="doc1",
+                index_type=DocumentIndexType.VECTOR,
+                status=DocumentIndexStatus.CREATING,
+                version=3,
+                observed_version=2,
+                processing_token="tok-current",
+                lease_expires_at=utc_now() + timedelta(minutes=5),
+            )
+        )
+        sqlite_session.commit()
+
+        monkeypatch.setattr(reconciler_module, "get_sync_session", lambda: iter([sqlite_session]))
+
+        index_task_callbacks.on_index_created("doc1", DocumentIndexType.VECTOR.value, 3, "tok-stale", "{}")
+
+        refreshed = sqlite_session.get(DocumentIndex, 1)
+        assert refreshed.status == DocumentIndexStatus.CREATING
+        assert refreshed.processing_token == "tok-current"
+        assert refreshed.observed_version == 2
+
 
 class TestCollectionSummaryReconciler:
     def test_summary_claim_is_committed_before_dispatch_and_rolls_back_on_failure(self, monkeypatch):
@@ -137,17 +275,21 @@ class TestCollectionSummaryReconciler:
         reconciler = CollectionSummaryReconciler()
         summary = SimpleNamespace(id="sum1", collection_id="col1", version=7)
 
-        monkeypatch.setattr(reconciler, "_claim_summary_for_processing", lambda session, summary_id, version: True)
+        monkeypatch.setattr(
+            reconciler,
+            "_claim_summary_for_processing",
+            lambda session, summary_id, version: "tok-sum1",
+        )
 
         rollback_calls = []
         dispatch_state = {}
 
-        def fake_schedule(summary_id, collection_id, target_version):
+        def fake_schedule(summary_id, collection_id, target_version, processing_token):
             dispatch_state["committed_before_dispatch"] = fake_session.committed
             raise RuntimeError("dispatch failed")
 
-        def fake_rollback(summary_id, target_version, error_message):
-            rollback_calls.append((summary_id, target_version, error_message))
+        def fake_rollback(summary_id, target_version, processing_token, error_message):
+            rollback_calls.append((summary_id, target_version, processing_token, error_message))
 
         monkeypatch.setattr(reconciler, "_schedule_summary_generation", fake_schedule)
         monkeypatch.setattr(reconciler, "_rollback_summary_claim", fake_rollback)
@@ -157,7 +299,89 @@ class TestCollectionSummaryReconciler:
 
         assert fake_session.commit_count == 1
         assert dispatch_state["committed_before_dispatch"] is True
-        assert rollback_calls == [("sum1", 7, "dispatch failed")]
+        assert rollback_calls == [("sum1", 7, "tok-sum1", "dispatch failed")]
+
+    def test_stale_reclaim_only_reclaims_expired_tokenized_rows(self, sqlite_session):
+        now = utc_now()
+        expired = now - timedelta(minutes=5)
+        future = now + timedelta(minutes=5)
+
+        expired_summary = CollectionSummary(
+            id="sum-expired",
+            collection_id="col1",
+            status=CollectionSummaryStatus.GENERATING,
+            version=2,
+            observed_version=1,
+            processing_token="tok-expired",
+            lease_expires_at=expired,
+        )
+        live_summary = CollectionSummary(
+            id="sum-live",
+            collection_id="col2",
+            status=CollectionSummaryStatus.GENERATING,
+            version=3,
+            observed_version=2,
+            processing_token="tok-live",
+            lease_expires_at=future,
+        )
+        missing_token = CollectionSummary(
+            id="sum-missing-token",
+            collection_id="col3",
+            status=CollectionSummaryStatus.GENERATING,
+            version=4,
+            observed_version=3,
+            processing_token=None,
+            lease_expires_at=expired,
+        )
+        sqlite_session.add_all([expired_summary, live_summary, missing_token])
+        sqlite_session.commit()
+
+        reconciler = CollectionSummaryReconciler()
+        reclaimed = reconciler._reclaim_stale_summaries(sqlite_session)
+        sqlite_session.commit()
+
+        assert reclaimed == 1
+
+        refreshed = {
+            row.id: row
+            for row in sqlite_session.execute(select(CollectionSummary).order_by(CollectionSummary.id)).scalars().all()
+        }
+
+        assert refreshed["sum-expired"].status == CollectionSummaryStatus.PENDING
+        assert refreshed["sum-expired"].processing_token is None
+        assert refreshed["sum-expired"].lease_expires_at is None
+        assert refreshed["sum-expired"].error_message == "stale lease reclaimed"
+
+        assert refreshed["sum-live"].status == CollectionSummaryStatus.GENERATING
+        assert refreshed["sum-live"].processing_token == "tok-live"
+        assert refreshed["sum-live"].lease_expires_at == future
+
+        assert refreshed["sum-missing-token"].status == CollectionSummaryStatus.GENERATING
+        assert refreshed["sum-missing-token"].processing_token is None
+        assert refreshed["sum-missing-token"].lease_expires_at == expired
+
+    def test_old_summary_failure_callback_token_is_ignored(self, sqlite_session, monkeypatch):
+        sqlite_session.add(
+            CollectionSummary(
+                id="sum1",
+                collection_id="col1",
+                status=CollectionSummaryStatus.GENERATING,
+                version=5,
+                observed_version=4,
+                processing_token="tok-current",
+                lease_expires_at=utc_now() + timedelta(minutes=5),
+            )
+        )
+        sqlite_session.commit()
+
+        monkeypatch.setattr(reconciler_module, "get_sync_session", lambda: iter([sqlite_session]))
+
+        collection_summary_callbacks.on_summary_failed("sum1", "boom", 5, "tok-stale")
+
+        refreshed = sqlite_session.get(CollectionSummary, "sum1")
+        assert refreshed.status == CollectionSummaryStatus.GENERATING
+        assert refreshed.processing_token == "tok-current"
+        assert refreshed.error_message is None
 
 
 class TestCollectionSummaryTask:
@@ -167,12 +391,20 @@ class TestCollectionSummaryTask:
         class RetryTriggered(Exception):
             pass
 
-        def fake_generate(summary_id, collection_id, target_version):
+        def fake_generate(summary_id, collection_id, target_version, processing_token, callback_allowed=None):
             raise RuntimeError("summary failed")
 
-        def fake_on_summary_failed(summary_id, error_message, target_version):
-            callback_calls.append((summary_id, error_message, target_version))
+        def fake_on_summary_failed(summary_id, error_message, target_version, processing_token):
+            callback_calls.append((summary_id, error_message, target_version, processing_token))
 
+        monkeypatch.setattr(
+            "config.celery_tasks._validate_collection_summary_relevance",
+            lambda summary_id, target_version, processing_token: None,
+        )
+        monkeypatch.setattr(
+            "config.celery_tasks._make_collection_summary_lease_renewer",
+            lambda summary_id, target_version, processing_token: FakeRenewer(),
+        )
         monkeypatch.setattr(
             "aperag.service.collection_summary_service.collection_summary_service.generate_collection_summary_task",
             fake_generate,
@@ -186,8 +418,94 @@ class TestCollectionSummaryTask:
         collection_summary_task.push_request(retries=collection_summary_task.max_retries)
         try:
             with pytest.raises(RetryTriggered, match="retry scheduled"):
-                collection_summary_task.run("sum1", "col1", 9)
+                collection_summary_task.run("sum1", "col1", 9, "tok-9")
         finally:
             collection_summary_task.pop_request()
 
-        assert callback_calls == [("sum1", "summary failed", 9)]
+        assert callback_calls == [("sum1", "summary failed", 9, "tok-9")]
+
+    def test_collection_summary_task_suppresses_failure_callback_after_ownership_lost(self, monkeypatch):
+        callback_calls = []
+
+        def fake_generate(summary_id, collection_id, target_version, processing_token, callback_allowed=None):
+            raise RuntimeError("summary failed after owner lost")
+
+        monkeypatch.setattr(
+            "config.celery_tasks._validate_collection_summary_relevance",
+            lambda summary_id, target_version, processing_token: None,
+        )
+        monkeypatch.setattr(
+            "config.celery_tasks._make_collection_summary_lease_renewer",
+            lambda summary_id, target_version, processing_token: FakeRenewer(ownership_lost=True),
+        )
+        monkeypatch.setattr(
+            "aperag.service.collection_summary_service.collection_summary_service.generate_collection_summary_task",
+            fake_generate,
+        )
+        monkeypatch.setattr(
+            "aperag.tasks.reconciler.collection_summary_callbacks.on_summary_failed",
+            lambda *args, **kwargs: callback_calls.append((args, kwargs)),
+        )
+        monkeypatch.setattr(
+            collection_summary_task,
+            "retry",
+            lambda **kwargs: pytest.fail("retry should not be scheduled after ownership loss"),
+        )
+
+        collection_summary_task.push_request(retries=collection_summary_task.max_retries)
+        try:
+            result = collection_summary_task.run("sum1", "col1", 9, "tok-9")
+        finally:
+            collection_summary_task.pop_request()
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "ownership_lost"
+        assert callback_calls == []
+
+
+class TestIndexTaskOwnership:
+    def test_create_index_task_returns_skipped_when_ownership_lost(self, monkeypatch, parsed_document_payload):
+        callback_calls = []
+
+        result_stub = SimpleNamespace(
+            success=True,
+            error=None,
+            data={"index": "ok"},
+            to_dict=lambda: {"success": True},
+        )
+
+        monkeypatch.setattr(
+            "config.celery_tasks._validate_task_relevance",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "config.celery_tasks._make_document_index_lease_renewer",
+            lambda targets, description: FakeRenewer(ownership_lost=True),
+        )
+        monkeypatch.setattr(
+            "aperag.tasks.document.document_index_task.create_index",
+            lambda document_id, index_type, parsed_data: result_stub,
+        )
+        monkeypatch.setattr(
+            create_index_task,
+            "_handle_index_success",
+            lambda *args, **kwargs: callback_calls.append((args, kwargs)),
+        )
+
+        context = {
+            "VECTOR_version": 2,
+            "VECTOR_processing_token": "tok-2",
+            "VECTOR_index_id": 11,
+        }
+
+        create_index_task.push_request(retries=0)
+        try:
+            result = create_index_task.run("doc1", DocumentIndexType.VECTOR.value, parsed_document_payload, context)
+        finally:
+            create_index_task.pop_request()
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "ownership_lost"
+        assert result["document_id"] == "doc1"
+        assert result["index_type"] == DocumentIndexType.VECTOR.value
+        assert callback_calls == []


### PR DESCRIPTION
## What changed
- add `processing_token` and `lease_expires_at` to `DocumentIndex` and `CollectionSummary`, plus the supporting migration and status/lease indexes
- implement a reusable processing-lease renewer and wire `parse_document_task`, `create_index_task`, `update_index_task`, `delete_index_task`, and `collection_summary_task` onto the `claim -> renew -> callback` contract
- add safe stale reclaim in the index and summary reconcilers, gated on `status + processing_token + lease_expires_at`
- gate index and summary callbacks on `status/version/token` and atomically clear token/lease on success, failure, dispatch rollback, and reclaim
- lower `reconcile-indexes` beat interval from `3600s` to `300s` so index-side recovery is usable by default
- add targeted unit coverage for stale reclaim, token-mismatch callback rejection, retry-exhausted summary failure, and ownership-lost suppression

## Why
The previous stopgap PR fixed `claim -> commit -> dispatch`, but it still had no correct self-recovery path for genuinely orphaned in-progress work. The new reclaim path needs two properties at the same time:
- do not reclaim legitimate long-running work based on claim time alone
- do not let old attempts write into new state after reclaim

This PR closes that gap by combining lease renewal with an attempt owner token.

## Impact
- customers get bounded automatic recovery for orphaned index and summary work without hidden cross-talk between attempts
- live tasks keep their lease renewed while parsing / indexing / summarizing, so reclaim is no longer a hard task-duration timeout
- ownership loss exits are soft: tasks log and stop instead of writing spurious business failures

## Validation
- `uv run --with pytest-asyncio pytest tests/unit_test/tasks/test_reconciler.py -q`
- `ruff check config/celery_tasks.py aperag/service/collection_summary_service.py aperag/tasks/reconciler.py tests/unit_test/tasks/test_reconciler.py`
- `ruff format --check config/celery_tasks.py aperag/service/collection_summary_service.py aperag/tasks/reconciler.py tests/unit_test/tasks/test_reconciler.py`
- `python3 -m py_compile config/celery_tasks.py aperag/service/collection_summary_service.py aperag/tasks/reconciler.py tests/unit_test/tasks/test_reconciler.py`
- `git diff --check`
