### PR TITLE
test: harden parser diagnostics and fetch-url coverage

### DIFF
--- a/aperag/docparser/markitdown_parser.py
+++ b/aperag/docparser/markitdown_parser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import tempfile
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -74,6 +75,7 @@ class MarkItDownParser(BaseParser):
 
     def _parse_file(self, path: Path, metadata: dict[str, Any] = {}, **kwargs) -> list[Part]:
         try:
+            self._validate_binary_container(path)
             mid = MarkItDown()
             result = mid.convert_local(path, keep_data_uris=True)
             return parse_md(result.markdown, metadata)
@@ -86,3 +88,47 @@ class MarkItDownParser(BaseParser):
                 code="parse_failed",
                 detail=str(e),
             ) from e
+
+    def _validate_binary_container(self, path: Path) -> None:
+        extension = path.suffix.lower()
+        if extension == ".pdf":
+            self._validate_pdf_header(path)
+            return
+
+        required_members = {
+            ".docx": ("[Content_Types].xml", "word/document.xml"),
+            ".xlsx": ("[Content_Types].xml", "xl/workbook.xml"),
+            ".pptx": ("[Content_Types].xml", "ppt/presentation.xml"),
+        }.get(extension)
+        if required_members is None:
+            return
+
+        try:
+            with zipfile.ZipFile(path) as archive:
+                members = set(archive.namelist())
+        except zipfile.BadZipFile as exc:
+            raise ParserError(
+                f"Corrupted {extension} document",
+                parser_name=self.name,
+                code="corrupted_document",
+                detail=f"{extension} is not a valid OOXML package: {exc}",
+            ) from exc
+
+        missing_members = [member for member in required_members if member not in members]
+        if missing_members:
+            raise ParserError(
+                f"Corrupted {extension} document",
+                parser_name=self.name,
+                code="corrupted_document",
+                detail=f"{extension} is missing required OOXML entries: {', '.join(missing_members)}",
+            )
+
+    def _validate_pdf_header(self, path: Path) -> None:
+        header = path.read_bytes()[:5]
+        if header != b"%PDF-":
+            raise ParserError(
+                "Corrupted .pdf document",
+                parser_name=self.name,
+                code="corrupted_document",
+                detail="Missing %PDF file header.",
+            )

--- a/tests/COVERAGE_MATRIX.md
+++ b/tests/COVERAGE_MATRIX.md
@@ -12,7 +12,9 @@ This matrix is the working contract for converging the test tree toward:
 | Capability | Unit | HTTP E2E Smoke | HTTP E2E Full | Remaining Pytest E2E | Integration / Contract | Current Decision |
 | --- | --- | --- | --- | --- | --- | --- |
 | docparser file-format smoke (`txt/md/html/ipynb/docx/xlsx/pptx/pdf/csv/tsv/xml/rst/eml` plus longer markdown/html and richer office fixtures) | yes | no | no | no | no | keep as unit smoke/regression coverage for the default local parser path |
+| docparser bad-document diagnostics (`corrupted docx/xlsx/pptx/pdf`, encrypted pdf, empty text) | yes | no | no | no | no | keep as unit coverage for stable parser diagnostics and non-crashing empty-file behavior |
 | docparser preflight / fail-fast contract | yes | no | no | no | no | keep as unit coverage for entry-time parser diagnostics |
+| fetch-url import staging / fallback contract | yes | no | no | no | no | keep as unit coverage for reader fallback, staging upload contract, and per-url failure reporting |
 | parser health / support matrix | yes | yes | no | no | no | unit tests guard support classification; HTTP smoke keeps the endpoint visible |
 | auth | no | yes | no | no | no | fully owned by Hurl |
 | collection CRUD | partial | yes | no | no | no | fully owned by Hurl |

