### PR TITLE
[codex] disable legacy evaluation agent path

### DIFF
--- a/aperag/db/repositories/evaluation.py
+++ b/aperag/db/repositories/evaluation.py
@@ -23,6 +23,48 @@ from aperag.utils.utils import utc_now
 
 
 class AsyncEvaluationRepositoryMixin(AsyncRepositoryProtocol):
+    async def disable_active_evaluations(self, error_message: str) -> tuple[int, int]:
+        """Hard-disables active evaluations and their runnable items."""
+
+        async def _operation(session: AsyncSession):
+            active_eval_ids = list(
+                (
+                    await session.scalars(
+                        select(Evaluation.id).where(
+                            Evaluation.status.in_([EvaluationStatus.PENDING, EvaluationStatus.RUNNING])
+                        )
+                    )
+                ).all()
+            )
+            if not active_eval_ids:
+                return 0, 0
+
+            now = utc_now()
+            evaluation_result = await session.execute(
+                update(Evaluation)
+                .where(Evaluation.id.in_(active_eval_ids))
+                .values(
+                    status=EvaluationStatus.FAILED,
+                    error_message=error_message,
+                    gmt_updated=now,
+                )
+            )
+            item_result = await session.execute(
+                update(EvaluationItem)
+                .where(EvaluationItem.evaluation_id.in_(active_eval_ids))
+                .where(EvaluationItem.status.in_([EvaluationItemStatus.PENDING, EvaluationItemStatus.RUNNING]))
+                .values(
+                    status=EvaluationItemStatus.FAILED,
+                    llm_judge_score=0,
+                    llm_judge_reasoning=error_message,
+                    gmt_updated=now,
+                )
+            )
+            await session.flush()
+            return evaluation_result.rowcount or 0, item_result.rowcount or 0
+
+        return await self.execute_with_transaction(_operation)
+
     async def create_evaluation(self, evaluation: Evaluation, questions: List[Question]) -> Evaluation:
         """Creates a new evaluation."""
 

--- a/aperag/service/evaluation_service.py
+++ b/aperag/service/evaluation_service.py
@@ -46,6 +46,28 @@ MAX_CONCURRENT_EVALUATIONS = int(os.getenv("MAX_CONCURRENT_EVALUATIONS", 5))
 MAX_CONCURRENT_PROCESSING_TASKS_PER_EVALUATION = int(os.getenv("MAX_CONCURRENT_PROCESSING_TASKS_PER_EVALUATION", 1))
 EVALUATION_ITEM_PROCESSING_TASK_TIMEOUT_MINUTES = int(os.getenv("EVALUATION_ITEM_PROCESSING_TASK_TIMEOUT_MINUTES", 15))
 APERAG_API_BASE_URL = os.getenv("APERAG_API_BASE_URL", "http://localhost:8000")
+EVALUATION_FEATURE_ENABLED = False
+EVALUATION_DISABLED_MESSAGE = "Evaluation is disabled during Agent framework retirement."
+
+
+class EvaluationDisabledError(RuntimeError):
+    """Raised when the legacy evaluation feature is intentionally retired."""
+
+
+def ensure_evaluation_feature_enabled():
+    if not EVALUATION_FEATURE_ENABLED:
+        raise EvaluationDisabledError(EVALUATION_DISABLED_MESSAGE)
+
+
+async def disable_active_evaluation_runs(db_ops: AsyncDatabaseOps) -> tuple[int, int]:
+    disabled_evaluations, disabled_items = await db_ops.disable_active_evaluations(EVALUATION_DISABLED_MESSAGE)
+    if disabled_evaluations or disabled_items:
+        logger.warning(
+            "Disabled evaluation retirement path: %s evaluations, %s items",
+            disabled_evaluations,
+            disabled_items,
+        )
+    return disabled_evaluations, disabled_items
 
 
 class EvaluationExecutor:
@@ -65,6 +87,10 @@ class EvaluationExecutor:
         logger.info("Scanning for pending and running evaluations...")
 
         async for session in get_async_session(self.engine):
