### PR TITLE
feat(qdrant): multitenancy + INT8 quantization + memory optimizations

### DIFF
--- a/aperag/config.py
+++ b/aperag/config.py
@@ -121,6 +121,20 @@ class Config(BaseSettings):
         '{"url":"http://localhost", "port":6333, "distance":"Cosine"}', alias="VECTOR_DB_CONTEXT"
     )
 
+    # Qdrant multitenancy & memory-optimization toggles. These are merged into
+    # the vector_db_context dict that the connector receives, so downstream
+    # code keeps using a single ctx-shaped object.
+    qdrant_multitenant: bool = Field(True, alias="QDRANT_MULTITENANT")
+    qdrant_quantization_enabled: bool = Field(True, alias="QDRANT_QUANTIZATION_ENABLED")
+    qdrant_quantization_type: str = Field("int8", alias="QDRANT_QUANTIZATION_TYPE")
+    qdrant_quantization_quantile: float = Field(0.99, alias="QDRANT_QUANTIZATION_QUANTILE")
+    qdrant_quantization_always_ram: bool = Field(True, alias="QDRANT_QUANTIZATION_ALWAYS_RAM")
+    qdrant_hnsw_on_disk: bool = Field(True, alias="QDRANT_HNSW_ON_DISK")
+    qdrant_default_segment_number: int = Field(2, alias="QDRANT_DEFAULT_SEGMENT_NUMBER")
+    qdrant_mmap_threshold_kb: int = Field(20480, alias="QDRANT_MMAP_THRESHOLD_KB")
+    qdrant_vectors_on_disk: bool = Field(True, alias="QDRANT_VECTORS_ON_DISK")
+    qdrant_on_disk_payload: bool = Field(True, alias="QDRANT_ON_DISK_PAYLOAD")
+
     # Object store
     object_store_type: str = Field("local", alias="OBJECT_STORE_TYPE")
     object_store_local_config: Optional[LocalObjectStoreConfig] = None
@@ -322,9 +336,43 @@ AsyncSessionDep = Annotated[AsyncSession, Depends(get_async_session)]
 SyncSessionDep = Annotated[Session, Depends(get_sync_session)]
 
 
-def get_vector_db_connector(collection: str) -> VectorStoreConnectorAdaptor:
-    # todo: specify the collection for different user
-    # one person one collection
+def build_vector_db_context(collection: str, vector_size: Optional[int] = None) -> Dict[str, Any]:
+    """Build the ctx dict that QdrantVectorStoreConnector expects.
+
+    Centralised so both the app and the migration script produce identical
+    contexts. The ``vector_size`` argument is required when multitenancy is
+    enabled — different embedding models map to different physical Qdrant
+    collections (``aperag_vectors_{size}_{distance}``), so we must know the
+    size before we route.
+    """
     ctx = json.loads(settings.vector_db_context)
     ctx["collection"] = collection
+
+    if vector_size is not None:
+        ctx["vector_size"] = int(vector_size)
+
+    # Merge the operator-level knobs into the ctx. Individual callers can still
+    # override by pre-setting the field in VECTOR_DB_CONTEXT JSON.
+    ctx.setdefault("multitenant", settings.qdrant_multitenant)
+    ctx.setdefault("quantization_enabled", settings.qdrant_quantization_enabled)
+    ctx.setdefault("quantization_type", settings.qdrant_quantization_type)
+    ctx.setdefault("quantization_quantile", settings.qdrant_quantization_quantile)
+    ctx.setdefault("quantization_always_ram", settings.qdrant_quantization_always_ram)
+    ctx.setdefault("hnsw_on_disk", settings.qdrant_hnsw_on_disk)
+    ctx.setdefault("default_segment_number", settings.qdrant_default_segment_number)
+    ctx.setdefault("mmap_threshold_kb", settings.qdrant_mmap_threshold_kb)
+    ctx.setdefault("vectors_on_disk", settings.qdrant_vectors_on_disk)
+    ctx.setdefault("on_disk_payload", settings.qdrant_on_disk_payload)
+    return ctx
+
+
+def get_vector_db_connector(collection: str, vector_size: Optional[int] = None) -> VectorStoreConnectorAdaptor:
+    """Return a VectorStoreConnectorAdaptor bound to the given ApeRAG collection.
+
+    ``collection`` is treated as the tenant id. ``vector_size`` should be passed
+    whenever it is known by the caller (index/search paths that already have an
+    embedding model in hand); the connector falls back to ctx-level defaults
+    when omitted, which is acceptable for delete-only paths.
+    """
+    ctx = build_vector_db_context(collection, vector_size=vector_size)
     return VectorStoreConnectorAdaptor(settings.vector_db_type, ctx=ctx)

--- a/aperag/index/summary_index.py
+++ b/aperag/index/summary_index.py
@@ -87,7 +87,8 @@ class SummaryIndexer(BaseIndexer):
                 # Get embedding model and vector store
                 embedding_model, vector_size = get_collection_embedding_service_sync(collection)
                 vector_store_adaptor = get_vector_db_connector(
-                    collection=generate_vector_db_collection_name(collection_id=collection.id)
+                    collection=generate_vector_db_collection_name(collection_id=collection.id),
+                    vector_size=vector_size,
                 )
 
                 # Create a TextPart for the summary
@@ -184,8 +185,10 @@ class SummaryIndexer(BaseIndexer):
             # Delete old summary vectors from vector database if they exist
             if old_summary_ctx_ids:
                 try:
+                    _, vector_size = get_collection_embedding_service_sync(collection)
                     vector_store_adaptor = get_vector_db_connector(
-                        collection=generate_vector_db_collection_name(collection_id=collection.id)
+                        collection=generate_vector_db_collection_name(collection_id=collection.id),
+                        vector_size=vector_size,
                     )
                     vector_store_adaptor.connector.delete(ids=old_summary_ctx_ids)
                     logger.info(f"Deleted {len(old_summary_ctx_ids)} old summary vectors for document {document_id}")
@@ -243,8 +246,10 @@ class SummaryIndexer(BaseIndexer):
             # Delete summary vectors from vector database if they exist
             if summary_ctx_ids:
                 try:
+                    _, vector_size = get_collection_embedding_service_sync(collection)
                     vector_store_adaptor = get_vector_db_connector(
-                        collection=generate_vector_db_collection_name(collection_id=collection.id)
+                        collection=generate_vector_db_collection_name(collection_id=collection.id),
+                        vector_size=vector_size,
                     )
                     vector_store_adaptor.connector.delete(ids=summary_ctx_ids)
                     logger.info(f"Deleted {len(summary_ctx_ids)} summary vectors for document {document_id}")

--- a/aperag/index/vector_index.py
+++ b/aperag/index/vector_index.py
@@ -56,17 +56,21 @@ class VectorIndexer(BaseIndexer):
             # Get embedding model and create embeddings
             embedding_model, vector_size = get_collection_embedding_service_sync(collection)
             vector_store_adaptor = get_vector_db_connector(
-                collection=generate_vector_db_collection_name(collection_id=collection.id)
+                collection=generate_vector_db_collection_name(collection_id=collection.id),
+                vector_size=vector_size,
             )
 
             # Filter out non-text parts
             doc_parts = [part for part in doc_parts if hasattr(part, "content") and part.content]
 
-            # Add indexer metadata to parts for proper identification
+            # Tag every chunk with its indexer and its owning ApeRAG collection.
+            # ``collection_id`` is the multitenancy tenant key; the Qdrant
+            # connector uses it for both payload and filter.
             for part in doc_parts:
                 if not hasattr(part, "metadata"):
                     part.metadata = {}
                 part.metadata["indexer"] = "vector"
+                part.metadata["collection_id"] = collection.id
 
             # Generate embeddings and store in vector database
             ctx_ids = create_embeddings_and_store(
@@ -130,9 +134,13 @@ class VectorIndexer(BaseIndexer):
                     index_data = json.loads(doc_index.index_data)
                     old_ctx_ids = index_data.get("context_ids", [])
 
+            # Create new vectors first (we need the embedding model to size the connector)
+            embedding_model, vector_size = get_collection_embedding_service_sync(collection)
+
             # Get vector store adaptor
             vector_store_adaptor = get_vector_db_connector(
-                collection=generate_vector_db_collection_name(collection_id=collection.id)
+                collection=generate_vector_db_collection_name(collection_id=collection.id),
+                vector_size=vector_size,
             )
 
             # Delete old vectors
@@ -143,14 +151,12 @@ class VectorIndexer(BaseIndexer):
             # Filter out non-text parts
             doc_parts = [part for part in doc_parts if hasattr(part, "content") and part.content]
 
-            # Add indexer metadata to parts for proper identification
+            # Tag every chunk with its indexer and its owning ApeRAG collection.
             for part in doc_parts:
                 if not hasattr(part, "metadata"):
                     part.metadata = {}
                 part.metadata["indexer"] = "vector"
-
-            # Create new vectors
-            embedding_model, vector_size = get_collection_embedding_service_sync(collection)
+                part.metadata["collection_id"] = collection.id
             ctx_ids = create_embeddings_and_store(
                 parts=doc_parts,
                 vector_store_adaptor=vector_store_adaptor,
@@ -215,9 +221,18 @@ class VectorIndexer(BaseIndexer):
                     success=True, index_type=self.index_type, metadata={"message": "No context IDs to delete"}
                 )
 
-            # Delete vectors from vector database
+            # Delete vectors from vector database. We still need vector_size so
+            # the connector routes to the correct global collection.
+            try:
+                _, vector_size = get_collection_embedding_service_sync(collection)
+            except Exception:
+                # Fall back to None; the connector will use its configured default.
+                # Worst case we hit the wrong global collection and the delete is
+                # a no-op, which is safe.
+                vector_size = None
             vector_db = get_vector_db_connector(
-                collection=generate_vector_db_collection_name(collection_id=collection.id)
+                collection=generate_vector_db_collection_name(collection_id=collection.id),
+                vector_size=vector_size,
             )
             vector_db.connector.delete(ids=ctx_ids)
 

--- a/aperag/index/vision_index.py
+++ b/aperag/index/vision_index.py
@@ -92,7 +92,8 @@ class VisionIndexer(BaseIndexer):
             )
 
         vector_store_adaptor = get_vector_db_connector(
-            collection=generate_vector_db_collection_name(collection_id=collection.id)
+            collection=generate_vector_db_collection_name(collection_id=collection.id),
+            vector_size=vector_size,
         )
         all_ctx_ids = []
 
@@ -282,9 +283,15 @@ class VisionIndexer(BaseIndexer):
                     success=True, index_type=self.index_type, metadata={"message": "No context IDs to delete"}
                 )
 
-            # Delete vectors from vector database
+            # Delete vectors from vector database. Vision index shares the
+            # same global collection as text chunks (keyed by vector_size).
+            try:
+                _, vector_size = get_collection_embedding_service_sync(collection)
+            except Exception:
+                vector_size = None
             vector_db = get_vector_db_connector(
-                collection=generate_vector_db_collection_name(collection_id=collection.id)
+                collection=generate_vector_db_collection_name(collection_id=collection.id),
+                vector_size=vector_size,
             )
             vector_db.connector.delete(ids=ctx_ids)
 

