### PR TITLE
[codex] fix document detail previews

### DIFF
--- a/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { DocumentPreview } from '@/api';
-import { Markdown } from '@/components/markdown';
+import { buildDocumentAssetUrl, Markdown } from '@/components/markdown';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -33,6 +33,13 @@ export const DocumentDetail = ({
     return Boolean(documentPreview.doc_filename?.match(/\.pdf/));
   }, [documentPreview.doc_filename]);
 
+  const hasPdfPreview = Boolean(
+    isPdf && documentPreview.converted_pdf_object_path,
+  );
+  const visionChunks = documentPreview.vision_chunks || [];
+  const hasVisionPreview = visionChunks.length > 0;
+  const defaultTab = hasPdfPreview ? 'pdf' : 'markdown';
+
   useEffect(() => {
     const loadPDF = async () => {
       const { pdfjs } = await import('react-pdf');
@@ -47,7 +54,7 @@ export const DocumentDetail = ({
 
   return (
     <>
-      <Tabs defaultValue="markdown" className="gap-4">
+      <Tabs defaultValue={defaultTab} className="gap-4">
         <div className="flex flex-row items-center justify-between gap-2">
           <div className="flex flex-row items-center gap-4">
             <Button asChild variant="ghost" size="icon">
@@ -63,8 +70,11 @@ export const DocumentDetail = ({
           <div className="flex flex-row gap-6">
             <div className="text-muted-foreground flex flex-row items-center gap-4 text-sm"></div>
             <TabsList>
+              {hasPdfPreview && <TabsTrigger value="pdf">PDF</TabsTrigger>}
+              {hasVisionPreview && (
+                <TabsTrigger value="vision">Images</TabsTrigger>
+              )}
               <TabsTrigger value="markdown">Markdown</TabsTrigger>
-              {isPdf && <TabsTrigger value="pdf">PDF</TabsTrigger>}
             </TabsList>
           </div>
         </div>
@@ -72,12 +82,70 @@ export const DocumentDetail = ({
         <TabsContent value="markdown">
           <Card>
             <CardContent>
-              <Markdown>{documentPreview.markdown_content}</Markdown>
+              {documentPreview.markdown_content?.trim() ? (
+                <Markdown>{documentPreview.markdown_content}</Markdown>
+              ) : (
+                <div className="text-muted-foreground py-6 text-sm">
+                  Markdown preview is unavailable for this document.
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
 
-        {isPdf && (
+        {hasVisionPreview && (
+          <TabsContent value="vision">
+            <div className="grid gap-4 lg:grid-cols-2">
+              {visionChunks.map((chunk, index) => {
+                const collectionIdValue =
+                  typeof collectionId === 'string' ? collectionId : collectionId?.[0];
+                const documentIdValue =
+                  typeof documentId === 'string' ? documentId : documentId?.[0];
+                const imageUrl =
+                  chunk.asset_id && collectionIdValue && documentIdValue
+                    ? buildDocumentAssetUrl(
+                        `asset://${chunk.asset_id}?collection_id=${collectionIdValue}&document_id=${documentIdValue}`,
+                        {
+                          collectionId: collectionIdValue,
+                          documentId: documentIdValue,
+                          mode: 'marketplace',
+                        },
+                      )
+                    : undefined;
+                const pageIdx =
+                  typeof chunk.metadata === 'object' &&
+                  chunk.metadata &&
+                  'page_idx' in chunk.metadata
+                    ? Number(chunk.metadata.page_idx) + 1
+                    : undefined;
+
+                return (
+                  <Card key={chunk.id || chunk.asset_id || index}>
+                    <CardContent className="space-y-4">
+                      {imageUrl ? (
+                        <img
+                          src={imageUrl}
+                          alt={`Document image ${index + 1}`}
+                          className="w-full rounded-md border"
+                        />
+                      ) : null}
+                      <div className="space-y-2">
+                        <div className="text-sm font-medium">
+                          {pageIdx ? `Page ${pageIdx}` : `Image ${index + 1}`}
+                        </div>
+                        <div className="text-muted-foreground whitespace-pre-wrap text-sm">
+                          {chunk.text || 'No extracted image summary available.'}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          </TabsContent>
+        )}
+
+        {hasPdfPreview && (
           <TabsContent value="pdf">
             <PDFDocument
               file={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v1/marketplace/collections/${collectionId}/documents/${documentId}/object?path=${documentPreview.converted_pdf_object_path}`}

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -2,7 +2,7 @@
 import { Document, DocumentPreview } from '@/api';
 import { getDocumentStatusColor } from '@/app/workspace/collections/tools';
 import { FormatDate } from '@/components/format-date';
-import { Markdown } from '@/components/markdown';
+import { buildDocumentAssetUrl, Markdown } from '@/components/markdown';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -39,6 +39,13 @@ export const DocumentDetail = ({
     return Boolean(documentPreview.doc_filename?.match(/\.pdf/));
   }, [documentPreview.doc_filename]);
 
+  const hasPdfPreview = Boolean(
+    isPdf && documentPreview.converted_pdf_object_path,
+  );
+  const visionChunks = documentPreview.vision_chunks || [];
+  const hasVisionPreview = visionChunks.length > 0;
+  const defaultTab = hasPdfPreview ? 'pdf' : 'markdown';
+
   useEffect(() => {
     const loadPDF = async () => {
       const { pdfjs } = await import('react-pdf');
@@ -53,7 +60,7 @@ export const DocumentDetail = ({
 
   return (
     <>
-      <Tabs defaultValue="markdown" className="gap-4">
+      <Tabs defaultValue={defaultTab} className="gap-4">
         <div className="flex flex-row items-center justify-between gap-2">
           <div className="flex flex-row items-center gap-4">
             <Button asChild variant="ghost" size="icon">
@@ -89,8 +96,11 @@ export const DocumentDetail = ({
               </div>
             </div>
             <TabsList>
+              {hasPdfPreview && <TabsTrigger value="pdf">PDF</TabsTrigger>}
+              {hasVisionPreview && (
+                <TabsTrigger value="vision">Images</TabsTrigger>
+              )}
               <TabsTrigger value="markdown">Markdown</TabsTrigger>
-              {isPdf && <TabsTrigger value="pdf">PDF</TabsTrigger>}
             </TabsList>
           </div>
         </div>
@@ -98,12 +108,65 @@ export const DocumentDetail = ({
         <TabsContent value="markdown">
           <Card>
             <CardContent>
-              <Markdown>{documentPreview.markdown_content}</Markdown>
+              {documentPreview.markdown_content?.trim() ? (
+                <Markdown>{documentPreview.markdown_content}</Markdown>
+              ) : (
+                <div className="text-muted-foreground py-6 text-sm">
+                  Markdown preview is unavailable for this document.
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
 
-        {isPdf && (
+        {hasVisionPreview && (
+          <TabsContent value="vision">
+            <div className="grid gap-4 lg:grid-cols-2">
+              {visionChunks.map((chunk, index) => {
+                const imageUrl = chunk.asset_id
+                  ? buildDocumentAssetUrl(
+                      `asset://${chunk.asset_id}?collection_id=${collection.id}&document_id=${document.id}`,
+                      {
+                        collectionId: collection.id,
+                        documentId: document.id,
+                        mode: 'workspace',
+                      },
+                    )
+                  : undefined;
+                const pageIdx =
+                  typeof chunk.metadata === 'object' &&
+                  chunk.metadata &&
+                  'page_idx' in chunk.metadata
+                    ? Number(chunk.metadata.page_idx) + 1
+                    : undefined;
+
+                return (
+                  <Card key={chunk.id || chunk.asset_id || index}>
+                    <CardContent className="space-y-4">
+                      {imageUrl ? (
+                        <img
+                          src={imageUrl}
+                          alt={`Document image ${index + 1}`}
+                          className="w-full rounded-md border"
+                        />
+                      ) : null}
+                      <div className="space-y-2">
+                        <div className="text-sm font-medium">
+                          {pageIdx ? `Page ${pageIdx}` : `Image ${index + 1}`}
+                        </div>
+                        <div className="text-muted-foreground whitespace-pre-wrap text-sm">
+                          {chunk.text || 'No extracted image summary available.'}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          </TabsContent>
+        )}
+
+        {hasPdfPreview && (
           <TabsContent value="pdf">
             <PDFDocument
               file={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v1/collections/${collection.id}/documents/${document.id}/object?path=${documentPreview.converted_pdf_object_path}`}

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -3,13 +3,12 @@
 import { cn } from '@/lib/utils';
 import { ImageIcon } from 'lucide-react';
 import Link from 'next/link';
+import { useParams, usePathname } from 'next/navigation';
 import {
   JSX,
   MouseEventHandler,
   useCallback,
-  useEffect,
   useMemo,
-  useState,
 } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
@@ -28,6 +27,55 @@ import { Table, TableBody, TableCell, TableHeader, TableRow } from './ui/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
 import './markdown.css';
+
+type AssetContext = {
+  collectionId?: string;
+  documentId?: string;
+  mode?: 'workspace' | 'marketplace';
+};
+
+const getRouteParam = (value: string | string[] | undefined) => {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+};
+
+const parseAssetUrl = (src: string) => {
+  const [assetId = '', queryString = ''] = src.replace('asset://', '').split('?');
+  const params = new URLSearchParams(queryString);
+
+  return {
+    assetId,
+    collectionId: params.get('collection_id') || undefined,
+    documentId: params.get('document_id') || undefined,
+  };
+};
+
+export const buildDocumentAssetUrl = (src: string, context?: AssetContext) => {
+  if (!src.startsWith('asset://')) {
+    return src;
+  }
+
+  const { assetId, collectionId: queryCollectionId, documentId: queryDocumentId } =
+    parseAssetUrl(src);
+
+  const collectionId = queryCollectionId || context?.collectionId;
+  const documentId = queryDocumentId || context?.documentId;
+
+  if (!assetId || !collectionId || !documentId) {
+    return undefined;
+  }
+
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const routePrefix =
+    context?.mode === 'marketplace' ? 'marketplace/collections' : 'collections';
+  const query = new URLSearchParams({
+    path: `assets/${assetId}`,
+  });
+
+  return `${basePath}/api/v1/${routePrefix}/${collectionId}/documents/${documentId}/object?${query.toString()}`;
+};
 
 const securityLink = (props: JSX.IntrinsicElements['a']) => {
   const target = props.href?.match(/^http/) ? '_blank' : '_self';
@@ -88,24 +136,31 @@ const unSecurityLink = (props: JSX.IntrinsicElements['a']) => {
 
 export const CustomImage = ({
   src,
+  resolveAssetUrl,
   ...props
-}: JSX.IntrinsicElements['img']) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [imageUrl, setImageUrl] = useState<string>();
+}: JSX.IntrinsicElements['img'] & {
+  resolveAssetUrl?: (src: string) => string | undefined;
+}) => {
+  const imageUrl = useMemo(() => {
+    if (typeof src !== 'string') {
+      return undefined;
+    }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const getImageSrc = useCallback(async () => {
-    if (typeof src !== 'string') return;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [path, queryString] = src.replace('asset://', '').split('?');
-  }, [src]);
+    if (src.startsWith('asset://')) {
+      return resolveAssetUrl?.(src);
+    }
 
-  useEffect(() => {}, []);
-
-  return;
+    return src;
+  }, [resolveAssetUrl, src]);
 
   return imageUrl ? (
-    <img {...props} alt={props.alt} src={imageUrl} />
+    <img
+      {...props}
+      alt={props.alt}
+      src={imageUrl}
+      loading="lazy"
+      style={{ maxWidth: '100%', height: 'auto' }}
+    />
   ) : (
     <Skeleton className="my-4 h-[125px] w-full rounded-xl py-4 pt-8 text-center">
       <ImageIcon className="mx-auto size-12 opacity-20" />
@@ -113,7 +168,7 @@ export const CustomImage = ({
   );
 };
 
-export const mdComponents = {
+const createMdComponents = (resolveAssetUrl?: (src: string) => string | undefined) => ({
   h1: (props: JSX.IntrinsicElements['h1']) => (
     <h1 className="my-6 text-5xl font-bold first:mt-0 last:mb-0">
       {props.children}
@@ -170,7 +225,13 @@ export const mdComponents = {
         </Skeleton>
       );
     } else if (typeof src === 'string' && src.startsWith('asset://')) {
-      return <CustomImage src={src} {...props} />;
+      return (
+        <CustomImage
+          src={src}
+          {...props}
+          resolveAssetUrl={resolveAssetUrl}
+        />
+      );
     } else {
       return (
         <img
@@ -259,7 +320,7 @@ export const mdComponents = {
   th: (props: JSX.IntrinsicElements['th']) => (
     <TableCell>{props.children}</TableCell>
   ),
-};
+});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const mdRehypePlugins: any = [
@@ -292,6 +353,9 @@ export const Markdown = ({
   security?: boolean;
   children?: string;
 }) => {
+  const pathname = usePathname();
+  const params = useParams<{ collectionId?: string; documentId?: string }>();
+
   const rehypePlugins = useMemo(() => {
     const plugins = [...mdRehypePlugins];
     if (rehypeToc) {
@@ -305,15 +369,36 @@ export const Markdown = ({
     return plugins;
   }, [rehypeToc]);
 
+  const assetContext = useMemo(
+    () => ({
+      collectionId: getRouteParam(params?.collectionId),
+      documentId: getRouteParam(params?.documentId),
+      mode: pathname?.startsWith('/marketplace/')
+        ? ('marketplace' as const)
+        : ('workspace' as const),
+    }),
+    [params?.collectionId, params?.documentId, pathname],
+  );
+
+  const resolveAssetUrl = useCallback(
+    (src: string) => buildDocumentAssetUrl(src, assetContext),
+    [assetContext],
+  );
+
+  const components = useMemo(
+    () => ({
+      a: security ? securityLink : unSecurityLink,
+      ...createMdComponents(resolveAssetUrl),
+    }),
+    [resolveAssetUrl, security],
+  );
+
   return (
     <ReactMarkdown
       rehypePlugins={rehypePlugins}
       remarkPlugins={mdRemarkPlugins}
       urlTransform={(url) => url}
-      components={{
-        a: security ? securityLink : unSecurityLink,
-        ...mdComponents,
-      }}
+      components={components}
     >
       {children}
     </ReactMarkdown>

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -322,6 +322,9 @@ const createMdComponents = (resolveAssetUrl?: (src: string) => string | undefine
   ),
 });
 
+// Keep the legacy export for MDX consumers that do not need route-aware asset resolution.
+export const mdComponents = createMdComponents();
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const mdRehypePlugins: any = [
   rehypeRaw,


### PR DESCRIPTION
## What changed
- fixed `asset://` image rendering inside markdown previews so extracted document assets can render instead of silently disappearing
- added an `Images` tab to workspace and marketplace document detail pages for documents that already have `vision_chunks`
- defaulted PDF documents with a converted preview to the `PDF` tab and added an explicit empty-state for missing markdown previews

## Why
While checking the document detail page, I confirmed two separate issues:
- local blank previews were partly caused by a split local object-store setup between API and worker worktrees
- the real frontend bug was that `asset://...` images in markdown were never rendered, and visual extraction results were not surfaced in the detail page at all

This PR fixes the frontend part so PDF/image-heavy documents have a more reliable detail-page experience.

## Impact
- document markdown can now render extracted assets referenced by `asset://...`
- users can inspect extracted visual chunks directly from the document detail page
- PDF-backed documents open on a more stable default tab instead of landing on a noisy markdown conversion first

## Validation
- manually reproduced against the online sample `KubeBlocks Docs / user_docs.troubleshooting.known-issues.pdf`
- `git diff --check`
- local web lint/typecheck was not run in this workspace because `web/node_modules` is not installed here
