### PR TITLE
fix(ui): reveal API keys only once after creation

### DIFF
--- a/aperag/service/api_key_service.py
+++ b/aperag/service/api_key_service.py
@@ -21,6 +21,7 @@ from aperag.db.ops import AsyncDatabaseOps, async_db_ops
 from aperag.exceptions import ResourceNotFoundException
 from aperag.schema.view_models import ApiKey as ApiKeyModel
 from aperag.schema.view_models import ApiKeyCreate, ApiKeyList, ApiKeyUpdate
+from aperag.views.utils import mask_api_key
 
 
 class ApiKeyService:
@@ -33,16 +34,8 @@ class ApiKeyService:
         else:
             self.db_ops = AsyncDatabaseOps(session)  # Create custom instance for transaction control
 
-    # Convert database ApiKey model to API response model
-    def mask_api_key(self, key: str) -> str:
-        if not key:
-            return key
-        if len(key) <= 8:
-            return "*" * len(key)
-        return f"{key[:4]}{'*' * (len(key) - 8)}{key[-4:]}"
-
     def to_api_key_model(self, apikey: ApiKey, mask_key: bool = True) -> ApiKeyModel:
-        key = self.mask_api_key(apikey.key) if mask_key else apikey.key
+        key = mask_api_key(apikey.key) if mask_key else apikey.key
         return ApiKeyModel(
             id=str(apikey.id),
             key=key,

--- a/tests/unit_test/test_api_key_service.py
+++ b/tests/unit_test/test_api_key_service.py
@@ -1,0 +1,75 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from aperag.service.api_key_service import ApiKeyService
+from aperag.views.utils import mask_api_key
+
+
+def build_api_key(key: str = "sk-1234567890abcdef", description: str = "test key"):
+    now = datetime.now(UTC)
+    return SimpleNamespace(
+        id="api-key-id",
+        key=key,
+        description=description,
+        gmt_created=now,
+        gmt_updated=now,
+        last_used_at=None,
+    )
+
+
+def test_to_api_key_model_masks_by_default():
+    service = ApiKeyService()
+    token = build_api_key()
+
+    result = service.to_api_key_model(token)
+
+    assert result.key == mask_api_key(token.key)
+
+
+async def test_list_api_keys_returns_masked_keys():
+    service = ApiKeyService()
+    token = build_api_key()
+    service.db_ops = MagicMock()
+    service.db_ops.query_api_keys = AsyncMock(return_value=[token])
+
+    result = await service.list_api_keys("user-id")
+
+    assert len(result.items) == 1
+    assert result.items[0].key == mask_api_key(token.key)
+
+
+async def test_create_api_key_returns_plaintext_key_once():
+    service = ApiKeyService()
+    token = build_api_key()
+    service.db_ops = MagicMock()
+    service.db_ops.create_api_key = AsyncMock(return_value=token)
+
+    result = await service.create_api_key("user-id", SimpleNamespace(description="created key"))
+
+    assert result.key == token.key
+
+
+async def test_update_api_key_returns_masked_key():
+    service = ApiKeyService()
+    token = build_api_key(description="updated key")
+    service.db_ops = MagicMock()
+    service.db_ops.update_api_key_by_id = AsyncMock(return_value=token)
+
+    result = await service.update_api_key("user-id", "api-key-id", SimpleNamespace(description="updated key"))
+
+    assert result.key == mask_api_key(token.key)

--- a/web/src/app/workspace/api-keys/api-key-actions.tsx
+++ b/web/src/app/workspace/api-keys/api-key-actions.tsx
@@ -19,14 +19,18 @@ import {
   FormItem,
   FormMessage,
 } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { apiClient } from '@/lib/api/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Slot } from '@radix-ui/react-slot';
+import copy from 'copy-to-clipboard';
+import { Copy } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 import * as z from 'zod';
 
 const apiKeySchema = z.object({
@@ -45,9 +49,14 @@ export const ApiKeyActions = ({
   const page_api_keys = useTranslations('page_api_keys');
   const common_action = useTranslations('common.action');
   const common_tips = useTranslations('common.tips');
+  const components_copy_to_clipboard = useTranslations(
+    'components.copy_to_clipboard',
+  );
   const [createOrUpdateVisible, setCreateOrUpdateVisible] =
     useState<boolean>(false);
   const [deleteVisible, setDeleteVisible] = useState<boolean>(false);
+  const [createdApiKey, setCreatedApiKey] = useState<ApiKey | null>(null);
+  const [createdKeyVisible, setCreatedKeyVisible] = useState<boolean>(false);
   const router = useRouter();
   const form = useForm<z.infer<typeof apiKeySchema>>({
     resolver: zodResolver(apiKeySchema),
@@ -72,10 +81,16 @@ export const ApiKeyActions = ({
       }
       if (res?.status === 200) {
         setCreateOrUpdateVisible(false);
+        if (action === 'add' && res.data) {
+          setCreatedApiKey(res.data);
+          setCreatedKeyVisible(true);
+          form.reset({ description: '' });
+          return;
+        }
         setTimeout(router.refresh, 300);
       }
     },
-    [action, apiKey?.id, router],
+    [action, apiKey?.id, form, router],
   );
 
   const handleDelete = useCallback(async () => {
@@ -89,6 +104,21 @@ export const ApiKeyActions = ({
       }
     }
   }, [action, apiKey?.id, router]);
+
+  const handleCopyCreatedKey = useCallback(() => {
+    if (!createdApiKey?.key) {
+      return;
+    }
+
+    copy(createdApiKey.key);
+    toast.success(components_copy_to_clipboard('copied'));
+  }, [components_copy_to_clipboard, createdApiKey?.key]);
+
+  const handleCloseCreatedKey = useCallback(() => {
+    setCreatedKeyVisible(false);
+    setCreatedApiKey(null);
+    setTimeout(router.refresh, 300);
+  }, [router]);
 
   if (action === 'delete') {
     return (
@@ -124,62 +154,102 @@ export const ApiKeyActions = ({
     );
   } else {
     return (
-      <Dialog
-        open={createOrUpdateVisible}
-        onOpenChange={() => setCreateOrUpdateVisible(false)}
-      >
-        <DialogTrigger asChild>
-          <Slot
-            onClick={(e) => {
-              setCreateOrUpdateVisible(true);
-              e.preventDefault();
-            }}
-          >
-            {children}
-          </Slot>
-        </DialogTrigger>
-        <DialogContent showCloseButton={false}>
-          <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(handleCreateOrUpdate)}
-              className="space-y-8"
+      <>
+        <Dialog
+          open={createOrUpdateVisible}
+          onOpenChange={() => setCreateOrUpdateVisible(false)}
+        >
+          <DialogTrigger asChild>
+            <Slot
+              onClick={(e) => {
+                setCreateOrUpdateVisible(true);
+                e.preventDefault();
+              }}
             >
-              <DialogHeader>
-                <DialogTitle>API Key</DialogTitle>
-                <DialogDescription></DialogDescription>
-              </DialogHeader>
-              <FormField
-                control={form.control}
-                name="description"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormControl>
-                      <Textarea
-                        placeholder={page_api_keys('api_key_placeholder')}
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {page_api_keys('api_key_description')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setCreateOrUpdateVisible(false)}
-                >
-                  {common_action('cancel')}
-                </Button>
-                <Button type="submit">{common_action('save')}</Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
+              {children}
+            </Slot>
+          </DialogTrigger>
+          <DialogContent showCloseButton={false}>
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(handleCreateOrUpdate)}
+                className="space-y-8"
+              >
+                <DialogHeader>
+                  <DialogTitle>API Key</DialogTitle>
+                  <DialogDescription></DialogDescription>
+                </DialogHeader>
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Textarea
+                          placeholder={page_api_keys('api_key_placeholder')}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        {page_api_keys('api_key_description')}
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <DialogFooter>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setCreateOrUpdateVisible(false)}
+                  >
+                    {common_action('cancel')}
+                  </Button>
+                  <Button type="submit">{common_action('save')}</Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </DialogContent>
+        </Dialog>
+        <Dialog open={createdKeyVisible}>
+          <DialogContent
+            showCloseButton={false}
+            onEscapeKeyDown={(event) => event.preventDefault()}
+            onInteractOutside={(event) => event.preventDefault()}
+          >
+            <DialogHeader>
+              <DialogTitle>{page_api_keys('created_api_key_title')}</DialogTitle>
+              <DialogDescription>
+                {page_api_keys('created_api_key_description')}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <p className="text-sm font-medium">
+                  {page_api_keys('created_api_key_label')}
+                </p>
+                <Input
+                  readOnly
+                  value={createdApiKey?.key || ''}
+                  className="font-mono text-xs"
+                />
+              </div>
+              <p className="text-muted-foreground text-sm">
+                {page_api_keys('created_api_key_hint')}
+              </p>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={handleCopyCreatedKey}>
+                <Copy />
+                {page_api_keys('copy_created_api_key')}
+              </Button>
+              <Button onClick={handleCloseCreatedKey}>
+                {page_api_keys('saved_api_key')}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   }
 };

--- a/web/src/app/workspace/api-keys/api-key-table.tsx
+++ b/web/src/app/workspace/api-keys/api-key-table.tsx
@@ -15,10 +15,9 @@ import {
 } from '@tanstack/react-table';
 import * as React from 'react';
 
-import { CopyToClipboard } from '@/components/copy-to-clipboard';
-
 import { z } from 'zod';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 
 import { Checkbox } from '@/components/ui/checkbox';
@@ -106,10 +105,8 @@ export function ApiKeyTable({ data }: { data: ApiKey[] }) {
       cell: ({ row }) => {
         return (
           <div className="flex flex-row items-center gap-2">
-            <span>{row.original.key}</span>
-            {row.original.key && (
-              <CopyToClipboard variant="ghost" text={row.original.key} />
-            )}
+            <span className="font-mono text-sm">{row.original.key}</span>
+            <Badge variant="outline">{page_api_keys('masked_badge')}</Badge>
           </div>
         );
       },
@@ -204,6 +201,9 @@ export function ApiKeyTable({ data }: { data: ApiKey[] }) {
             value={searchValue}
             onChange={(e) => setSearchValue(e.currentTarget.value)}
           />
+          <p className="text-muted-foreground mt-2 text-xs">
+            {page_api_keys('masked_notice')}
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <ApiKeyActions action="add">

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -94,7 +94,15 @@
     "add_api_keys": "Create Api Key",
     "edit_api_keys": "Edit",
     "delete_api_key": "Delete Api Key",
-    "delete_api_key_confirm": "Confirm deletion of the API key?"
+    "delete_api_key_confirm": "Confirm deletion of the API key?",
+    "masked_badge": "Masked",
+    "masked_notice": "Existing API keys are masked in the list. The full key is shown only once, right after creation.",
+    "created_api_key_title": "Save your API key now",
+    "created_api_key_description": "This is the only time the full API key will be shown.",
+    "created_api_key_label": "Full API key",
+    "created_api_key_hint": "Copy it now and store it in a password manager, secret manager, or environment variable before closing this dialog.",
+    "copy_created_api_key": "Copy API key",
+    "saved_api_key": "I've saved this key"
   },
   "page_audit_logs": {
     "metadata": {

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -94,7 +94,15 @@
     "add_api_keys": "创建API密钥",
     "edit_api_keys": "编辑",
     "delete_api_key": "删除API密钥",
-    "delete_api_key_confirm": "确认删除此API密钥？"
+    "delete_api_key_confirm": "确认删除此API密钥？",
+    "masked_badge": "已脱敏",
+    "masked_notice": "列表中的 API 密钥默认只显示脱敏值。完整密钥只会在创建成功后展示一次。",
+    "created_api_key_title": "请立即保存你的 API 密钥",
+    "created_api_key_description": "这是完整 API 密钥唯一一次明文展示。",
+    "created_api_key_label": "完整 API 密钥",
+    "created_api_key_hint": "请现在复制，并在关闭前保存到密码管理器、密钥管理系统或环境变量中。",
+    "copy_created_api_key": "复制 API 密钥",
+    "saved_api_key": "我已保存"
   },
   "page_audit_logs": {
     "metadata": {


### PR DESCRIPTION
## Summary
- keep API key list and update responses masked by default while leaving create to return the plaintext key once
- replace the misleading table copy action with a one-time post-create dialog that shows and copies the real key explicitly
- add unit coverage for the create/list/update API key response contract

## Validation
- uv run --extra test pytest tests/unit_test/test_api_key_service.py
- yarn lint --file src/app/workspace/api-keys/api-key-actions.tsx --file src/app/workspace/api-keys/api-key-table.tsx