--- a/aperag/llm/embed/embedding_utils.py
+++ b/aperag/llm/embed/embedding_utils.py
@@ -63,6 +63,16 @@ def create_embeddings_and_store(
     chunk_overlap = chunk_overlap or settings.chunk_overlap_size
     tokenizer = tokenizer or get_default_tokenizer()
 
+    # Tenant id — every node must carry it so the Qdrant multitenancy filter
+    # (payload: collection_id) works. We pull it from the connector rather than
+    # asking callers to pass it in, so existing call sites only need to set
+    # ``collection_id`` themselves if they want to override it.
+    tenant_id = None
+    try:
+        tenant_id = getattr(vector_store_adaptor.connector, "tenant_id", None)
+    except Exception:
+        tenant_id = None
+
     nodes: List[BaseNode] = []
 
     # 1. Rechunk the document parts (resulting in text parts)
@@ -103,6 +113,10 @@ def create_embeddings_and_store(
         # 2.3 Prepare metadata for the node
         metadata = part.metadata.copy()
         metadata["source"] = metadata.get("name", "")
+        # 2.3.1 Ensure the tenant key is present. Callers may already set it
+        # (vision/summary indexers do); if not, we fall back to the connector.
+        if tenant_id and not metadata.get("collection_id"):
+            metadata["collection_id"] = tenant_id
         # 2.4 Create TextNode
         nodes.append(TextNode(text=text, metadata=metadata))
 

--- a/aperag/service/document_service.py
+++ b/aperag/service/document_service.py
@@ -51,7 +51,6 @@ from aperag.utils.pagination import (
 )
 from aperag.utils.uncompress import SUPPORTED_COMPRESSED_EXTENSIONS
 from aperag.utils.utils import calculate_file_hash, generate_vector_db_collection_name, utc_now
-from aperag.vectorstore.connector import VectorStoreConnectorAdaptor
 
 logger = logging.getLogger(__name__)
 
@@ -802,19 +801,28 @@ class DocumentService:
             if not ctx_ids:
                 return []
 
-            # 2. Retrieve chunks from Qdrant
+            # 2. Retrieve chunks via the vector-store connector. We go through
+            # the connector (not the raw qdrant client) because in multitenant
+            # mode it (a) routes to the correct global Qdrant collection based
+            # on vector_size and (b) enforces the tenant-id guard.
             try:
-                collection_name = generate_vector_db_collection_name(collection_id=collection_id)
-                ctx = json.loads(settings.vector_db_context)
-                ctx["collection"] = collection_name
-                vector_store_adaptor = VectorStoreConnectorAdaptor(settings.vector_db_type, ctx=ctx)
-                qdrant_client = vector_store_adaptor.connector.client
+                collection_obj = await self.db_ops.query_collection(user_id, collection_id)
+                vector_size = None
+                if collection_obj is not None:
+                    try:
+                        from aperag.llm.embed.base_embedding import get_collection_embedding_service_sync
 
-                points = qdrant_client.retrieve(
-                    collection_name=collection_name,
-                    ids=ctx_ids,
-                    with_payload=True,
+                        _, vector_size = get_collection_embedding_service_sync(collection_obj)
+                    except Exception:
+                        vector_size = None
+
+                from aperag.config import get_vector_db_connector as _get_vdb
+
+                vector_store_adaptor = _get_vdb(
+                    collection=generate_vector_db_collection_name(collection_id=collection_id),
+                    vector_size=vector_size,
                 )
+                points = vector_store_adaptor.connector.retrieve(ids=ctx_ids, with_payload=True)
 
                 # 3. Format the response
                 chunks = []
@@ -880,19 +888,26 @@ class DocumentService:
             if not ctx_ids:
                 return []
 
-            # 2. Retrieve chunks from Qdrant
+            # 2. Retrieve chunks via the connector for the same reasons as
+            # get_document_chunks above (tenant-aware routing).
             try:
-                collection_name = generate_vector_db_collection_name(collection_id=collection_id)
-                ctx = json.loads(settings.vector_db_context)
-                ctx["collection"] = collection_name
-                vector_store_adaptor = VectorStoreConnectorAdaptor(settings.vector_db_type, ctx=ctx)
-                qdrant_client = vector_store_adaptor.connector.client
+                collection_obj = await self.db_ops.query_collection(user_id, collection_id)
+                vector_size = None
+                if collection_obj is not None:
+                    try:
+                        from aperag.llm.embed.base_embedding import get_collection_embedding_service_sync
 
-                points = qdrant_client.retrieve(
-                    collection_name=collection_name,
-                    ids=ctx_ids,
-                    with_payload=True,
+                        _, vector_size = get_collection_embedding_service_sync(collection_obj)
+                    except Exception:
+                        vector_size = None
+
+                from aperag.config import get_vector_db_connector as _get_vdb
+
+                vector_store_adaptor = _get_vdb(
+                    collection=generate_vector_db_collection_name(collection_id=collection_id),
+                    vector_size=vector_size,
                 )
+                points = vector_store_adaptor.connector.retrieve(ids=ctx_ids, with_payload=True)
 
                 # 3. Format the response
                 vision_chunks = []

--- a/aperag/service/search_pipeline_service.py
+++ b/aperag/service/search_pipeline_service.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import asyncio
-import json
 import logging
 from functools import partial
 from typing import List, Optional, Tuple
 
-from aperag.config import settings
+from aperag.config import build_vector_db_context, settings
 from aperag.context.context import ContextManager
 from aperag.db.models import Collection
 from aperag.db.ops import async_db_ops
@@ -191,9 +190,8 @@ class SearchPipelineService:
     ) -> List[DocumentWithScore]:
         try:
             collection_name = generate_vector_db_collection_name(collection.id)
-            embedding_model, _ = get_collection_embedding_service_sync(collection)
-            vectordb_ctx = json.loads(settings.vector_db_context)
-            vectordb_ctx["collection"] = collection_name
+            embedding_model, vector_size = get_collection_embedding_service_sync(collection)
+            vectordb_ctx = build_vector_db_context(collection_name, vector_size=vector_size)
             context_manager = ContextManager(collection_name, embedding_model, settings.vector_db_type, vectordb_ctx)
 
             vector = await asyncio.to_thread(embedding_model.embed_query, query)
@@ -283,9 +281,8 @@ class SearchPipelineService:
     ) -> List[DocumentWithScore]:
         try:
             collection_name = generate_vector_db_collection_name(collection.id)
-            embedding_model, _ = get_collection_embedding_service_sync(collection)
-            vectordb_ctx = json.loads(settings.vector_db_context)
-            vectordb_ctx["collection"] = collection_name
+            embedding_model, vector_size = get_collection_embedding_service_sync(collection)
+            vectordb_ctx = build_vector_db_context(collection_name, vector_size=vector_size)
             context_manager = ContextManager(collection_name, embedding_model, settings.vector_db_type, vectordb_ctx)
 
             vector = await asyncio.to_thread(embedding_model.embed_query, query)
@@ -322,9 +319,8 @@ class SearchPipelineService:
     ) -> List[DocumentWithScore]:
         try:
             collection_name = generate_vector_db_collection_name(collection.id)
-            embedding_model, _ = get_collection_embedding_service_sync(collection)
-            vectordb_ctx = json.loads(settings.vector_db_context)
-            vectordb_ctx["collection"] = collection_name
+            embedding_model, vector_size = get_collection_embedding_service_sync(collection)
+            vectordb_ctx = build_vector_db_context(collection_name, vector_size=vector_size)
             context_manager = ContextManager(collection_name, embedding_model, settings.vector_db_type, vectordb_ctx)
 
             vector = await asyncio.to_thread(embedding_model.embed_query, query)

--- a/aperag/tasks/collection.py
+++ b/aperag/tasks/collection.py
@@ -119,13 +119,21 @@ class CollectionTask:
             return TaskResult(success=False, error=f"Collection deletion failed: {str(e)}")
 
     def _initialize_vector_databases(self, collection_id: str, collection) -> None:
-        """Initialize vector database collections"""
+        """Ensure vector-store provisioning for this tenant.
+
+        In multitenant mode this is essentially a no-op per tenant: the global
+        Qdrant collection is created lazily on first use (idempotent inside
+        the connector). We still call through so new deployments get their
+        global collection primed at cluster-creation time rather than on the
+        first user upload.
+        """
         # Get embedding service
         _, vector_size = get_collection_embedding_service_sync(collection)
 
-        # Create main vector database collection
+        # Create main vector database collection (idempotent in multitenant mode)
         vector_db_conn = get_vector_db_connector(
-            collection=generate_vector_db_collection_name(collection_id=collection_id)
+            collection=generate_vector_db_collection_name(collection_id=collection_id),
+            vector_size=vector_size,
         )
         vector_db_conn.connector.create_collection(vector_size=vector_size)
 
@@ -187,14 +195,38 @@ class CollectionTask:
         return deletion_stats
 
     def _delete_vector_databases(self, collection_id: str) -> None:
-        """Delete vector database collections"""
-        # Delete main vector database collection
+        """Purge this tenant's vector data.
+
+        * Multitenant mode (default): deletes only the points whose
+          ``collection_id`` payload matches; the shared global Qdrant
+          collection is left in place for other tenants.
+        * Legacy mode: drops the whole per-tenant Qdrant collection.
+
+        We best-effort resolve ``vector_size`` so the connector routes to the
+        right global collection. If resolution fails (e.g. embedding provider
+        has been removed), we fall back to the default; the deletion becomes a
+        no-op on the wrong collection, which is safe.
+        """
+        collection = db_ops.query_collection_by_id(collection_id, ignore_deleted=False)
+        vector_size = None
+        if collection is not None:
+            try:
+                _, vector_size = get_collection_embedding_service_sync(collection)
+            except Exception as e:
+                logger.warning(
+                    "Could not resolve vector_size for collection %s during delete; "
+                    "falling back to default routing: %s",
+                    collection_id,
+                    e,
+                )
+
         vector_db_conn = get_vector_db_connector(
-            collection=generate_vector_db_collection_name(collection_id=collection_id)
+            collection=generate_vector_db_collection_name(collection_id=collection_id),
+            vector_size=vector_size,
         )
         vector_db_conn.connector.delete_collection()
 
-        logger.debug(f"Deleted vector database collections for collection {collection_id}")
+        logger.debug(f"Deleted vector database data for collection {collection_id}")
 
     def _delete_fulltext_index(self, collection_id: str) -> None:
         """Delete fulltext search index"""

--- a/aperag/vectorstore/qdrant_connector.py
+++ b/aperag/vectorstore/qdrant_connector.py
@@ -1,12 +1,48 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qdrant vector store connector.
+
+The connector supports two physical layouts, switchable per-context:
+
+* **multitenant** (default, new): one Qdrant collection per ``(vector_size, distance)``
+  pair, shared by all ApeRAG collections. Every point carries a ``collection_id``
+  payload field used for tenant isolation. A keyword index with ``is_tenant=True``
+  is registered so the Qdrant optimizer groups points by tenant on disk, which
+  keeps query cost comparable to per-tenant collections.
+
+* **legacy** (``multitenant=false``): one Qdrant collection per ApeRAG collection
+  (the historical behavior). Preserved for rollback during the migration window.
+
+Both layouts use the same connector API. Callers pass ``collection`` in the ctx
+(the ApeRAG collection id); the connector internally maps it to either the
+physical collection name (legacy) or the tenant filter (multitenant).
+"""
+
+from __future__ import annotations
+
 import json
 import logging
 import os
-from typing import Any, Dict
+import threading
+from typing import Any, Dict, List, Optional
 
 import qdrant_client
 from llama_index.vector_stores.qdrant import QdrantVectorStore
+from qdrant_client import models as rest
+from qdrant_client.http.exceptions import UnexpectedResponse
 from qdrant_client.http.models import ScoredPoint
-from qdrant_client.models import VectorParams
 
 from aperag.query.query import DocumentWithScore, QueryResult, QueryWithEmbedding
 from aperag.vectorstore.base import VectorStoreConnector
@@ -14,11 +50,213 @@ from aperag.vectorstore.base import VectorStoreConnector
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# constants & helpers
+# ---------------------------------------------------------------------------
+
+# Payload field used as the tenant discriminator. When is_tenant=True is set on
+# the keyword index over this field, Qdrant physically groups points with the
+# same tenant into the same segments, which restores per-tenant locality while
+# keeping only one collection.
+TENANT_PAYLOAD_KEY = "collection_id"
+
+# Module-level cache of physical collections already ensured within this
+# process. Avoids an RPC on every connector instantiation. Thread-safe because
+# it's only appended to, never mutated concurrently in conflicting ways.
+_ENSURED_COLLECTIONS: set = set()
+_ENSURE_LOCK = threading.Lock()
+
+
+def global_collection_name(vector_size: int, distance: str) -> str:
+    """Return the physical Qdrant collection name for a given vector shape.
+
+    We partition by ``(vector_size, distance)`` because Qdrant requires vectors
+    in a single collection to share both; different embedding models produce
+    different vector shapes and must therefore live in distinct collections.
+    """
+    return f"aperag_vectors_{int(vector_size)}_{distance.lower()}"
+
+
+def _coerce_distance(distance: Any) -> rest.Distance:
+    """Normalize a distance value into ``rest.Distance``.
+
+    Qdrant's enum keys are uppercase (``COSINE``, ``EUCLID``, ``DOT``,
+    ``MANHATTAN``) but their string values are capitalized ("Cosine", …).
+    Callers in this repo use the capitalized string form (from VECTOR_DB_CONTEXT
+    JSON), so we accept both: enum lookup by member name, case-insensitive.
+    """
+    if isinstance(distance, rest.Distance):
+        return distance
+    name = str(distance).strip().upper()
+    if name == "EUCLIDIAN":  # common typo we've seen in configs
+        name = "EUCLID"
+    try:
+        return rest.Distance[name]
+    except KeyError as e:
+        raise ValueError(f"unsupported qdrant distance: {distance!r}") from e
+
+
+def _quantization_config(cfg: Dict[str, Any]) -> Optional[rest.QuantizationConfig]:
+    """Build a QuantizationConfig from ctx fields (or return None).
+
+    INT8 scalar quantization is the only mode we currently enable by default.
+    ``quantile=0.99`` clips outliers so a few extreme vector values don't blow
+    up the int8 range. ``always_ram=True`` keeps the quantized vectors in RAM
+    while the full-precision vectors are served from mmap — this is the
+    recommended high-throughput/low-RAM tradeoff.
+    """
+    if not cfg.get("quantization_enabled", False):
+        return None
+    qtype = str(cfg.get("quantization_type", "int8")).lower()
+    if qtype == "int8":
+        return rest.ScalarQuantization(
+            scalar=rest.ScalarQuantizationConfig(
+                type=rest.ScalarType.INT8,
+                quantile=float(cfg.get("quantization_quantile", 0.99)),
+                always_ram=bool(cfg.get("quantization_always_ram", True)),
+            )
+        )
+    if qtype in ("binary", "bin"):
+        return rest.BinaryQuantization(
+            binary=rest.BinaryQuantizationConfig(always_ram=bool(cfg.get("quantization_always_ram", True)))
+        )
+    raise ValueError(f"unsupported qdrant quantization type: {qtype!r}")
+
+
+def _hnsw_config(cfg: Dict[str, Any]) -> rest.HnswConfigDiff:
+    return rest.HnswConfigDiff(
+        m=int(cfg.get("hnsw_m", 16)),
+        ef_construct=int(cfg.get("hnsw_ef_construct", 100)),
+        on_disk=bool(cfg.get("hnsw_on_disk", True)),
+    )
+
+
+def _optimizers_config(cfg: Dict[str, Any]) -> rest.OptimizersConfigDiff:
+    return rest.OptimizersConfigDiff(
+        default_segment_number=int(cfg.get("default_segment_number", 2)),
+        memmap_threshold=int(cfg.get("mmap_threshold_kb", 20480)),
+    )
+
+
+def _ensure_tenant_payload_index(client: Any, collection_name: str) -> None:
+    """Register the keyword index on the tenant payload field.
+
+    Tries ``is_tenant=True`` first (Qdrant >= 1.11, enables segment-level
+    defragmentation so queries touch only per-tenant blocks). Falls back to a
+    plain keyword index on older servers (Qdrant 1.10) — multitenancy still
+    works at the filter level, just without the storage-layout optimization.
+
+    Idempotent: "already exists" responses are swallowed; the first successful
+    shape (plain or is_tenant) wins and stays.
+    """
+    # Attempt the optimized shape first.
+    try:
+        client.create_payload_index(
+            collection_name=collection_name,
+            field_name=TENANT_PAYLOAD_KEY,
+            field_schema=rest.KeywordIndexParams(
+                type=rest.KeywordIndexType.KEYWORD,
+                is_tenant=True,
+            ),
+        )
+        return
+    except UnexpectedResponse as e:
+        msg = str(e).lower()
+        if "already exists" in msg:
+            return
+        # Older Qdrant: unknown field, unrecognized variant, or 400. Fall
+        # through and try without is_tenant.
+        logger.warning(
+            "qdrant: is_tenant keyword index rejected on %s (%s). "
+            "Falling back to plain keyword index; multitenancy filter still works "
+            "but per-tenant segment defragmentation (Qdrant >= 1.11) is unavailable.",
+            collection_name,
+            e,
+        )
+
+    # Plain fallback — just a keyword index, no is_tenant.
+    try:
+        client.create_payload_index(
+            collection_name=collection_name,
+            field_name=TENANT_PAYLOAD_KEY,
+            field_schema=rest.KeywordIndexParams(type=rest.KeywordIndexType.KEYWORD),
+        )
+    except UnexpectedResponse as e:
+        msg = str(e).lower()
+        if "already exists" not in msg:
+            logger.warning(
+                "qdrant: plain keyword index on %s/%s also failed: %s",
+                collection_name,
+                TENANT_PAYLOAD_KEY,
+                e,
+            )
+            # Fall through to legacy "field_schema as string" API as a last
+            # resort on very old clients / servers.
+            try:
+                client.create_payload_index(
+                    collection_name=collection_name,
+                    field_name=TENANT_PAYLOAD_KEY,
+                    field_schema="keyword",
+                )
+            except UnexpectedResponse as e2:
+                if "already exists" not in str(e2).lower():
+                    raise
+
+
+def _merge_tenant_filter(user_filter: Any, tenant_id: Optional[str]) -> Any:
+    """Combine an externally provided filter with the tenant guard.
+
+    The tenant guard is always required in multitenant mode. If the caller
+    already passed a Filter, we wrap it under ``must`` so both constraints are
+    AND-ed. If the caller passed nothing, we just return the tenant filter.
+    """
+    if not tenant_id:
+        return user_filter
+    tenant_clause = rest.FieldCondition(key=TENANT_PAYLOAD_KEY, match=rest.MatchValue(value=tenant_id))
+    if user_filter is None:
+        return rest.Filter(must=[tenant_clause])
+    if isinstance(user_filter, rest.Filter):
+        # If the existing filter already has a must, just append; else wrap.
+        must = list(user_filter.must or [])
+        must.append(tenant_clause)
+        return rest.Filter(
+            must=must,
+            should=user_filter.should,
+            must_not=user_filter.must_not,
+            min_should=user_filter.min_should,
+        )
+    # Unknown filter shape: log and pass through only the tenant guard to be
+    # safe — merging arbitrary objects into a Filter.must risks pydantic
+    # validation failures at the Qdrant API boundary.
+    logger.warning("dropping user_filter of unsupported type %s when applying tenant guard", type(user_filter).__name__)
+    return rest.Filter(must=[tenant_clause])
+
+
+# ---------------------------------------------------------------------------
+# connector
+# ---------------------------------------------------------------------------
+
+
 class QdrantVectorStoreConnector(VectorStoreConnector):
     def __init__(self, ctx: Dict[str, Any], **kwargs: Any) -> None:
         super().__init__(ctx, **kwargs)
         self.ctx = ctx
-        self.collection_name = ctx.get("collection", "collection")
+
+        # Storage layout flags (defaults match the optimized / safe production layout).
+        self.multitenant: bool = bool(ctx.get("multitenant", True))
+        self.cfg = ctx  # retained for _quantization_config / _hnsw_config
+
+        # Tenant = ApeRAG collection id. In multitenant mode we refuse to
+        # construct the connector without one: a silent fallback to a
+        # placeholder would write points under a shared pseudo-tenant and
+        # cross-tenant reads would match them — i.e. a silent data leak.
+        tenant_raw = ctx.get("collection")
+        if self.multitenant and not tenant_raw:
+            raise ValueError(
+                "QdrantVectorStoreConnector(multitenant=True) requires ctx['collection'] "
+                "(the ApeRAG collection id used as tenant key); got empty/missing."
+            )
+        self.tenant_id: str = str(tenant_raw) if tenant_raw else "collection"
 
         self.url = ctx.get("url", "http://localhost")
         self.port = ctx.get("port", 6333)
@@ -26,9 +264,16 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
         self.prefer_grpc = ctx.get("prefer_grpc", False)
         self.https = ctx.get("https", False)
         self.timeout = ctx.get("timeout", 300)
-        self.vector_size = ctx.get("vector_size", 1536)
+        self.vector_size = int(ctx.get("vector_size", 1536))
         self.distance = ctx.get("distance", "Cosine")
 
+        # Physical Qdrant collection name.
+        if self.multitenant:
+            self.collection_name = global_collection_name(self.vector_size, str(self.distance))
+        else:
+            self.collection_name = self.tenant_id
+
+        # Client
         if self.url == ":memory:":
             self.client = qdrant_client.QdrantClient(":memory:")
         else:
@@ -42,17 +287,94 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
                 **kwargs,
             )
 
+        # In multitenant mode pre-create the global collection (idempotent)
+        # so llama_index's auto-creation path sees "exists" and doesn't try to
+        # recreate it with a stripped-down config.
+        if self.multitenant:
+            self._ensure_collection()
+
+        # llama_index facade used for inserts / delete-by-id.
         self.store = QdrantVectorStore(
             client=self.client,
             collection_name=self.collection_name,
-            vectors_config=VectorParams(size=self.vector_size, distance=self.distance),
+            vectors_config=rest.VectorParams(
+                size=self.vector_size,
+                distance=_coerce_distance(self.distance),
+            ),
         )
 
+    # ------------------------------------------------------------------ ensure
+    def _ensure_collection(self) -> None:
+        """Idempotently make sure the physical collection and tenant index exist.
+
+        Cached at module level so subsequent connector instantiations in the
+        same process skip the RPC.
+        """
+        cache_key = f"{self.url}:{self.port}:{self.collection_name}"
+        if cache_key in _ENSURED_COLLECTIONS:
+            return
+
+        with _ENSURE_LOCK:
+            if cache_key in _ENSURED_COLLECTIONS:
+                return
+            try:
+                exists = self.client.collection_exists(self.collection_name)
+            except Exception:
+                # If we cannot even check, don't cache — try again next time.
+                logger.exception("qdrant: collection_exists check failed for %s", self.collection_name)
+                raise
+
+            if not exists:
+                logger.info(
+                    "qdrant: creating global collection %s (size=%d, distance=%s, multitenant=%s)",
+                    self.collection_name,
+                    self.vector_size,
+                    self.distance,
+                    self.multitenant,
+                )
+                try:
+                    self.client.create_collection(
+                        collection_name=self.collection_name,
+                        vectors_config=rest.VectorParams(
+                            size=self.vector_size,
+                            distance=_coerce_distance(self.distance),
+                            on_disk=bool(self.cfg.get("vectors_on_disk", True)),
+                        ),
+                        hnsw_config=_hnsw_config(self.cfg),
+                        optimizers_config=_optimizers_config(self.cfg),
+                        quantization_config=_quantization_config(self.cfg),
+                        on_disk_payload=bool(self.cfg.get("on_disk_payload", True)),
+                    )
+                except UnexpectedResponse as e:
+                    # Another process raced us to create it; treat as success.
+                    if "already exists" not in str(e).lower():
+                        raise
+                    logger.info("qdrant: collection %s already exists (race)", self.collection_name)
+
+            # Create tenant payload index. Uses ``is_tenant=True`` when the
+            # server supports it (Qdrant >= 1.11), otherwise falls back to a
+            # plain keyword index. See _ensure_tenant_payload_index for why.
+            if self.multitenant:
+                try:
+                    _ensure_tenant_payload_index(self.client, self.collection_name)
+                except Exception:
+                    logger.exception(
+                        "qdrant: failed to create tenant index on %s (will retry next time)",
+                        self.collection_name,
+                    )
+                    raise
+
+            _ENSURED_COLLECTIONS.add(cache_key)
+
+    # ------------------------------------------------------------------ search
     def search(self, query: QueryWithEmbedding, **kwargs):
         consistency = kwargs.get("consistency", "majority")
         search_params = kwargs.get("search_params")
         score_threshold = kwargs.get("score_threshold", 0.1)
         filter_conditions = kwargs.get("filter")
+
+        if self.multitenant:
+            filter_conditions = _merge_tenant_filter(filter_conditions, self.tenant_id)
 
         hits = self.client.query_points(
             collection_name=self.collection_name,
@@ -76,40 +398,183 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
     def _convert_scored_point_to_document_with_score(self, scored_point: ScoredPoint) -> DocumentWithScore | None:
         try:
             payload = scored_point.payload or {}
-            text = scored_point.payload.get("text") or json.loads(payload["_node_content"]).get("text")
-            metadata = payload.get("metadata") or json.loads(payload["_node_content"]).get("metadata")
-            # todo source phrase
-            relationships = json.loads(payload["_node_content"]).get("relationships")
-            if relationships is not None and metadata.get("source") is None:
-                source = relationships.get("1").get("metadata").get("source")
-                metadata["source"] = os.path.basename(source)
+            # Points written through llama_index carry a serialized node under
+            # ``_node_content`` and usually also a top-level ``text`` field.
+            # Points written directly (migration script / ad-hoc tooling /
+            # tests) may carry only a top-level ``text``. Handle both without
+            # raising KeyError on older or externally-written rows.
+            node_content_raw = payload.get("_node_content")
+            node_content = None
+            if isinstance(node_content_raw, str):
+                try:
+                    node_content = json.loads(node_content_raw)
+                except json.JSONDecodeError:
+                    logger.warning("qdrant: _node_content is not valid JSON for point %s", scored_point.id)
+
+            text = payload.get("text")
+            if text is None and node_content is not None:
+                text = node_content.get("text")
+
+            metadata = payload.get("metadata")
+            if metadata is None and node_content is not None:
+                metadata = node_content.get("metadata")
+            if metadata is None:
+                # Fall back to the raw payload for externally-written points.
+                # We shallow-copy so callers can mutate without corrupting
+                # the connector's in-flight state.
+                metadata = {k: v for k, v in payload.items() if k not in ("_node_content", "text")}
+
+            relationships = node_content.get("relationships") if node_content is not None else None
+            if relationships is not None and isinstance(metadata, dict) and metadata.get("source") is None:
+                try:
+                    source = relationships.get("1", {}).get("metadata", {}).get("source")
+                    if source:
+                        metadata["source"] = os.path.basename(source)
+                except AttributeError:
+                    pass
+
             return DocumentWithScore(
                 id=scored_point.id,
-                text=text,  # type: ignore
-                metadata=metadata,  # type: ignore
-                embedding=scored_point.vector,  # type: ignore
+                text=text,
+                metadata=metadata,
+                embedding=scored_point.vector,
                 score=scored_point.score,
             )
         except Exception:
             logger.exception("Failed to convert scored point to document")
             return None
 
+    # ------------------------------------------------------------------ delete
     def delete(self, **delete_kwargs: Any):
         ids = delete_kwargs.get("ids")
-        if ids:
-            self.store.delete_nodes(ids)
+        if not ids:
+            return
 
+        if self.multitenant:
+            # Defense-in-depth: also bind the tenant_id so a rogue id list
+            # cannot cross-tenant-delete. IDs are UUIDs so collisions are
+            # already astronomically unlikely, but the guard is cheap.
+            self.client.delete(
+                collection_name=self.collection_name,
+                points_selector=rest.FilterSelector(
+                    filter=rest.Filter(
+                        must=[
+                            rest.FieldCondition(key=TENANT_PAYLOAD_KEY, match=rest.MatchValue(value=self.tenant_id)),
+                            rest.HasIdCondition(has_id=list(ids)),
+                        ]
+                    )
+                ),
+            )
+        else:
+            self.store.delete_nodes(list(ids))
+
+    # -------------------------------------------------------- create/delete col
     def create_collection(self, **kwargs: Any):
-        vector_size = kwargs.get("vector_size")
-        from qdrant_client.http import models as rest
+        """Create / ensure the physical Qdrant collection.
 