+            if not EVALUATION_FEATURE_ENABLED:
+                await disable_active_evaluation_runs(AsyncDatabaseOps(session))
+                return
+
             # 1. Schedule new evaluations
             running_count_stmt = select(func.count(Evaluation.id)).where(Evaluation.status == EvaluationStatus.RUNNING)
             running_count = (await session.execute(running_count_stmt)).scalar_one()
@@ -134,6 +160,10 @@ class EvaluationExecutor:
         logger.info(f"Initializing evaluation {evaluation_id}")
         async for session in get_async_session(self.engine):
             try:
+                if not EVALUATION_FEATURE_ENABLED:
+                    await disable_active_evaluation_runs(AsyncDatabaseOps(session))
+                    return
+
                 evaluation = await session.get(Evaluation, evaluation_id)
                 if not evaluation:
                     logger.error(f"Evaluation {evaluation_id} not found.")
@@ -180,6 +210,10 @@ class EvaluationExecutor:
                     return
 
                 async for session in get_async_session(self.engine):
+                    if not EVALUATION_FEATURE_ENABLED:
+                        await disable_active_evaluation_runs(AsyncDatabaseOps(session))
+                        return
+
                     evaluation = await session.get(Evaluation, evaluation_id)
                     if not evaluation or evaluation.gmt_deleted or evaluation.status != EvaluationStatus.RUNNING:
                         logger.info(f"Evaluation {evaluation_id} is not in a runnable state. Halting.")
@@ -234,6 +268,10 @@ class EvaluationExecutor:
 
         async for session in get_async_session(self.engine):
             try:
+                if not EVALUATION_FEATURE_ENABLED:
+                    await disable_active_evaluation_runs(AsyncDatabaseOps(session))
+                    return
+
                 update_stmt = (
                     update(EvaluationItem)
                     .where(EvaluationItem.id == item_id)
@@ -521,6 +559,7 @@ class EvaluationService:
 
     async def create_evaluation(self, request: view_models.EvaluationCreate, user_id: str) -> Evaluation:
         """Creates a new evaluation task."""
+        ensure_evaluation_feature_enabled()
 
         # Basic configuration checks
         question_set = await self.db_ops.get_question_set_by_id(request.question_set_id, user_id)
@@ -631,6 +670,7 @@ class EvaluationService:
 
     async def pause_evaluation(self, eval_id: str, user_id: str) -> Evaluation | None:
         """Pauses a running evaluation."""
+        ensure_evaluation_feature_enabled()
         return await self.db_ops.update_evaluation_status(
             eval_id,
             user_id,
@@ -640,6 +680,7 @@ class EvaluationService:
 
     async def resume_evaluation(self, eval_id: str, user_id: str) -> Evaluation | None:
         """Resumes a paused evaluation by setting it back to pending."""
+        ensure_evaluation_feature_enabled()
         evaluation = await self.db_ops.update_evaluation_status(
             eval_id, user_id, EvaluationStatus.PENDING, [EvaluationStatus.PAUSED]
         )
@@ -652,6 +693,7 @@ class EvaluationService:
 
     async def retry_evaluation(self, eval_id: str, user_id: str, scope: str) -> Evaluation | None:
         """Retries items in an evaluation based on the scope."""
+        ensure_evaluation_feature_enabled()
         evaluation = await self.db_ops.retry_evaluation(eval_id, user_id, scope)
         if evaluation:
             # Trigger the scheduler to pick it up

--- a/aperag/views/evaluation.py
+++ b/aperag/views/evaluation.py
@@ -14,17 +14,18 @@
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from aperag.chat.history.message import StoredChatMessage
 from aperag.db.models import User
-from aperag.exceptions import CollectionNotFoundException
 from aperag.schema import view_models
-from aperag.service.agent_chat_service import AgentChatService
-from aperag.service.collection_service import collection_service
-from aperag.service.evaluation_service import evaluation_service
+from aperag.service.evaluation_service import EVALUATION_DISABLED_MESSAGE, EvaluationDisabledError, evaluation_service
 from aperag.service.question_set_service import question_set_service
 from aperag.views.auth import required_user
 
-router = APIRouter(tags=["evaluation"])
+
+async def evaluation_feature_disabled():
+    raise HTTPException(status_code=410, detail=EVALUATION_DISABLED_MESSAGE)
+
+
+router = APIRouter(tags=["evaluation"], dependencies=[Depends(evaluation_feature_disabled)])
 
 MAX_QUESTIONS_PER_SET = 1000
 
@@ -202,10 +203,10 @@ async def create_evaluation(
     request: view_models.EvaluationCreate,
     user: User = Depends(required_user),
 ):
-    # TODO: check quota limit
-    # The request model is generated from OpenAPI spec, so it should match the new structure.
-    # No changes needed here as long as the view_models are up to date.
-    return await evaluation_service.create_evaluation(request, user.id)
+    try:
+        return await evaluation_service.create_evaluation(request, user.id)
+    except EvaluationDisabledError as exc:
+        raise HTTPException(status_code=410, detail=str(exc)) from exc
 
 
 @router.get("/evaluations/{eval_id}", response_model=view_models.EvaluationDetail)
@@ -254,7 +255,10 @@ async def pause_evaluation(
     eval_id: str,
     user: User = Depends(required_user),
 ):
-    evaluation = await evaluation_service.pause_evaluation(eval_id, user.id)
+    try:
+        evaluation = await evaluation_service.pause_evaluation(eval_id, user.id)
+    except EvaluationDisabledError as exc:
+        raise HTTPException(status_code=410, detail=str(exc)) from exc
     if not evaluation:
         raise HTTPException(status_code=404, detail="Evaluation not found")
     return evaluation
@@ -265,7 +269,10 @@ async def resume_evaluation(
     eval_id: str,
     user: User = Depends(required_user),
 ):
-    evaluation = await evaluation_service.resume_evaluation(eval_id, user.id)
+    try:
+        evaluation = await evaluation_service.resume_evaluation(eval_id, user.id)
+    except EvaluationDisabledError as exc:
+        raise HTTPException(status_code=410, detail=str(exc)) from exc
     if not evaluation:
         raise HTTPException(status_code=404, detail="Evaluation not found")
     return evaluation
@@ -277,7 +284,10 @@ async def retry_evaluation(
     scope: str = Query("failed", enum=["failed", "all"]),
     user: User = Depends(required_user),
 ):
-    evaluation = await evaluation_service.retry_evaluation(eval_id, user.id, scope)
+    try:
+        evaluation = await evaluation_service.retry_evaluation(eval_id, user.id, scope)
+    except EvaluationDisabledError as exc:
+        raise HTTPException(status_code=410, detail=str(exc)) from exc
     if not evaluation:
         raise HTTPException(status_code=404, detail="Evaluation not found")
     return evaluation
@@ -291,43 +301,7 @@ async def chat_with_agent_for_evaluation(
     request: view_models.EvaluationChatWithAgentRequest,
     user: User = Depends(required_user),
 ):
-    """
-    (Internal) Handles a chat request for an evaluation item.
-    This endpoint is called by the Celery worker to execute agent logic in the FastAPI process.
-    """
-    agent_service = AgentChatService()
-    try:
-        collection = await collection_service.get_collection(user.id, request.collection_id)
-        if not collection:
-            raise CollectionNotFoundException(f"Collection {request.collection_id} not found.")
-        collections = [collection]
-    except CollectionNotFoundException as e:
-        raise HTTPException(status_code=404, detail=str(e))
-
-    result = await agent_service.chat_for_evaluation(
-        query=request.question_text,
-        user_id=user.id,
-        model_name=request.agent_llm_config.model_name,
-        model_service_provider=request.agent_llm_config.model_service_provider,
-        custom_llm_provider=request.agent_llm_config.custom_llm_provider,
-        collections=collections,
-        language=request.language or "en-US",
-    )
-
-    # AgentErrorResponse is a TypedDict, which does not support instance checks,
-    # so we check the type field.
-    if isinstance(result, dict) and result.get("type") == "error":
-        return view_models.AgentErrorResponse(
-            type="error",
-            id=result["id"],
-            data=result["data"],
-            timestamp=result["timestamp"],
-        )
-    elif isinstance(result, StoredChatMessage):
-        msgs = result.to_frontend_format()
-        return view_models.ChatSuccessResponse(messages=msgs)
-    else:
-        raise HTTPException(status_code=500, detail=f"Unknown response type, object: {result}")
+    raise HTTPException(status_code=410, detail=EVALUATION_DISABLED_MESSAGE)
 
 
 # endregion

--- a/tests/unit_test/test_evaluation_retirement.py
+++ b/tests/unit_test/test_evaluation_retirement.py
@@ -1,0 +1,53 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+import aperag.service.evaluation_service as evaluation_service_module
+import aperag.views.evaluation as evaluation_view
+
+
+@pytest.mark.asyncio
+async def test_create_resume_retry_raise_when_evaluation_feature_disabled():
+    service = evaluation_service_module.EvaluationService()
+
+    with pytest.raises(evaluation_service_module.EvaluationDisabledError):
+        await service.create_evaluation(object(), "user-1")
+
+    with pytest.raises(evaluation_service_module.EvaluationDisabledError):
+        await service.resume_evaluation("eval-1", "user-1")
+
+    with pytest.raises(evaluation_service_module.EvaluationDisabledError):
+        await service.retry_evaluation("eval-1", "user-1", "all")
+
+
+@pytest.mark.asyncio
+async def test_schedule_evaluations_bulk_disables_active_runs_when_retired(monkeypatch):
+    fake_session = object()
+    disable_mock = AsyncMock(return_value=(2, 3))
+
+    async def _fake_get_async_session(_engine):
+        yield fake_session
+
+    class _FakeDbOps:
+        def __init__(self, session):
+            assert session is fake_session
+
+        disable_active_evaluations = disable_mock
+
+    monkeypatch.setattr(evaluation_service_module, "get_async_session", _fake_get_async_session)
+    monkeypatch.setattr(evaluation_service_module, "AsyncDatabaseOps", _FakeDbOps)
+
+    executor = evaluation_service_module.EvaluationExecutor(engine=None)
+    await executor.schedule_evaluations()
+
+    disable_mock.assert_awaited_once_with(evaluation_service_module.EVALUATION_DISABLED_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_evaluation_routes_raise_gone_when_feature_retired():
+    with pytest.raises(HTTPException) as exc_info:
+        await evaluation_view.evaluation_feature_disabled()
+
+    assert exc_info.value.status_code == 410
+    assert exc_info.value.detail == evaluation_service_module.EVALUATION_DISABLED_MESSAGE

--- a/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
@@ -30,9 +30,6 @@ import {
   Download,
   EllipsisVertical,
   Files,
-  FlaskConical,
-  History,
-  MailQuestionMark,
   Settings,
   Trash,
   VectorSquare,
@@ -57,7 +54,6 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
   const page_collections = useTranslations('page_collections');
   const page_documents = useTranslations('page_documents');
   const page_graph = useTranslations('page_graph');
-  const page_evaluation = useTranslations('page_evaluation');
 
   const urls = useMemo(() => {
     return {
@@ -234,34 +230,6 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
               </span>
             </Link>
           </Button> */}
-
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                data-active={Boolean(pathname.match(/(evaluations|questions)/))}
-                className="hover:border-b-primary data-[active=true]:border-b-primary h-10 rounded-none border-y-2 border-y-transparent px-1 focus-visible:border-transparent focus-visible:ring-0 has-[>svg]:px-2"
-              >
-                <FlaskConical /> {page_evaluation('metadata.title')}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-45">
-              <DropdownMenuItem asChild>
-                <Link
-                  href={`/workspace/collections/${collection.id}/evaluations`}
-                >
-                  <History /> {page_evaluation('evaluation_history')}
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link
-                  href={`/workspace/collections/${collection.id}/questions`}
-                >
-                  <MailQuestionMark /> {page_evaluation('question_set')}
-                </Link>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
 
           <Button
             asChild

--- a/web/src/app/workspace/collections/[collectionId]/evaluations/[evaluationId]/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/evaluations/[evaluationId]/page.tsx
@@ -1,61 +1,10 @@
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-
-import { getServerApi } from '@/lib/api/server';
-
-import { getTranslations } from 'next-intl/server';
-import { notFound } from 'next/navigation';
-import { CollectionHeader } from '../../collection-header';
-import { EvaluationResult } from './evaluation-result';
+import { redirect } from 'next/navigation';
 
 export default async function Page({
   params,
 }: {
   params: Promise<{ evaluationId: string; collectionId: string }>;
 }) {
-  const { evaluationId, collectionId } = await params;
-  const serverApi = await getServerApi();
-  const page_evaluation = await getTranslations('page_evaluation');
-  const page_collections = await getTranslations('page_collections');
-  let evaluation;
-
-  try {
-    const [evaluationRes] = await Promise.all([
-      serverApi.evaluationApi.getEvaluationApiV1EvaluationsEvalIdGet({
-        evalId: evaluationId,
-      }),
-    ]);
-    evaluation = evaluationRes.data;
-  } catch (err) {
-    console.log(err);
-  }
-
-  if (!evaluation) {
-    notFound();
-  }
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: page_collections('metadata.title'),
-            href: '/workspace/collections',
-          },
-          {
-            title: page_evaluation('metadata.title'),
-            href: `/workspace/collections/${collectionId}/evaluations`,
-          },
-          { title: evaluation.name || '--' },
-        ]}
-      />
-      <CollectionHeader />
-      <PageContent>
-        <EvaluationResult evaluation={evaluation} />
-      </PageContent>
-    </PageContainer>
-  );
+  const { collectionId } = await params;
+  redirect(`/workspace/collections/${collectionId}`);
 }

--- a/web/src/app/workspace/collections/[collectionId]/evaluations/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/evaluations/page.tsx
@@ -1,12 +1,4 @@
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
-import { getTranslations } from 'next-intl/server';
-import { CollectionHeader } from '../collection-header';
-import { EvaluationList } from './evaluation-list';
+import { redirect } from 'next/navigation';
 
 export default async function Page({
   params,
@@ -14,33 +6,5 @@ export default async function Page({
   params: Promise<{ collectionId: string }>;
 }) {
   const { collectionId } = await params;
-  const serverApi = await getServerApi();
-  const page_evaluation = await getTranslations('page_evaluation');
-  const page_collections = await getTranslations('page_collections');
-  const [resEvaluations] = await Promise.all([
-    serverApi.evaluationApi.listEvaluationsApiV1EvaluationsGet({
-      collectionId,
-      page: 1,
-      pageSize: 100,
-    }),
-  ]);
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: page_collections('metadata.title'),
-            href: '/workspace/collections',
-          },
-          { title: page_evaluation('metadata.title') },
-        ]}
-      />
-      <CollectionHeader />
-
-      <PageContent>
-        <EvaluationList evaluations={resEvaluations.data.items || []} />
-      </PageContent>
-    </PageContainer>
-  );
+  redirect(`/workspace/collections/${collectionId}`);
 }

