### PR TITLE
perf: bound graph hot paths by storage primitives

### DIFF
--- a/aperag/db/repositories/graph.py
+++ b/aperag/db/repositories/graph.py
@@ -593,6 +593,29 @@ class GraphRepositoryMixin:
 
         return self._execute_query(_get_graph_node_ids)
 
+    def search_graph_node_ids_by_label(self, workspace: str, node_label: str, limit: int) -> List[str]:
+        """Search graph node IDs by label pattern in stable ascending order."""
+        if limit <= 0:
+            return []
+
+        def _search_graph_node_ids_by_label(session):
+            stmt = (
+                select(LightRAGGraphNode.entity_id)
+                .where(
+                    and_(
+                        LightRAGGraphNode.workspace == workspace,
+                        LightRAGGraphNode.entity_id.ilike(f"%{node_label}%"),
+                    )
+                )
+                .order_by(LightRAGGraphNode.entity_id)
+                .limit(limit)
+            )
+
+            result = session.execute(stmt)
+            return [row[0] for row in result]
+
+        return self._execute_query(_search_graph_node_ids_by_label)
+
     def get_graph_edges_batch(
         self, workspace: str, edge_pairs: List[Tuple[str, str]]
     ) -> Dict[Tuple[str, str], Dict[str, Any]]:

--- a/aperag/graph/lightrag/base.py
+++ b/aperag/graph/lightrag/base.py
@@ -502,6 +502,18 @@ class BaseGraphStorage(StorageNameSpace, ABC):
         """
         return None
 
+    async def search_node_ids_by_label(self, node_label: str, limit: int) -> list[str] | None:
+        """Return node IDs matching a label pattern in stable ascending ID order."""
+        return None
+
+    async def get_nodes_by_source_ids(self, chunk_ids: list[str]) -> dict[str, dict] | None:
+        """Return graph nodes whose source_id overlaps the provided chunk IDs."""
+        return None
+
+    async def get_edges_by_source_ids(self, chunk_ids: list[str]) -> dict[tuple[str, str], dict] | None:
+        """Return graph edges whose source_id overlaps the provided chunk IDs."""
+        return None
+
     @abstractmethod
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
         """Insert a new node or update an existing node in the graph.

--- a/aperag/graph/lightrag/kg/nebula_sync_impl.py
+++ b/aperag/graph/lightrag/kg/nebula_sync_impl.py
@@ -22,6 +22,7 @@ from nebula3.common import ttypes
 from aperag.db.nebula_sync_manager import NebulaSyncConnectionManager
 
 from ..base import BaseGraphStorage
+from ..prompt import GRAPH_FIELD_SEP
 from ..types import KnowledgeGraph
 from ..utils import logger
 
@@ -121,6 +122,13 @@ def _safe_error_msg(result) -> str:
             return f"Nebula operation failed (error code: {result.error_code()})"
         except Exception:
             return "Nebula operation failed (unknown error)"
+
+
+def _source_ids_overlap(source_id: Any, chunk_ids: set[str]) -> bool:
+    """Apply exact GRAPH_FIELD_SEP token matching after candidate narrowing in Nebula."""
+    if not isinstance(source_id, str) or not source_id or not chunk_ids:
+        return False
+    return bool(set(source_id.split(GRAPH_FIELD_SEP)).intersection(chunk_ids))
 
 
 @final
@@ -514,6 +522,92 @@ class NebulaSyncStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_incident_edges_with_data_batch)
 