--- a/tests/unit_test/docparser/test_markitdown_parser_diagnostics.py
+++ b/tests/unit_test/docparser/test_markitdown_parser_diagnostics.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+import pikepdf
+import pytest
+
+from aperag.docparser.base import ParserChainError
+from aperag.docparser.doc_parser import DocParser
+from aperag.index.document_parser import document_parser
+
+
+def _write_minimal_pdf(path: Path, text: str = "PDF Diagnostic Smoke") -> None:
+    stream = f"BT /F1 18 Tf 72 720 Td ({text}) Tj ET".encode("latin-1")
+    objects = [
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n",
+        b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+        f"5 0 obj\n<< /Length {len(stream)} >>\nstream\n".encode("latin-1") + stream + b"\nendstream\nendobj\n",
+    ]
+
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for obj in objects:
+        offsets.append(len(pdf))
+        pdf.extend(obj)
+
+    startxref = len(pdf)
+    pdf.extend(f"xref\n0 {len(offsets)}\n".encode("latin-1"))
+    pdf.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        pdf.extend(f"{offset:010d} 00000 n \n".encode("latin-1"))
+    pdf.extend(f"trailer\n<< /Size {len(offsets)} /Root 1 0 R >>\nstartxref\n{startxref}\n%%EOF\n".encode("latin-1"))
+    path.write_bytes(pdf)
+
+
+@pytest.mark.parametrize(
+    ("filename", "payload", "detail_snippet"),
+    [
+        ("broken.docx", b"not a zip container", "valid OOXML package"),
+        ("broken.xlsx", b"not a zip container", "valid OOXML package"),
+        ("broken.pptx", b"not a zip container", "valid OOXML package"),
+        ("broken.pdf", b"not a real pdf", "%PDF file header"),
+    ],
+)
+def test_doc_parser_reports_corrupted_binary_documents_with_fixed_diagnostics(
+    tmp_path: Path,
+    filename: str,
+    payload: bytes,
+    detail_snippet: str,
+) -> None:
+    sample = tmp_path / filename
+    sample.write_bytes(payload)
+
+    parser = DocParser(parser_config={"use_markitdown": True, "use_mineru": False})
+
+    with pytest.raises(ParserChainError) as exc_info:
+        parser.parse_file(sample, metadata={"source": filename})
+
+    assert exc_info.value.source == "runtime"
+    assert exc_info.value.code == "parser_chain_failed"
+    assert exc_info.value.attempts[0].parser_name == "markitdown"
+    assert exc_info.value.attempts[0].code == "corrupted_document"
+    assert detail_snippet in (exc_info.value.attempts[0].detail or "")
+
+
+def test_doc_parser_reports_encrypted_pdf_as_diagnostic_failure(tmp_path: Path) -> None:
+    plain_pdf = tmp_path / "plain.pdf"
+    encrypted_pdf = tmp_path / "encrypted.pdf"
+    _write_minimal_pdf(plain_pdf, text="Secret PDF")
+
+    with pikepdf.open(plain_pdf) as pdf:
+        pdf.save(encrypted_pdf, encryption=pikepdf.Encryption(owner="owner-secret", user="user-secret", R=4))
+
+    parser = DocParser(parser_config={"use_markitdown": True, "use_mineru": False})
+
+    with pytest.raises(ParserChainError) as exc_info:
+        parser.parse_file(encrypted_pdf, metadata={"source": "encrypted.pdf"})
+
+    assert exc_info.value.code == "parser_chain_failed"
+    assert exc_info.value.attempts[0].parser_name == "markitdown"
+    assert "password" in (exc_info.value.detail or "").lower() or "pdfpasswordincorrect" in (
+        exc_info.value.detail or ""
+    ).lower()
+
+
+def test_document_parser_keeps_empty_text_documents_as_empty_content(tmp_path: Path) -> None:
+    sample = tmp_path / "empty.txt"
+    sample.write_text("", encoding="utf-8")
+
+    result = document_parser.process_document_parsing(str(sample), {"source": "empty.txt"})
+
+    assert result.content == ""
+    assert result.doc_parts == []