--- a/web/src/app/workspace/collections/[collectionId]/questions/[questionSetId]/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/questions/[questionSetId]/page.tsx
@@ -1,61 +1,10 @@
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
-import { getTranslations } from 'next-intl/server';
-import { notFound } from 'next/navigation';
-import { CollectionHeader } from '../../collection-header';
-import { QuestionsList } from './questions-list';
+import { redirect } from 'next/navigation';
 
 export default async function Page({
   params,
 }: {
   params: Promise<{ questionSetId: string; collectionId: string }>;
 }) {
-  const { questionSetId, collectionId } = await params;
-  const page_question_set = await getTranslations('page_question_set');
-  const page_collections = await getTranslations('page_collections');
-
-  const serverApi = await getServerApi();
-
-  let questionSet;
-
-  try {
-    const [questionSetRes] = await Promise.all([
-      serverApi.evaluationApi.getQuestionSetApiV1QuestionSetsQsIdGet({
-        qsId: questionSetId,
-      }),
-    ]);
-    questionSet = questionSetRes.data;
-  } catch (err) {
-    console.log(err);
-  }
-
-  if (!questionSet) {
-    notFound();
-  }
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: page_collections('metadata.title'),
-            href: '/workspace/collections',
-          },
-          {
-            title: page_question_set('metadata.title'),
-            href: `/workspace/collections/${collectionId}/questions`,
-          },
-          { title: questionSet.name || '--' },
-        ]}
-      />
-      <CollectionHeader />
-      <PageContent>
-        <QuestionsList questionSet={questionSet} />
-      </PageContent>
-    </PageContainer>
-  );
+  const { collectionId } = await params;
+  redirect(`/workspace/collections/${collectionId}`);
 }

