### PR TITLE
fix: merge alembic heads after agent runtime v3

### DIFF
--- a/aperag/migration/versions/20260420232500-c7d4e2f9b8a1.py
+++ b/aperag/migration/versions/20260420232500-c7d4e2f9b8a1.py
@@ -1,0 +1,22 @@
+"""merge agent runtime and celery lease heads
+
+Revision ID: c7d4e2f9b8a1
+Revises: b9f1c2d3e4a5, 9f3c2d7b1a4e
+Create Date: 2026-04-20 23:25:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+revision: str = "c7d4e2f9b8a1"
+down_revision: Union[str, Sequence[str], None] = ("b9f1c2d3e4a5", "9f3c2d7b1a4e")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Merge alembic heads for a single startup path."""
+
+
+def downgrade() -> None:
+    """Downgrade merge revision."""


### PR DESCRIPTION
## Summary
- add a no-op alembic merge revision to collapse the post-#1492 multiple-head state
- restore a single valid target for `alembic -c aperag/alembic.ini upgrade head` during api startup

## Root cause
After `#1492`, the migration graph had two heads:
- `b9f1c2d3e4a5`
- `9f3c2d7b1a4e`

`start-api.sh` runs `alembic -c aperag/alembic.ini upgrade head` before uvicorn starts. Under multiple heads, that command fails and the api container exits before the healthcheck can stabilize.

## Validation
- `uv run alembic -c aperag/alembic.ini heads` -> single head `c7d4e2f9b8a1`
- `uv run alembic -c aperag/alembic.ini upgrade head --sql` -> succeeds locally
