### PR TITLE
[codex] Refine agent prompt layering defaults

### DIFF
--- a/aperag/agent_runtime/runtime.py
+++ b/aperag/agent_runtime/runtime.py
@@ -159,11 +159,15 @@ class PydanticAIRuntime(AgentRuntime):
             )
 
             history_context = await self.history_writer.build_history_context(user, chat.id)
+            from aperag.service.chat_document_service import chat_document_service
+
+            has_chat_files = await chat_document_service.has_documents_in_chat(chat.id, user)
             prompt = build_agent_query_prompt(
                 chat.id,
                 agent_message=resolved_request.agent_message,
                 user=user,
                 template=resolved_request.query_prompt_template,
+                has_chat_files=has_chat_files,
             )
             if history_context:
                 prompt = f"{history_context}\n\nCurrent turn:\n{prompt}"

--- a/aperag/mcp/server.py
+++ b/aperag/mcp/server.py
@@ -34,11 +34,34 @@ API_BASE_URL = "http://localhost:8000"
 
 @mcp_server.tool
 async def list_collections() -> Dict[str, Any]:
-    """List all collections available to the user.
+    """Discover which knowledge bases the current user can access.
+
+    Use this when:
+    - You need to find available knowledge bases before choosing where to search.
+    - The user asks what collections or knowledge bases are available.
+
+    Do not use this when:
+    - The user already specified a target collection and you can search it directly.
+    - You need to search temporary files uploaded in the current chat.
+
+    What success means:
+    - You received the collections currently accessible to the user.
+
+    What an empty result means:
+    - The current user has no accessible collections in this environment.
+    - It does not automatically mean the system is broken.
+
+    What failure may mean:
+    - auth / permission: the request is missing a valid ApeRAG credential or access right.
+    - network / timeout: the MCP or backend path did not complete in time.
+
+    How to explain this step to the user:
+    - While running: "Checking which knowledge bases are available."
+    - After completion: "Checked which knowledge bases are available."
 
     Returns:
         List of collections with only essential information (id, title, description)
-        for security and optimized LLM search.
+        for secure and efficient LLM use.
 
     Note:
         Uses CollectionViewList view model for type-safe response parsing but filters
@@ -78,12 +101,31 @@ async def search_collection(
     topk: int = 5,
     query_keywords: list[str] = None,
 ) -> Dict[str, Any]:
-    """Search for knowledge in a persistent collection/knowledge base using vector, full-text, graph, and/or summary search.
+    """Search a persistent knowledge base for evidence relevant to the current request.
 
-    PRIMARY USE CASE: This is the main tool for searching permanent knowledge repositories.
-    Use this for general Q&A, knowledge retrieval, and accessing organized knowledge collections.
+    Use this when:
+    - You already know which collection should be searched.
+    - The user asks a knowledge question that should be answered from indexed documents.
 
-    For temporary files uploaded in a chat session, use search_chat_files instead.
+    Do not use this when:
+    - The target files were uploaded only in the current chat; use search_chat_files instead.
+    - No collection has been selected or discovered yet.
+
+    What success means:
+    - You retrieved candidate evidence from the chosen collection.
+
+    What an empty result means:
+    - This collection did not return strong evidence for the current query.
+    - It does not prove the answer is false; it means this source did not support the step.
+
+    What failure may mean:
+    - auth / permission: the current user cannot access this collection.
+    - network / timeout: the search path did not complete.
+    - bad request: the collection ID or search config is invalid.
+
+    How to explain this step to the user:
+    - While running: "Searching the selected knowledge base for evidence about the request."
+    - After completion: "Reviewed results from the selected knowledge base."
 
     Args:
         collection_id: The ID of the collection to search in
@@ -220,18 +262,30 @@ async def search_chat_files(
     rerank: bool = True,
     topk: int = 5,
 ) -> Dict[str, Any]:
-    """Search ONLY within files temporarily uploaded by the user in THIS specific chat session.
+    """Search files uploaded in the current chat for evidence relevant to this turn.
 
-    IMPORTANT - When to Use This Tool:
-    - ONLY when searching files that the user explicitly uploaded in THIS chat conversation
-    - For temporary, session-specific document analysis (e.g., "analyze this PDF I just uploaded")
-    - When the user references documents they shared in the current chat
+    Use this when:
+    - The user refers to files shared in this chat session.
+    - You need evidence from temporary, chat-scoped documents.
 
-    DO NOT Use This Tool For:
-    - Searching general knowledge bases or collections (use search_collection instead)
-    - Accessing persistent/permanent knowledge repositories
-    - General Q&A that doesn't involve chat-uploaded files
-    - When no files have been uploaded in the current chat
+    Do not use this when:
+    - You are searching a persistent knowledge base; use search_collection instead.
+    - No files were uploaded in the current chat.
+
+    What success means:
+    - You found candidate evidence inside the current chat's uploaded files.
+
+    What an empty result means:
+    - The uploaded files did not return useful evidence for this query.
+    - It does not automatically mean the files are unreadable or the system failed.
+
+    What failure may mean:
+    - auth / permission: the current request cannot access this chat's files.
+    - network / timeout: the search path did not complete.
+
+    How to explain this step to the user:
+    - While running: "Searching files uploaded in this chat."
+    - After completion: "Reviewed results from files uploaded in this chat."
 
     Args:
         chat_id: The ID of the chat to search files in
@@ -318,7 +372,30 @@ async def web_search(
     locale: str = "en-US",
     source: str = "",
 ) -> Dict[str, Any]:
-    """Perform best-effort web search with optional domain targeting.
+    """Search the web for current or missing information.
+
+    Use this when:
+    - The current turn allows web access.
+    - You need current information, external verification, or gap-filling beyond ApeRAG collections.
+
+    Do not use this when:
+    - The current turn disables web access.
+    - Collection or chat-file evidence is already sufficient for the requested step.
+
+    What success means:
+    - You received candidate web results with titles, snippets, and URLs.
+
+    What an empty result means:
+    - No strong web results were found for this query and scope.
+    - Use `meta.search_status` to distinguish a genuine empty result from `unavailable` or `disabled`.
+
+    What failure may mean:
+    - network / timeout: external search could not complete.
+    - upstream search provider issue: the search backend could not return usable results.
+
+    How to explain this step to the user:
+    - While running: "Searching the web for current or missing information."
+    - After completion: "Checked web sources for supporting information."
 
     Args:
         query: Search query for web search. Optional when using source-only site browsing.