--- a/web/src/app/workspace/collections/[collectionId]/questions/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/questions/page.tsx
@@ -1,12 +1,4 @@
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
-import { getTranslations } from 'next-intl/server';
-import { CollectionHeader } from '../collection-header';
-import { QuestionSetList } from './question-set-list';
+import { redirect } from 'next/navigation';
 
 export default async function Page({
   params,
@@ -14,33 +6,5 @@ export default async function Page({
   params: Promise<{ collectionId: string }>;
 }) {
   const { collectionId } = await params;
-  const serverApi = await getServerApi();
-  const page_question_set = await getTranslations('page_question_set');
-  const page_collections = await getTranslations('page_collections');
-
-  const [questionSetsRes] = await Promise.all([
-    serverApi.evaluationApi.listQuestionSetsApiV1QuestionSetsGet({
-      collectionId,
-      page: 1,
-      pageSize: 100,
-    }),
-  ]);
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: page_collections('metadata.title'),
-            href: '/workspace/collections',
-          },
-          { title: page_question_set('metadata.title') },
-        ]}
-      />
-      <CollectionHeader />
-      <PageContent>
-        <QuestionSetList questionSets={questionSetsRes.data.items || []} />
-      </PageContent>
-    </PageContainer>
-  );
+  redirect(`/workspace/collections/${collectionId}`);
 }


