### PR TITLE
[codex] harden agent runtime v3 main path

### DIFF
--- a/aperag/agent_runtime/services.py
+++ b/aperag/agent_runtime/services.py
@@ -45,6 +45,38 @@ def _parse_bot_config(bot) -> Optional[view_models.BotConfig]:
         return None
 
 
+def _coerce_timeline_cursor(value: Any) -> int:
+    return value if isinstance(value, int) and value >= 0 else 0
+
+
+def _apply_runtime_state_to_turn(
+    turn_envelope: AgentTurnEnvelope, runtime_state: dict[str, Any] | None, latest_sequence: int
+) -> AgentTurnEnvelope:
+    timeline_cursor = max(_coerce_timeline_cursor(turn_envelope.timeline_cursor), latest_sequence)
+    updates: dict[str, Any] = {"timeline_cursor": timeline_cursor}
+    if not runtime_state:
+        return turn_envelope.model_copy(update=updates)
+
+    updates["timeline_cursor"] = max(timeline_cursor, _coerce_timeline_cursor(runtime_state.get("timeline_cursor")))
+    if "status" in runtime_state:
+        updates["status"] = runtime_state["status"]
+    if runtime_state.get("answer_artifact_id"):
+        updates["answer_artifact_id"] = runtime_state["answer_artifact_id"]
+    if runtime_state.get("reference_bundle_artifact_id"):
+        updates["reference_bundle_artifact_id"] = runtime_state["reference_bundle_artifact_id"]
+    if runtime_state.get("error_code"):
+        updates["error_code"] = runtime_state["error_code"]
+    if runtime_state.get("error_message"):
+        updates["error_message"] = runtime_state["error_message"]
+    return turn_envelope.model_copy(update=updates)
+
+
+def _extract_answer_text_from_artifact(artifact) -> str:
+    if not artifact or not isinstance(artifact.payload, dict):
+        return ""
+    return artifact.payload.get("text") or artifact.payload.get("content") or ""
+
+
 class TurnService:
     def __init__(self, db_ops: AsyncDatabaseOps | None = None, redis_store: AgentRuntimeRedisStore | None = None):
         self.db_ops = db_ops or async_db_ops
@@ -179,28 +211,11 @@ class TurnService:
 
         runtime_state = await self.redis_store.get_runtime_state(turn_id)
         artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn_id)
-        turn_envelope = self.to_turn_envelope(turn)
         timeline = [merged_events[key] for key in sorted(merged_events)]
         latest_sequence = timeline[-1].sequence if timeline else 0
-
-        if runtime_state:
-            timeline_cursor = runtime_state.get("timeline_cursor")
-            turn_envelope = turn_envelope.model_copy(
-                update={
-                    "status": runtime_state.get("status", turn_envelope.status),
-                    "timeline_cursor": max(
-                        turn_envelope.timeline_cursor,
-                        timeline_cursor if isinstance(timeline_cursor, int) else latest_sequence,
-                        latest_sequence,
-                    ),
-                    "answer_artifact_id": runtime_state.get("answer_artifact_id", turn_envelope.answer_artifact_id),
-                    "reference_bundle_artifact_id": runtime_state.get(
-                        "reference_bundle_artifact_id", turn_envelope.reference_bundle_artifact_id
-                    ),
-                    "error_code": runtime_state.get("error_code", turn_envelope.error_code),
-                    "error_message": runtime_state.get("error_message", turn_envelope.error_message),
-                }
-            )
+        turn_envelope = _apply_runtime_state_to_turn(
+            self.to_turn_envelope(turn), runtime_state, latest_sequence=latest_sequence
+        )
 
         return AgentTurnSnapshot(
             turn=turn_envelope,
@@ -383,17 +398,19 @@ class HistoryWriter:
             if turn.status != AgentTurnStatus.COMPLETED or turn.id in legacy_turn_ids:
                 continue
             artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn.id)
-            answer = next(
-                (
-                    artifact
-                    for artifact in artifacts
-                    if getattr(artifact.artifact_type, "value", artifact.artifact_type) == "answer"
-                ),
-                None,
-            )
-            answer_text = ""
-            if answer and isinstance(answer.payload, dict):
-                answer_text = answer.payload.get("text") or answer.payload.get("content") or ""
+            answer = None
+            if turn.answer_artifact_id:
+                answer = next((artifact for artifact in artifacts if artifact.id == turn.answer_artifact_id), None)
+            if not answer:
+                answer = next(
+                    (
+                        artifact
+                        for artifact in artifacts
+                        if getattr(artifact.artifact_type, "value", artifact.artifact_type) == "answer"
+                    ),
+                    None,
+                )
+            answer_text = _extract_answer_text_from_artifact(answer)
             if not answer_text:
                 continue
             v3_lines.append(f"User: {turn.input_text}")