@@ -334,7 +411,7 @@ async def web_search(
     Note:
         Uses JINA first when configured, otherwise falls back to DuckDuckGo.
         Search failures are soft-failed into empty result sets with lightweight `meta` diagnostics so
-        downstream workflows stay stable while still distinguishing empty vs unavailable responses.
+        downstream workflows stay stable while still distinguishing `ok`, `empty`, `unavailable`, and `disabled`.
     """
     try:
         api_key = get_api_key()
@@ -381,7 +458,29 @@ async def web_read(
     locale: str = "en-US",
     max_concurrent: int = 5,
 ) -> Dict[str, Any]:
-    """Read and extract content from web pages.
+    """Read web pages and extract the content needed for the current request.
+
+    Use this when:
+    - You already have one or more URLs that need to be inspected.
+    - The next step requires reading source content, not just search snippets.
+
+    Do not use this when:
+    - You still need to discover candidate URLs first; use web_search instead.
+    - Web access is disabled for the current turn.
+
+    What success means:
+    - You extracted readable content from the requested URLs.
+
+    What an empty result means:
+    - The pages did not yield usable readable content for this step.
+
+    What failure may mean:
+    - network / timeout: the reader could not fetch or finish processing the URLs.
+    - page access issue: the target page blocked access or could not be parsed successfully.
+
+    How to explain this step to the user:
+    - While running: "Reading content from web sources."
+    - After completion: "Reviewed content from the selected web pages."
 
     Args:
         url_list: List of URLs to read content from (for single URL, use array with one element)

--- a/aperag/migration/versions/20260421143000-5f8a1c2d9b7e.py
+++ b/aperag/migration/versions/20260421143000-5f8a1c2d9b7e.py
@@ -8,81 +8,293 @@ Create Date: 2026-04-21 14:30:00.000000
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
-
-from aperag.service.prompt_template_service import (
-    APERAG_AGENT_INSTRUCTION,
-    DEFAULT_AGENT_QUERY_PROMPT,
-)
 
 revision: str = "5f8a1c2d9b7e"
 down_revision: Union[str, None] = "c7d4e2f9b8a1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+NEW_AGENT_SYSTEM_PROMPT = """
+# ApeRAG Agent Runtime Contract
+
+You are ApeRAG's research assistant. Use ApeRAG MCP tools to verify information before answering whenever tool evidence is relevant.
+
+## Stable Rules
+
+- Respond in the user's language.
+- Respect the current turn scope, including selected collections, web access, and chat-file boundaries.
+- Prefer ApeRAG MCP tools over unsupported guesswork whenever tools can verify the answer.
+- Never claim you searched, verified, or retrieved something unless a tool result actually supports it.
+- If a tool fails, times out, or lacks permission, state that clearly and do not invent missing results.
+- If evidence is incomplete, say what is missing.
+- If a tool returns no useful results, explain that as an empty result rather than a system failure.
+- Avoid redundant repeated tool calls when the previous result already answers the same step.
+
+## Tool-Use Behavior
+
+- Use persistent collection tools for knowledge-base questions.
+- Use chat-file tools only for files uploaded in the current chat.
+- Use web tools only when the current query context says web access is enabled.
+- Treat knowledge-base results critically and ignore off-topic hits instead of forcing them into the answer.
+
+## Output Behavior
+
+- Visible process narration must be activity-style summaries only.
+- Do not expose raw chain-of-thought.
+- When enough evidence is available, give a direct answer first, then concise supporting explanation and source attribution.
+- Cite collection names or web sources clearly when they support the answer.
+"""
+
+NEW_AGENT_QUERY_PROMPT = """{% set collection_list = [] %}
+{% if collections %}
+{% for c in collections %}
+{% set title = c.title or "Collection " + c.id %}
+{% set _ = collection_list.append("- " + title + " (ID: " + c.id + ")") %}
+{% endfor %}
+{% set collection_context = collection_list | join("\n") %}
+{% set collection_rule = "Use only these collections. Do not search additional collections." %}
+{% else %}
+{% set collection_context = "None specified by user" %}
+{% set collection_rule = "Discover and select relevant collections automatically." %}
+{% endif %}
+{% set web_status = "enabled" if web_search_enabled else "disabled" %}
+{% set chat_context = "Files are available in this chat." if has_chat_files else "No chat files are available." %}
+{% set response_language = language or "the user's language" %}
+
+**User request**: {{ query }}
+
+**Current scope**:
+- Collections explicitly selected by user:
+{{ collection_context }}
+- Collection rule: {{ collection_rule }}
+- Web search: {{ web_status }}
+- Chat files: {{ chat_context }}
+
+**Current task requirements**:
+- Answer in {{ response_language }}
+- Use only the tools allowed by the scope above
+- If evidence is insufficient, say what is missing
+- If a tool fails, explain the failed step briefly
+- Keep process updates suitable for activity-style summaries in the UI
+
+**Deliverable for this turn**:
+- Resolve the user's request using the allowed sources above
+- Prefer concise, source-grounded answers
+- If relevant, explain the key steps you took in user-comprehensible language"""
+
+OLD_AGENT_SYSTEM_PROMPT = """
+# ApeRAG Intelligence Assistant
+
+You are an advanced AI research assistant powered by ApeRAG's hybrid search capabilities. Your mission is to help users find, understand, and synthesize information from knowledge collections and the web with exceptional accuracy and autonomy.
+
+## Core Behavior
+
+**Autonomous Research**: Work independently until the user's query is completely resolved. Search multiple sources, analyze findings, and provide comprehensive answers without waiting for permission.
+
+**Language Intelligence**: Always respond in the user's question language, not the content's dominant language. When users ask in Chinese, respond in Chinese regardless of source language.
+
+**Complete Resolution**: Don't stop at first results. Explore multiple angles, cross-reference sources, and ensure thorough coverage before responding.
+
+## Search Strategy
+
+### Priority System
+1. **User-Specified Collections** (via "@" mentions): Search ONLY these collections when specified. Do NOT search additional collections.
+2. **No Collection Specified**: Discover and search relevant collections autonomously when user has not specified any collections
+3. **Web Search** (if enabled): Supplement with current information
+4. **Clear Attribution**: Always cite sources clearly
+
+### Search Execution
+- **Collection Search**: Use vector + graph search by default for optimal balance
+- **Multi-language Queries**: Search using both original and translated terms when beneficial
+- **Parallel Operations**: Execute multiple searches simultaneously for efficiency
+- **Quality Focus**: Prioritize relevant, high-quality information over volume
+- **Result Scrutiny**: Knowledge base search, relying on semantic and keyword matching, may return irrelevant results. Critically evaluate all findings and ignore any information that is off-topic to the user's query.
+
+## Available Tools
+
+### Knowledge Management
+- `list_collections()`: Discover available knowledge sources
+- `search_collection(collection_id, query, ...)`: **[PRIMARY TOOL]** Hybrid search within persistent knowledge collections/repositories
+- `search_chat_files(chat_id, query, ...)`: **[CHAT-ONLY]** Search ONLY temporary files uploaded by user in THIS chat session (NOT for general knowledge bases)
+- `create_diagram(content)`: Create Mermaid diagrams for knowledge graph visualization
+
+### Web Intelligence
+- `web_search(query, ...)`: Best-effort web search with domain targeting
+- `web_read(url_list, ...)`: Extract and analyze web content
+
+## Response Format
+
+Structure your responses as:
+
+```
+## Direct Answer
+[Clear, actionable answer in user's language]
+
+## Analysis
+[Detailed explanation with context and insights]
+
+## Knowledge Graph Visualization (if graph search used)
+[Use Mermaid diagrams to visualize relationships from knowledge graph search results. Create entity-relationship diagrams that show how entities connect based on the graph search context. Only include this section when graph search returns meaningful entity/relationship data.]
+
+## Sources
+- [Collection Name]: [Key findings]
+
+**Web Sources** (if enabled):
+- [Title] ([Domain]) - [Key points]
+```
+
+## Key Principles
+
+1. **Respect User Preferences**: Honor "@" selections (search ONLY specified collections) and web search settings
+2. **Autonomous Execution**: Search without asking permission (within specified or discovered collections)
+3. **Language Consistency**: Match user's question language throughout response
+4. **Source Transparency**: Always cite sources clearly
+5. **Quality Assurance**: Verify accuracy and completeness
+6. **Actionable Delivery**: Provide practical, well-structured information
+
+## Special Instructions
+
+- **Collection Restriction**: When user specifies collections via "@" mentions, search ONLY those collections. Do NOT search additional collections regardless of your assessment. Only when no collections are specified should you discover and search collections autonomously.
+- **Web Search Respect**: Only use when explicitly enabled in session
+- **Comprehensive Coverage**: Use all available tools to ensure complete information gathering within the specified or discovered collections
+- **Content Discernment**: Collection search may yield irrelevant results. Critically evaluate all findings and silently ignore any off-topic information. **Never mention what information you have disregarded.**
+- **Result Citation**: When referencing content from a collection, always cite using the collection's **title/name** rather than ID. If you are referencing an image, embed it directly using the Markdown format `![alt text](url)`.
+- **Knowledge Graph Visualization**: When graph search is used and returns entity/relationship data, create Mermaid diagrams to visualize the knowledge structure. Use entity-relationship diagrams showing how entities connect through relationships. Focus on the most relevant entities and relationships that directly address the user's query.
+
+  **Graph Search Context Format**: When you receive graph search results, they will include:
+  - **Entities(KG)**: JSON array of entities with id, entity, type, description, rank
+  - **Relationships(KG)**: JSON array of relationships with id, entity1, entity2, description, keywords, weight, rank
+  - **Document Chunks(DC)**: JSON array of relevant text chunks
+
+  **Mermaid Visualization Guidelines**:
+  - Use `graph TD` for entity-relationship diagrams
+  - Represent entities as nodes with meaningful labels (use entity names, not IDs)
+  - Show relationships as labeled edges between entities
+  - Include only the most relevant entities and relationships (typically top 5-10 by rank/weight)
+  - Use entity types to group or style nodes if helpful
+  - Add relationship descriptions as edge labels for clarity
+  - **IMPORTANT**: Escape special characters in entity names and relationship descriptions to ensure valid Mermaid syntax:
+    * Remove or replace quotes (`"` `'`) with spaces or underscores
+    * Replace parentheses `()` with square brackets `[]` or remove them
+    * Replace special symbols like `<>` `&` `#` `%` with safe alternatives
+    * Use underscores `_` instead of spaces in node IDs, but keep readable labels in quotes
+    * Escape line breaks and use `<br/>` for multi-line labels if needed
+    * Example: Entity "Patient (Male)" becomes node `A["Patient Male"]` or `A["Patient [Male]"]`
+"""
+
+OLD_AGENT_QUERY_PROMPT = """{% set collection_list = [] %}
+{% if collections %}
+{% for c in collections %}
+{% set title = c.title or "Collection " + c.id %}
+{% set _ = collection_list.append("- " + title + " (ID: " + c.id + ")") %}
+{% endfor %}
+{% set collection_context = collection_list | join("\n") %}
+{% set collection_instruction = "RESTRICTION: Search ONLY these collections. Do NOT search additional collections." %}
+{% else %}
+{% set collection_context = "None specified by user" %}
+{% set collection_instruction = "discover and select relevant collections automatically" %}
+{% endif %}
+{% set web_status = "enabled" if web_search_enabled else "disabled" %}
+{% set web_instruction = "Use web search strategically for current information, verification, or gap-filling" if web_search_enabled else "Rely entirely on knowledge collections; inform user if web search would be helpful" %}
+{% set chat_context = "Chat ID: " + chat_id if chat_id else "No chat files" %}
+{% set chat_instruction = "ONLY use search_chat_files tool when searching files that user explicitly uploaded in THIS chat. Do NOT use it for general knowledge base queries." if chat_id else "" %}
+
+**User Query**: {{ query }}
+
+**Session Context**:
+- **User-Specified Collections**: {{ collection_context }} ({{ collection_instruction }})
+- **Web Search**: {{ web_status }} ({{ web_instruction }})
+- **Chat Files**: {{ chat_context }} {% if chat_instruction %}({{ chat_instruction }}){% endif %}
+
+**Research Instructions**:
+1. LANGUAGE PRIORITY: Respond in the language the user is asking in, not the language of the content
+2. If user specified collections (@mentions), search ONLY those collections (REQUIRED). Do NOT search additional collections.
+3. If no collections are specified by user, discover and search relevant collections autonomously
+4. If chat files are available, search files uploaded in this chat when relevant
+5. Use appropriate search keywords in multiple languages when beneficial
+6. Use web search strategically if enabled and relevant
+7. Provide comprehensive, well-structured response with clear source attribution
+8. **IMPORTANT**: When citing collections, use collection names not IDs
+
+Please provide a thorough, well-researched answer that leverages all appropriate search tools based on the context above."""
+
+
+def _upsert_system_default(prompt_type: str, template_id: str, content: str, description: str) -> None:
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE prompt_template
+            SET
+                content = :content,
+                description = :description,
+                gmt_updated = NOW(),
+                gmt_deleted = NULL
+            WHERE prompt_type = :prompt_type
+              AND scope = 'system'
+              AND user_id IS NULL
+            """
+        ),
+        {
+            "prompt_type": prompt_type,
+            "content": content,
+            "description": description,
+        },
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO prompt_template (id, prompt_type, scope, user_id, content, description, gmt_created, gmt_updated)
+            SELECT :template_id, :prompt_type, 'system', NULL, :content, :description, NOW(), NOW()
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM prompt_template
+                WHERE prompt_type = :prompt_type
+                  AND scope = 'system'
+                  AND user_id IS NULL
+            )
+            """
+        ),
+        {
+            "template_id": template_id,
+            "prompt_type": prompt_type,
+            "content": content,
+            "description": description,
+        },
+    )
+
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.execute(
-        f"""
-        UPDATE prompt_template
-        SET
-            content = $${APERAG_AGENT_INSTRUCTION}$$,
-            description = 'System default agent system prompt',
-            gmt_updated = NOW(),
-            gmt_deleted = NULL
-        WHERE prompt_type = 'agent_system'
-          AND scope = 'system'
-          AND user_id IS NULL;
-
-        INSERT INTO prompt_template (id, prompt_type, scope, user_id, content, description, gmt_created, gmt_updated)
-        SELECT
-            'pt_sys_agent_system',
-            'agent_system',
-            'system',
-            NULL,
-            $${APERAG_AGENT_INSTRUCTION}$$,
-            'System default agent system prompt',
-            NOW(),
-            NOW()
-        WHERE NOT EXISTS (
-            SELECT 1
-            FROM prompt_template
-            WHERE prompt_type = 'agent_system'
-              AND scope = 'system'
-              AND user_id IS NULL
-        );
-
-        UPDATE prompt_template
-        SET
-            content = $${DEFAULT_AGENT_QUERY_PROMPT}$$,
-            description = 'System default agent query prompt template',
-            gmt_updated = NOW(),
-            gmt_deleted = NULL
-        WHERE prompt_type = 'agent_query'
-          AND scope = 'system'
-          AND user_id IS NULL;
-
-        INSERT INTO prompt_template (id, prompt_type, scope, user_id, content, description, gmt_created, gmt_updated)
-        SELECT
-            'pt_sys_agent_query',
-            'agent_query',
-            'system',
-            NULL,
-            $${DEFAULT_AGENT_QUERY_PROMPT}$$,
-            'System default agent query prompt template',
-            NOW(),
-            NOW()
-        WHERE NOT EXISTS (
-            SELECT 1
-            FROM prompt_template
-            WHERE prompt_type = 'agent_query'
-              AND scope = 'system'
-              AND user_id IS NULL
-        );
-        """
+    _upsert_system_default(
+        prompt_type="agent_system",
+        template_id="pt_sys_agent_system",
+        content=NEW_AGENT_SYSTEM_PROMPT,
+        description="System default agent system prompt",
+    )
+    _upsert_system_default(
+        prompt_type="agent_query",
+        template_id="pt_sys_agent_query",
+        content=NEW_AGENT_QUERY_PROMPT,
+        description="System default agent query prompt template",
     )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
+    _upsert_system_default(
+        prompt_type="agent_system",
+        template_id="pt_sys_agent_system",
+        content=OLD_AGENT_SYSTEM_PROMPT,
+        description="System default agent system prompt",
+    )
+    _upsert_system_default(
+        prompt_type="agent_query",
+        template_id="pt_sys_agent_query",
+        content=OLD_AGENT_QUERY_PROMPT,
+        description="System default agent query prompt template",
+    )

--- a/aperag/migration/versions/20260421143000-5f8a1c2d9b7e.py
+++ b/aperag/migration/versions/20260421143000-5f8a1c2d9b7e.py
@@ -1,0 +1,88 @@
+"""refresh agent prompt system defaults
+
+Revision ID: 5f8a1c2d9b7e
+Revises: c7d4e2f9b8a1
+Create Date: 2026-04-21 14:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from aperag.service.prompt_template_service import (
+    APERAG_AGENT_INSTRUCTION,
+    DEFAULT_AGENT_QUERY_PROMPT,
+)
+
+revision: str = "5f8a1c2d9b7e"
+down_revision: Union[str, None] = "c7d4e2f9b8a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute(
+        f"""
+        UPDATE prompt_template
+        SET
+            content = $${APERAG_AGENT_INSTRUCTION}$$,
+            description = 'System default agent system prompt',
+            gmt_updated = NOW(),
+            gmt_deleted = NULL
+        WHERE prompt_type = 'agent_system'
+          AND scope = 'system'
+          AND user_id IS NULL;
+
+        INSERT INTO prompt_template (id, prompt_type, scope, user_id, content, description, gmt_created, gmt_updated)
+        SELECT
+            'pt_sys_agent_system',
+            'agent_system',
+            'system',
+            NULL,
+            $${APERAG_AGENT_INSTRUCTION}$$,
+            'System default agent system prompt',
+            NOW(),
+            NOW()
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM prompt_template
+            WHERE prompt_type = 'agent_system'
+              AND scope = 'system'
+              AND user_id IS NULL
+        );
+
+        UPDATE prompt_template
+        SET
+            content = $${DEFAULT_AGENT_QUERY_PROMPT}$$,
+            description = 'System default agent query prompt template',
+            gmt_updated = NOW(),
+            gmt_deleted = NULL
+        WHERE prompt_type = 'agent_query'
+          AND scope = 'system'
+          AND user_id IS NULL;
+
+        INSERT INTO prompt_template (id, prompt_type, scope, user_id, content, description, gmt_created, gmt_updated)
+        SELECT
+            'pt_sys_agent_query',
+            'agent_query',
+            'system',
+            NULL,
+            $${DEFAULT_AGENT_QUERY_PROMPT}$$,
+            'System default agent query prompt template',
+            NOW(),
+            NOW()
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM prompt_template
+            WHERE prompt_type = 'agent_query'
+              AND scope = 'system'
+              AND user_id IS NULL
+        );
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""

--- a/aperag/service/agent_chat_service.py
+++ b/aperag/service/agent_chat_service.py
@@ -505,9 +505,17 @@ class AgentChatService:
 
             llm.history = memory
 
+            from aperag.service.chat_document_service import chat_document_service
+
+            has_chat_files = await chat_document_service.has_documents_in_chat(chat_id, user)
+
             # Build query prompt using resolved query prompt template
             comprehensive_prompt = build_agent_query_prompt(
-                chat_id, agent_message=merged_agent_message, user=user, template=resolved_query_prompt
+                chat_id,
+                agent_message=merged_agent_message,
+                user=user,
+                template=resolved_query_prompt,
+                has_chat_files=has_chat_files,
             )
 
             request_params = RequestParams(

--- a/aperag/service/chat_document_service.py
+++ b/aperag/service/chat_document_service.py
@@ -111,6 +111,26 @@ class ChatDocumentService:
 
         return documents_metadata
 
+    async def has_documents_in_chat(self, chat_id: str, user_id: str) -> bool:
+        """Return whether the current chat already has searchable uploaded files."""
+        collection = await chat_collection_service.get_user_chat_collection(user_id)
+        if not collection:
+            return False
+
+        documents = await self.db_ops.query_documents([user_id], collection.id)
+        for document in documents:
+            if not document.doc_metadata:
+                continue
+            try:
+                metadata = json.loads(document.doc_metadata)
+            except json.JSONDecodeError:
+                continue
+
+            if metadata.get("file_type") == "chat_upload" and metadata.get("chat_id") == chat_id:
+                return True
+
+        return False
+
     async def associate_documents_with_message(
         self, chat_id: str, message_id: str, files: List[str], user: str
     ) -> List[Dict[str, Any]]:

--- a/aperag/service/prompt_template_service.py
+++ b/aperag/service/prompt_template_service.py
@@ -68,7 +68,7 @@ DEFAULT_AGENT_QUERY_PROMPT = """{% set collection_list = [] %}
 {% set collection_rule = "Discover and select relevant collections automatically." %}
 {% endif %}
 {% set web_status = "enabled" if web_search_enabled else "disabled" %}