### PR DESCRIPTION
## What changed
- hard-disabled the legacy evaluation control surface and internal chat endpoint with explicit `410 Gone` responses
- added retirement logic to bulk-fail active `PENDING/RUNNING` evaluations and stop scheduler / worker execution from dispatching old agent-chat work
- removed the collection-level evaluation entry in the frontend and redirected evaluation/question pages back to the collection view
- added focused unit tests for the disabled feature gate and scheduler short-circuit behavior

## Why
`#9` is the remaining gate on retiring the old Agent framework. Evaluation was still the last live dependency on the old `AgentChatService` path. This patch cuts that dependency cleanly so the retirement line can continue.

## Impact
- old evaluation pages are no longer reachable from the UI
- evaluation and question-set APIs now return explicit disabled responses instead of continuing down the legacy path
- queued or active legacy evaluation runs are marked failed and will not continue dispatching work
- no schema or historical records were deleted in this patch

## Validation
- `python -m py_compile aperag/db/repositories/evaluation.py aperag/service/evaluation_service.py aperag/views/evaluation.py`
- `pytest tests/unit_test/test_evaluation_retirement.py -q`
- `ruff check aperag/db/repositories/evaluation.py aperag/service/evaluation_service.py aperag/views/evaluation.py tests/unit_test/test_evaluation_retirement.py`

## Notes
- local frontend eslint could not be run in this worktree because the repo does not currently have a local `node_modules/.bin/eslint` available
- `#11` residual cleanup is intentionally left out of this PR