--- a/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
+++ b/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
@@ -163,7 +163,7 @@ class _FakeRequest:
 
 @pytest.mark.asyncio
 async def test_turn_snapshot_merges_persisted_events_cached_events_and_runtime_state():
-    turn = _build_turn()
+    turn = _build_turn(answer_artifact_id="artifact-db", timeline_cursor=0)
     persisted_event = _build_event(1, "turn.started", status="running")
     cached_event = AgentTimelineEventEnvelope(
         event_id="event-2",
@@ -188,8 +188,9 @@ async def test_turn_snapshot_merges_persisted_events_cached_events_and_runtime_s
             events=[cached_event],
             runtime_state={
                 "status": "RUNNING",
-                "timeline_cursor": 2,
-                "answer_artifact_id": "artifact-1",
+                "timeline_cursor": 1,
+                "answer_artifact_id": None,
+                "reference_bundle_artifact_id": "bundle-1",
             },
         ),
     )
@@ -198,7 +199,8 @@ async def test_turn_snapshot_merges_persisted_events_cached_events_and_runtime_s
 
     assert snapshot.turn.status == "RUNNING"
     assert snapshot.turn.timeline_cursor == 2
-    assert snapshot.turn.answer_artifact_id == "artifact-1"
+    assert snapshot.turn.answer_artifact_id == "artifact-db"
+    assert snapshot.turn.reference_bundle_artifact_id == "bundle-1"
     assert [event.sequence for event in snapshot.timeline] == [1, 2]
     assert snapshot.artifacts[0].artifact_id == "artifact-1"
 
@@ -231,15 +233,25 @@ async def test_history_writer_keeps_legacy_history_and_appends_missing_v3_turns(
         id="turn-v3",
         status=AgentTurnStatus.COMPLETED,
         input_text="new question",
+        answer_artifact_id="artifact-answer",
+    )
+    incomplete_answer_turn = _build_turn(
+        id="turn-v3-missing-answer",
+        status=AgentTurnStatus.COMPLETED,
+        input_text="missing answer question",
     )
     answer_artifact = SimpleNamespace(
+        id="artifact-answer",
         artifact_type="answer",
         payload={"text": "new answer"},
     )
     writer = HistoryWriter(
         db_ops=_FakeHistoryDbOps(
-            turns=[completed_turn],
-            artifacts_by_turn={"turn-v3": [answer_artifact]},
+            turns=[completed_turn, incomplete_answer_turn],
+            artifacts_by_turn={
+                "turn-v3": [answer_artifact],
+                "turn-v3-missing-answer": [],
+            },
         )
     )
 