+    async def get_nodes_by_source_ids(self, chunk_ids: list[str]) -> dict[str, dict] | None:
+        """Retrieve nodes whose source_id references any of the provided chunk IDs."""
+
+        def _sync_get_nodes_by_source_ids():
+            with NebulaSyncConnectionManager.get_session(space=self._space_name) as session:
+                if not chunk_ids:
+                    return {}
+
+                query_conditions = []
+                params = {}
+                unique_chunk_ids = sorted(set(chunk_ids))
+                for index, chunk_id in enumerate(unique_chunk_ids):
+                    param_name = f"chunk_{index}"
+                    query_conditions.append(f"properties(vertex).source_id CONTAINS ${param_name}")
+                    params[param_name] = chunk_id
+
+                query = f"""
+                LOOKUP ON base
+                WHERE properties(vertex).source_id IS NOT NULL
+                  AND ({" OR ".join(query_conditions)})
+                YIELD id(vertex) AS vid, properties(vertex) AS props
+                """
+                result = session.execute_parameter(query, _prepare_nebula_params(params))
+
+                chunk_id_set = set(unique_chunk_ids)
+                nodes = {}
+                if result.is_succeeded():
+                    for row in result:
+                        entity_id = row.values()[0].as_string()
+                        props = row.values()[1].as_map()
+                        node_dict = self._convert_nebula_value_map(props)
+                        if not _source_ids_overlap(node_dict.get("source_id"), chunk_id_set):
+                            continue
+                        node_dict["entity_id"] = entity_id
+                        nodes[entity_id] = node_dict
+                return nodes
+
+        return await asyncio.to_thread(_sync_get_nodes_by_source_ids)
+
+    async def get_edges_by_source_ids(self, chunk_ids: list[str]) -> dict[tuple[str, str], dict] | None:
+        """Retrieve edges whose source_id references any of the provided chunk IDs."""
+
+        def _sync_get_edges_by_source_ids():
+            with NebulaSyncConnectionManager.get_session(space=self._space_name) as session:
+                if not chunk_ids:
+                    return {}
+
+                query_conditions = []
+                params = {}
+                unique_chunk_ids = sorted(set(chunk_ids))
+                for index, chunk_id in enumerate(unique_chunk_ids):
+                    param_name = f"chunk_{index}"
+                    query_conditions.append(f"properties(edge).source_id CONTAINS ${param_name}")
+                    params[param_name] = chunk_id
+
+                query = f"""
+                MATCH (src:base)-[e:DIRECTED]-(dst:base)
+                WHERE e.source_id IS NOT NULL
+                  AND ({" OR ".join(query_conditions)})
+                RETURN id(src) AS src_id, id(dst) AS dst_id, properties(e) AS props
+                """
+                result = session.execute_parameter(query, _prepare_nebula_params(params))
+
+                chunk_id_set = set(unique_chunk_ids)
+                edges = {}
+                if result.is_succeeded():
+                    for row in result:
+                        src = row.values()[0].as_string()
+                        dst = row.values()[1].as_string()
+                        props = row.values()[2].as_map()
+                        edge_dict = self._convert_nebula_value_map(props)
+                        if not _source_ids_overlap(edge_dict.get("source_id"), chunk_id_set):
+                            continue
+                        for key, default_value in {
+                            "weight": 0.0,
+                            "source_id": None,
+                            "description": None,
+                            "keywords": None,
+                        }.items():
+                            if key not in edge_dict:
+                                edge_dict[key] = default_value
+                        edges[(src, dst)] = edge_dict
+                return edges
+
+        return await asyncio.to_thread(_sync_get_edges_by_source_ids)
+
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
         """Upsert a node in the database."""
 
@@ -620,6 +714,33 @@ class NebulaSyncStorage(BaseGraphStorage):
                 return node_ids
 
         return await asyncio.to_thread(_sync_get_node_ids)
+
+    async def search_node_ids_by_label(self, node_label: str, limit: int) -> list[str] | None:
+        """Search node IDs directly in Nebula without materializing all labels."""
+
+        def _sync_search_node_ids_by_label():
+            with NebulaSyncConnectionManager.get_session(space=self._space_name) as session:
+                query = """
+                LOOKUP ON base
+                WHERE properties(vertex).entity_id CONTAINS $node_label
+                YIELD properties(vertex).entity_id AS label
+                | ORDER BY $-.label
+                | LIMIT $limit
+                """
+                result = session.execute_parameter(
+                    query,
+                    _prepare_nebula_params({"node_label": node_label, "limit": limit}),
+                )
+
+                labels = []
+                if result.is_succeeded():
+                    for row in result:
+                        label = row.values()[0].as_string()
+                        if label:
+                            labels.append(label)
+                return labels
+
+        return await asyncio.to_thread(_sync_search_node_ids_by_label)
 
     async def delete_node(self, node_id: str) -> None:
         """Delete a node and its incident edges."""