-        self.client.recreate_collection(
+        * In multitenant mode this is a no-op beyond re-validating the global
+          collection. Each ApeRAG collection shares the global one — the
+          per-tenant identity lives purely in the payload.
+        * In legacy mode (``multitenant=False``) this provisions a dedicated
+          collection named after ``tenant_id``, with the same optimizations
+          (INT8 quantization, on-disk HNSW, smaller segments).
+        """
+        vector_size = int(kwargs.get("vector_size") or self.vector_size)
+        self.vector_size = vector_size
+
+        if self.multitenant:
+            # Physical collection may have been sized at connector init; if the
+            # caller passed a different vector_size, route to the correct
+            # global collection and ensure it *before* recreating the
+            # llama_index store. This ordering matters: QdrantVectorStore's
+            # __init__ caches `_collection_initialized` from a
+            # `collection_exists` probe, so if we build it first and the
+            # collection doesn't exist yet, the first add() call will try to
+            # create it again with llama_index's minimal config (no
+            # quantization / HNSW on_disk / segment count), which would then
+            # lose to "already exists" but generate a spurious RPC.
+            self.collection_name = global_collection_name(vector_size, str(self.distance))
+            self._ensure_collection()
+            self.store = QdrantVectorStore(
+                client=self.client,
+                collection_name=self.collection_name,
+                vectors_config=rest.VectorParams(
+                    size=self.vector_size,
+                    distance=_coerce_distance(self.distance),
+                ),
+            )
+            return
+
+        # Legacy path: one Qdrant collection per tenant, but still with the
+        # optimized defaults so new legacy collections don't regress.
+        if self.client.collection_exists(self.collection_name):
+            return
+        self.client.create_collection(
             collection_name=self.collection_name,
             vectors_config=rest.VectorParams(
                 size=vector_size,
-                distance=rest.Distance.COSINE,
+                distance=_coerce_distance(self.distance),
+                on_disk=bool(self.cfg.get("vectors_on_disk", True)),
             ),
+            hnsw_config=_hnsw_config(self.cfg),
+            optimizers_config=_optimizers_config(self.cfg),
+            quantization_config=_quantization_config(self.cfg),
+            on_disk_payload=bool(self.cfg.get("on_disk_payload", True)),
         )
 
     def delete_collection(self, **kwargs: Any):
-        self.client.delete_collection(collection_name=self.collection_name)
+        """Remove *this tenant's* data.
+
+        * Multitenant: delete all points whose payload matches ``collection_id``,
+          leaving the global collection (and other tenants) untouched.
+        * Legacy: drop the whole physical collection.
+        """
+        if self.multitenant:
+            try:
+                self.client.delete(
+                    collection_name=self.collection_name,
+                    points_selector=rest.FilterSelector(
+                        filter=rest.Filter(
+                            must=[
+                                rest.FieldCondition(
+                                    key=TENANT_PAYLOAD_KEY,
+                                    match=rest.MatchValue(value=self.tenant_id),
+                                )
+                            ]
+                        )
+                    ),
+                )
+            except UnexpectedResponse as e:
+                # If the global collection itself is gone (e.g. fresh cluster,
+                # tenant never wrote anything) treat as already-deleted.
+                if "not found" in str(e).lower() or "doesn't exist" in str(e).lower():
+                    return
+                raise
+            return
+
+        try:
+            self.client.delete_collection(collection_name=self.collection_name)
+        except UnexpectedResponse as e:
+            if "not found" in str(e).lower() or "doesn't exist" in str(e).lower():
+                return
+            raise
+
+    # ---------------------------------------------------------------- retrieval
+    def retrieve(self, ids: List[str], with_payload: bool = True, with_vectors: bool = False):
+        """Retrieve points by id, enforcing the tenant guard in multitenant mode.
+
+        Exposed because several service-layer call sites (document preview /
+        chunk listing) used to call ``self.client.retrieve`` directly against a
+        per-tenant collection; after multitenancy they must both target the
+        global collection *and* filter by tenant.
+        """
+        points = self.client.retrieve(
+            collection_name=self.collection_name,
+            ids=list(ids),
+            with_payload=with_payload,
+            with_vectors=with_vectors,
+        )
+        if not self.multitenant:
+            return points
+        # Defense-in-depth filter: drop any points that don't match the tenant.
+        return [p for p in points if (p.payload or {}).get(TENANT_PAYLOAD_KEY) == self.tenant_id]

--- a/deploy/aperag/values.yaml
+++ b/deploy/aperag/values.yaml
@@ -140,6 +140,19 @@ api:
     # Vector DB
     VECTOR_DB_TYPE: qdrant
     VECTOR_DB_CONTEXT: '{"url":"http://qdrant-cluster-qdrant-qdrant", "port":6333, "distance":"Cosine", "timeout": 1000}'
+    # Qdrant multitenancy + memory-optimization defaults.
+    # Switch QDRANT_MULTITENANT to "False" to fall back to the legacy
+    # one-collection-per-ApeRAG-collection layout (for rollback only).
+    QDRANT_MULTITENANT: "True"
+    QDRANT_QUANTIZATION_ENABLED: "True"
+    QDRANT_QUANTIZATION_TYPE: "int8"
+    QDRANT_QUANTIZATION_QUANTILE: "0.99"
+    QDRANT_QUANTIZATION_ALWAYS_RAM: "True"
+    QDRANT_HNSW_ON_DISK: "True"
+    QDRANT_DEFAULT_SEGMENT_NUMBER: "2"
+    QDRANT_MMAP_THRESHOLD_KB: "20480"
+    QDRANT_VECTORS_ON_DISK: "True"
+    QDRANT_ON_DISK_PAYLOAD: "True"
     # Object Store
     OBJECT_STORE_TYPE: local
     OBJECT_STORE_LOCAL_ROOT_DIR: /data/objects

--- a/deploy/databases/qdrant/values.yaml
+++ b/deploy/databases/qdrant/values.yaml
@@ -29,3 +29,22 @@ storage: 20
 ## customized default values to override kblib chart's values
 extra:
   terminationPolicy: Delete
+
+## NOTE: Qdrant server-side configuration (memmap threshold / HNSW on_disk /
+## segment number / WAL capacity) is NOT configurable through this chart — the
+## kubeblocks qdrant-cluster chart does not expose a pod-env passthrough. The
+## ApeRAG connector (aperag/vectorstore/qdrant_connector.py::_ensure_collection)
+## already applies full per-collection config at create time so app-managed
+## collections are correctly optimized without server-side defaults.
+##
+## If you want the same defaults to apply to collections created OUTSIDE
+## ApeRAG (raw Qdrant API) or to legacy pre-migration collections, patch the
+## Qdrant StatefulSet manually after helm install:
+##
+##     kubectl -n <ns> set env statefulset/qdrant-cluster-qdrant \
+##       QDRANT__STORAGE__OPTIMIZERS__DEFAULT_SEGMENT_NUMBER=2 \
+##       QDRANT__STORAGE__OPTIMIZERS__MEMMAP_THRESHOLD_KB=20480 \
+##       QDRANT__STORAGE__HNSW_INDEX__ON_DISK=true \
+##       QDRANT__STORAGE__WAL__WAL_CAPACITY_MB=8
+##
+## See docs/zh-CN/design/qdrant_memory_optimization.md for the full rationale.

--- a/docs/zh-CN/design/qdrant_memory_optimization.md
+++ b/docs/zh-CN/design/qdrant_memory_optimization.md
@@ -1,0 +1,434 @@
+# Qdrant 内存占用治理与多租户化改造
+
+> 写作缘由：香港 ACK 集群的 Qdrant 容器 RSS 已经涨到 12.5 GiB（limit 16 GiB），但线上只有 ~~1600 个用户、~~1.3 万文档、~60 万向量 chunk。经过排查确认**绝大部分内存不是花在业务数据上，而是花在"每个 ApeRAG Collection 建一个 Qdrant Collection"造成的元数据/段级结构性浪费**。如果不治理，随着用户增长 Qdrant 会成为整个系统的扩展瓶颈。
+>
+> 相关仓库：
+>
+> - 应用代码：[apecloud/ApeRAG](https://github.com/apecloud/ApeRAG)
+> - 生产部署 values：[apecloud/aperag-values](https://github.com/apecloud/aperag-values)
+
+---
+
+## 1. 现场快照（2026-04-20，hk 集群）
+
+```text
+pod         : qdrant-cluster-qdrant-0  (KubeBlocks qdrant 0.9.1, qdrant 1.10.0)
+limit       : 4 cpu / 16 GiB
+RSS         : 12.47 GiB  (77% of limit)
+RssAnon     : 12.52 GiB  ← 基本都是匿名堆/mmap
+RssFile     :  1.05 GiB
+VmSize      :  153 GiB   ← 线程栈预留 + 大量 mmap
+Threads     :  1872      ← 关键异常指标
+Storage dir :  8.0 GiB   (/qdrant/storage)
+```
+
+Qdrant 自身 telemetry 聚合：
+
+
+| 指标                     | 数值                 | 备注                                   |
+| ---------------------- | ------------------ | ------------------------------------ |
+| collections 总数         | **1847**           | pg 中 ACTIVE 2003 + DELETED 179       |
+| 空 collection（0 points） | **1260 (68%)**     | 结构性浪费的主要来源                           |
+| 非空 collection          | 587                | 真正产生业务价值                             |
+| 总 segments             | 7387               | 每 collection 默认 4 段                  |
+| 总 points               | 575 772            |                                      |
+| 总 vectors              | 600 795            | 1024 维、Cosine                        |
+| 已建 HNSW 索引的 vectors    | **90 005 (仅 15%)** | `indexing_threshold=20 MB` ≈ 5000 向量 |
+| 真正跨过索引阈值的 collection   | **3**              | 其他 584 个都走暴力扫描                       |
+
+
+业务侧（postgres `aperag` 库）：
+
+
+| 指标                          | 数值            |
+| --------------------------- | ------------- |
+| `user` 行数                   | 1611          |
+| `collection` ACTIVE         | 2003          |
+| `collection` DELETED        | 179           |
+| `document` 总行数              | 13 044        |
+| `document` COMPLETE         | 5 404         |
+| `document` EXPIRED / FAILED | 5 114 / 1 440 |
+
+
+---
+
+## 2. 12 GiB 内存都去哪了
+
+
+| 组成                                  | 估算值                                       | 解释                                                                                                                                      |
+| ----------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| 向量原始数据常驻 RAM                        | **~2.4 GiB**                              | 默认 `storage_type: Memory`，600 795 × 1024 × 4 B                                                                                          |
+| HNSW 图（RAM）                         | ~10–50 MiB                                | `hnsw_index.on_disk=false`，但只有 9 万 vec 被索引                                                                                              |
+| **7387 × RocksDB 实例静态开销**           | **~3–5 GiB**                              | 每个 segment 都是一个独立 RocksDB 库（MANIFEST/LOG/OPTIONS/LOCK 一套），memtable arena + block cache + table reader cache + bloom filter 按最小配置都要几 MiB |
+| **1847 × collection 级 Qdrant 内部结构** | **~2–3 GiB**                              | id_mapper、deleted bitset、payload index、分片元数据、tokio task                                                                                 |
+| **1872 threads** 的栈 + async 状态      | ~0.3–0.8 GiB                              | 每线程 VM 预留 8 MiB 但 RSS 只算 touched 页                                                                                                      |
+| WAL / 小文件回写缓冲                       | ~0.5 GiB                                  | `wal_capacity_mb=32` × 活动分片                                                                                                             |
+| **合计**                              | **≈ 9–11 GiB anon + 1 GiB file ≈ 12 GiB** | ✅ 与实测吻合                                                                                                                                 |
+
+
+**结论一句话**：12 GiB 里**只有大约 2.4 GiB 是真正存业务向量的**，剩下的 ~10 GiB 全是"1847 × 4 段 = 7387 个 RocksDB + 每 collection 的元数据"这种**与数据量无关、只与 collection 数量线性相关的成本**。
+
+---
+
+## 3. 根因：一个 ApeRAG Collection = 一个 Qdrant Collection
+
+当前实现位于 `aperag/vectorstore/qdrant_connector.py`：
+
+```102:112:aperag/vectorstore/qdrant_connector.py
+    def create_collection(self, **kwargs: Any):
+        vector_size = kwargs.get("vector_size")
+        from qdrant_client.http import models as rest
+
+        self.client.recreate_collection(
+            collection_name=self.collection_name,
+            vectors_config=rest.VectorParams(
+                size=vector_size,
+                distance=rest.Distance.COSINE,
+            ),
+        )
+```
+
+配合 `aperag/utils/utils.py::generate_vector_db_collection_name` 的映射：
+
+```44:46:aperag/utils/utils.py
+def generate_vector_db_collection_name(collection_id) -> str:
+    return str(collection_id)
+```
+
+也就是：用户每建一个 ApeRAG Collection，ApeRAG 就调用 `recreate_collection` 创建一个同名 Qdrant Collection。
+
+这是 Qdrant **官方明确反对**的用法。Qdrant 的文档 [https://qdrant.tech/documentation/guides/multiple-partitions/](https://qdrant.tech/documentation/guides/multiple-partitions/) 开头第一段就在强调：
+
+> In many cases, it is more efficient to use a **single collection** with payload-based partitioning. This approach is called **multitenancy**.
+
+照当前趋势继续线性膨胀：
+
+
+| 阶段     | 用户   | ApeRAG Collection | Qdrant RSS 预期  |
+| ------ | ---- | ----------------- | -------------- |
+| 现状     | 1.6k | 2k                | 12 GiB         |
+| 2× 增长  | 3k   | 4k                | ~25 GiB        |
+| 10× 增长 | 16k  | 20k               | 120+ GiB，单机不可行 |
+
+
+业务向量数据其实只涨了线性的一小段，**真正爆炸的是 collection 元数据**。
+
+---
+
+## 4. 解决方案
+
+按 **收益/改动量** 排序分成三档。ABC 三档可以独立落地、互不阻塞。
+
+### A 档 · 立即可做（今天完成，预计省 3–5 GiB，零代码改动）
+
+#### A.1 清理"孤儿 + 已删除"的 Qdrant collection
+
+判定规则（**只删 pg 里已经 DELETED 或根本不存在的**，不动任何 ACTIVE 记录，即便它在 Qdrant 里是空的也保留，因为业务上用户可能还没来得及上传文档）：
+
+```text
+待删 = { qdrant 里存在的 collection } ∩ ( { pg.collection.status='DELETED' } ∪ { pg 里不存在的孤儿 } )
+```
+
+该清理已经由本次治理配套的 subagent 执行，详见本文档末尾"附录 · 清理执行记录"。
+
+#### A.2 调整 Qdrant Server 侧默认值
+
+改动 Qdrant 的 `config.yaml`（通过 KubeBlocks 的 config 模板或启动环境变量注入均可）：
+
+```yaml
+storage:
+  optimizers:
+    # 4 段 → 2 段，RocksDB 实例数直接减半
+    default_segment_number: 2
+
+    # 超过 20 MiB 的 segment 用 mmap 存储向量，冷数据交给 kernel page cache 管
+    memmap_threshold_kb: 20480
+
+  hnsw_index:
+    # HNSW 图也落盘，查询路径会多一次 page fault 但内存占用大幅降低
+    on_disk: true
+
+  wal:
+    # 绝大多数 collection 很小，32 MiB 的 WAL 段太奢侈
+    wal_capacity_mb: 8
+```
+
+**落地位置**：
+
+- 仓库内自部署脚本：`deploy/databases/qdrant/values.yaml`（目前只有 CPU/mem/storage/version，需要新增一节覆盖 Qdrant config）。
+- 生产 helm values：`apecloud/aperag-values` 仓库内的 qdrant values 文件（该仓库独立维护，需要在 PR 里一起更新）。
+
+> 注意：`default_segment_number` 调整**不会自动应用到已存在的 collection**，需要对现有 collection 发起 `PATCH /collections/{name}` 或通过 optimizer 重建才能生效。建议在 A.1 清理之后，通过 `UpdateCollection` API 批量刷一遍。
+
+### B 档 · 中期（1–2 天，一次性砍掉 ~70% 内存，彻底解决扩展性）
+
+#### B.1 重新设计：多租户 = 单 Qdrant collection + payload 索引过滤
+
+##### B.1.1 Qdrant 多租户的官方模型
+
+Qdrant 为此专门提供了三项能力，缺一不可：
+
+1. **全局单 collection**：所有租户共用一个 Qdrant collection（例如 `aperag_vectors`）。原来每个 ApeRAG Collection 的 vector size 如果不一样，就按"向量维度 + 距离"分成少数几个全局 collection（例如 `aperag_vectors_1024_cosine`、`aperag_vectors_1536_cosine`）。
+2. **给 point 加上 tenant 维度的 payload 字段**：在每次 upsert 时，payload 里必须带 `collection_id`（ApeRAG Collection ID）。`point.id` 继续用现有的 chunk id 方案。
+3. **给 tenant 字段建 keyword 索引，并启用 tenant 优化**：
+  ```http
+   PUT /collections/aperag_vectors_1024_cosine/index
+   {
+     "field_name": "collection_id",
+     "field_schema": {
+       "type": "keyword",
+       "is_tenant": true          # 关键：告诉 Qdrant 这是多租户分区字段
+     }
+   }
+  ```
+   `is_tenant: true` 是 Qdrant **1.11+** 引入的特殊标记（[官方发布说明](https://qdrant.tech/blog/qdrant-1.11.x/)）。打开后，Qdrant 的 optimizer 会**按照 tenant 字段对点进行物理分组存储**（tenant 相同的点会被尽量放在同一个 segment 内），查询时相当于只扫描对应 tenant 的子集，性能和独立 collection 几乎等价。
+
+   **⚠️ 版本兼容**：生产现在的 Qdrant 是 **1.10.0**，不支持 `is_tenant`。连接器在 `aperag/vectorstore/qdrant_connector.py::_ensure_tenant_payload_index` 里采用了兜底策略：优先尝试 `is_tenant=True`，失败时降级为普通 keyword 索引。在 1.10 上：
+   - ✅ payload filter 本身完全工作，租户隔离语义严格成立；
+   - ✅ "1847 个 collection → 1 个" 的合并收益完全拿到（~3–5 GiB 的 RocksDB 实例开销立刻消失）；
+   - ❌ segment 级 defragmentation 不会生效，tenant 点会混存在同一批 segment 中，查询时 HNSW 需要跨更多"别人的"节点。预期 p95 查询延迟有几十百分比的退化（退化量随全局 collection 的总点数线性增长）。
+
+   **强烈建议**：把 Qdrant server 从 1.10.0 升到 1.11.x（或 1.12.x）作为本次停服窗口的一部分。升级只需改镜像 tag，不涉及数据迁移。升上去后，新建 collection 自动带 is_tenant 优化；**已有的全局 collection 上的索引不会自动升级**——需要在升级后重建索引：
+   ```sh
+   curl -X DELETE  $QDRANT/collections/aperag_vectors_1024_cosine/index/collection_id
+   # 重启任意 ApeRAG 进程，其连接器启动时会检测不存在，自动用 is_tenant=True 重建
+   ```
+
+##### B.1.2 查询时的过滤模板
+
+所有 `search / query_points / scroll` 都必须带 tenant 过滤：
+
+```python
+hits = client.query_points(
+    collection_name="aperag_vectors_1024_cosine",
+    query=query_vector,
+    query_filter=Filter(
+        must=[
+            FieldCondition(key="collection_id", match=MatchValue(value=ctx.collection))
+        ]
+    ),
+    limit=top_k,
+)
+```
+
+##### B.1.3 代码落点
+
+需要修改的主要位置：
+
+
+| 文件                                                                      | 改动                                                                                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aperag/vectorstore/qdrant_connector.py`                                | ① 去掉每次 `create_collection` 调 `recreate_collection`；改成惰性启动时 `ensure_global_collection(vector_size, distance)`（存在则跳过，不存在则创建并建 `is_tenant` 索引）。② `search/upsert/delete` 全部带上 `collection_id` 过滤。③ 删点时用 `delete_points_by_filter({collection_id, ids})` 限定在当前 tenant 内。 |
+| `aperag/utils/utils.py::generate_vector_db_collection_name`             | 废弃。替换为 `get_global_qdrant_collection_name(vector_size, distance)`。保留旧函数一段时间以便在"迁移中"回读兼容。                                                                                                                                                                            |
+| `aperag/tasks/collection.py::CollectionTask.create / delete`            | 创建时不再 `create_collection`，只需确保全局 collection 存在；删除时改成"按 filter 批量删点"而不是 `delete_collection`。                                                                                                                                                                         |
+| `aperag/service/search_pipeline_service.py` 及 `aperag/index/*_index.py` | 每一处 `get_vector_db_connector(...)` 调用点都要把 ApeRAG collection id 作为 tenant filter 传入。                                                                                                                                                                                 |
+| `aperag/config.py::get_vector_db_connector`                             | 建议新增签名 `get_vector_db_connector(collection_id: str)`，内部查询向量维度后路由到对应的全局 collection；在 ctx 里挂上 `tenant_key`、`tenant_value`。                                                                                                                                            |
+
+
+##### B.1.4 停服迁移策略（本次采用）
+
+考虑到停服窗口明确、时长可控，本次采用**停服一次性迁移**，避免双写的复杂度：
+
+1. **停服**：停掉 apiserver / celery worker / beat，Qdrant 仍然运行。
+2. **迁移**：跑 `scripts/migrate_qdrant_multitenancy.py`：
+   - 自动枚举所有 `col<hex>` 源 collection，跳过孤儿（DB 里查不到的）；
+   - 为每个 `(vector_size, distance)` 组合创建 `aperag_vectors_{size}_{distance}` 全局 collection，写入完整配置（INT8 量化 / HNSW on_disk / 2 segments / mmap 阈值 / tenant index）；
+   - scroll 源 collection 所有点，把 `payload.collection_id = <源 collection 名>` 注入后 upsert 进全局 collection；
+   - **默认不删源 collection**，需要显式 `--delete-old` 或第二阶段 `--only-delete`；
+3. **发布新版代码**，默认 `QDRANT_MULTITENANT=True`。
+4. **观察 24 h**：读路径（document chunks / search / retrieve）、写路径（新建 collection、新上传文档）都正常后；
+5. **清理**：再跑一次 `--only-delete` 把老的 `col<hex>` collection 删除。
+
+> **⚠️ 单向门警告**：一旦新版代码接收任何新写入（新建 collection、新上传文档、新 chat 产生的 chunk），`QDRANT_MULTITENANT` **不能简单切回 `False` 就算回滚**——那期间写入的新点只在 `aperag_vectors_*` 里，legacy 模式下看不到；同期新建的 ApeRAG Collection 也不会有对应的 `col<hex>` 物理 collection。如果必须回滚，需要反向迁移（从全局 collection 按 `collection_id` scroll 回每个 `col<hex>`）——这段逻辑目前**未实现**。所以：回滚窗口 = 新版代码上线到接收第一笔新写入之间的那几分钟。如果发现问题必须在窗口内决策。
+
+> **另一个单向影响**：是否在停服窗口里把 Qdrant server 顺带从 1.10.0 升到 1.11.x 也是一次决策——见 B.1.1。升级一次就回不去了（KubeBlocks qdrant 0.9.1 支持任意 tag 切换，但数据文件在 1.11 上会被 optimizer 重排）。
+
+##### B.1.5 预期收益
+
+
+| 项                   | 现状           | 多租户化后                    |
+| ------------------- | ------------ | ------------------------ |
+| Qdrant collection 数 | 1847         | ~1–3（按向量维度分）             |
+| Segment 数           | 7387         | ~数十                      |
+| RocksDB 实例数         | 7387         | ~数十                      |
+| RSS（同等数据量）          | 12 GiB       | **~2–3 GiB**             |
+| 再增长 10× 用户后的 RSS    | 120 GiB（不可行） | **~10–15 GiB**（线性随真实数据量） |
+
+
+### C 档 · 锦上添花
+
+#### C.1 **默认开启标量量化（INT8）**
+
+对绝大多数 1024–1536 维的 embedding，INT8 的精度损失小于 1%，但可以把向量存储从 float32 压到 int8，**立刻省 4×**（2.4 GiB → ~0.6 GiB），并且 Qdrant 的量化实现会让向量主体走 mmap，压力进一步下降。
+
+**代码侧改造**（与 B.1.3 同批完成最省力）：
+
+```python
+# aperag/vectorstore/qdrant_connector.py
+
+from qdrant_client.http import models as rest
+
+def _default_quantization_config() -> rest.QuantizationConfig:
+    return rest.ScalarQuantization(
+        scalar=rest.ScalarQuantizationConfig(
+            type=rest.ScalarType.INT8,
+            quantile=0.99,     # 鲁棒分位裁剪，离群点不影响量化区间
+            always_ram=True,   # 量化后的向量留在 RAM，原 float 全量走 mmap
+        )
+    )
+
+def _default_hnsw_config() -> rest.HnswConfigDiff:
+    return rest.HnswConfigDiff(
+        m=16,
+        ef_construct=100,
+        on_disk=True,          # HNSW 图落盘
+    )
+
+def _default_optimizer_config() -> rest.OptimizersConfigDiff:
+    return rest.OptimizersConfigDiff(
+        default_segment_number=2,
+        memmap_threshold=20000,  # 单位 KB
+    )
+```
+
+在 `ensure_global_collection` / 未来所有 `create_collection` 路径里默认带上这三项。
+
+**配置侧改造**（推荐按环境变量可覆盖）：在 `aperag/config.py::Settings` 里新增：
+
+```python
+qdrant_enable_quantization: bool = Field(True, alias="QDRANT_ENABLE_QUANTIZATION")
+qdrant_quantization_type: str = Field("int8", alias="QDRANT_QUANTIZATION_TYPE")
+qdrant_hnsw_on_disk: bool = Field(True, alias="QDRANT_HNSW_ON_DISK")
+qdrant_default_segment_number: int = Field(2, alias="QDRANT_DEFAULT_SEGMENT_NUMBER")
+```
+
+然后在两处 values 里把默认值同步过去：
+
+1. **`deploy/aperag/values.yaml`**（当前仓库）：在 `vars` 段追加：
+
+   ```yaml
+   QDRANT_ENABLE_QUANTIZATION: "true"
+   QDRANT_QUANTIZATION_TYPE: "int8"
+   QDRANT_HNSW_ON_DISK: "true"
+   QDRANT_DEFAULT_SEGMENT_NUMBER: "2"
+   ```
+
+2. **`apecloud/aperag-values`**（独立仓库，生产部署用）：同步上面四个环境变量；Qdrant 子 chart 的 server-side 配置（`deploy/databases/qdrant/values.yaml` 等价项）也要加：
+
+   ```yaml
+   extra:
+     config:
+       storage:
+         optimizers:
+           default_segment_number: 2
+           memmap_threshold_kb: 20480
+         hnsw_index:
+           on_disk: true
+         wal:
+           wal_capacity_mb: 8
+   ```
+
+   > aperag-values 仓库的 PR 需要和本仓库的 Settings/connector 代码改动**同步发版**，避免应用开了量化但旧 Qdrant 不支持的问题。
+   >
+   > **Qdrant 版本要求**：INT8 量化 / HNSW on_disk / 2 segments / mmap threshold 这些选项 **1.10.0 全部支持**，无需升级。但多租户 **`is_tenant=True`** 需要 **1.11+**；生产 1.10.0 会被连接器自动降级为普通 keyword 索引——功能正确但失去 segment 级 defragmentation。**建议在本次停服窗口里把 Qdrant 也升到 1.11+**（只改镜像 tag，无数据迁移），或在下一次停服窗口里升，并接受 1.11 之前的查询延迟退化。详见 B.1.1 的版本兼容说明。
+
+#### C.2 其他零散优化
+
+- `wal_capacity_mb: 8`（见 A.2）：对于 ApeRAG 这种写入量并不高的场景，32 MiB 是过度预留。
+- `on_disk_payload: true`：现状已经是 true，保持即可。
+- 搜索侧：如果开启 INT8 量化，在 `search_params` 里加 `quantization: { rescore: true, oversampling: 2.0 }`，用重排恢复精度。
+
+---
+
+## 5. 落地排期建议
+
+
+| 周    | 改动                                                    | 负责方向        |
+| ---- | ----------------------------------------------------- | ----------- |
+| 本周   | A.1 清理（已由 subagent 执行）、A.2 Server 侧配置上线到 staging      | DevOps + 后端 |
+| 本周末  | A.2 推到 prod，观察内存变化 48h                                | DevOps      |
+| 次周   | B.1.3 代码改造 + C.1 量化默认开启，提 PR 到 ApeRAG & aperag-values | 后端          |
+| 次周末  | B.1.4 双写上线 staging                                    | 后端          |
+| +2 周 | B.1.4 回填 + 切读 + 清理老 collection                        | 后端 + DevOps |
+
+
+---
+
+## 6. 验证与监控
+
+做完后要有"三条线"的可观测能力：
+
+1. **Qdrant pod RSS**：`container_memory_working_set_bytes{pod="qdrant-cluster-qdrant-0"}`。目标：从 12 GiB 降至 ≤ 4 GiB。
+2. **Qdrant 自身 metrics**（暴露在 `/metrics`）：`collections_total`、`pending_optimizations`、`segments_total`。
+3. **RAG 查询延迟/召回**：以现有测试集 replay，要求 recall@10 降幅 < 2%，p95 延迟增幅 < 20%（量化 + on_disk 的权衡）。
+
+把这三条线加到 Grafana 里，作为此次治理的验收门槛。
+
+---
+
+## 附录 · 清理执行记录
+
+本次治理启动时，由 subagent 在 `ack-hong-kong` 集群执行了 A.1 的清理脚本。执行结果追加在本节：
+
+### 执行时间
+
+2026-04-20 20:44 CST（UTC+8），集群 `ack-hong-kong`，操作人：cleanup subagent（串行 REST DELETE，单条确认，无并发）。
+
+### 基线（清理前）
+
+| 项 | 值 |
+|---|---|
+| Qdrant collection 总数 | **1847** |
+| PG `status='ACTIVE'` | 2003（其中 1833 已在 Qdrant、170 尚未上传文档） |
+| PG `status='DELETED'` | 179（其中 165 早就不在 Qdrant，仅 14 条残留） |
+| Qdrant `qdrant` 容器 RSS | **12 517 MiB**（约 12.2 GiB，`kubectl top pod --containers`） |
+
+### 待删清单分类
+
+严格按 `IN_QDRANT \ ACTIVE_IN_PG` 计算，共 **14** 条，全部来源于 PG `status='DELETED'`：
+
+| 分类 | 数量 |
+|---|---|
+| DELETED 来源（PG 标记 DELETED 但 Qdrant 仍残留） | **14** |
+| 孤儿来源（Qdrant 有、PG 完全查不到） | **0** |
+
+完整列表：
+
+```
+col234abe498124212b  col2de94bc540c00373  col364fc3b305b38d9d  col428bbf8564ba165a
+col430ad0d0358e4787  col56460b3f4eb88690  col69178ab2362c6391  col78e7bbbe447907eb
+col8682c84fbda6333b  col896e0ebd4d699b89  colafa077fd51475227  colc18fb93c44d9f2be
+colc49a291371cc17fc  colf67799b2b73f391e
+```
+
+### 删除执行结果
+
+通过 `kubectl port-forward qdrant-cluster-qdrant-0 16333:6333` + `curl -X DELETE http://localhost:16333/collections/{name}` 逐条删除，串行、无并发，完成后关闭 port-forward。
+
+| 项 | 值 |
+|---|---|
+| 发起 DELETE 请求数 | 14 |
+| HTTP 200 且 `result=true` | 13 |
+| HTTP 200 但 `result=false`（Qdrant 端 "collection 已不存在" 的幂等响应） | 1（首条 `col234abe498124212b`） |
+| 真实失败（HTTP 非 200） | **0** |
+| 删除后抽检 14 个名字的 `GET /collections/{name}` | **全部 404**，确认已从 Qdrant 完全消失 |
+
+### 清理后状态
+
+| 项 | 值（立即） |
+|---|---|
+| Qdrant collection 总数 | **1833**（-14） |
+| Qdrant `qdrant` 容器 RSS | **12 492 MiB**（约 12.2 GiB，立即值 ≈ -25 MiB） |
+
+> 说明：Qdrant 1.10 的 `DELETE /collections/{name}` 只把 collection 从 meta 中摘除，底层段文件回收 / mmap unmap 依赖 optimizer 下一轮调度，进程 RSS 的下降通常滞后。**本条记录为删除完成瞬时的 `kubectl top` 值，真实回收预计在 24 h 内体现。**
+
+### 本次清理的关键结论（重要）
+
+1. **历史上已清过一轮**：PG 有 179 条 `DELETED`，其中 **165 条在之前的治理中已经从 Qdrant 移除**，本次仅残留 14 条；**完全没有孤儿**（Qdrant 里每一个 collection 都能在 PG 里找到对应行）。
+2. **"空 collection 很多"并不等于"可删的很多"**：PG `ACTIVE` 2003 条中，有 170 条仍未在 Qdrant 写入（或写入了还未上传文档），按产品规则属于"用户已建未用"的合法状态，**绝不能删**。真正可清的"空 collection"只是 DELETED 残留（本次 14 条）。这解释了为什么 A.1 步骤实际可清理量远小于"空 collection 总数"。
+3. **A.1 对 12 GiB RSS 的直接收益非常有限**：本次仅摘除 14 个 collection 的 meta，即便 optimizer 回收完毕，预期可释放的 RSS 也远不到 GiB 级。**真正降低 Qdrant 内存占用要靠正文提到的 B 档（多租户化，单 collection + payload index）与 C 档（INT8 量化 + `always_ram=false`）**。A.1 的价值在于"把账对齐、防止 DELETED 残留继续累积"。
+4. **正文第 2 章「12 GiB 分账」依然成立**：清理后活跃 collection 从 1847 → 1833，仅下降 0.76%，原分账中"**1847 × collection 内部结构（HNSW 图 / payload index / 段 header / 通道缓冲）**"一行的量级与结论不变，无需改写正文。
+
+### 失败条目列表
+
+无真实失败。唯一的非典型响应（首条 `col234abe498124212b` 返回 `result:false`）为 Qdrant 端的幂等提示，对象事实上已不存在；抽检 `GET /collections/col234abe498124212b` 返回 404，最终状态正确。

--- a/scripts/migrate_qdrant_multitenancy.py
+++ b/scripts/migrate_qdrant_multitenancy.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Migrate Qdrant data from the per-collection layout to the multitenant layout.
+
+Before: one Qdrant collection per ApeRAG collection (``col<hex>``).
+After:  a single global Qdrant collection per ``(vector_size, distance)``
+        pair, with a ``collection_id`` payload field + is_tenant keyword index.
+
+Intended to be run once, during a stop-the-world migration window. The script
+is **idempotent**: it can be re-run safely if interrupted — we only upsert by
+id, and the Qdrant delete of old collections only runs with ``--delete-old``.
+
+Typical workflow:
+
+    # 1. Dry run: just tell me what you would do
+    python scripts/migrate_qdrant_multitenancy.py --dry-run
+
+    # 2. Run the actual migration (writes to global collection; keeps old ones)
+    python scripts/migrate_qdrant_multitenancy.py
+
+    # 3. After verifying read paths on the new collection, delete old ones
+    python scripts/migrate_qdrant_multitenancy.py --delete-old --only-delete
+
+Behavior contract:
+
+* For every non-empty source Qdrant collection whose name matches an ApeRAG
+  ``collection.id`` in the database:
+    - Resolve the vector_size (from the source collection's config).
+    - Ensure the global ``aperag_vectors_{size}_{distance}`` collection exists
+      with full INT8 quantization + on-disk HNSW + tenant index.
+    - Scroll all points out, batch upsert them into the global collection with
+      ``payload.collection_id = <ApeRAG collection id>`` injected.
+* Safety rails:
+    - By default we do NOT delete source collections (``--delete-old`` opts in).
+    - ``--only-delete`` assumes migration already happened and simply drops the
+      old per-tenant collections. This is the "commit" phase of a two-stage run.
+    - ``--dry-run`` prints the plan and returns without writing.
+    - ``--limit N`` restricts the migration to the first N source collections
+      (useful for staged rollouts or smoke tests).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set, Tuple
+
+# Make sure the repo root is importable regardless of how this script is invoked.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from qdrant_client import QdrantClient  # noqa: E402
+from qdrant_client import models as rest  # noqa: E402
+from qdrant_client.http.exceptions import UnexpectedResponse  # noqa: E402
+
+from aperag.config import settings  # noqa: E402
+from aperag.utils.utils import generate_vector_db_collection_name  # noqa: E402
+from aperag.vectorstore.qdrant_connector import (  # noqa: E402
+    TENANT_PAYLOAD_KEY,
+    _coerce_distance,
+    _ensure_tenant_payload_index,
+    _hnsw_config,
+    _optimizers_config,
+    _quantization_config,
+    global_collection_name,
+)
+
+# Safety assertion: the migration writes ``collection.id`` into
+# ``payload.collection_id`` (the tenant key). If somebody ever changes the
+# mapping function to add a prefix or hash, our migration would silently
+# write the wrong tenant id. Catch that right here.
+_probe = "col_migration_probe_0123456789abcdef"
+assert generate_vector_db_collection_name(collection_id=_probe) == _probe, (
+    "generate_vector_db_collection_name must be an identity-on-str mapping for migration safety; "
+    "update this migration script if the mapping has changed."
+)
+del _probe
+
+logger = logging.getLogger("migrate_qdrant")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _connect_qdrant() -> QdrantClient:
+    ctx = json.loads(settings.vector_db_context)
+    return QdrantClient(
+        url=ctx.get("url", "http://localhost"),
+        port=ctx.get("port", 6333),
+        grpc_port=ctx.get("grpc_port", 6334),
+        prefer_grpc=ctx.get("prefer_grpc", False),
+        https=ctx.get("https", False),
+        timeout=ctx.get("timeout", 300),
+    )
+
+
+def _load_aperag_collection_ids() -> Set[str]:
+    """Return the set of ApeRAG collection ids currently known to the DB.
+
+    We intentionally include both ACTIVE and DELETED rows. An orphan Qdrant
+    collection (one that exists in Qdrant but not in the DB at all) is left
+    alone by the migration — the operator decides whether to clean it up via
+    the separate cleanup script.
+    """
+    from sqlalchemy import select
+
+    from aperag.config import get_sync_session
+    from aperag.db import models as db_models
+
+    ids: Set[str] = set()
+    for session in get_sync_session():
+        rows = session.execute(select(db_models.Collection.id)).all()
+        ids.update(r[0] for r in rows)
+    return ids
+
+
+@dataclass
+class SourceInfo:
+    name: str
+    vector_size: int
+    distance: str
+    points: int
+
+
+def _inspect_source_collection(client: QdrantClient, name: str) -> Optional[SourceInfo]:
+    try:
+        info = client.get_collection(name)
+    except UnexpectedResponse:
+        return None
+    vectors_cfg = info.config.params.vectors
+    # In our codebase every collection uses the unnamed-default vector; if a
+    # named-vector config turns up, we explicitly bail so a human can decide.
+    if isinstance(vectors_cfg, dict):
+        logger.warning("collection %s uses named vectors; skipping (requires manual migration)", name)
+        return None
+    size = int(vectors_cfg.size)
+    dist = vectors_cfg.distance.name if hasattr(vectors_cfg.distance, "name") else str(vectors_cfg.distance)
+    points = int(getattr(info, "points_count", 0) or 0)
+    return SourceInfo(name=name, vector_size=size, distance=dist, points=points)
+
+
+def _ensure_global_collection(client: QdrantClient, vector_size: int, distance: str, dry_run: bool) -> str:
+    dest = global_collection_name(vector_size, distance)
+    if dry_run:
+        logger.info("[dry-run] would ensure global collection %s", dest)
+        return dest
+    if not client.collection_exists(dest):
+        logger.info("creating global collection %s", dest)
+        cfg = {
+            "quantization_enabled": True,
+            "quantization_type": "int8",
+            "quantization_quantile": 0.99,
+            "quantization_always_ram": True,
+            "hnsw_on_disk": True,
+            "default_segment_number": 2,
+            "mmap_threshold_kb": 20480,
+        }
+        client.create_collection(
+            collection_name=dest,
+            vectors_config=rest.VectorParams(
+                size=vector_size,
+                # Use the connector's coercion helper rather than Distance[x].
+                # Distance member names are UPPERCASE (`COSINE`), values are
+                # capitalized (`Cosine`); a naive lookup by the capitalized
+                # value would KeyError on the first run (Qdrant ships the
+                # capitalized form in GetCollection responses).
+                distance=_coerce_distance(distance),
+                on_disk=True,
+            ),
+            hnsw_config=_hnsw_config(cfg),
+            optimizers_config=_optimizers_config(cfg),
+            quantization_config=_quantization_config(cfg),
+            on_disk_payload=True,
+        )
+    _ensure_tenant_payload_index(client, dest)
+    return dest
+
+
+def _migrate_one(
+    client: QdrantClient,
+    source: SourceInfo,
+    batch_size: int,
+    dry_run: bool,
+) -> Tuple[int, int]:
+    """Move all points from ``source`` into its global collection.
+
+    Returns (migrated, skipped).
+    """
+    dest = _ensure_global_collection(client, source.vector_size, source.distance, dry_run=dry_run)
+    if dry_run:
+        logger.info("[dry-run] would migrate %d points: %s -> %s", source.points, source.name, dest)
+        return source.points, 0
+
+    offset = None
+    total_migrated = 0
+    total_skipped = 0
+    while True:
+        records, next_offset = client.scroll(
+            collection_name=source.name,
+            limit=batch_size,
+            offset=offset,
+            with_payload=True,
+            with_vectors=True,
+        )
+        if not records:
+            break
+
+        points: List[rest.PointStruct] = []
+        for rec in records:
+            # Merge the tenant id into the payload. If somebody already set it
+            # (vision / summary indexers do), we overwrite defensively — the
+            # source collection's name is the single source of truth.
+            payload = dict(rec.payload or {})
+            payload[TENANT_PAYLOAD_KEY] = source.name
+
+            vec = rec.vector
+            # Scroll may return vectors as a dict for named-vector collections.
+            # We ensured earlier that source uses the default vector, so this
+            # should always be a plain list[float]; still guard defensively.
+            if isinstance(vec, dict):
+                # Single entry dict -> unwrap the only value.
+                if len(vec) == 1:
+                    vec = next(iter(vec.values()))
+                else:
+                    logger.warning("point %s in %s has multi-vector; skipping", rec.id, source.name)
+                    total_skipped += 1
+                    continue
+
+            points.append(rest.PointStruct(id=rec.id, vector=vec, payload=payload))
+
+        if points:
+            client.upsert(collection_name=dest, points=points, wait=True)
+            total_migrated += len(points)
+
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    logger.info("migrated %s -> %s : %d points (skipped %d)", source.name, dest, total_migrated, total_skipped)
+    return total_migrated, total_skipped
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dry-run", action="store_true", help="print plan without writing")
+    parser.add_argument("--batch-size", type=int, default=512, help="scroll/upsert batch size")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="only process the first N source collections (0 = all)",
+    )
+    parser.add_argument(
+        "--only-name",
+        type=str,
+        default=None,
+        help="restrict to a single source collection name (for targeted testing)",
+    )
+    parser.add_argument(
+        "--delete-old",
+        action="store_true",
+        help="after successful migration, DELETE source per-collection Qdrant collections",
+    )
+    parser.add_argument(
+        "--only-delete",
+        action="store_true",
+        help=(
+            "skip the migrate phase, only delete per-collection Qdrant collections "
+            "whose id is present in the ApeRAG DB (assumes a prior successful migration)"
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="enable DEBUG logging",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    client = _connect_qdrant()
+    aperag_ids = _load_aperag_collection_ids()
+    logger.info("ApeRAG DB knows %d collection ids", len(aperag_ids))
+
+    # Enumerate source collections: everything whose name matches an ApeRAG id.
+    existing = {c.name for c in client.get_collections().collections}
+    logger.info("Qdrant exposes %d collections", len(existing))
+
+    source_names = sorted(existing & aperag_ids)
+    if args.only_name:
+        if args.only_name not in source_names:
+            logger.error("--only-name %s not found among source collections", args.only_name)
+            return 2
+        source_names = [args.only_name]
+    if args.limit > 0:
+        source_names = source_names[: args.limit]
+    logger.info("will process %d source collections", len(source_names))
+
+    # Inspect each source so we know target global collections up front.
+    sources: List[SourceInfo] = []
+    per_size: Dict[Tuple[int, str], int] = {}
+    for name in source_names:
+        info = _inspect_source_collection(client, name)
+        if info is None:
+            logger.warning("skipping %s (could not inspect)", name)
+            continue
+        sources.append(info)
+        per_size[(info.vector_size, info.distance)] = per_size.get((info.vector_size, info.distance), 0) + info.points
+
+    logger.info("targeted global collections:")
+    for (size, dist), pts in sorted(per_size.items()):
+        logger.info(
+            "  %s : %d points from %d source collections",
+            global_collection_name(size, dist),
+            pts,
+            sum(1 for s in sources if (s.vector_size, s.distance) == (size, dist)),
+        )
+
+    if not args.only_delete:
+        # Do the migration.
+        t0 = time.time()
+        total_points = 0
+        total_skipped = 0
+        for i, src in enumerate(sources, 1):
+            if src.points == 0:
+                logger.info(
+                    "[%d/%d] %s is empty; skipping copy (tenant has nothing to migrate)", i, len(sources), src.name
+                )
+                continue
+            logger.info(
+                "[%d/%d] migrating %s (%d points, size=%d)", i, len(sources), src.name, src.points, src.vector_size
+            )
+            migrated, skipped = _migrate_one(client, src, batch_size=args.batch_size, dry_run=args.dry_run)
+            total_points += migrated
+            total_skipped += skipped
+        logger.info(
+            "migration phase done in %.1fs, migrated=%d, skipped=%d", time.time() - t0, total_points, total_skipped
+        )
+
+    if args.delete_old or args.only_delete:
+        if args.dry_run:
+            logger.info("[dry-run] would delete %d source collections", len(sources))
+        else:
+            for i, src in enumerate(sources, 1):
+                try:
+                    client.delete_collection(collection_name=src.name)
+                    logger.info("[%d/%d] deleted old collection %s", i, len(sources), src.name)
+                except UnexpectedResponse as e:
+                    logger.warning("delete_collection(%s) failed: %s", src.name, e)
+
+    logger.info("done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_test/vectorstore/test_build_vector_db_context.py
+++ b/tests/unit_test/vectorstore/test_build_vector_db_context.py
@@ -1,0 +1,88 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Behavioral tests for ``aperag.config.build_vector_db_context``.
+
+These tests guard the contract that every call site depends on:
+
+* ``collection`` always ends up in ctx as the tenant id (even when overridden
+  by VECTOR_DB_CONTEXT).
+* All optimization flags (multitenant / quantization / HNSW / segments /
+  mmap / payload on_disk) appear in ctx with their settings-level defaults so
+  downstream ``QdrantVectorStoreConnector`` never has to fall back to hard-
+  coded defaults.
+* Per-call ctx overrides win over settings-level defaults (important for the
+  migration script which explicitly disables multitenant for source reads).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aperag.config import build_vector_db_context, settings
+
+
+@pytest.fixture
+def clean_vector_db_context(monkeypatch):
+    """Reset VECTOR_DB_CONTEXT to a known minimal shape for each test."""
+    monkeypatch.setattr(
+        settings,
+        "vector_db_context",
+        json.dumps({"url": "http://example", "port": 6333, "distance": "Cosine"}),
+    )
+
+
+def test_build_context_injects_collection_and_vector_size(clean_vector_db_context):
+    ctx = build_vector_db_context("coltest", vector_size=1024)
+    assert ctx["collection"] == "coltest"
+    assert ctx["vector_size"] == 1024
+
+
+def test_build_context_propagates_all_optimization_flags(clean_vector_db_context, monkeypatch):
+    # explicit settings values to avoid drift if defaults change
+    monkeypatch.setattr(settings, "qdrant_multitenant", True)
+    monkeypatch.setattr(settings, "qdrant_quantization_enabled", True)
+    monkeypatch.setattr(settings, "qdrant_quantization_type", "int8")
+    monkeypatch.setattr(settings, "qdrant_quantization_quantile", 0.98)
+    monkeypatch.setattr(settings, "qdrant_quantization_always_ram", False)
+    monkeypatch.setattr(settings, "qdrant_hnsw_on_disk", True)
+    monkeypatch.setattr(settings, "qdrant_default_segment_number", 3)
+    monkeypatch.setattr(settings, "qdrant_mmap_threshold_kb", 10000)
+    monkeypatch.setattr(settings, "qdrant_vectors_on_disk", True)
+    monkeypatch.setattr(settings, "qdrant_on_disk_payload", True)
+
+    ctx = build_vector_db_context("col1", vector_size=1024)
+
+    assert ctx["multitenant"] is True
+    assert ctx["quantization_enabled"] is True
+    assert ctx["quantization_type"] == "int8"
+    assert ctx["quantization_quantile"] == pytest.approx(0.98)
+    assert ctx["quantization_always_ram"] is False
+    assert ctx["hnsw_on_disk"] is True
+    assert ctx["default_segment_number"] == 3
+    assert ctx["mmap_threshold_kb"] == 10000
+    assert ctx["vectors_on_disk"] is True
+    assert ctx["on_disk_payload"] is True
+
+
+def test_build_context_respects_ctx_override(monkeypatch):
+    # If the operator pins a flag inside VECTOR_DB_CONTEXT JSON, it must win
+    # over the settings-level default. This is how the migration script tells
+    # the connector "read me in legacy mode even though the global default is
+    # multitenant".
+    monkeypatch.setattr(
+        settings,
+        "vector_db_context",
+        json.dumps({"url": "http://example", "port": 6333, "multitenant": False, "distance": "Cosine"}),
+    )
+    monkeypatch.setattr(settings, "qdrant_multitenant", True)
+
+    ctx = build_vector_db_context("col1", vector_size=1024)
+    assert ctx["multitenant"] is False  # ctx override wins

--- a/tests/unit_test/vectorstore/test_qdrant_connector.py
+++ b/tests/unit_test/vectorstore/test_qdrant_connector.py
@@ -1,0 +1,155 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the Qdrant connector's pure-logic helpers.
+
+We deliberately avoid spinning up a Qdrant process here — only the
+configuration/filter-synthesis logic is covered. End-to-end behavior is
+exercised manually against staging during the migration window.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+from qdrant_client import models as rest
+
+from aperag.vectorstore.qdrant_connector import (
+    TENANT_PAYLOAD_KEY,
+    _coerce_distance,
+    _hnsw_config,
+    _merge_tenant_filter,
+    _optimizers_config,
+    _quantization_config,
+    global_collection_name,
+)
+
+# ---------------------------------------------------------------------------
+# global_collection_name
+# ---------------------------------------------------------------------------
+
+
+def test_global_collection_name_is_stable_and_lowercased():
+    assert global_collection_name(1024, "Cosine") == "aperag_vectors_1024_cosine"
+    assert global_collection_name(1536, "cosine") == "aperag_vectors_1536_cosine"
+    # Case-insensitive on the distance component so callers don't have to care.
+    assert global_collection_name(768, "DOT") == "aperag_vectors_768_dot"
+
+
+def test_global_collection_name_accepts_float_size():
+    # callers sometimes float-ify the dim by accident — we must still produce a
+    # valid collection name without decimals.
+    assert global_collection_name(1024.0, "Cosine") == "aperag_vectors_1024_cosine"
+
+
+# ---------------------------------------------------------------------------
+# _coerce_distance
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_distance_accepts_strings_and_enum():
+    assert _coerce_distance("Cosine") is rest.Distance.COSINE
+    assert _coerce_distance("cosine") is rest.Distance.COSINE
+    assert _coerce_distance(rest.Distance.DOT) is rest.Distance.DOT
+
+
+def test_coerce_distance_rejects_garbage():
+    with pytest.raises(ValueError):
+        _coerce_distance("banana")
+
+
+# ---------------------------------------------------------------------------
+# quantization / hnsw / optimizer config builders
+# ---------------------------------------------------------------------------
+
+
+def test_quantization_config_disabled_returns_none():
+    assert _quantization_config({"quantization_enabled": False}) is None
+
+
+def test_quantization_config_int8_defaults():
+    cfg = _quantization_config({"quantization_enabled": True})
+    assert isinstance(cfg, rest.ScalarQuantization)
+    assert cfg.scalar.type is rest.ScalarType.INT8
+    # defaults: quantile=0.99, always_ram=True
+    assert cfg.scalar.quantile == pytest.approx(0.99)
+    assert cfg.scalar.always_ram is True
+
+
+def test_quantization_config_binary():
+    cfg = _quantization_config(
+        {"quantization_enabled": True, "quantization_type": "binary", "quantization_always_ram": False}
+    )
+    assert isinstance(cfg, rest.BinaryQuantization)
+    assert cfg.binary.always_ram is False
+
+
+def test_quantization_config_unknown_type_raises():
+    with pytest.raises(ValueError):
+        _quantization_config({"quantization_enabled": True, "quantization_type": "product"})
+
+
+def test_hnsw_config_defaults_on_disk():
+    cfg = _hnsw_config({})
+    assert cfg.m == 16
+    assert cfg.ef_construct == 100
+    assert cfg.on_disk is True
+
+
+def test_optimizer_config_defaults():
+    cfg = _optimizers_config({})
+    assert cfg.default_segment_number == 2
+    assert cfg.memmap_threshold == 20480
+
+
+# ---------------------------------------------------------------------------
+# _merge_tenant_filter
+# ---------------------------------------------------------------------------
+
+
+def _tenant_cond(value: str) -> rest.FieldCondition:
+    return rest.FieldCondition(key=TENANT_PAYLOAD_KEY, match=rest.MatchValue(value=value))
+
+
+def test_merge_tenant_filter_without_user_filter():
+    out = _merge_tenant_filter(None, "colabc")
+    assert isinstance(out, rest.Filter)
+    assert out.must == [_tenant_cond("colabc")]
+
+
+def test_merge_tenant_filter_without_tenant_is_noop():
+    # If tenant_id is falsy we must not alter the user's filter.
+    existing = rest.Filter(must=[rest.FieldCondition(key="foo", match=rest.MatchValue(value="bar"))])
+    assert _merge_tenant_filter(existing, None) is existing
+    assert _merge_tenant_filter(None, None) is None
+
+
+def test_merge_tenant_filter_preserves_should_and_must_not():
+    user = rest.Filter(
+        must=[rest.FieldCondition(key="chat_id", match=rest.MatchValue(value="cX"))],
+        should=[rest.FieldCondition(key="indexer", match=rest.MatchValue(value="vector"))],
+    )
+    out = _merge_tenant_filter(user, "colabc")
+
+    assert isinstance(out, rest.Filter)
+    # tenant clause appended to must
+    assert len(out.must) == 2
+    assert out.must[-1] == _tenant_cond("colabc")
+    # should clause untouched
+    assert out.should == user.should
+
+
+def test_merge_tenant_filter_handles_unknown_filter_type():
+    # If something non-Filter slips through we drop it (logging a warning) and
+    # return only the tenant guard; we must never try to stuff arbitrary objects
+    # into rest.Filter.must since pydantic will reject them at the API boundary.
+    foreign: Dict[str, Any] = {"weird": True}
+    out = _merge_tenant_filter(foreign, "colabc")
+    assert isinstance(out, rest.Filter)
+    assert out.must == [_tenant_cond("colabc")]

--- a/tests/unit_test/vectorstore/test_qdrant_multitenancy_integration.py
+++ b/tests/unit_test/vectorstore/test_qdrant_multitenancy_integration.py
@@ -1,0 +1,331 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Integration tests for the multitenant Qdrant connector using ``:memory:``.
+
+The reviewer's most important concern was "are two tenants actually isolated?"
+— a property that can only be validated end-to-end against a running Qdrant.
+The ``qdrant_client.QdrantClient(":memory:")`` local mode gives us a real
+point-store implementation (with scroll / upsert / filter semantics) without
+requiring a server process, so these tests execute in <1 s each.
+
+Note: payload indexes are a no-op in local mode (the client prints a warning
+to that effect). That's fine — we're exercising correctness of the
+filter-based isolation, not the segment-level defragmentation benefit.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+import pytest
+
+pytest.importorskip("qdrant_client")
+
+from qdrant_client import QdrantClient  # noqa: E402
+from qdrant_client import models as rest  # noqa: E402
+
+from aperag.query.query import QueryWithEmbedding  # noqa: E402
+from aperag.vectorstore import qdrant_connector as qc  # noqa: E402
+from aperag.vectorstore.qdrant_connector import (  # noqa: E402
+    TENANT_PAYLOAD_KEY,
+    QdrantVectorStoreConnector,
+    global_collection_name,
+)
+
+VECTOR_SIZE = 4
+VEC_A = [1.0, 0.0, 0.0, 0.0]
+VEC_B = [0.0, 1.0, 0.0, 0.0]
+
+
+@pytest.fixture(autouse=True)
+def _reset_ensured_cache():
+    """Clear the module-level "already ensured" cache between tests.
+
+    The cache is a process-level optimization that would normally skip the
+    create_collection RPC for (url, collection_name) tuples we've seen
+    before. In tests we spin up a fresh in-memory QdrantClient per test —
+    without a reset, the second test's connector would skip ensure and then
+    talk to a client that doesn't have the collection, blowing up at the
+    first upsert.
+    """
+    qc._ENSURED_COLLECTIONS.clear()
+    yield
+    qc._ENSURED_COLLECTIONS.clear()
+
+
+@pytest.fixture
+def shared_client():
+    """One in-memory Qdrant client shared by all connectors in a test.
+
+    In production each connector instance talks to the same remote Qdrant,
+    so they see each other's writes. In tests we must mimic that by having
+    every connector reuse the same client — otherwise ``tenant A`` and
+    ``tenant B`` would each get their own isolated :memory: store and the
+    whole "are they isolated?" question becomes trivially true for the
+    wrong reason.
+    """
+    return QdrantClient(":memory:")
+
+
+def _make_connector(
+    tenant_id: str,
+    client: QdrantClient,
+    multitenant: bool = True,
+) -> QdrantVectorStoreConnector:
+    """Spin up a connector bound to a caller-provided client.
+
+    We patch ``_ENSURED_COLLECTIONS`` via fixture (so ensure runs), and we
+    monkey-patch the client reference right after construction — because the
+    connector's ``__init__`` builds its own client from the ctx; we want all
+    connectors in a test to share one in-memory store.
+    """
+    ctx = {
+        "url": ":memory:",
+        "collection": tenant_id,
+        "vector_size": VECTOR_SIZE,
+        "distance": "Cosine",
+        "multitenant": multitenant,
+        # Quantization is meaningless for 4-dim local mode; disable to keep
+        # create_collection valid in the in-memory backend (which doesn't
+        # implement all quantization variants).
+        "quantization_enabled": False,
+        "hnsw_on_disk": False,
+    }
+    # Strategy: pre-populate the shared client by running ensure_collection
+    # logic through ONE connector, then force subsequent connectors to reuse
+    # the same client.
+    conn = QdrantVectorStoreConnector.__new__(QdrantVectorStoreConnector)
+    conn.ctx = ctx
+    conn.multitenant = multitenant
+    conn.cfg = ctx
+    if multitenant and not ctx.get("collection"):
+        raise ValueError("QdrantVectorStoreConnector(multitenant=True) requires ctx['collection']")
+    conn.tenant_id = str(tenant_id)
+    conn.url = ":memory:"
+    conn.port = 6333
+    conn.grpc_port = 6334
+    conn.prefer_grpc = False
+    conn.https = False
+    conn.timeout = 300
+    conn.vector_size = VECTOR_SIZE
+    conn.distance = "Cosine"
+    conn.client = client
+
+    if multitenant:
+        conn.collection_name = global_collection_name(VECTOR_SIZE, "Cosine")
+        conn._ensure_collection()
+    else:
+        conn.collection_name = tenant_id
+        # Legacy mode: caller explicitly creates the physical collection.
+        if not client.collection_exists(conn.collection_name):
+            client.create_collection(
+                collection_name=conn.collection_name,
+                vectors_config=rest.VectorParams(size=VECTOR_SIZE, distance=rest.Distance.COSINE),
+            )
+
+    # llama_index store — not used in these tests, but the connector API
+    # expects the attribute to be set. Importing here avoids the cost when
+    # tests don't need it.
+    from llama_index.vector_stores.qdrant import QdrantVectorStore
+
+    conn.store = QdrantVectorStore(
+        client=client,
+        collection_name=conn.collection_name,
+        vectors_config=rest.VectorParams(size=VECTOR_SIZE, distance=rest.Distance.COSINE),
+    )
+    return conn
+
+
+def _seed_points(
+    conn: QdrantVectorStoreConnector,
+    vectors: List[List[float]],
+    tenant_payload: str,
+) -> List[str]:
+    """Write raw points straight into the connector's physical collection.
+
+    We deliberately bypass ``store.add()`` because llama_index serializes the
+    entire node into ``_node_content`` and adds other derived fields, which
+    muddies tests focused on tenant-payload filtering. Direct upsert with
+    ``rest.PointStruct`` mirrors what the migration script does.
+    """
+    ids = [str(uuid.uuid4()) for _ in vectors]
+    points = [
+        rest.PointStruct(id=pid, vector=vec, payload={TENANT_PAYLOAD_KEY: tenant_payload})
+        for pid, vec in zip(ids, vectors)
+    ]
+    conn.client.upsert(collection_name=conn.collection_name, points=points, wait=True)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# tenant isolation on search
+# ---------------------------------------------------------------------------
+
+
+def test_multitenant_search_is_isolated_between_tenants(shared_client):
+    """Two tenants writing to the same physical collection must not see each
+    other's points through the connector's search path, because the connector
+    silently adds a ``collection_id`` ``must`` clause."""
+    a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
+
+    assert a.collection_name == b.collection_name == global_collection_name(VECTOR_SIZE, "Cosine"), (
+        "Both tenants must be routed to the same physical global collection"
+    )
+
+    _seed_points(a, [VEC_A, VEC_A], tenant_payload=a.tenant_id)
+    _seed_points(b, [VEC_A, VEC_B], tenant_payload=b.tenant_id)
+
+    # Tenant A queries with VEC_A: should hit only its own 2 points.
+    q = QueryWithEmbedding(query="", top_k=10, embedding=VEC_A)
+    res_a = a.search(q, score_threshold=0.0)
+    res_b = b.search(q, score_threshold=0.0)
+
+    tenants_seen_by_a = {r.metadata.get(TENANT_PAYLOAD_KEY) for r in res_a.results if r.metadata}
+    tenants_seen_by_b = {r.metadata.get(TENANT_PAYLOAD_KEY) for r in res_b.results if r.metadata}
+
+    assert tenants_seen_by_a == {a.tenant_id}, f"tenant A saw foreign points: {tenants_seen_by_a}"
+    assert tenants_seen_by_b == {b.tenant_id}, f"tenant B saw foreign points: {tenants_seen_by_b}"
+    assert len(res_a.results) == 2
+    # B has one VEC_A and one VEC_B; VEC_B's cosine similarity to the query VEC_A is 0 so
+    # it may be filtered out by score_threshold=0 depending on implementation, but both
+    # points belong to B regardless.
+    assert len(res_b.results) >= 1
+
+
+# ---------------------------------------------------------------------------
+# delete(ids=...) must not cross tenants
+# ---------------------------------------------------------------------------
+
+
+def test_delete_by_ids_does_not_cross_tenants_even_if_ids_leak(shared_client):
+    """If A somehow passes B's point ids into ``delete(ids=...)``, the
+    connector's defense-in-depth filter (``HasIdCondition`` +
+    ``FieldCondition(tenant)``) must refuse to delete them."""
+    a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
+
+    ids_a = _seed_points(a, [VEC_A], tenant_payload=a.tenant_id)
+    ids_b = _seed_points(b, [VEC_B], tenant_payload=b.tenant_id)
+
+    # A tries to delete B's id (simulating a confused caller).
+    a.delete(ids=ids_b)
+
+    # B's point must still exist; A's own point is untouched.
+    remaining_b = a.client.retrieve(collection_name=b.collection_name, ids=ids_b)
+    remaining_a = a.client.retrieve(collection_name=a.collection_name, ids=ids_a)
+    assert len(remaining_b) == 1, "Cross-tenant delete must be a no-op, B's point should survive"
+    assert len(remaining_a) == 1, "A's own data should be unaffected when misusing delete"
+
+    # Sanity: A's own ids still delete correctly.
+    a.delete(ids=ids_a)
+    remaining_a2 = a.client.retrieve(collection_name=a.collection_name, ids=ids_a)
+    assert len(remaining_a2) == 0
+
+
+# ---------------------------------------------------------------------------
+# delete_collection() = per-tenant purge, not physical drop
+# ---------------------------------------------------------------------------
+
+
+def test_delete_collection_multitenant_purges_only_own_tenant(shared_client):
+    """``delete_collection`` on tenant A must wipe A's points but keep the
+    global collection alive and B's points intact."""
+    a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
+
+    _seed_points(a, [VEC_A, VEC_A, VEC_A], tenant_payload=a.tenant_id)
+    ids_b = _seed_points(b, [VEC_B, VEC_B], tenant_payload=b.tenant_id)
+
+    a.delete_collection()
+
+    # Global collection must still exist (other tenants depend on it).
+    assert a.client.collection_exists(a.collection_name)
+
+    # Every A point gone; every B point still present.
+    a_points, _ = a.client.scroll(
+        collection_name=a.collection_name,
+        scroll_filter=rest.Filter(
+            must=[rest.FieldCondition(key=TENANT_PAYLOAD_KEY, match=rest.MatchValue(value=a.tenant_id))]
+        ),
+        limit=100,
+    )
+    assert a_points == [], "delete_collection must remove ALL of tenant A's points"
+
+    remaining_b = b.client.retrieve(collection_name=b.collection_name, ids=ids_b)
+    assert len(remaining_b) == 2, "delete_collection(A) must not touch tenant B's points"
+
+
+# ---------------------------------------------------------------------------
+# retrieve() defense-in-depth
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_drops_foreign_tenant_points(shared_client):
+    """``retrieve(ids=...)`` in multitenant mode must post-filter out points
+    whose ``collection_id`` payload doesn't match the connector's tenant_id,
+    even if the caller passes in an id that happens to exist under another
+    tenant."""
+    a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
+
+    ids_a = _seed_points(a, [VEC_A], tenant_payload=a.tenant_id)
+    ids_b = _seed_points(b, [VEC_B], tenant_payload=b.tenant_id)
+
+    # A calls retrieve with a mixture of its own and B's ids.
+    mixed = ids_a + ids_b
+    points = a.retrieve(ids=mixed, with_payload=True)
+
+    # Only A's ids survive the post-filter.
+    retrieved_ids = {str(p.id) for p in points}
+    assert retrieved_ids == set(ids_a), f"leaked foreign points: {retrieved_ids - set(ids_a)}"
+
+
+# ---------------------------------------------------------------------------
+# legacy mode still works
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_mode_uses_tenant_name_as_physical_collection(shared_client):
+    """``multitenant=False`` must preserve the historical layout: the physical
+    Qdrant collection is named after the tenant id, and no tenant filter is
+    applied."""
+    legacy = _make_connector("col_legacy_legacyxxxx", client=shared_client, multitenant=False)
+    assert legacy.collection_name == "col_legacy_legacyxxxx"
+    assert legacy.multitenant is False
+
+    _seed_points(legacy, [VEC_A], tenant_payload="irrelevant_in_legacy")
+
+    # Legacy search does NOT add any tenant filter, so the point comes back
+    # even though its payload.collection_id is unrelated to the tenant.
+    q = QueryWithEmbedding(query="", top_k=5, embedding=VEC_A)
+    res = legacy.search(q, score_threshold=0.0)
+    assert len(res.results) == 1
+    # DocumentWithScore doesn't expose id/embedding directly; the metadata
+    # fallback path (for non-llama_index-shaped payloads) preserves the
+    # tenant-payload key so we can check it made it through the connector.
+    assert res.results[0].metadata.get(TENANT_PAYLOAD_KEY) == "irrelevant_in_legacy"
+
+
+# ---------------------------------------------------------------------------
+# ctor sanity: multitenant without tenant id is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_multitenant_without_tenant_id_raises():
+    with pytest.raises(ValueError, match="requires ctx\\['collection'\\]"):
+        QdrantVectorStoreConnector(
+            {
+                "url": ":memory:",
+                "collection": "",  # empty -> rejected
+                "vector_size": 4,
+                "multitenant": True,
+            }
+        )