@@ -259,6 +271,7 @@ async def test_history_writer_keeps_legacy_history_and_appends_missing_v3_turns(
     assert "Assistant: old answer" in context
     assert "User: new question" in context
     assert "Assistant: new answer" in context
+    assert "missing answer question" not in context
 
 
 @pytest.mark.asyncio

--- a/web/src/components/chat/chat-messages.tsx
+++ b/web/src/components/chat/chat-messages.tsx
@@ -118,6 +118,21 @@ function cloneMessages(messages: ChatMessage[][]) {
   return messages.map((parts) => [...parts]);
 }
 
+function hasAnswerArtifact(snapshot: AgentTurnSnapshot) {
+  return snapshot.artifacts.some((artifact) => artifact.artifact_type === 'answer');
+}
+
+function getStreamingAnswerFromSnapshot(snapshot: AgentTurnSnapshot) {
+  if (hasAnswerArtifact(snapshot)) return '';
+  return snapshot.timeline
+    .filter(
+      (event) =>
+        event.type === 'text.delta' && typeof event.data.delta === 'string',
+    )
+    .map((event) => event.data.delta as string)
+    .join('');
+}
+
 export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
   const { chatRename } = useBotContext();
   const { botId, chatId } = useParams<{ botId: string; chatId: string }>();
@@ -153,7 +168,8 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
         const next = updater(previous[turnId]);
         if (!next) {
           if (!(turnId in previous)) return previous;
-          const { [turnId]: _, ...rest } = previous;
+          const rest = { ...previous };
+          delete rest[turnId];
           return rest;
         }
         return {
@@ -280,13 +296,14 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
 
   const mergeSnapshot = useCallback(
     (snapshot: AgentTurnSnapshot) => {
-      setTurnState(snapshot.turn.turn_id, (previous) => ({
+      const streamingAnswer = getStreamingAnswerFromSnapshot(snapshot);
+      setTurnState(snapshot.turn.turn_id, () => ({
         snapshot: {
           turn: snapshot.turn,
           timeline: snapshot.timeline,
           artifacts: snapshot.artifacts,
         },
-        streamingAnswer: previous?.streamingAnswer || '',
+        streamingAnswer,
         pending: !isTerminalStatus(snapshot.turn.status),
       }));
       ensureTurnGroups(snapshot.turn, false);
@@ -700,11 +717,18 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
   }, [chat.history]);
 
   useEffect(() => {
+    const storedActiveTurnId =
+      typeof window === 'undefined'
+        ? null
+        : window.sessionStorage.getItem(activeTurnStorageKey);
     const potentialTurnIds = [
       ...new Set(
         (chat.history || [])
           .map((parts) => getAiGroupId(parts))
-          .filter((value): value is string => Boolean(value)),
+          .filter(
+            (value): value is string =>
+              Boolean(value) && value !== storedActiveTurnId,
+          ),
       ),
     ];
 
@@ -731,7 +755,13 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     return () => {
       cancelled = true;
     };
-  }, [chat.history, fetchSnapshot, mergeSnapshot, turnStates]);
+  }, [
+    activeTurnStorageKey,
+    chat.history,
+    fetchSnapshot,
+    mergeSnapshot,
+    turnStates,
+  ]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !chat.id) return;
@@ -779,8 +809,9 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
   ]);
 
   useEffect(() => {
+    const activeStreams = streamsRef.current;
     return () => {
-      Object.keys(streamsRef.current).forEach((turnId) => closeStream(turnId));
+      Object.keys(activeStreams).forEach((turnId) => closeStream(turnId));
     };
   }, [closeStream]);
 

--- a/web/src/middlewares/apiProxy.ts
+++ b/web/src/middlewares/apiProxy.ts
@@ -11,17 +11,23 @@ export function withApiProxy(next: NextMiddleware): NextMiddleware {
 
     const host = process.env.API_SERVER_ENDPOINT || 'http://localhost:8000';
     const apiServerBasePath = process.env.API_SERVER_BASE_PATH || '/api/v1';
+    const apiPathMatch = pathname.match(/\/api\/v(1|2)(\/.*)?$/);
 
-    if (pathname.match(new RegExp('/api/v1'))) {
+    if (apiPathMatch) {
       const destination = new URL(host);
       const url = req.nextUrl.clone();
       url.host = destination.host;
       url.port = destination.port;
 
       if (process.env.NEXT_PUBLIC_BASE_PATH) {
+        const requestedApiPrefix = `/api/v${apiPathMatch[1]}`;
+        const proxyBasePath =
+          requestedApiPrefix === '/api/v1'
+            ? apiServerBasePath
+            : apiServerBasePath.replace(/\/api\/v1$/, requestedApiPrefix);
         url.pathname = pathname.replace(
           process.env.NEXT_PUBLIC_BASE_PATH,
-          apiServerBasePath,
+          proxyBasePath,
         );
       }
 


### PR DESCRIPTION
## What changed
- hardened Agent Runtime V3 snapshot and history merge semantics in `aperag/agent_runtime/services.py`
- tightened active-turn recovery and snapshot merge behavior in `web/src/components/chat/chat-messages.tsx`
- added `/api/v2` proxy rewriting in `web/src/middlewares/apiProxy.ts` so local web dev correctly reaches the backend agent runtime routes
- strengthened `tests/unit_test/agent_runtime/test_agent_runtime_v3.py` around snapshot cursor, artifact pointer, and mixed-history behavior

## Why
- fix the direct blocker where sending a message from the local web app failed with a frontend 404 because `/api/v2` requests were not rewritten to the backend
- make the V3 default path more stable by treating snapshot state as the source of truth and avoiding stale active-turn hydration / artifact-pointer drift

## Impact
- local `POST /api/v2/agent/chats/{chat_id}/turns` now reaches the backend instead of failing at the frontend proxy layer
- active-turn recovery and mixed-history context are less likely to drift from persisted runtime state

## Root cause
- the frontend send path already used the correct V3 route, but `web` only proxied `/api/v1`, so `/api/v2` requests never left the Next dev server

## Validation
- `uv run pytest tests/unit_test/agent_runtime/test_agent_runtime_v3.py -q`
- `uv run ruff check aperag/agent_runtime/services.py tests/unit_test/agent_runtime/test_agent_runtime_v3.py`
- `uv run ruff format --check aperag/agent_runtime/services.py tests/unit_test/agent_runtime/test_agent_runtime_v3.py`
- `git diff --check`
- `yarn --cwd web lint --file src/components/chat/chat-messages.tsx --file src/middlewares/apiProxy.ts`
- manual verification: local `/api/v2` create-turn request now rewrites to backend and returns backend `401` instead of frontend `404`
