### PR TITLE
Fix duplicate agent turn execution with per-turn lease

### DIFF
--- a/aperag/agent_runtime/runtime.py
+++ b/aperag/agent_runtime/runtime.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import logging
 import os
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -27,13 +28,19 @@ from pydantic_ai.providers.openai import OpenAIProvider
 
 from aperag.agent_runtime.schemas import CreateTurnRequest, ReferenceBundleItem, VisibleAgentState
 from aperag.agent_runtime.services import ArtifactService, EventService, HistoryWriter, TurnService, _parse_bot_config
+from aperag.agent_runtime.storage import DEFAULT_AGENT_TURN_LEASE_TTL_SECONDS
 from aperag.db.models import AgentArtifactType, AgentEventActor, AgentTurnStatus
 from aperag.db.ops import async_db_ops
 from aperag.exceptions import ResourceNotFoundException, ValidationException
 from aperag.schema import view_models
 from aperag.service.prompt_template_service import build_agent_query_prompt, prompt_template_service
+from aperag.tasks.processing_lease import generate_processing_token
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_AGENT_TURN_LEASE_RENEW_INTERVAL_SECONDS = int(
+    os.getenv("APERAG_AGENT_TURN_LEASE_RENEW_INTERVAL_SECONDS", "30")
+)
 
 
 @dataclass
@@ -46,8 +53,85 @@ class ResolvedAgentRequest:
     aperag_api_key: str
 
 
+class TurnLeaseLostError(RuntimeError):
+    pass
+
+
+class TurnLeaseGuard:
+    def __init__(
+        self,
+        *,
+        turn_service: TurnService,
+        turn_id: str,
+        owner_token: str,
+        ttl_seconds: int = DEFAULT_AGENT_TURN_LEASE_TTL_SECONDS,
+        renew_interval_seconds: int = DEFAULT_AGENT_TURN_LEASE_RENEW_INTERVAL_SECONDS,
+    ):
+        self.turn_service = turn_service
+        self.turn_id = turn_id
+        self.owner_token = owner_token
+        self.ttl_seconds = max(ttl_seconds, 1)
+        self.renew_interval_seconds = max(renew_interval_seconds, 1)
+        self._stop_event = asyncio.Event()
+        self._ownership_lost = asyncio.Event()
+        self._renew_task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        if self._renew_task is not None:
+            return
+        self._renew_task = asyncio.create_task(
+            self._renew_loop(),
+            name=f"agent-runtime-lease-renew-{self.turn_id}",
+        )
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._renew_task is not None:
+            self._renew_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._renew_task
+        try:
+            await self.turn_service.redis_store.release_turn_claim(self.turn_id, self.owner_token)
+        except Exception:
+            logger.exception("Failed to release turn lease for %s", self.turn_id)
+
+    @property
+    def ownership_lost(self) -> bool:
+        return self._ownership_lost.is_set()
+
+    def ensure_owned(self) -> None:
+        if self.ownership_lost:
+            raise TurnLeaseLostError(f"Turn lease ownership lost for {self.turn_id}")
+
+    async def _renew_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self.renew_interval_seconds)
+                return
+            except asyncio.TimeoutError:
+                pass
+
+            try:
+                renewed = await self.turn_service.redis_store.renew_turn_claim(
+                    self.turn_id,
+                    self.owner_token,
+                    ttl_seconds=self.ttl_seconds,
+                )
+            except Exception:
+                logger.exception("Failed to renew turn lease for %s", self.turn_id)
+                continue
+
+            if renewed:
+                continue
+
+            self._ownership_lost.set()
+            logger.warning("Turn lease ownership lost for %s", self.turn_id)
+            self._stop_event.set()
+            return
+
+
 class AgentRuntime:
-    async def run_turn(self, *, turn, chat, bot, user: str, request: CreateTurnRequest) -> None:
+    async def run_turn(self, *, turn, chat, bot, user: str, request: CreateTurnRequest, lease_owner: str) -> None:
         raise NotImplementedError()
 
     async def cancel_turn(self, turn_id: str) -> None:
@@ -65,10 +149,22 @@ class AgentRuntimeTaskManager:
             self.turn_service, self.event_service, self.artifact_service, self.history_writer
         )
 
-    def launch_turn(self, *, turn, chat, bot, user: str, request: CreateTurnRequest) -> None:
+    async def claim_turn(self, turn_id: str) -> str | None:
+        owner_token = generate_processing_token()
+        claimed = await self.turn_service.redis_store.try_claim_turn(turn_id, owner_token)
+        return owner_token if claimed else None
+
+    def launch_turn(self, *, turn, chat, bot, user: str, request: CreateTurnRequest, lease_owner: str) -> None:
         async def _runner():
             try:
-                await self.runtime.run_turn(turn=turn, chat=chat, bot=bot, user=user, request=request)
+                await self.runtime.run_turn(
+                    turn=turn,
+                    chat=chat,
+                    bot=bot,
+                    user=user,
+                    request=request,
+                    lease_owner=lease_owner,
+                )
             finally:
                 self.tasks.pop(turn.id, None)
 
@@ -120,11 +216,12 @@ class PydanticAIRuntime(AgentRuntime):
     async def cancel_turn(self, turn_id: str) -> None:
         await self.turn_service.redis_store.mark_cancelled(turn_id)
 
-    async def run_turn(self, *, turn, chat, bot, user: str, request: CreateTurnRequest) -> None:
+    async def run_turn(self, *, turn, chat, bot, user: str, request: CreateTurnRequest, lease_owner: str) -> None:
         sequence = 0
         text_chunks: list[str] = []
         reference_items: list[ReferenceBundleItem] = []
         tool_summaries: list[str] = []
+        lease_guard = TurnLeaseGuard(turn_service=self.turn_service, turn_id=turn.id, owner_token=lease_owner)
 
         async def emit(
             event_type: str,
@@ -147,8 +244,11 @@ class PydanticAIRuntime(AgentRuntime):
             )
 
         try:
+            await lease_guard.start()
             await self.turn_service.redis_store.clear_cancelled(turn.id)
+            lease_guard.ensure_owned()
             resolved_request = await self._resolve_request(user=user, chat_id=chat.id, bot=bot, request=request)
+            lease_guard.ensure_owned()
             await self.turn_service.mark_running(turn.id)
             await emit("turn.started", actor=AgentEventActor.SYSTEM, status="running", data={"chat_id": chat.id})
             await emit(
@@ -194,7 +294,7 @@ class PydanticAIRuntime(AgentRuntime):
                 )
 
                 async for event in agent.run_stream_events(prompt):
-                    await self._check_cancelled(turn.id)
+                    await self._check_cancelled(turn.id, lease_guard=lease_guard)
 
                     if isinstance(event, pai_messages.FunctionToolCallEvent):
                         tool_name = event.part.tool_name
@@ -292,6 +392,7 @@ class PydanticAIRuntime(AgentRuntime):
                                 data={"delta": final_text},
                             )
 
+            lease_guard.ensure_owned()
             answer_text = "".join(text_chunks).strip()
             answer_artifact = await self.artifact_service.create_artifact(
                 turn_id=turn.id,
@@ -350,7 +451,13 @@ class PydanticAIRuntime(AgentRuntime):
                 tool_summaries=tool_summaries,
                 references=reference_items,
             )
+        except TurnLeaseLostError:
+            logger.warning("Agent Runtime V3 lease lost for turn %s; exiting duplicate runner", turn.id)
+            return
         except asyncio.CancelledError:
+            if lease_guard.ownership_lost:
+                logger.warning("Agent Runtime V3 cancelled after lease loss for turn %s", turn.id)
+                return
             await emit(
                 "agent.state.changed",
                 actor=AgentEventActor.AGENT,
@@ -367,6 +474,13 @@ class PydanticAIRuntime(AgentRuntime):
             await self.turn_service.mark_cancelled(turn.id, sequence=sequence)
             raise
         except Exception as exc:
+            if lease_guard.ownership_lost:
+                logger.warning(
+                    "Agent Runtime V3 suppressing failure for turn %s after lease loss: %s",
+                    turn.id,
+                    exc,
+                )
+                return
             logger.exception("Agent Runtime V3 turn failed: %s", turn.id)
             error_artifact = await self.artifact_service.create_artifact(
                 turn_id=turn.id,
@@ -406,6 +520,8 @@ class PydanticAIRuntime(AgentRuntime):
                 error_message=str(exc),
                 tool_summaries=tool_summaries,
             )
+        finally:
+            await lease_guard.stop()
 
     async def _resolve_request(
         self, *, user: str, chat_id: str, bot, request: CreateTurnRequest
@@ -468,7 +584,9 @@ class PydanticAIRuntime(AgentRuntime):
             aperag_api_key=aperag_api_key,
         )
 
-    async def _check_cancelled(self, turn_id: str) -> None:
+    async def _check_cancelled(self, turn_id: str, lease_guard: TurnLeaseGuard | None = None) -> None:
+        if lease_guard:
+            lease_guard.ensure_owned()
         if await self.turn_service.redis_store.is_cancelled(turn_id):
             raise asyncio.CancelledError()
 

--- a/aperag/agent_runtime/runtime.py
+++ b/aperag/agent_runtime/runtime.py
@@ -38,9 +38,7 @@ from aperag.tasks.processing_lease import generate_processing_token
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_AGENT_TURN_LEASE_RENEW_INTERVAL_SECONDS = int(
-    os.getenv("APERAG_AGENT_TURN_LEASE_RENEW_INTERVAL_SECONDS", "30")
-)
+DEFAULT_AGENT_TURN_LEASE_RENEW_INTERVAL_SECONDS = int(os.getenv("APERAG_AGENT_TURN_LEASE_RENEW_INTERVAL_SECONDS", "30"))
 
 
 @dataclass

--- a/aperag/agent_runtime/storage.py
+++ b/aperag/agent_runtime/storage.py
@@ -13,10 +13,27 @@
 # limitations under the License.
 
 import json
+import os
 from typing import Any
 
 from aperag.agent_runtime.schemas import AgentTimelineEventEnvelope
 from aperag.db.redis_manager import RedisConnectionManager
+
+DEFAULT_AGENT_TURN_LEASE_TTL_SECONDS = int(os.getenv("APERAG_AGENT_TURN_LEASE_TTL_SECONDS", "300"))
+
+_RENEW_TURN_LEASE_SCRIPT = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+end
+return 0
+"""
+
+_RELEASE_TURN_LEASE_SCRIPT = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+"""
 
 
 class AgentRuntimeRedisStore:
@@ -32,6 +49,9 @@ class AgentRuntimeRedisStore:
 
     def _cancel_key(self, turn_id: str) -> str:
         return f"{self.prefix}:turn:{turn_id}:cancelled"
+
+    def _lease_key(self, turn_id: str) -> str:
+        return f"{self.prefix}:turn:{turn_id}:lease"
 
     async def append_event(self, event: AgentTimelineEventEnvelope) -> None:
         client = await RedisConnectionManager.get_async_client()
@@ -75,3 +95,20 @@ class AgentRuntimeRedisStore:
     async def is_cancelled(self, turn_id: str) -> bool:
         client = await RedisConnectionManager.get_async_client()
         return await client.exists(self._cancel_key(turn_id)) > 0
+
+    async def try_claim_turn(self, turn_id: str, owner_token: str, ttl_seconds: int | None = None) -> bool:
+        client = await RedisConnectionManager.get_async_client()
+        ttl = max(ttl_seconds or DEFAULT_AGENT_TURN_LEASE_TTL_SECONDS, 1)
+        claimed = await client.set(self._lease_key(turn_id), owner_token, ex=ttl, nx=True)
+        return bool(claimed)
+
+    async def renew_turn_claim(self, turn_id: str, owner_token: str, ttl_seconds: int | None = None) -> bool:
+        client = await RedisConnectionManager.get_async_client()
+        ttl = max(ttl_seconds or DEFAULT_AGENT_TURN_LEASE_TTL_SECONDS, 1)
+        renewed = await client.eval(_RENEW_TURN_LEASE_SCRIPT, 1, self._lease_key(turn_id), owner_token, ttl)
+        return bool(renewed)
+
+    async def release_turn_claim(self, turn_id: str, owner_token: str) -> bool:
+        client = await RedisConnectionManager.get_async_client()
+        released = await client.eval(_RELEASE_TURN_LEASE_SCRIPT, 1, self._lease_key(turn_id), owner_token)
+        return bool(released)

--- a/aperag/views/agent_runtime.py
+++ b/aperag/views/agent_runtime.py
@@ -49,10 +49,17 @@ async def create_turn_view(
     request: Request, chat_id: str, body: CreateTurnRequest, user: User = Depends(required_user)
 ) -> CreateTurnResponse:
     chat, bot, turn, created = await runtime_manager.turn_service.create_or_get_turn(str(user.id), chat_id, body)
-    if created or (
-        turn.status in {AgentTurnStatus.QUEUED, AgentTurnStatus.RUNNING} and turn.id not in runtime_manager.tasks
-    ):
-        runtime_manager.launch_turn(turn=turn, chat=chat, bot=bot, user=str(user.id), request=body)
+    if created or turn.status in {AgentTurnStatus.QUEUED, AgentTurnStatus.RUNNING}:
+        lease_owner = await runtime_manager.claim_turn(turn.id)
+        if lease_owner:
+            runtime_manager.launch_turn(
+                turn=turn,
+                chat=chat,
+                bot=bot,
+                user=str(user.id),
+                request=body,
+                lease_owner=lease_owner,
+            )
 
     return CreateTurnResponse(
         turn=runtime_manager.turn_service.to_turn_envelope(turn),

--- a/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
+++ b/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 import aperag.agent_runtime.services as agent_runtime_services
+import aperag.agent_runtime.storage as agent_runtime_storage
 from aperag.agent_runtime.schemas import (
     AgentArtifactEnvelope,
     AgentTimelineEventEnvelope,
@@ -42,6 +43,27 @@ class _FakeRedisStore:
         current.update(state)
         self.runtime_state = current
         return current
+
+
+class _FakeLeaseRedisClient:
+    def __init__(self):
+        self.values = {}
+
+    async def set(self, key, value, ex=None, nx=False):
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    async def eval(self, script, _numkeys, key, token, *_args):
+        if "EXPIRE" in script:
+            return 1 if self.values.get(key) == token else 0
+        if "DEL" in script:
+            if self.values.get(key) == token:
+                self.values.pop(key, None)
+                return 1
+            return 0
+        raise AssertionError(f"Unexpected script: {script}")
 
 
 class _FakeDbOps:
@@ -228,6 +250,30 @@ async def test_create_or_get_turn_recovers_existing_turn_after_idempotency_race(
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_redis_store_turn_claim_renew_and_release(monkeypatch):
+    client = _FakeLeaseRedisClient()
+
+    async def _fake_get_async_client(_cls, redis_url=None):
+        return client
+
+    monkeypatch.setattr(
+        agent_runtime_storage.RedisConnectionManager,
+        "get_async_client",
+        classmethod(_fake_get_async_client),
+    )
+
+    store = agent_runtime_storage.AgentRuntimeRedisStore(prefix="test-agent-runtime")
+
+    assert await store.try_claim_turn("turn-1", "owner-a") is True
+    assert await store.try_claim_turn("turn-1", "owner-b") is False
+    assert await store.renew_turn_claim("turn-1", "owner-a") is True
+    assert await store.renew_turn_claim("turn-1", "owner-b") is False
+    assert await store.release_turn_claim("turn-1", "owner-b") is False
+    assert await store.release_turn_claim("turn-1", "owner-a") is True
+    assert await store.try_claim_turn("turn-1", "owner-b") is True
+
+
+@pytest.mark.asyncio
 async def test_history_writer_keeps_legacy_history_and_appends_missing_v3_turns(monkeypatch):
     completed_turn = _build_turn(
         id="turn-v3",
@@ -343,8 +389,14 @@ async def test_agent_runtime_views_create_stream_snapshot_cancel_and_artifact(mo
             self.event_service = _FakeEventService()
             self.artifact_service = _FakeArtifactService()
             self.tasks = {}
+            self.claim_turn_id = None
+            self.claim_turn_result = "lease-owner"
             self.launch_args = None
             self.cancelled_turn_id = None
+
+        async def claim_turn(self, turn_id):
+            self.claim_turn_id = turn_id
+            return self.claim_turn_result
 
         def launch_turn(self, **kwargs):
             self.launch_args = kwargs
@@ -367,7 +419,9 @@ async def test_agent_runtime_views_create_stream_snapshot_cancel_and_artifact(mo
     )
     assert create_response.turn.turn_id == "turn-1"
     assert create_response.stream_url.endswith("/api/v2/agent/chats/chat-1/turns/turn-1/events")
+    assert fake_runtime_manager.claim_turn_id == "turn-1"
     assert fake_runtime_manager.launch_args["turn"].id == "turn-1"
+    assert fake_runtime_manager.launch_args["lease_owner"] == "lease-owner"
 
     snapshot_response = await agent_runtime_view.get_turn_snapshot_view(
         "chat-1",
@@ -404,3 +458,47 @@ async def test_agent_runtime_views_create_stream_snapshot_cancel_and_artifact(mo
     joined = "".join(chunks)
     assert "event: turn.started" in joined
     assert '"turn_id": "turn-1"' in joined
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_view_create_skips_launch_when_turn_claim_fails(monkeypatch):
+    turn = _build_turn(status=AgentTurnStatus.QUEUED, timeline_cursor=0)
+
+    class _FakeTurnService:
+        async def create_or_get_turn(self, _user, _chat_id, _body):
+            return (
+                SimpleNamespace(id="chat-1"),
+                SimpleNamespace(id="bot-1"),
+                turn,
+                True,
+            )
+
+        def to_turn_envelope(self, _turn):
+            return TurnService.to_turn_envelope(turn)
+
+    class _FakeRuntimeManager:
+        def __init__(self):
+            self.turn_service = _FakeTurnService()
+            self.claim_turn_id = None
+            self.launch_args = None
+
+        async def claim_turn(self, turn_id):
+            self.claim_turn_id = turn_id
+            return None
+
+        def launch_turn(self, **kwargs):
+            self.launch_args = kwargs
+
+    fake_runtime_manager = _FakeRuntimeManager()
+    monkeypatch.setattr(agent_runtime_view, "runtime_manager", fake_runtime_manager)
+
+    response = await agent_runtime_view.create_turn_view(
+        _FakeRequest(),
+        "chat-1",
+        CreateTurnRequest(query="hello"),
+        user=SimpleNamespace(id="user-1"),
+    )
+
+    assert response.turn.turn_id == "turn-1"
+    assert fake_runtime_manager.claim_turn_id == "turn-1"
+    assert fake_runtime_manager.launch_args is None


### PR DESCRIPTION
## Summary
- add Redis-backed per-turn lease claim/renew/release primitives for agent runtime
- gate turn launch on a distributed claim instead of process-local task state
- keep the lease alive during runtime execution and exit quietly if ownership is lost
- add unit coverage for lease semantics and launch gating

## Testing
- ./.venv/bin/python -m py_compile aperag/agent_runtime/storage.py aperag/agent_runtime/runtime.py aperag/views/agent_runtime.py tests/unit_test/agent_runtime/test_agent_runtime_v3.py
- ./.venv/bin/pytest tests/unit_test/agent_runtime/test_agent_runtime_v3.py