### PR TITLE
[codex] retire legacy agent websocket main path

### DIFF
--- a/aperag/service/chat_service.py
+++ b/aperag/service/chat_service.py
@@ -221,6 +221,7 @@ class ChatService:
             result = {"action": "upserted", "feedback": feedback}
         return result
 
+
 # Create a global service instance for easy access
 # This uses the global db_ops instance and doesn't require session management in views
 chat_service_global = ChatService()

--- a/aperag/service/chat_service.py
+++ b/aperag/service/chat_service.py
@@ -15,7 +15,6 @@
 import logging
 from typing import Optional
 
-from fastapi import WebSocket, WebSocketDisconnect
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aperag.db import models as db_models
@@ -25,7 +24,6 @@ from aperag.schema import view_models
 from aperag.schema.view_models import Chat, ChatDetails
 from aperag.utils.history import (
     RedisChatMessageHistory,
-    fail_response,
     get_async_redis_client,
 )
 
@@ -222,35 +220,6 @@ class ChatService:
             )
             result = {"action": "upserted", "feedback": feedback}
         return result
-
-    async def handle_websocket_chat(self, websocket: WebSocket, user: str, bot_id: str, chat_id: str):
-        """Handle WebSocket chat connections for agent-type bots."""
-        await websocket.accept()
-
-        try:
-            bot = await self.db_ops.query_bot(user, bot_id)
-            if not bot:
-                await websocket.send_text(fail_response("error", "Bot not found"))
-                return
-
-            if bot.type != db_models.BotType.AGENT:
-                await websocket.send_text(fail_response("error", "Only agent bots are supported"))
-                return
-
-            from aperag.service.agent_chat_service import AgentChatService
-
-            agent_service = AgentChatService()
-            await agent_service.handle_websocket_agent_chat(websocket, user, bot_id, chat_id)
-
-        except WebSocketDisconnect:
-            logger.info(f"WebSocket disconnected for bot {bot_id}, chat {chat_id}")
-        except Exception as e:
-            logger.exception(f"WebSocket error: {e}")
-            try:
-                await websocket.send_text(fail_response("error", str(e)))
-            except Exception as e:
-                logger.exception(f"Error sending fail response: {e}")
-
 
 # Create a global service instance for easy access
 # This uses the global db_ops instance and doesn't require session management in views

--- a/aperag/views/chat.py
+++ b/aperag/views/chat.py
@@ -14,7 +14,7 @@
 
 import logging
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile, WebSocket
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile
 
 from aperag.db.models import User
 from aperag.exceptions import BusinessException
@@ -25,7 +25,7 @@ from aperag.service.chat_service import chat_service_global
 from aperag.service.chat_title_service import chat_title_service
 from aperag.service.collection_service import collection_service
 from aperag.utils.audit_decorator import audit
-from aperag.views.auth import UserManager, authenticate_websocket_user, get_user_manager, required_user
+from aperag.views.auth import required_user
 
 logger = logging.getLogger(__name__)
 