### PR DESCRIPTION
## 背景

生产香港 K8s 的 Qdrant RSS 涨到 **12.5 GiB / 16 GiB limit**，但线上只有 ~1600 用户、~13k 文档、~600k 向量 chunk。排查见
[docs/zh-CN/design/qdrant_memory_optimization.md](docs/zh-CN/design/qdrant_memory_optimization.md)：

- **1847 个 Qdrant collection × 4 个 segment / collection = 7387 个 RocksDB 实例**，这块本身就吃 3–5 GiB。
- 向量按 \`storage_type: Memory\` 常驻 RAM（~2.4 GiB），HNSW 也在 RAM。
- **真正业务数据只有 ~2.4 GiB，剩下 ~10 GiB 全是 collection 元数据 + RocksDB 开销 + 线程栈**，随用户线性增长 → 10× 用户 ≈ 120 GiB，单机不可行。

明天会停服做数据迁移 + 发新版。

## 本 PR 范围（A/B/C 三档合并）

### A 档：服务端配置兜底（`deploy/*/values.yaml`）
- `deploy/aperag/values.yaml` 新增 `QDRANT_MULTITENANT` / `QDRANT_QUANTIZATION_*` / `QDRANT_HNSW_ON_DISK` / `QDRANT_DEFAULT_SEGMENT_NUMBER` / `QDRANT_MMAP_THRESHOLD_KB` 等环境变量，默认开启多租户 + INT8 + on_disk HNSW。
- `deploy/databases/qdrant/values.yaml` 注释里补充了手动 \`kubectl set env\` 给 SRE（KubeBlocks qdrant-cluster chart 没有 env 透传字段）。

### B 档：多租户化
- 单一全局 Qdrant collection 按 \`(vector_size, distance)\` 分区（\`aperag_vectors_1024_cosine\` 等）。
- 每个 point payload 带 \`collection_id\`；注册 keyword 索引时**优先 \`is_tenant=True\`（Qdrant 1.11+），兜底降级为普通 keyword 索引（Qdrant 1.10 可用）**。
- 所有 search / delete / retrieve / scroll 在多租户模式下自动带上 \`collection_id\` 过滤；\`delete(ids=...)\` 额外加 \`HasIdCondition\` + tenant \`FieldCondition\` 做 defense-in-depth，防止跨租户误删。
- \`delete_collection()\` 在多租户模式变成"只删本 tenant 的点"，不动全局 collection；legacy 模式仍走物理 drop。
- 保留 legacy 模式（\`QDRANT_MULTITENANT=False\`）作紧急回滚开关。

### C 档：内存默认值（都走连接器的 create_collection）
- INT8 scalar quantization（\`quantile=0.99\`，\`always_ram=True\`）— 向量主体 4× 压缩、量化向量留 RAM 查询。
- HNSW on_disk = True — 图走 mmap，kernel 管热数据。
- \`default_segment_number=2\`（原 auto = CPU 数 = 4） — RocksDB 实例直接 ×½。
- \`memmap_threshold_kb=20480\` — 超过 20 MiB 的 segment 用 mmap。

### 配套
- **迁移脚本** \`scripts/migrate_qdrant_multitenancy.py\`：枚举 \`col<hex>\` 源 collection（只挑 pg 里存在的）→ 确保全局 collection + tenant 索引 → scroll 点补 \`collection_id\` payload → upsert 到全局。支持 \`--dry-run\` / \`--only-name\` / \`--limit\` / \`--delete-old\` / \`--only-delete\` 两阶段安全发布。幂等可重跑。脚本启动时有断言防止 \`generate_vector_db_collection_name\` 未来变了挡不住。
- **设计文档** \`docs/zh-CN/design/qdrant_memory_optimization.md\`：包含版本兼容、回滚 one-way door 警告、停服迁移步骤。

### 测试
新增 \`tests/unit_test/vectorstore/\` 共 23 个测试（+6 集成）：

- 纯逻辑：\`global_collection_name\` / \`_coerce_distance\` / \`_quantization_config\` / \`_hnsw_config\` / \`_optimizers_config\` / \`_merge_tenant_filter\`。
- 配置：\`build_vector_db_context\` 的 settings 注入 + ctx override 优先级。
- **集成（in-memory QdrantClient，1s）**：
  - 两个 tenant 写同一全局 collection，search 互不可见。
  - \`delete(ids=...)\` 误传对方 id 不会跨租户删。
  - \`delete_collection()\` 只清本租户，全局 collection + 其他租户保留。
  - \`retrieve(ids=...)\` 自动过滤非本租户点。
  - legacy 模式物理 collection 命名 + 无 tenant filter。
  - 多租户模式空 tenant_id 构造直接 raise。

**全仓 430 passed / 5 skipped。** ruff lint + format 绿。

## 已处理的 CR blocker（自 CR 一轮已修）

1. 迁移脚本 distance 枚举 KeyError（改用连接器的 \`_coerce_distance\`）。
2. 生产 Qdrant 1.10.0 不支持 \`is_tenant\`（加三层 fallback + 清晰日志 + 文档勘误）。
3. \`tenant_id\` 默认值 \`"collection"\` 陷阱（多租户模式改为 raise）。
4. \`create_collection\` 里 \`self.store\` 重建顺序反了（与 \`__init__\` 对齐）。
5. \`qdrant_server_env:\` 死配置（删除 yaml key，替换为 \`kubectl set env\` 运维手册注释）。
6. \`_convert_scored_point_to_document_with_score\` KeyError 风险（兜底兼容非 llama_index 风格 payload）。
7. 迁移单向门警告 / 回滚窗口说明写进设计文档。

## 留给后续 PR（设计文档也写了 TODO）

- \`vector_size=None\` fallback 导致删点可能打到错误全局 collection（建议把 \`vector_size\` 存进 \`DocumentIndex.index_data\`）。
- \`get_collection_embedding_service_sync\` 在 event loop 里跑同步 DB 查询（全仓历史问题，不本次动）。
- 连接器自动往 nodes 写 \`collection_id\` 的强护栏（目前依赖 indexer 自觉，测试已覆盖"目前一致"）。

## 发布顺序（供明天停服窗口参考）

1. **\[可选但强推]** 把 Qdrant server 从 1.10.0 升到 1.11.x（只改镜像 tag，无数据迁移），\`is_tenant\` 才能真正生效带来 defragmentation 收益；不升级也能跑但查询 p95 会因 tenant 数据混存退化。
2. 停服（apiserver / celery worker / beat）。
3. 跑 \`python scripts/migrate_qdrant_multitenancy.py --dry-run\` 核对待迁移数量，再不带 \`--dry-run\` 正式跑一次。
4. 发布本 PR 代码（\`QDRANT_MULTITENANT=True\` 默认）。
5. 观察 24 h 读写正常。
6. 跑 \`python scripts/migrate_qdrant_multitenancy.py --only-delete\` 清老 collection；此时 Qdrant RSS 预期回落到 **~2–3 GiB**。

## 预期收益

| 项 | 现状 | 本 PR 后 |
|---|---|---|
| Qdrant collection 数 | 1847 | ~1–3（按维度分） |
| Segment 数 | 7387 | ~数十 |
| RocksDB 实例数 | 7387 | ~数十 |
| RSS（同等数据量） | 12 GiB | ~2–3 GiB |
| 10× 用户增长后的 RSS | 120+ GiB（不可行） | ~10–15 GiB（线性随数据量） |

## Test plan

- [x] 单元测试（17 个）：纯逻辑 + 配置构建
- [x] 集成测试（6 个）：in-memory QdrantClient 验证租户隔离
- [x] 全仓回归：\`make test\` / \`pytest tests/unit_test/\` = 430 passed, 5 skipped
- [x] Lint/format：\`make lint\` 绿
- [ ] staging 上用和生产**完全相同**的 Qdrant 1.10.0 试跑迁移脚本 + 发布 + 查询回归
- [ ] 明天停服窗口内：dry-run → 正式迁移 → 发布 → 24h 观察 → --only-delete 清理老 collection

Made with [Cursor](https://cursor.com)