### PR TITLE
[codex] show collection titles in chat mentions

### DIFF
--- a/web/src/components/chat/message-parts-user.tsx
+++ b/web/src/components/chat/message-parts-user.tsx
@@ -1,14 +1,39 @@
 import { ChatMessage } from '@/api';
 import { Markdown } from '@/components/markdown';
+import { useBotContext } from '@/components/providers/bot-provider';
 import { UserRound } from 'lucide-react';
+import { useMemo } from 'react';
 import { MessageTimestamp } from './message-timestamp';
 
 export const MessagePartsUser = ({ parts }: { parts: ChatMessage[] }) => {
+  const { collections } = useBotContext();
+
+  const message = useMemo(() => {
+    const rawMessage = parts?.map((part) => part.data || '').join('') || '';
+    if (!rawMessage || collections.length === 0) return rawMessage;
+
+    const collectionNameById = new Map(
+      collections
+        .filter((collection) => collection.id)
+        .map((collection) => [
+          collection.id as string,
+          collection.title || collection.id || '',
+        ]),
+    );
+
+    const mentionPattern = /(^|\s)@([A-Za-z0-9]{24})(?=\s|$)/g;
+    return rawMessage.replace(mentionPattern, (match, prefix, collectionId) => {
+      const collectionName = collectionNameById.get(collectionId);
+      if (!collectionName) return match;
+      return `${prefix}@${collectionName}`;
+    });
+  }, [collections, parts]);
+
   return (
     <div className="ml-auto flex w-max flex-row gap-4">
       <div className="flex max-w-sm flex-col gap-2 sm:max-w-lg md:max-w-2xl lg:max-w-3xl xl:max-w-4xl">
         <div className="bg-primary text-primary-foreground rounded-lg p-4 text-sm">
-          <Markdown>{parts?.map((part) => part.data || '').join('')}</Markdown>
+          <Markdown>{message}</Markdown>
         </div>
         <MessageTimestamp parts={parts} />
       </div>


### PR DESCRIPTION
## Summary
- resolve  mentions in user messages against bot context collections
- render the collection title instead of the raw collection id when a match exists
- keep unmatched mentions unchanged

## Verification
- yarn eslint src/components/chat/message-parts-user.tsx