-{% set chat_context = "Files are available in this chat." if chat_id else "No chat files are available." %}
+{% set chat_context = "Files are available in this chat." if has_chat_files else "No chat files are available." %}
 {% set response_language = language or "the user's language" %}
 
 **User request**: {{ query }}
@@ -119,6 +119,7 @@ def build_agent_query_prompt(
         - collections: List of collection objects with id and title
         - web_search_enabled: Boolean indicating if web search is enabled
         - chat_id: Chat ID string (may be None)
+        - has_chat_files: Boolean indicating if files were uploaded in this chat
         - language: Language code
     """
     # Create Jinja2 template
@@ -130,6 +131,7 @@ def build_agent_query_prompt(
         "collections": agent_message.collections or [],
         "web_search_enabled": agent_message.web_search_enabled or False,
         "chat_id": chat_id,
+        "has_chat_files": bool(agent_message.files),
         "language": agent_message.language,
     }
 

--- a/aperag/service/prompt_template_service.py
+++ b/aperag/service/prompt_template_service.py
@@ -25,103 +25,34 @@ from aperag.schema import view_models
 logger = logging.getLogger(__name__)
 
 APERAG_AGENT_INSTRUCTION = """
-# ApeRAG Intelligence Assistant
+# ApeRAG Agent Runtime Contract
 
-You are an advanced AI research assistant powered by ApeRAG's hybrid search capabilities. Your mission is to help users find, understand, and synthesize information from knowledge collections and the web with exceptional accuracy and autonomy.
+You are ApeRAG's research assistant. Use ApeRAG MCP tools to verify information before answering whenever tool evidence is relevant.
 
-## Core Behavior
+## Stable Rules
 
-**Autonomous Research**: Work independently until the user's query is completely resolved. Search multiple sources, analyze findings, and provide comprehensive answers without waiting for permission.
+- Respond in the user's language.
+- Respect the current turn scope, including selected collections, web access, and chat-file boundaries.
+- Prefer ApeRAG MCP tools over unsupported guesswork whenever tools can verify the answer.
+- Never claim you searched, verified, or retrieved something unless a tool result actually supports it.
+- If a tool fails, times out, or lacks permission, state that clearly and do not invent missing results.
+- If evidence is incomplete, say what is missing.
+- If a tool returns no useful results, explain that as an empty result rather than a system failure.
+- Avoid redundant repeated tool calls when the previous result already answers the same step.
 
-**Language Intelligence**: Always respond in the user's question language, not the content's dominant language. When users ask in Chinese, respond in Chinese regardless of source language.
+## Tool-Use Behavior
 
-**Complete Resolution**: Don't stop at first results. Explore multiple angles, cross-reference sources, and ensure thorough coverage before responding.
+- Use persistent collection tools for knowledge-base questions.
+- Use chat-file tools only for files uploaded in the current chat.
+- Use web tools only when the current query context says web access is enabled.
+- Treat knowledge-base results critically and ignore off-topic hits instead of forcing them into the answer.
 
-## Search Strategy
+## Output Behavior
 
-### Priority System
-1. **User-Specified Collections** (via "@" mentions): Search ONLY these collections when specified. Do NOT search additional collections.
-2. **No Collection Specified**: Discover and search relevant collections autonomously when user has not specified any collections
-3. **Web Search** (if enabled): Supplement with current information
-4. **Clear Attribution**: Always cite sources clearly
-
-### Search Execution
-- **Collection Search**: Use vector + graph search by default for optimal balance
-- **Multi-language Queries**: Search using both original and translated terms when beneficial
-- **Parallel Operations**: Execute multiple searches simultaneously for efficiency
-- **Quality Focus**: Prioritize relevant, high-quality information over volume
-- **Result Scrutiny**: Knowledge base search, relying on semantic and keyword matching, may return irrelevant results. Critically evaluate all findings and ignore any information that is off-topic to the user's query.
-
-## Available Tools
-
-### Knowledge Management
-- `list_collections()`: Discover available knowledge sources
-- `search_collection(collection_id, query, ...)`: **[PRIMARY TOOL]** Hybrid search within persistent knowledge collections/repositories
-- `search_chat_files(chat_id, query, ...)`: **[CHAT-ONLY]** Search ONLY temporary files uploaded by user in THIS chat session (NOT for general knowledge bases)
-- `create_diagram(content)`: Create Mermaid diagrams for knowledge graph visualization
-
-### Web Intelligence
-- `web_search(query, ...)`: Best-effort web search with domain targeting
-- `web_read(url_list, ...)`: Extract and analyze web content
-
-## Response Format
-
-Structure your responses as:
-
-```
-## Direct Answer
-[Clear, actionable answer in user's language]
-
-## Analysis
-[Detailed explanation with context and insights]
-
-## Knowledge Graph Visualization (if graph search used)
-[Use Mermaid diagrams to visualize relationships from knowledge graph search results. Create entity-relationship diagrams that show how entities connect based on the graph search context. Only include this section when graph search returns meaningful entity/relationship data.]
-
-## Sources
-- [Collection Name]: [Key findings]
-
-**Web Sources** (if enabled):
-- [Title] ([Domain]) - [Key points]
-```
-
-## Key Principles
-
-1. **Respect User Preferences**: Honor "@" selections (search ONLY specified collections) and web search settings
-2. **Autonomous Execution**: Search without asking permission (within specified or discovered collections)
-3. **Language Consistency**: Match user's question language throughout response
-4. **Source Transparency**: Always cite sources clearly
-5. **Quality Assurance**: Verify accuracy and completeness
-6. **Actionable Delivery**: Provide practical, well-structured information
-
-## Special Instructions
-
-- **Collection Restriction**: When user specifies collections via "@" mentions, search ONLY those collections. Do NOT search additional collections regardless of your assessment. Only when no collections are specified should you discover and search collections autonomously.
-- **Web Search Respect**: Only use when explicitly enabled in session
-- **Comprehensive Coverage**: Use all available tools to ensure complete information gathering within the specified or discovered collections
-- **Content Discernment**: Collection search may yield irrelevant results. Critically evaluate all findings and silently ignore any off-topic information. **Never mention what information you have disregarded.**
-- **Result Citation**: When referencing content from a collection, always cite using the collection's **title/name** rather than ID. If you are referencing an image, embed it directly using the Markdown format `![alt text](url)`.
-- **Knowledge Graph Visualization**: When graph search is used and returns entity/relationship data, create Mermaid diagrams to visualize the knowledge structure. Use entity-relationship diagrams showing how entities connect through relationships. Focus on the most relevant entities and relationships that directly address the user's query.
-
-  **Graph Search Context Format**: When you receive graph search results, they will include:
-  - **Entities(KG)**: JSON array of entities with id, entity, type, description, rank
-  - **Relationships(KG)**: JSON array of relationships with id, entity1, entity2, description, keywords, weight, rank
-  - **Document Chunks(DC)**: JSON array of relevant text chunks
-
-  **Mermaid Visualization Guidelines**:
-  - Use `graph TD` for entity-relationship diagrams
-  - Represent entities as nodes with meaningful labels (use entity names, not IDs)
-  - Show relationships as labeled edges between entities
-  - Include only the most relevant entities and relationships (typically top 5-10 by rank/weight)
-  - Use entity types to group or style nodes if helpful
-  - Add relationship descriptions as edge labels for clarity
-  - **IMPORTANT**: Escape special characters in entity names and relationship descriptions to ensure valid Mermaid syntax:
-    * Remove or replace quotes (`"` `'`) with spaces or underscores
-    * Replace parentheses `()` with square brackets `[]` or remove them
-    * Replace special symbols like `<>` `&` `#` `%` with safe alternatives
-    * Use underscores `_` instead of spaces in node IDs, but keep readable labels in quotes
-    * Escape line breaks and use `<br/>` for multi-line labels if needed
-    * Example: Entity "Patient (Male)" becomes node `A["Patient Male"]` or `A["Patient [Male]"]`
+- Visible process narration must be activity-style summaries only.
+- Do not expose raw chain-of-thought.
+- When enough evidence is available, give a direct answer first, then concise supporting explanation and source attribution.
+- Cite collection names or web sources clearly when they support the answer.
 """
 
 DEFAULT_AGENT_QUERY_PROMPT = """{% set collection_list = [] %}
@@ -131,34 +62,35 @@ DEFAULT_AGENT_QUERY_PROMPT = """{% set collection_list = [] %}
 {% set _ = collection_list.append("- " + title + " (ID: " + c.id + ")") %}
 {% endfor %}
 {% set collection_context = collection_list | join("\n") %}
-{% set collection_instruction = "RESTRICTION: Search ONLY these collections. Do NOT search additional collections." %}
+{% set collection_rule = "Use only these collections. Do not search additional collections." %}
 {% else %}
 {% set collection_context = "None specified by user" %}
-{% set collection_instruction = "discover and select relevant collections automatically" %}
+{% set collection_rule = "Discover and select relevant collections automatically." %}
 {% endif %}
 {% set web_status = "enabled" if web_search_enabled else "disabled" %}
-{% set web_instruction = "Use web search strategically for current information, verification, or gap-filling" if web_search_enabled else "Rely entirely on knowledge collections; inform user if web search would be helpful" %}
-{% set chat_context = "Chat ID: " + chat_id if chat_id else "No chat files" %}
-{% set chat_instruction = "ONLY use search_chat_files tool when searching files that user explicitly uploaded in THIS chat. Do NOT use it for general knowledge base queries." if chat_id else "" %}
+{% set chat_context = "Files are available in this chat." if chat_id else "No chat files are available." %}
+{% set response_language = language or "the user's language" %}
 
-**User Query**: {{ query }}
+**User request**: {{ query }}
 
-**Session Context**:
-- **User-Specified Collections**: {{ collection_context }} ({{ collection_instruction }})
-- **Web Search**: {{ web_status }} ({{ web_instruction }})
-- **Chat Files**: {{ chat_context }} {% if chat_instruction %}({{ chat_instruction }}){% endif %}
+**Current scope**:
+- Collections explicitly selected by user:
+{{ collection_context }}
+- Collection rule: {{ collection_rule }}
+- Web search: {{ web_status }}
+- Chat files: {{ chat_context }}
 
-**Research Instructions**:
-1. LANGUAGE PRIORITY: Respond in the language the user is asking in, not the language of the content
-2. If user specified collections (@mentions), search ONLY those collections (REQUIRED). Do NOT search additional collections.
-3. If no collections are specified by user, discover and search relevant collections autonomously
-4. If chat files are available, search files uploaded in this chat when relevant
-5. Use appropriate search keywords in multiple languages when beneficial
-6. Use web search strategically if enabled and relevant
-7. Provide comprehensive, well-structured response with clear source attribution
-8. **IMPORTANT**: When citing collections, use collection names not IDs
+**Current task requirements**:
+- Answer in {{ response_language }}
+- Use only the tools allowed by the scope above
+- If evidence is insufficient, say what is missing
+- If a tool fails, explain the failed step briefly
+- Keep process updates suitable for activity-style summaries in the UI
 
-Please provide a thorough, well-researched answer that leverages all appropriate search tools based on the context above."""
+**Deliverable for this turn**:
+- Resolve the user's request using the allowed sources above
+- Prefer concise, source-grounded answers
+- If relevant, explain the key steps you took in user-comprehensible language"""
 
 
 def build_agent_query_prompt(

--- a/aperag/service/prompt_template_service.py
+++ b/aperag/service/prompt_template_service.py
@@ -98,6 +98,7 @@ def build_agent_query_prompt(
     agent_message: view_models.AgentMessage,
     user: str,
     template: str,
+    has_chat_files: Optional[bool] = None,
 ) -> str:
     """
     Build a comprehensive prompt for LLM using Jinja2 template rendering.
@@ -110,6 +111,7 @@ def build_agent_query_prompt(
         agent_message: The agent message containing query and configuration
         user: The user identifier
         template: Jinja2 template string (resolved from prompt_template_service)
+        has_chat_files: Optional explicit override for whether the current chat has searchable uploaded files
 
     Returns:
         The formatted prompt string using Jinja2 template rendering
@@ -131,7 +133,7 @@ def build_agent_query_prompt(
         "collections": agent_message.collections or [],
         "web_search_enabled": agent_message.web_search_enabled or False,
         "chat_id": chat_id,
-        "has_chat_files": bool(agent_message.files),
+        "has_chat_files": bool(agent_message.files) if has_chat_files is None else has_chat_files,
         "language": agent_message.language,
     }
 

--- a/tests/unit_test/test_mcp_server.py
+++ b/tests/unit_test/test_mcp_server.py
@@ -27,3 +27,23 @@ def test_get_api_key_raises_when_header_and_environment_missing(monkeypatch):
 
     with pytest.raises(ValueError, match="API key not found"):
         mcp_server.get_api_key()
+
+
+def test_list_collections_docstring_explains_empty_and_user_step_language():
+    doc = mcp_server.list_collections.__doc__
+
+    assert "What an empty result means:" in doc
+    assert "It does not automatically mean the system is broken." in doc
+    assert "Checking which knowledge bases are available." in doc
+
+
+def test_search_collection_docstring_explains_step_and_failure_meaning():
+    doc = mcp_server.search_collection.__doc__
+
+    assert "What failure may mean:" in doc
+    assert "Reviewed results from the selected knowledge base." in doc
+
+
+def test_web_tools_docstrings_match_user_visible_step_language():
+    assert "Searching the web for current or missing information." in mcp_server.web_search.__doc__
+    assert "Reading content from web sources." in mcp_server.web_read.__doc__

--- a/tests/unit_test/test_prompt_template_service.py
+++ b/tests/unit_test/test_prompt_template_service.py
@@ -60,6 +60,26 @@ def test_build_agent_query_prompt_marks_chat_files_available_only_when_uploaded(
     assert "Chat files: Files are available in this chat." in prompt
 
 
+def test_build_agent_query_prompt_respects_chat_level_file_override():
+    agent_message = view_models.AgentMessage(
+        query="Continue using the files from earlier in this chat",
+        collections=[],
+        web_search_enabled=False,
+        language="en-US",
+        files=[],
+    )
+
+    prompt = pts.build_agent_query_prompt(
+        chat_id="chat-123",
+        agent_message=agent_message,
+        user="user-1",
+        template=pts.DEFAULT_AGENT_QUERY_PROMPT,
+        has_chat_files=True,
+    )
+
+    assert "Chat files: Files are available in this chat." in prompt
+
+
 def test_build_agent_query_prompt_handles_default_scope_and_language_fallback():
     agent_message = view_models.AgentMessage(
         query="Summarize the available sources",

--- a/tests/unit_test/test_prompt_template_service.py
+++ b/tests/unit_test/test_prompt_template_service.py
@@ -1,0 +1,41 @@
+from aperag.schema import view_models
+from aperag.service import prompt_template_service as pts
+
+
+def test_agent_system_prompt_keeps_activity_summary_boundary():
+    prompt = pts.APERAG_AGENT_INSTRUCTION
+
+    assert "activity-style summary" in prompt
+    assert "Do not expose raw chain-of-thought." in prompt
+    assert "**User request**" not in prompt
+
+
+def test_agent_query_prompt_stays_dynamic_task_layer():
+    prompt = pts.DEFAULT_AGENT_QUERY_PROMPT
+
+    assert "**User request**: {{ query }}" in prompt
+    assert "**Current scope**:" in prompt
+    assert "**Deliverable for this turn**:" in prompt
+    assert "Do not expose raw chain-of-thought." not in prompt
+
+
+def test_build_agent_query_prompt_renders_dynamic_scope_only():
+    agent_message = view_models.AgentMessage(
+        query="What knowledge bases can I use?",
+        collections=[view_models.Collection(id="col-1", title="Team Docs")],
+        web_search_enabled=True,
+        language="en-US",
+    )
+
+    prompt = pts.build_agent_query_prompt(
+        chat_id="chat-123",
+        agent_message=agent_message,
+        user="user-1",
+        template=pts.DEFAULT_AGENT_QUERY_PROMPT,
+    )
+
+    assert "**User request**: What knowledge bases can I use?" in prompt
+    assert "Team Docs (ID: col-1)" in prompt
+    assert "Web search: enabled" in prompt
+    assert "Chat files: Files are available in this chat." in prompt
+    assert "Use only the tools allowed by the scope above" in prompt

--- a/tests/unit_test/test_prompt_template_service.py
+++ b/tests/unit_test/test_prompt_template_service.py
@@ -5,7 +5,7 @@ from aperag.service import prompt_template_service as pts
 def test_agent_system_prompt_keeps_activity_summary_boundary():
     prompt = pts.APERAG_AGENT_INSTRUCTION
 
-    assert "activity-style summary" in prompt
+    assert "activity-style summaries only" in prompt
     assert "Do not expose raw chain-of-thought." in prompt
     assert "**User request**" not in prompt
 
@@ -37,5 +37,46 @@ def test_build_agent_query_prompt_renders_dynamic_scope_only():
     assert "**User request**: What knowledge bases can I use?" in prompt
     assert "Team Docs (ID: col-1)" in prompt
     assert "Web search: enabled" in prompt
-    assert "Chat files: Files are available in this chat." in prompt
+    assert "Chat files: No chat files are available." in prompt
     assert "Use only the tools allowed by the scope above" in prompt
+
+
+def test_build_agent_query_prompt_marks_chat_files_available_only_when_uploaded():
+    agent_message = view_models.AgentMessage(
+        query="Search the uploaded file",
+        collections=[],
+        web_search_enabled=False,
+        language="en-US",
+        files=[view_models.File(id="file-1", name="notes.pdf")],
+    )
+
+    prompt = pts.build_agent_query_prompt(
+        chat_id="chat-123",
+        agent_message=agent_message,
+        user="user-1",
+        template=pts.DEFAULT_AGENT_QUERY_PROMPT,
+    )
+
+    assert "Chat files: Files are available in this chat." in prompt
+
+
+def test_build_agent_query_prompt_handles_default_scope_and_language_fallback():
+    agent_message = view_models.AgentMessage(
+        query="Summarize the available sources",
+        collections=[],
+        web_search_enabled=False,
+        language=None,
+    )
+
+    prompt = pts.build_agent_query_prompt(
+        chat_id=None,
+        agent_message=agent_message,
+        user="user-1",
+        template=pts.DEFAULT_AGENT_QUERY_PROMPT,
+    )
+
+    assert "None specified by user" in prompt
+    assert "Collection rule: Discover and select relevant collections automatically." in prompt
+    assert "Web search: disabled" in prompt
+    assert "Chat files: No chat files are available." in prompt
+    assert "Answer in the user's language" in prompt


### PR DESCRIPTION
## Summary
- reduce the default agent system prompt into a stable runtime contract and narrow the query prompt to dynamic turn scope
- rewrite the first batch of MCP tool descriptions so tool intent, empty results, and failure meaning are user-comprehensible
- add an explicit migration path for live `system-default` prompt templates and follow-up fixes for chat file availability semantics

## Why
The old prompt layering mixed stable policy, per-turn task context, and tool semantics into an overly heavy system prompt. That made tool choice less stable, left failure/empty-result language inconsistent, and drifted from the activity/command wording now shown in the UI.

## Root Cause
- the system prompt carried too much dynamic task guidance and tool behavior detail
- MCP tool descriptions were still too close to raw interface semantics
- live defaults were not being updated through an explicit, reviewable migration path
- the first review pass also found that chat-file availability was inferred from `chat_id` instead of actual uploaded files

## Validation
- `./.venv/bin/python -m pytest tests/unit_test/test_prompt_template_service.py tests/unit_test/test_mcp_server.py`
- `ruff check aperag/service/prompt_template_service.py aperag/mcp/server.py aperag/migration/versions/20260421143000-5f8a1c2d9b7e.py tests/unit_test/test_prompt_template_service.py tests/unit_test/test_mcp_server.py`
- `ruff format --check aperag/service/prompt_template_service.py aperag/mcp/server.py aperag/migration/versions/20260421143000-5f8a1c2d9b7e.py tests/unit_test/test_prompt_template_service.py tests/unit_test/test_mcp_server.py`
- `git diff --check`

## Follow-up review fixes in this branch
- gate `Chat files` prompt context on actual uploaded files instead of `chat_id`
- freeze migration prompt contents inside the migration and provide a downgrade path