--- a/tests/unit_test/test_document_service_fetch_url.py
+++ b/tests/unit_test/test_document_service_fetch_url.py
@@ -1,0 +1,159 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from aperag.schema import view_models
+from aperag.service.document_service import DocumentService
+
+
+class _FakeReaderService:
+    plans = []
+    calls = []
+
+    def __init__(self, provider_name=None, provider_config=None):
+        self.provider_name = provider_name
+        self.provider_config = provider_config or {}
+
+    async def __aenter__(self):
+        type(self).calls.append((self.provider_name, self.provider_config))
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def read(self, request):
+        assert request.url_list
+        return type(self).plans.pop(0)
+
+
+def _web_read_response(*results: view_models.WebReadResultItem) -> view_models.WebReadResponse:
+    succeeded = sum(1 for result in results if result.status == "success")
+    return view_models.WebReadResponse(
+        results=list(results),
+        total_urls=len(results),
+        successful=succeeded,
+        failed=len(results) - succeeded,
+        processing_time=0.1,
+    )
+
+
+def test_fetch_url_documents_imports_markdown_via_trafilatura_when_no_jina_key(monkeypatch):
+    service = DocumentService()
+    service.upload_document = AsyncMock(
+        return_value=view_models.UploadDocumentResponse(
+            document_id="doc-fetch-1",
+            filename="ACME Report.md",
+            size=18,
+            status="UPLOADED",
+        )
+    )
+
+    _FakeReaderService.calls = []
+    _FakeReaderService.plans = [
+        _web_read_response(
+            view_models.WebReadResultItem(
+                url="https://example.com/report",
+                status="success",
+                title="ACME Report",
+                content="# ACME Report\n\nquarterly parser import",
+            )
+        )
+    ]
+
+    monkeypatch.setattr("aperag.db.ops.async_db_ops.query_provider_api_key", AsyncMock(return_value=None))
+    monkeypatch.setattr("aperag.websearch.reader.reader_service.ReaderService", _FakeReaderService)
+
+    response = asyncio.run(service.fetch_url_documents("user-1", "col-1", ["https://example.com/report"]))
+
+    assert response.succeeded == 1
+    assert response.failed == 0
+    assert response.results[0].fetch_status == "success"
+    assert response.results[0].document_id == "doc-fetch-1"
+    assert _FakeReaderService.calls == [("trafilatura", {})]
+
+    upload_args = service.upload_document.await_args.args
+    assert upload_args[:2] == ("user-1", "col-1")
+    upload_file = upload_args[2]
+    assert upload_file.filename == "ACME Report.md"
+    assert upload_file.content_type == "text/markdown"
+    assert asyncio.run(upload_file.read()).decode("utf-8") == "# ACME Report\n\nquarterly parser import"
+
+
+def test_fetch_url_documents_falls_back_when_jina_returns_no_successes(monkeypatch):
+    service = DocumentService()
+    service.upload_document = AsyncMock(
+        return_value=view_models.UploadDocumentResponse(
+            document_id="doc-fetch-2",
+            filename="Fallback Title.md",
+            size=12,
+            status="UPLOADED",
+        )
+    )
+
+    _FakeReaderService.calls = []
+    _FakeReaderService.plans = [
+        _web_read_response(
+            view_models.WebReadResultItem(
+                url="https://example.com/fallback",
+                status="error",
+                error="provider timeout",
+                error_code="timeout",
+            )
+        ),
+        _web_read_response(
+            view_models.WebReadResultItem(
+                url="https://example.com/fallback",
+                status="success",
+                title="Fallback Title",
+                content="fallback markdown body",
+            )
+        ),
+    ]
+
+    monkeypatch.setattr("aperag.db.ops.async_db_ops.query_provider_api_key", AsyncMock(return_value="jina-key"))
+    monkeypatch.setattr("aperag.websearch.reader.reader_service.ReaderService", _FakeReaderService)
+
+    response = asyncio.run(service.fetch_url_documents("user-1", "col-1", ["https://example.com/fallback"]))
+
+    assert response.succeeded == 1
+    assert response.failed == 0
+    assert [call[0] for call in _FakeReaderService.calls] == ["jina", "trafilatura"]
+
+
+def test_fetch_url_documents_reports_upload_failures_per_url(monkeypatch):
+    service = DocumentService()
+    service.upload_document = AsyncMock(side_effect=RuntimeError("quota exceeded"))
+
+    _FakeReaderService.calls = []
+    _FakeReaderService.plans = [
+        _web_read_response(
+            view_models.WebReadResultItem(
+                url="https://example.com/quota",
+                status="success",
+                title="Quota Title",
+                content="quota body",
+            )
+        )
+    ]
+
+    monkeypatch.setattr("aperag.db.ops.async_db_ops.query_provider_api_key", AsyncMock(return_value=None))
+    monkeypatch.setattr("aperag.websearch.reader.reader_service.ReaderService", _FakeReaderService)
+
+    response = asyncio.run(service.fetch_url_documents("user-1", "col-1", ["https://example.com/quota"]))
+
+    assert response.succeeded == 0
+    assert response.failed == 1
+    assert response.results[0].fetch_status == "error"
+    assert "quota exceeded" in (response.results[0].error or "")
+
+
+def test_fetch_url_documents_rejects_more_than_ten_urls():
+    service = DocumentService()
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(service.fetch_url_documents("user-1", "col-1", [f"https://example.com/{idx}" for idx in range(11)]))
+
+    assert exc_info.value.status_code == 400
+    assert "maximum 10 URLs" in exc_info.value.detail


### PR DESCRIPTION
## Summary
- harden MarkItDown binary-container diagnostics for corrupted docx/xlsx/pptx/pdf inputs
- add regression tests for corrupted/encrypted/empty parser edge cases
- add fetch-url unit coverage for reader fallback, per-url upload errors, and max-url validation

## Validation
- `uvx ruff check aperag/docparser/markitdown_parser.py tests/unit_test/docparser/test_markitdown_parser_diagnostics.py tests/unit_test/test_document_service_fetch_url.py`
- `python3 -m py_compile aperag/docparser/markitdown_parser.py tests/unit_test/docparser/test_markitdown_parser_diagnostics.py tests/unit_test/test_document_service_fetch_url.py`
- ad-hoc `uv run python` checks for corrupted/encrypted parser diagnostics and fetch-url fallback behavior
- local `pytest` entrypoint still blocked by missing `pytest_asyncio` in the workspace venv; final gate should rely on GitHub checks