--- a/aperag/graph/lightrag/kg/neo4j_sync_impl.py
+++ b/aperag/graph/lightrag/kg/neo4j_sync_impl.py
@@ -755,6 +755,23 @@ class Neo4JSyncStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_node_ids)
 
+    async def search_node_ids_by_label(self, node_label: str, limit: int) -> list[str] | None:
+        """Search node IDs directly from Neo4j without materializing all labels."""
+
+        def _sync_search_node_ids_by_label():
+            with Neo4jSyncConnectionManager.get_session(database=self._DATABASE) as session:
+                query = """
+                MATCH (n:base)
+                WHERE n.entity_id IS NOT NULL AND n.entity_id CONTAINS $node_label
+                RETURN DISTINCT n.entity_id AS entity_id
+                ORDER BY entity_id
+                LIMIT $limit
+                """
+                result = session.run(query, node_label=node_label, limit=limit)
+                return [record["entity_id"] for record in result]
+
+        return await asyncio.to_thread(_sync_search_node_ids_by_label)
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=4, max=10),

--- a/aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py
+++ b/aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py
@@ -332,6 +332,16 @@ class PGOpsSyncGraphStorage(BaseGraphStorage):
 
         return await asyncio.to_thread(_sync_get_node_ids)
 
+    async def search_node_ids_by_label(self, node_label: str, limit: int) -> list[str] | None:
+        """Search node IDs directly from PostgreSQL without materializing all labels."""
+
+        def _sync_search_node_ids_by_label():
+            from aperag.db.ops import db_ops
+
+            return db_ops.search_graph_node_ids_by_label(self.workspace, node_label, limit)
+
+        return await asyncio.to_thread(_sync_search_node_ids_by_label)
+
     async def get_knowledge_graph(self, node_label: str, max_depth: int = 3, max_nodes: int = 1000) -> KnowledgeGraph:
         """
         Get a connected subgraph of nodes matching the specified label.
@@ -346,24 +356,22 @@ class PGOpsSyncGraphStorage(BaseGraphStorage):
             from aperag.db.ops import db_ops
 
             result = KnowledgeGraph()
-            MAX_GRAPH_NODES = max_nodes
-
-            # Get all labels first
-            all_labels = db_ops.get_all_graph_labels(self.workspace)
-
-            # Filter based on node_label pattern
             if node_label == "*":
-                # Get all nodes (limited by max_nodes)
-                matching_labels = all_labels[:MAX_GRAPH_NODES]
+                top_degree_nodes_result = db_ops.get_top_degree_graph_nodes(self.workspace, max_nodes)
+                if top_degree_nodes_result:
+                    nodes_data, _total_nodes = top_degree_nodes_result
+                    matching_labels = list(nodes_data.keys())
+                else:
+                    nodes_data = {}
+                    matching_labels = []
             else:
-                # Filter by pattern (similar to LIKE operation)
-                matching_labels = [label for label in all_labels if node_label in label]
-                if len(matching_labels) > MAX_GRAPH_NODES:
-                    matching_labels = matching_labels[:MAX_GRAPH_NODES]
+                matching_labels = db_ops.search_graph_node_ids_by_label(self.workspace, node_label, max_nodes)
+                nodes_data = {}
 
             # Get node details for each matching label using batch operation
             if matching_labels:
-                nodes_data = db_ops.get_graph_nodes_batch(self.workspace, matching_labels)
+                if not nodes_data:
+                    nodes_data = db_ops.get_graph_nodes_batch(self.workspace, matching_labels)
 
                 for entity_id, node_data in nodes_data.items():
                     # Unified semantics: id=entity_id, labels=[entity_type] or [entity_id], edges by entity_id

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -970,58 +970,14 @@ class LightRAG:
             entities_to_update_in_graph = {}
             relationships_to_delete_from_graph = set()
             relationships_to_update_in_graph = {}
-            graph_fallback_batch_size = 200
+            graph_nodes = await self.chunk_entity_relation_graph.get_nodes_by_source_ids(chunk_id_list)
+            graph_edges = await self.chunk_entity_relation_graph.get_edges_by_source_ids(chunk_id_list)
 
-            graph_nodes = {}
-            graph_edges = {}
-
-            if hasattr(self.chunk_entity_relation_graph, "get_nodes_by_source_ids"):
-                graph_nodes = await self.chunk_entity_relation_graph.get_nodes_by_source_ids(chunk_id_list)
-            if hasattr(self.chunk_entity_relation_graph, "get_edges_by_source_ids"):
-                graph_edges = await self.chunk_entity_relation_graph.get_edges_by_source_ids(chunk_id_list)
-
-            if not graph_nodes:
-                all_labels = await self.chunk_entity_relation_graph.get_all_labels()
-                for start in range(0, len(all_labels), graph_fallback_batch_size):
-                    batch_labels = all_labels[start : start + graph_fallback_batch_size]
-                    batch_nodes = await self.chunk_entity_relation_graph.get_nodes_batch(batch_labels)
-                    for node_label, node_data in batch_nodes.items():
-                        if not node_data or "source_id" not in node_data:
-                            continue
-                        sources = {
-                            source_id
-                            for source_id in split_string_by_multi_markers(node_data["source_id"], [GRAPH_FIELD_SEP])
-                            if source_id
-                        }
-                        if sources.intersection(chunk_ids):
-                            graph_nodes[node_label] = node_data
-
-            if not graph_edges and graph_nodes:
-                seen_edge_pairs = set()
-                graph_node_ids = list(graph_nodes.keys())
-                for start in range(0, len(graph_node_ids), graph_fallback_batch_size):
-                    batch_node_ids = graph_node_ids[start : start + graph_fallback_batch_size]
-                    node_edges_batch = await self.chunk_entity_relation_graph.get_nodes_edges_batch(batch_node_ids)
-                    edge_pairs = []
-                    for edge_list in node_edges_batch.values():
-                        for pair in edge_list:
-                            if pair not in seen_edge_pairs:
-                                edge_pairs.append({"src": pair[0], "tgt": pair[1]})
-                                seen_edge_pairs.add(pair)
-                    if edge_pairs:
-                        batch_edges = await self.chunk_entity_relation_graph.get_edges_batch(edge_pairs)
-                        for edge_pair, edge_data in batch_edges.items():
-                            if not edge_data or "source_id" not in edge_data:
-                                continue
-                            sources = {
-                                source_id
-                                for source_id in split_string_by_multi_markers(
-                                    edge_data["source_id"], [GRAPH_FIELD_SEP]
-                                )
-                                if source_id
-                            }
-                            if sources.intersection(chunk_ids):
-                                graph_edges[edge_pair] = edge_data
+            if graph_nodes is None or graph_edges is None:
+                backend_name = type(self.chunk_entity_relation_graph).__name__
+                raise NotImplementedError(
+                    f"{backend_name} does not support bounded source-id graph lookups required for document delete"
+                )
 
             for node_label, node_data in graph_nodes.items():
                 if not node_data or "source_id" not in node_data:
@@ -1694,14 +1650,14 @@ class LightRAG:
 
             sampled_labels = await self.chunk_entity_relation_graph.get_node_ids(limit=sample_size)
             if sampled_labels is None:
-                # Fallback for backends that have not implemented the lighter-weight primitive yet.
-                all_labels = await self.chunk_entity_relation_graph.get_all_labels()
-                self.lightrag_logger.debug(f"Found {len(all_labels)} entities in workspace {self.workspace}")
-                sampled_labels = all_labels[:sample_size] if len(all_labels) > sample_size else all_labels
-            else:
-                self.lightrag_logger.debug(
-                    f"Fetched {len(sampled_labels)} entity ids directly from storage for workspace {self.workspace}"
+                backend_name = type(self.chunk_entity_relation_graph).__name__
+                raise NotImplementedError(
+                    f"{backend_name} does not support bounded node-id sampling required for KG export"
                 )
+
+            self.lightrag_logger.debug(
+                f"Fetched {len(sampled_labels)} entity ids directly from storage for workspace {self.workspace}"
+            )
 
             self.lightrag_logger.debug(f"Sampling {len(sampled_labels)} entities for export")
 

--- a/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
+++ b/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
@@ -4,10 +4,10 @@ import pytest
 
 from aperag.graph.lightrag import utils_graph
 from aperag.graph.lightrag.base import QueryParam
-from aperag.graph.lightrag.lightrag import LightRAG
-from aperag.graph.lightrag.operate import _find_most_related_edges_from_entities, get_high_degree_nodes
 from aperag.graph.lightrag.kg.pg_ops_sync_vector_storage import PGOpsSyncVectorStorage
+from aperag.graph.lightrag.lightrag import LightRAG
 from aperag.graph.lightrag.namespace import NameSpace
+from aperag.graph.lightrag.operate import _find_most_related_edges_from_entities, get_high_degree_nodes
 from aperag.graph.lightrag_manager import _process_document_async
 
 
@@ -110,8 +110,7 @@ class _FakeGraphStorage:
     def __init__(self, nodes=None, edges_with_data_by_node=None):
         self.nodes = dict(nodes or {})
         self.edges_with_data_by_node = {
-            node_id: list(edges)
-            for node_id, edges in (edges_with_data_by_node or {}).items()
+            node_id: list(edges) for node_id, edges in (edges_with_data_by_node or {}).items()
         }
         self.calls = []
         self.upserted_nodes = []
@@ -373,10 +372,18 @@ class _FakeExportGraphStorage:
         self.calls.append(("get_incident_edges_with_data_batch", tuple(node_ids)))
         return {
             "entity-1": [
-                ("entity-1", "entity-2", {"description": "rel", "keywords": "kw", "weight": 3.0, "source_id": "chunk-1"})
+                (
+                    "entity-1",
+                    "entity-2",
+                    {"description": "rel", "keywords": "kw", "weight": 3.0, "source_id": "chunk-1"},
+                )
             ],
             "entity-2": [
-                ("entity-1", "entity-2", {"description": "rel", "keywords": "kw", "weight": 3.0, "source_id": "chunk-1"})
+                (
+                    "entity-1",
+                    "entity-2",
+                    {"description": "rel", "keywords": "kw", "weight": 3.0, "source_id": "chunk-1"},
+                )
             ],
         }
 
@@ -412,6 +419,25 @@ async def test_export_for_kg_eval_prefers_node_ids_and_incident_edges_primitive(
     assert ("get_incident_edges_with_data_batch", ("entity-1", "entity-2")) in rag.chunk_entity_relation_graph.calls
 
 
+class _FakeExportGraphStorageWithoutNodeIds:
+    async def get_node_ids(self, limit=None):
+        return None
+
+    async def get_all_labels(self):
+        raise AssertionError("get_all_labels() should no longer be used as silent fallback for export")
+
+
+@pytest.mark.asyncio
+async def test_export_for_kg_eval_raises_when_bounded_node_id_sampling_is_missing():
+    rag = LightRAG.__new__(LightRAG)
+    rag.workspace = "workspace-1"
+    rag.lightrag_logger = _FakeLogger()
+    rag.chunk_entity_relation_graph = _FakeExportGraphStorageWithoutNodeIds()
+
+    with pytest.raises(NotImplementedError, match="bounded node-id sampling"):
+        await LightRAG.export_for_kg_eval(rag, sample_size=2, include_source_texts=False)
+
+
 class _FakeOperateGraphStorage:
     def __init__(self):
         self.calls = []
@@ -420,7 +446,11 @@ class _FakeOperateGraphStorage:
         self.calls.append(("get_incident_edges_with_data_batch", tuple(node_ids)))
         return {
             "entity-1": [
-                ("entity-1", "entity-2", {"description": "edge desc", "keywords": "kw", "weight": 2.0, "source_id": "chunk-1"})
+                (
+                    "entity-1",
+                    "entity-2",
+                    {"description": "edge desc", "keywords": "kw", "weight": 2.0, "source_id": "chunk-1"},
+                )
             ]
         }
 
@@ -450,3 +480,52 @@ async def test_find_most_related_edges_from_entities_prefers_incident_edge_primi
     assert result[0]["src_tgt"] == ("entity-1", "entity-2")
     assert result[0]["rank"] == 9
     assert ("get_incident_edges_with_data_batch", ("entity-1",)) in graph_storage.calls
+
+
+class _FakeDeleteTextChunks:
+    async def get_by_doc_id(self, _doc_id):
+        return {
+            "chunk-1": {
+                "full_doc_id": "doc-1",
+                "content": "chunk content",
+            }
+        }
+
+    async def delete(self, _ids):
+        return None
+
+
+class _FakeDeleteVectorStorage:
+    async def get_by_chunk_ids(self, _chunk_ids):
+        return {}
+
+    async def upsert(self, _data):
+        return None
+
+    async def delete(self, _ids):
+        return None
+
+    async def delete_entity(self, _entity_name):
+        return None
+
+
+class _FakeDeleteGraphStorageWithoutSourcePrimitive:
+    async def get_nodes_by_source_ids(self, _chunk_ids):
+        return None
+
+    async def get_edges_by_source_ids(self, _chunk_ids):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_adelete_by_doc_id_raises_when_bounded_source_lookup_is_missing():
+    rag = LightRAG.__new__(LightRAG)
+    rag.workspace = "workspace-1"
+    rag.lightrag_logger = _FakeLogger()
+    rag.text_chunks = _FakeDeleteTextChunks()
+    rag.entities_vdb = _FakeDeleteVectorStorage()
+    rag.relationships_vdb = _FakeDeleteVectorStorage()
+    rag.chunk_entity_relation_graph = _FakeDeleteGraphStorageWithoutSourcePrimitive()
+
+    with pytest.raises(NotImplementedError, match="bounded source-id graph lookups"):
+        await LightRAG.adelete_by_doc_id(rag, "doc-1")


### PR DESCRIPTION
## Summary
- bound graph hot paths around storage-level primitives instead of silent full scans
- remove default full-scan fallbacks from knowledge-graph overview, document delete, and KG export sampling
- add bounded label-search and source-id lookup primitives for PG, Neo4j, and Nebula

## Before / After
| Path | Before | After | Guard / Test |
| --- | --- | --- | --- |
| knowledge graph overview/subgraph (`PGOpsSyncGraphStorage.get_knowledge_graph`) | `"*"` and label search could materialize all labels via `get_all_graph_labels()` and then filter in Python | `"*"` uses top-degree bounded primitive; label search uses `search_node_ids_by_label()` with stable ordering | existing graph hot-path unit coverage plus targeted storage primitive tests |
| document delete (`LightRAG.adelete_by_doc_id`) | could silently fall back to full label scan + batch node/edge fetch + Python filtering | requires bounded `get_nodes_by_source_ids()` / `get_edges_by_source_ids()`; no silent full-graph fallback remains | `test_adelete_by_doc_id_raises_when_bounded_source_lookup_is_missing` |
| export sample (`LightRAG.export_for_kg_eval`) | could fall back to `get_all_labels()` when bounded node-id sampling was missing | requires bounded `get_node_ids(limit)`; missing primitive now fails explicitly | `test_export_for_kg_eval_raises_when_bounded_node_id_sampling_is_missing` |

## Backend notes
- PostgreSQL: added `search_graph_node_ids_by_label()` repository primitive and rewired overview path to use bounded top-degree / label-search lookups.
- Neo4j: added bounded `search_node_ids_by_label()` for label search.
- Nebula: added bounded `search_node_ids_by_label()` and source-id candidate narrowing for nodes/edges; it narrows candidates in Nebula with `CONTAINS` and then applies exact `<SEP>` token filtering in Python to avoid false positives without falling back to a full graph scan.

## Scope
- stays inside `lightrag / graph repo / PG|Neo4j|Nebula impl / minimal tests`
- does not touch `operate.py`, graph product semantics, or new abstraction layers
- leaves broader query-shape / N+1 cleanup to follow-up `PR B`

## Validation
- `uv run pytest tests/unit_test/graphindex/test_lightrag_update_and_storage.py -q`
- `uvx ruff check aperag/db/repositories/graph.py aperag/graph/lightrag/base.py aperag/graph/lightrag/kg/nebula_sync_impl.py aperag/graph/lightrag/kg/neo4j_sync_impl.py aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py aperag/graph/lightrag/lightrag.py tests/unit_test/graphindex/test_lightrag_update_and_storage.py`
- `uv run python -m compileall aperag/graph/lightrag/kg/nebula_sync_impl.py aperag/graph/lightrag/lightrag.py aperag/graph/lightrag/kg/pg_ops_sync_graph_storage.py aperag/graph/lightrag/kg/neo4j_sync_impl.py`