### PR TITLE
[codex] fix MCP API key header extraction

### DIFF
--- a/aperag/mcp/server.py
+++ b/aperag/mcp/server.py
@@ -669,7 +669,7 @@ def get_api_key() -> str:
     # Try to get API key from HTTP headers first
     try:
         # Use FastMCP's dependency function to get HTTP headers
-        headers = get_http_headers()
+        headers = get_http_headers(include={"authorization"})
 
         if headers:
             # Try to extract Authorization header

--- a/tests/unit_test/test_mcp_server.py
+++ b/tests/unit_test/test_mcp_server.py
@@ -1,0 +1,29 @@
+import pytest
+
+from aperag.mcp import server as mcp_server
+
+
+def test_get_api_key_prefers_authorization_header(monkeypatch):
+    monkeypatch.delenv("APERAG_API_KEY", raising=False)
+    monkeypatch.setattr(
+        mcp_server,
+        "get_http_headers",
+        lambda include_all=False, include=None: {"authorization": "Bearer header-token"},
+    )
+
+    assert mcp_server.get_api_key() == "header-token"
+
+
+def test_get_api_key_falls_back_to_environment(monkeypatch):
+    monkeypatch.setenv("APERAG_API_KEY", "env-token")
+    monkeypatch.setattr(mcp_server, "get_http_headers", lambda include_all=False, include=None: {})
+
+    assert mcp_server.get_api_key() == "env-token"
+
+
+def test_get_api_key_raises_when_header_and_environment_missing(monkeypatch):
+    monkeypatch.delenv("APERAG_API_KEY", raising=False)
+    monkeypatch.setattr(mcp_server, "get_http_headers", lambda include_all=False, include=None: {})
+
+    with pytest.raises(ValueError, match="API key not found"):
+        mcp_server.get_api_key()


### PR DESCRIPTION
## What changed
- fixed `aperag/mcp/server.py::get_api_key()` to explicitly include the `authorization` header when reading request headers from FastMCP
- added `tests/unit_test/test_mcp_server.py` to lock header-first API key extraction, environment fallback, and missing-key failure behavior

## Root cause
- the new Agent runtime already sends `Authorization: Bearer <aperag_api_key>` to the ApeRAG MCP endpoint
- but `aperag/mcp/server.py` called `get_http_headers()` without including `authorization`
- FastMCP strips `authorization` by default, so header-based auth could never work here and `list_collections()` fell through to the missing-key error path

## Scope
- this is a narrow MCP auth extraction fix only
- not part of `#1500`
- no frontend, runtime contract, Hurl, or UI changes

## Validation
- `uv run pytest tests/unit_test/test_mcp_server.py -q`
- `uv run ruff check aperag/mcp/server.py tests/unit_test/test_mcp_server.py`
- `uv run ruff format --check aperag/mcp/server.py tests/unit_test/test_mcp_server.py`
- `git diff --check`