@@ -81,22 +81,6 @@ async def feedback_message_view(
     return await chat_service_global.feedback_message(
         str(user.id), chat_id, message_id, feedback.type, feedback.tag, feedback.message
     )
-
-
-@router.websocket("/bots/{bot_id}/chats/{chat_id}/connect")
-async def websocket_chat_endpoint(
-    websocket: WebSocket, bot_id: str, chat_id: str, user_manager: UserManager = Depends(get_user_manager)
-):
-    """WebSocket endpoint for real-time chat with bots
-
-    Supports cookie-based authentication to get user_id
-    """
-    # Authenticate user from WebSocket cookies
-    user_id = await authenticate_websocket_user(websocket, user_manager)
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Unauthorized")
-
-    await chat_service_global.handle_websocket_chat(websocket, user_id, bot_id, chat_id)
 
 
 @router.post("/bots/{bot_id}/chats/{chat_id}/title")

--- a/web/src/components/chat/chat-messages.tsx
+++ b/web/src/components/chat/chat-messages.tsx
@@ -27,8 +27,6 @@ import { MessagePartsUser } from './message-parts-user';
 
 const AGENT_RUNTIME_BASE_PATH = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/agent`;
 const ACTIVE_TURN_STORAGE_PREFIX = 'agent-runtime-v3:active-turn:';
-const LEGACY_WEBSOCKET_FALLBACK =
-  process.env.NEXT_PUBLIC_AGENT_LEGACY_WEBSOCKET_FALLBACK === '1';
 
 const TURN_EVENT_TYPES = [
   'turn.started',
@@ -140,7 +138,6 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     {},
   );
   const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
-  const [legacyFallbackEnabled, setLegacyFallbackEnabled] = useState(false);
 
   const streamsRef = useRef<Record<string, EventSource>>({});
   const reconnectTimersRef = useRef<
@@ -502,91 +499,6 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     [chatId, closeStream, fetchSnapshot, mergeSnapshot, onStreamEvent],
   );
 
-  const handleLegacyFallback = useCallback(
-    async (params: ChatInputSubmitParams) => {
-      setLegacyFallbackEnabled(true);
-      toast.info('Falling back to legacy websocket chat path.');
-
-      const protocol =
-        window.location.protocol === 'http:' ? 'ws://' : 'wss://';
-      const host = window.location.host;
-      const socket = new WebSocket(
-        `${protocol}${host}${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v1/bots/${botId}/chats/${chatId}/connect`,
-      );
-
-      socket.onmessage = (message) => {
-        const fragment = JSON.parse(message.data) as ChatMessage;
-        if (fragment.type === 'stop' && chatRename && chat) {
-          chatRename(chat);
-        }
-        setMessages((previous) => {
-          const next = cloneMessages(previous);
-          const partsIndex = next.findLastIndex((parts) =>
-            Boolean(
-              parts.find(
-                (part) =>
-                  part.id !== 'error' &&
-                  part.id === fragment.id &&
-                  part.role === 'ai',
-              ),
-            ),
-          );
-          const parts = partsIndex > -1 ? next[partsIndex] : undefined;
-
-          if (parts) {
-            if (fragment.type === 'stop') {
-              parts.push({
-                id: fragment.id,
-                type: 'references',
-                references: Array.isArray(fragment.data) ? fragment.data : [],
-                data: '',
-                role: 'ai',
-              });
-            }
-            if (fragment.type === 'start') {
-              parts.push({
-                ...fragment,
-                type: 'start',
-                data: '',
-              });
-            } else if (fragment.type === 'message') {
-              const part = parts.find((item) => item.type === 'message');
-              if (part) {
-                part.data = (part.data || '') + (fragment.data || '');
-              } else {
-                parts.push(fragment);
-              }
-            } else {
-              const part = parts.find(
-                (item) => fragment.part_id && fragment.part_id === item.part_id,
-              );
-              if (part) {
-                part.data = (part.data || '') + (fragment.data || '');
-              } else {
-                parts.push(fragment);
-              }
-            }
-            next[partsIndex] = [...parts];
-          } else {
-            next.push([{ ...fragment, role: 'ai' }]);
-          }
-
-          return next;
-        });
-      };
-
-      socket.onopen = () => {
-        socket.send(JSON.stringify(params));
-      };
-
-      socket.onerror = () => {
-        toast.error('Legacy websocket fallback failed.');
-        socket.close();
-      };
-    },
-    [botId, chat, chatId, chatRename],
-  );
-
   const handleSendMessage = useCallback(
     async (params: ChatInputSubmitParams) => {
       if (!chatId) return;
@@ -628,10 +540,6 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
             ? error.message
             : 'Failed to create a new agent turn.',
         );
-
-        if (LEGACY_WEBSOCKET_FALLBACK) {
-          await handleLegacyFallback(params);
-        }
       }
     },
     [
@@ -639,7 +547,6 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
       connectTurnStream,
       ensureTurnGroups,
       fetchJson,
-      handleLegacyFallback,
       setTurnState,
       updateActiveTurn,
     ],
@@ -852,11 +759,6 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
         loading={loading}
         onCancel={handleCancel}
       />
-      {legacyFallbackEnabled && (
-        <div className="text-muted-foreground px-4 text-xs">
-          Legacy websocket fallback is enabled for this session.
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## What changed
- removed the legacy websocket fallback path from `web/src/components/chat/chat-messages.tsx`
- removed the legacy websocket chat route from `aperag/views/chat.py`
- removed websocket dispatch from `aperag/service/chat_service.py` to old `AgentChatService`

## Why
The main chat path has already moved to the v2 turn/timeline flow. This PR cuts the remaining old websocket main-path dependency so the primary chat experience only uses the new service.

## Impact
- main chat no longer falls back to `/api/v1/bots/{bot_id}/chats/{chat_id}/connect`
- the old websocket route is no longer exposed from the primary chat path
- the remaining direct `AgentChatService()` dependency stays isolated to evaluation and follow-up retirement work

## Root cause
We still kept a websocket fallback, route, and dispatch from the old agent stack in the main chat path even after the v2 runtime became the primary flow.

## Validation
- `./.venv/bin/python -m py_compile aperag/views/chat.py aperag/service/chat_service.py`
- `yarn eslint src/components/chat/chat-messages.tsx`
- `rg -n "handle_websocket_chat\(|/bots/\{bot_id\}/chats/\{chat_id\}/connect|LEGACY_WEBSOCKET_FALLBACK|AgentChatService\("`
