### PR TITLE
[codex] add evaluation v2 frontend MVP skeleton

### DIFF
--- a/web/src/app/workspace/bots/[botId]/chats/[chatId]/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/chats/[chatId]/page.tsx
@@ -1,4 +1,5 @@
 import { ChatMessages } from '@/components/chat/chat-messages';
+import { BotSectionNav } from '@/components/evaluation/bot-section-nav';
 import {
   PageContainer,
   PageContent,
@@ -48,6 +49,9 @@ export default async function Page({
           },
         ]}
       />
+      <PageContent className="pb-0">
+        <BotSectionNav botId={botId} active="chats" />
+      </PageContent>
       <PageContent>
         <ChatMessages chat={chat} />
       </PageContent>

--- a/web/src/app/workspace/bots/[botId]/chats/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/chats/page.tsx
@@ -4,6 +4,7 @@ import {
   PageContent,
   PageHeader,
 } from '@/components/page-container';
+import { BotSectionNav } from '@/components/evaluation/bot-section-nav';
 import { getServerApi } from '@/lib/api/server';
 import _ from 'lodash';
 import { getTranslations } from 'next-intl/server';
@@ -36,6 +37,9 @@ export default async function Page({
         breadcrumbs={[{ title: page_chat('metadata.title') }]}
         extra=""
       />
+      <PageContent className="pb-0">
+        <BotSectionNav botId={botId} active="chats" />
+      </PageContent>
       <PageContent></PageContent>
     </PageContainer>
   );

--- a/web/src/app/workspace/bots/[botId]/evaluation/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/evaluation/page.tsx
@@ -1,0 +1,66 @@
+import {
+  PageContainer,
+  PageContent,
+  PageHeader,
+} from '@/components/page-container';
+import { BotSectionNav } from '@/components/evaluation/bot-section-nav';
+import { EvaluationRunsPanel } from '@/components/evaluation/evaluation-runs-panel';
+import { listEvaluationRuns } from '@/components/evaluation/server';
+import { getServerApi } from '@/lib/api/server';
+import { toJson } from '@/lib/utils';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ botId: string }>;
+}) {
+  const { botId } = await params;
+  const serverApi = await getServerApi();
+  const pageBot = await getTranslations('page_bot');
+  const pageBotEvaluation = await getTranslations('page_bot_evaluation');
+
+  let bot;
+
+  try {
+    const botRes = await serverApi.defaultApi.botsBotIdGet({
+      botId,
+    });
+    bot = toJson(botRes.data);
+  } catch {
+    notFound();
+  }
+
+  const runs = await listEvaluationRuns(botId);
+
+  return (
+    <PageContainer>
+      <PageHeader
+        breadcrumbs={[
+          {
+            title: pageBot('metadata.title'),
+          },
+          {
+            title: bot.title || botId,
+            href: `/workspace/bots/${botId}/chats`,
+          },
+          {
+            title: pageBotEvaluation('metadata.title'),
+          },
+        ]}
+      />
+      <PageContent className="pb-0">
+        <BotSectionNav botId={botId} active="evaluation" />
+      </PageContent>
+      <PageContent>
+        <EvaluationRunsPanel
+          bot={bot}
+          runs={runs.items}
+          unavailable={runs.unavailable}
+          error={runs.error}
+        />
+      </PageContent>
+    </PageContainer>
+  );
+}

--- a/web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx
@@ -1,0 +1,77 @@
+import {
+  PageContainer,
+  PageContent,
+  PageHeader,
+} from '@/components/page-container';
+import { BotSectionNav } from '@/components/evaluation/bot-section-nav';
+import { EvaluationRunDetail } from '@/components/evaluation/evaluation-run-detail';
+import {
+  getEvaluationRunDetail,
+  listEvaluationRunItems,
+} from '@/components/evaluation/server';
+import { getServerApi } from '@/lib/api/server';
+import { toJson } from '@/lib/utils';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ botId: string; runId: string }>;
+}) {
+  const { botId, runId } = await params;
+  const serverApi = await getServerApi();
+  const pageBot = await getTranslations('page_bot');
+  const pageBotEvaluation = await getTranslations('page_bot_evaluation');
+
+  let bot;
+
+  try {
+    const botRes = await serverApi.defaultApi.botsBotIdGet({
+      botId,
+    });
+    bot = toJson(botRes.data);
+  } catch {
+    notFound();
+  }
+
+  const [runDetail, runItems] = await Promise.all([
+    getEvaluationRunDetail(runId),
+    listEvaluationRunItems(runId),
+  ]);
+
+  return (
+    <PageContainer>
+      <PageHeader
+        breadcrumbs={[
+          {
+            title: pageBot('metadata.title'),
+          },
+          {
+            title: bot.title || botId,
+            href: `/workspace/bots/${botId}/evaluation`,
+          },
+          {
+            title: pageBotEvaluation('metadata.title'),
+            href: `/workspace/bots/${botId}/evaluation`,
+          },
+          {
+            title: runId,
+          },
+        ]}
+      />
+      <PageContent className="pb-0">
+        <BotSectionNav botId={botId} active="evaluation" />
+      </PageContent>
+      <PageContent>
+        <EvaluationRunDetail
+          botId={botId}
+          detail={runDetail.payload}
+          items={runItems.items}
+          unavailable={runDetail.unavailable || runItems.unavailable}
+          error={runDetail.error || runItems.error}
+        />
+      </PageContent>
+    </PageContainer>
+  );
+}

--- a/web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx
@@ -20,6 +20,16 @@ export default async function Page({
   params: Promise<{ botId: string; runId: string }>;
 }) {
   const { botId, runId } = await params;
+  const [runDetail, runItems] = await Promise.all([
+    getEvaluationRunDetail(runId),
+    listEvaluationRunItems(runId),
+  ]);
+  const resolvedBotId = runDetail.payload?.run?.bot_id || botId;
+
+  if (runDetail.payload?.run?.bot_id && runDetail.payload.run.bot_id !== botId) {
+    notFound();
+  }
+
   const serverApi = await getServerApi();
   const pageBot = await getTranslations('page_bot');
   const pageBotEvaluation = await getTranslations('page_bot_evaluation');
@@ -28,17 +38,12 @@ export default async function Page({
 
   try {
     const botRes = await serverApi.defaultApi.botsBotIdGet({
-      botId,
+      botId: resolvedBotId,
     });
     bot = toJson(botRes.data);
   } catch {
     notFound();
   }
-
-  const [runDetail, runItems] = await Promise.all([
-    getEvaluationRunDetail(runId),
-    listEvaluationRunItems(runId),
-  ]);
 
   return (
     <PageContainer>
@@ -48,12 +53,12 @@ export default async function Page({
             title: pageBot('metadata.title'),
           },
           {
-            title: bot.title || botId,
-            href: `/workspace/bots/${botId}/evaluation`,
+            title: bot.title || resolvedBotId,
+            href: `/workspace/bots/${resolvedBotId}/evaluation`,
           },
           {
             title: pageBotEvaluation('metadata.title'),
-            href: `/workspace/bots/${botId}/evaluation`,
+            href: `/workspace/bots/${resolvedBotId}/evaluation`,
           },
           {
             title: runId,
@@ -61,11 +66,11 @@ export default async function Page({
         ]}
       />
       <PageContent className="pb-0">
-        <BotSectionNav botId={botId} active="evaluation" />
+        <BotSectionNav botId={resolvedBotId} active="evaluation" />
       </PageContent>
       <PageContent>
         <EvaluationRunDetail
-          botId={botId}
+          botId={resolvedBotId}
           detail={runDetail.payload}
           items={runItems.items}
           unavailable={runDetail.unavailable || runItems.unavailable}

--- a/web/src/app/workspace/collections/[collectionId]/benchmarks/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/benchmarks/page.tsx
@@ -1,0 +1,45 @@
+import {
+  PageContainer,
+  PageContent,
+  PageHeader,
+} from '@/components/page-container';
+import { BenchmarksPanel } from '@/components/evaluation/benchmarks-panel';
+import { listBenchmarkDatasets } from '@/components/evaluation/server';
+import { CollectionHeader } from '../collection-header';
+import { getTranslations } from 'next-intl/server';
+
+export default async function Page({
+  params,
+}: Readonly<{
+  params: Promise<{ collectionId: string }>;
+}>) {
+  const { collectionId } = await params;
+  const pageCollections = await getTranslations('page_collections');
+  const pageBenchmarks = await getTranslations('page_benchmarks');
+
+  const datasets = await listBenchmarkDatasets(collectionId);
+
+  return (
+    <PageContainer>
+      <PageHeader
+        breadcrumbs={[
+          {
+            title: pageCollections('metadata.title'),
+            href: '/workspace/collections',
+          },
+          {
+            title: pageBenchmarks('metadata.title'),
+          },
+        ]}
+      />
+      <CollectionHeader />
+      <PageContent>
+        <BenchmarksPanel
+          items={datasets.items}
+          unavailable={datasets.unavailable}
+          error={datasets.error}
+        />
+      </PageContent>
+    </PageContainer>
+  );
+}

--- a/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
@@ -30,6 +30,7 @@ import {
   Download,
   EllipsisVertical,
   Files,
+  FlaskConical,
   Settings,
   Trash,
   VectorSquare,
@@ -52,12 +53,14 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
   const { collection, share, loadShare } = useCollectionContext();
   const pathname = usePathname();
   const page_collections = useTranslations('page_collections');
+  const page_benchmarks = useTranslations('page_benchmarks');
   const page_documents = useTranslations('page_documents');
   const page_graph = useTranslations('page_graph');
 
   const urls = useMemo(() => {
     return {
       documents: `/workspace/collections/${collection.id}/documents`,
+      benchmarks: `/workspace/collections/${collection.id}/benchmarks`,
       search: `/workspace/collections/${collection.id}/search`,
       graph: `/workspace/collections/${collection.id}/graph`,
       settings: `/workspace/collections/${collection.id}/settings`,
@@ -197,6 +200,20 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
               <Files />
               <span className="hidden sm:inline">
                 {page_documents('metadata.title')}
+              </span>
+            </Link>
+          </Button>
+
+          <Button
+            asChild
+            data-active={Boolean(pathname.match(urls.benchmarks))}
+            className="hover:border-b-primary data-[active=true]:border-b-primary h-10 rounded-none border-y-2 border-y-transparent px-1 has-[>svg]:px-2"
+            variant="ghost"
+          >
+            <Link href={urls.benchmarks}>
+              <FlaskConical />
+              <span className="hidden sm:inline">
+                {page_benchmarks('metadata.title')}
               </span>
             </Link>
           </Button>

--- a/web/src/components/evaluation/api-notice.tsx
+++ b/web/src/components/evaluation/api-notice.tsx
@@ -1,0 +1,16 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+
+export const EvaluationApiNotice = ({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) => {
+  return (
+    <Alert>
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{description}</AlertDescription>
+    </Alert>
+  );
+};

--- a/web/src/components/evaluation/benchmarks-panel.tsx
+++ b/web/src/components/evaluation/benchmarks-panel.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { FormatDate } from '@/components/format-date';
+import { Input } from '@/components/ui/input';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useTranslations } from 'next-intl';
+
+import { EvaluationApiNotice } from './api-notice';
+import { EvaluationEmptyState } from './empty-state';
+import { DatasetVersionStatusBadge } from './status-badge';
+import type { BenchmarkDataset } from './types';
+
+const matchesSearch = (dataset: BenchmarkDataset, searchValue: string) => {
+  const query = searchValue.trim().toLowerCase();
+  if (!query) return true;
+
+  return [
+    dataset.name,
+    dataset.description,
+    dataset.source_type,
+    dataset.latest_version?.version_name,
+    dataset.latest_version?.version,
+  ].some((value) => value?.toLowerCase().includes(query));
+};
+
+const getCaseCount = (dataset: BenchmarkDataset) => {
+  return dataset.case_count ?? dataset.latest_version?.case_count ?? 0;
+};
+
+export const BenchmarksPanel = ({
+  items,
+  unavailable,
+  error,
+}: {
+  items: BenchmarkDataset[];
+  unavailable: boolean;
+  error?: string;
+}) => {
+  const t = useTranslations('page_benchmarks');
+  const [searchValue, setSearchValue] = useState('');
+
+  const filteredItems = useMemo(() => {
+    return items.filter((dataset) => matchesSearch(dataset, searchValue));
+  }, [items, searchValue]);
+
+  const summary = useMemo(() => {
+    return {
+      datasets: items.length,
+      readyDatasets: items.filter(
+        (dataset) => dataset.latest_version?.status === 'published',
+      ).length,
+      totalCases: items.reduce((sum, dataset) => sum + getCaseCount(dataset), 0),
+    };
+  }, [items]);
+
+  if (unavailable) {
+    return (
+      <EvaluationApiNotice
+        title={t('not_available_title')}
+        description={error || t('not_available_description')}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('datasets')}</CardDescription>
+            <CardTitle className="text-3xl">{summary.datasets}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('ready_datasets')}</CardDescription>
+            <CardTitle className="text-3xl">{summary.readyDatasets}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('cases')}</CardDescription>
+            <CardTitle className="text-3xl">{summary.totalCases}</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">{t('metadata.title')}</h2>
+          <p className="text-muted-foreground text-sm">{t('metadata.description')}</p>
+        </div>
+        <Input
+          className="w-full md:max-w-sm"
+          placeholder={t('search_placeholder')}
+          value={searchValue}
+          onChange={(event) => setSearchValue(event.currentTarget.value)}
+        />
+      </div>
+
+      {filteredItems.length === 0 ? (
+        <EvaluationEmptyState
+          title={t('empty_title')}
+          description={t('empty_description')}
+        />
+      ) : (
+        <div className="grid gap-4 xl:grid-cols-2">
+          {filteredItems.map((dataset) => (
+            <Card
+              key={
+                dataset.id ||
+                dataset.name ||
+                `${dataset.source_type || 'dataset'}-${dataset.created_at || dataset.latest_version?.version || 'unknown'}`
+              }
+            >
+              <CardHeader className="gap-4">
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-1">
+                    <CardTitle className="text-xl">
+                      {dataset.name || dataset.id || '--'}
+                    </CardTitle>
+                    <CardDescription className="max-w-2xl">
+                      {dataset.description || t('no_description')}
+                    </CardDescription>
+                  </div>
+                  <DatasetVersionStatusBadge
+                    status={dataset.latest_version?.status}
+                  />
+                </div>
+              </CardHeader>
+              <CardContent className="grid gap-4">
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-xl border p-4">
+                    <div className="text-muted-foreground text-xs uppercase tracking-[0.2em]">
+                      {t('source_type')}
+                    </div>
+                    <div className="mt-2 font-medium">
+                      {dataset.source_type || '--'}
+                    </div>
+                  </div>
+                  <div className="rounded-xl border p-4">
+                    <div className="text-muted-foreground text-xs uppercase tracking-[0.2em]">
+                      {t('latest_version')}
+                    </div>
+                    <div className="mt-2 font-medium">
+                      {dataset.latest_version?.version_name ||
+                        dataset.latest_version?.version ||
+                        '--'}
+                    </div>
+                  </div>
+                  <div className="rounded-xl border p-4">
+                    <div className="text-muted-foreground text-xs uppercase tracking-[0.2em]">
+                      {t('cases')}
+                    </div>
+                    <div className="mt-2 font-medium">{getCaseCount(dataset)}</div>
+                  </div>
+                </div>
+
+                <div className="text-muted-foreground flex flex-wrap items-center gap-6 text-sm">
+                  <div>
+                    {t('version_count')}: {dataset.version_count ?? '--'}
+                  </div>
+                  <div>
+                    {t('created_at')}:{' '}
+                    {dataset.created_at ? (
+                      <FormatDate datetime={new Date(dataset.created_at)} />
+                    ) : (
+                      '--'
+                    )}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/src/components/evaluation/benchmarks-panel.tsx
+++ b/web/src/components/evaluation/benchmarks-panel.tsx
@@ -70,6 +70,15 @@ export const BenchmarksPanel = ({
     );
   }
 
+  if (error) {
+    return (
+      <EvaluationApiNotice
+        title={t('error_title')}
+        description={error || t('error_description')}
+      />
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6">
       <div className="grid gap-4 md:grid-cols-3">

--- a/web/src/components/evaluation/bot-section-nav.tsx
+++ b/web/src/components/evaluation/bot-section-nav.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { FlaskConical, MessageSquareText } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+
+export const BotSectionNav = async ({
+  botId,
+  active,
+}: {
+  botId: string;
+  active: 'chats' | 'evaluation';
+}) => {
+  const pageChat = await getTranslations('page_chat');
+  const pageBotEvaluation = await getTranslations('page_bot_evaluation');
+
+  const links = [
+    {
+      key: 'chats',
+      href: `/workspace/bots/${botId}/chats`,
+      label: pageChat('metadata.title'),
+      icon: MessageSquareText,
+    },
+    {
+      key: 'evaluation',
+      href: `/workspace/bots/${botId}/evaluation`,
+      label: pageBotEvaluation('metadata.title'),
+      icon: FlaskConical,
+    },
+  ] as const;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {links.map((link) => {
+        const Icon = link.icon;
+        const isActive = active === link.key;
+        return (
+          <Button
+            key={link.key}
+            asChild
+            variant={isActive ? 'default' : 'outline'}
+            className={cn(
+              'rounded-full',
+              !isActive && 'bg-background',
+            )}
+          >
+            <Link href={link.href}>
+              <Icon className="size-4" />
+              {link.label}
+            </Link>
+          </Button>
+        );
+      })}
+    </div>
+  );
+};

--- a/web/src/components/evaluation/empty-state.tsx
+++ b/web/src/components/evaluation/empty-state.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const EvaluationEmptyState = ({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) => {
+  return (
+    <Card className="border-dashed">
+      <CardHeader>
+        <CardTitle className="text-lg">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="text-muted-foreground text-sm">
+        {description}
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/components/evaluation/evaluation-run-detail.tsx
+++ b/web/src/components/evaluation/evaluation-run-detail.tsx
@@ -1,0 +1,386 @@
+'use client';
+
+import { useEffect, useMemo, useState, useTransition } from 'react';
+
+import { FormatDate } from '@/components/format-date';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Input } from '@/components/ui/input';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { EvaluationApiNotice } from './api-notice';
+import { EvaluationEmptyState } from './empty-state';
+import { EvaluationStatusBadge } from './status-badge';
+import type { EvaluationRunDetailResponse, EvaluationRunItem } from './types';
+
+const NON_TERMINAL_RUN_STATUSES = new Set(['queued', 'running']);
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+const getRunProgress = (detail?: EvaluationRunDetailResponse | null) => {
+  if (typeof detail?.progress?.percent === 'number') {
+    return detail.progress.percent;
+  }
+
+  if (!detail?.summary?.total || detail.summary.total <= 0) {
+    return 0;
+  }
+
+  const resolved =
+    (detail.summary.completed || 0) +
+    (detail.summary.failed || 0) +
+    (detail.summary.cancelled || 0);
+
+  return Math.round((resolved / detail.summary.total) * 100);
+};
+
+const extractErrorMessage = (payload: unknown) => {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'detail' in payload &&
+    typeof payload.detail === 'string'
+  ) {
+    return payload.detail;
+  }
+
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'message' in payload &&
+    typeof payload.message === 'string'
+  ) {
+    return payload.message;
+  }
+
+  return undefined;
+};
+
+const matchesSearch = (item: EvaluationRunItem, searchValue: string) => {
+  const query = searchValue.trim().toLowerCase();
+  if (!query) return true;
+
+  return [
+    item.case_key,
+    item.status,
+    item.error,
+    item.latest_attempt?.agent_chat_id,
+    item.latest_attempt?.agent_turn_id,
+  ].some((value) => value?.toLowerCase().includes(query));
+};
+
+export const EvaluationRunDetail = ({
+  botId,
+  detail,
+  items,
+  unavailable,
+  error,
+}: {
+  botId: string;
+  detail: EvaluationRunDetailResponse | null;
+  items: EvaluationRunItem[];
+  unavailable: boolean;
+  error?: string;
+}) => {
+  const t = useTranslations('page_bot_evaluation');
+  const router = useRouter();
+  const [searchValue, setSearchValue] = useState('');
+  const [isPending, startTransition] = useTransition();
+
+  const run = detail?.run;
+  const filteredItems = useMemo(() => {
+    return items.filter((item) => matchesSearch(item, searchValue));
+  }, [items, searchValue]);
+
+  useEffect(() => {
+    if (!run?.status || !NON_TERMINAL_RUN_STATUSES.has(run.status)) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      startTransition(() => {
+        router.refresh();
+      });
+    }, 5000);
+
+    return () => window.clearTimeout(timer);
+  }, [router, run?.status, startTransition]);
+
+  const refreshPage = () => {
+    startTransition(() => {
+      router.refresh();
+    });
+  };
+
+  const postAction = async (path: string, body?: unknown) => {
+    const response = await fetch(`${basePath}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const payload = await response.json().catch(() => undefined);
+
+    if (!response.ok) {
+      throw new Error(
+        extractErrorMessage(payload) ||
+          `Request failed with status ${response.status}`,
+      );
+    }
+
+    return payload;
+  };
+
+  const handleCancelRun = async () => {
+    if (!run?.id) return;
+
+    try {
+      await postAction(`/api/v2/evaluation-runs/${run.id}/cancel`);
+      toast.success(t('cancel_success'));
+      refreshPage();
+    } catch (actionError) {
+      toast.error(
+        actionError instanceof Error ? actionError.message : t('action_failed'),
+      );
+    }
+  };
+
+  const handleRetryItem = async (itemId?: string) => {
+    if (!run?.id || !itemId) return;
+
+    try {
+      await postAction(
+        `/api/v2/evaluation-runs/${run.id}/items/${itemId}/retry`,
+        {},
+      );
+      toast.success(t('retry_success'));
+      refreshPage();
+    } catch (actionError) {
+      toast.error(
+        actionError instanceof Error ? actionError.message : t('action_failed'),
+      );
+    }
+  };
+
+  if (unavailable) {
+    return (
+      <EvaluationApiNotice
+        title={t('not_available_title')}
+        description={error || t('not_available_description')}
+      />
+    );
+  }
+
+  if (!run) {
+    return (
+      <EvaluationEmptyState
+        title={t('empty_detail_title')}
+        description={t('empty_detail_description')}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid gap-4 xl:grid-cols-[1.4fr_repeat(4,1fr)]">
+        <Card className="xl:col-span-1">
+          <CardHeader>
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <CardDescription>{t('run_detail')}</CardDescription>
+                <CardTitle className="text-2xl">{run.id || '--'}</CardTitle>
+              </div>
+              <EvaluationStatusBadge status={run.status} />
+            </div>
+            <CardDescription>
+              {t('dataset_version')}: {run.dataset_version_id || '--'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">{t('progress')}</span>
+                <span>{getRunProgress(detail)}%</span>
+              </div>
+              <Progress value={getRunProgress(detail)} />
+            </div>
+            <div className="text-muted-foreground flex flex-wrap gap-6 text-sm">
+              <div>
+                {t('created_at')}:{' '}
+                {run.created_at ? (
+                  <FormatDate datetime={new Date(run.created_at)} />
+                ) : (
+                  '--'
+                )}
+              </div>
+              <div>
+                {t('updated_at')}:{' '}
+                {run.updated_at ? (
+                  <FormatDate datetime={new Date(run.updated_at)} />
+                ) : (
+                  '--'
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('summary_total')}</CardDescription>
+            <CardTitle className="text-3xl">{detail.summary?.total ?? 0}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('summary_running')}</CardDescription>
+            <CardTitle className="text-3xl">
+              {detail.summary?.running ?? 0}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('summary_completed')}</CardDescription>
+            <CardTitle className="text-3xl">
+              {detail.summary?.completed ?? 0}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('avg_score')}</CardDescription>
+            <CardTitle className="text-3xl">
+              {typeof detail.summary?.avg_score === 'number'
+                ? detail.summary.avg_score.toFixed(2)
+                : '--'}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle>{t('items')}</CardTitle>
+            <CardDescription>{t('items_description')}</CardDescription>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              className="w-full sm:w-72"
+              placeholder={t('search_placeholder')}
+              value={searchValue}
+              onChange={(event) => setSearchValue(event.currentTarget.value)}
+            />
+            {NON_TERMINAL_RUN_STATUSES.has(run.status || '') && (
+              <Button
+                variant="outline"
+                onClick={handleCancelRun}
+                disabled={isPending}
+              >
+                {t('cancel_run')}
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {filteredItems.length === 0 ? (
+            <EvaluationEmptyState
+              title={t('empty_items_title')}
+              description={t('empty_items_description')}
+            />
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('case_key')}</TableHead>
+                  <TableHead>{t('status_label')}</TableHead>
+                  <TableHead>{t('score')}</TableHead>
+                  <TableHead>{t('latest_attempt')}</TableHead>
+                  <TableHead>{t('trace')}</TableHead>
+                  <TableHead>{t('error')}</TableHead>
+                  <TableHead className="text-right">{t('actions')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredItems.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell className="font-medium">{item.case_key || '--'}</TableCell>
+                    <TableCell>
+                      <EvaluationStatusBadge status={item.status} />
+                    </TableCell>
+                    <TableCell>
+                      {typeof item.best_score === 'number'
+                        ? item.best_score.toFixed(2)
+                        : '--'}
+                    </TableCell>
+                    <TableCell>
+                      <div className="space-y-1">
+                        <div>
+                          {t('attempt_label')} #{item.latest_attempt?.attempt_no ?? '--'}
+                        </div>
+                        {item.latest_attempt?.finished_at && (
+                          <div className="text-muted-foreground text-xs">
+                            <FormatDate
+                              datetime={new Date(item.latest_attempt.finished_at)}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {item.latest_attempt?.agent_chat_id ? (
+                        <Link
+                          className="text-primary text-sm underline-offset-4 hover:underline"
+                          href={`/workspace/bots/${botId}/chats/${item.latest_attempt.agent_chat_id}`}
+                        >
+                          {t('open_chat')}
+                        </Link>
+                      ) : (
+                        '--'
+                      )}
+                    </TableCell>
+                    <TableCell className="max-w-60 whitespace-normal text-sm">
+                      {item.error || item.latest_attempt?.error || '--'}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {(item.status === 'failed' || item.status === 'cancelled') && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={isPending}
+                          onClick={() => handleRetryItem(item.id)}
+                        >
+                          {t('retry_item')}
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/web/src/components/evaluation/evaluation-run-detail.tsx
+++ b/web/src/components/evaluation/evaluation-run-detail.tsx
@@ -191,6 +191,15 @@ export const EvaluationRunDetail = ({
     );
   }
 
+  if (error) {
+    return (
+      <EvaluationApiNotice
+        title={t('error_title')}
+        description={error || t('error_description')}
+      />
+    );
+  }
+
   if (!run) {
     return (
       <EvaluationEmptyState
@@ -351,7 +360,7 @@ export const EvaluationRunDetail = ({
                       {item.latest_attempt?.agent_chat_id ? (
                         <Link
                           className="text-primary text-sm underline-offset-4 hover:underline"
-                          href={`/workspace/bots/${botId}/chats/${item.latest_attempt.agent_chat_id}`}
+                          href={`/workspace/bots/${run.bot_id || botId}/chats/${item.latest_attempt.agent_chat_id}`}
                         >
                           {t('open_chat')}
                         </Link>

--- a/web/src/components/evaluation/evaluation-runs-panel.tsx
+++ b/web/src/components/evaluation/evaluation-runs-panel.tsx
@@ -84,6 +84,15 @@ export const EvaluationRunsPanel = ({
     );
   }
 
+  if (error) {
+    return (
+      <EvaluationApiNotice
+        title={t('error_title')}
+        description={error || t('error_description')}
+      />
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6">
       <div className="grid gap-4 xl:grid-cols-[1.4fr_repeat(4,1fr)]">

--- a/web/src/components/evaluation/evaluation-runs-panel.tsx
+++ b/web/src/components/evaluation/evaluation-runs-panel.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import type { Bot } from '@/api';
+import { FormatDate } from '@/components/format-date';
+import { Progress } from '@/components/ui/progress';
+import { Input } from '@/components/ui/input';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import React from 'react';
+
+import { EvaluationApiNotice } from './api-notice';
+import { EvaluationEmptyState } from './empty-state';
+import { EvaluationStatusBadge } from './status-badge';
+import type { EvaluationRun } from './types';
+
+const getRunProgress = (run: EvaluationRun) => {
+  if (typeof run.progress?.percent === 'number') {
+    return run.progress.percent;
+  }
+
+  if (!run.summary?.total || run.summary.total <= 0) {
+    return 0;
+  }
+
+  const resolved =
+    (run.summary.completed || 0) +
+    (run.summary.failed || 0) +
+    (run.summary.cancelled || 0);
+
+  return Math.round((resolved / run.summary.total) * 100);
+};
+
+const matchesSearch = (run: EvaluationRun, searchValue: string) => {
+  const query = searchValue.trim().toLowerCase();
+  if (!query) return true;
+
+  return [run.id, run.dataset_version_id, run.status].some((value) =>
+    value?.toLowerCase().includes(query),
+  );
+};
+
+export const EvaluationRunsPanel = ({
+  bot,
+  runs,
+  unavailable,
+  error,
+}: {
+  bot?: Bot;
+  runs: EvaluationRun[];
+  unavailable: boolean;
+  error?: string;
+}) => {
+  const t = useTranslations('page_bot_evaluation');
+  const [searchValue, setSearchValue] = useState('');
+
+  const filteredRuns = useMemo(() => {
+    return runs.filter((run) => matchesSearch(run, searchValue));
+  }, [runs, searchValue]);
+
+  const summary = useMemo(() => {
+    return {
+      total: runs.length,
+      running: runs.filter((run) => run.status === 'running').length,
+      failed: runs.filter((run) => run.status === 'failed').length,
+      completed: runs.filter((run) => run.status === 'completed').length,
+    };
+  }, [runs]);
+
+  if (unavailable) {
+    return (
+      <EvaluationApiNotice
+        title={t('not_available_title')}
+        description={error || t('not_available_description')}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid gap-4 xl:grid-cols-[1.4fr_repeat(4,1fr)]">
+        <Card className="xl:col-span-1">
+          <CardHeader>
+            <CardDescription>{t('bot_scope')}</CardDescription>
+            <CardTitle className="text-2xl">{bot?.title || bot?.id || '--'}</CardTitle>
+            <CardDescription>{t('metadata.description')}</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('runs')}</CardDescription>
+            <CardTitle className="text-3xl">{summary.total}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('summary_running')}</CardDescription>
+            <CardTitle className="text-3xl">{summary.running}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('summary_completed')}</CardDescription>
+            <CardTitle className="text-3xl">{summary.completed}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t('summary_failed')}</CardDescription>
+            <CardTitle className="text-3xl">{summary.failed}</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">{t('metadata.title')}</h2>
+          <p className="text-muted-foreground text-sm">{t('metadata.description')}</p>
+        </div>
+        <Input
+          className="w-full md:max-w-sm"
+          placeholder={t('search_placeholder')}
+          value={searchValue}
+          onChange={(event) => setSearchValue(event.currentTarget.value)}
+        />
+      </div>
+
+      {filteredRuns.length === 0 ? (
+        <EvaluationEmptyState
+          title={t('empty_title')}
+          description={t('empty_description')}
+        />
+      ) : (
+        <div className="grid gap-4 xl:grid-cols-2">
+          {filteredRuns.map((run) => {
+            const key =
+              run.id || `${run.dataset_version_id}-${run.created_at || 'run'}`;
+            const content = (
+              <Card className="h-full transition-colors hover:bg-accent/30">
+                <CardHeader className="gap-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <CardTitle className="text-lg">{run.id || '--'}</CardTitle>
+                      <CardDescription>
+                        {t('dataset_version')}: {run.dataset_version_id || '--'}
+                      </CardDescription>
+                    </div>
+                    <EvaluationStatusBadge status={run.status} />
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">{t('progress')}</span>
+                      <span>{getRunProgress(run)}%</span>
+                    </div>
+                    <Progress value={getRunProgress(run)} />
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                    <div className="rounded-xl border p-3">
+                      <div className="text-muted-foreground text-xs">
+                        {t('summary_total')}
+                      </div>
+                      <div className="mt-2 text-lg font-semibold">
+                        {run.summary?.total ?? '--'}
+                      </div>
+                    </div>
+                    <div className="rounded-xl border p-3">
+                      <div className="text-muted-foreground text-xs">
+                        {t('summary_running')}
+                      </div>
+                      <div className="mt-2 text-lg font-semibold">
+                        {run.summary?.running ?? '--'}
+                      </div>
+                    </div>
+                    <div className="rounded-xl border p-3">
+                      <div className="text-muted-foreground text-xs">
+                        {t('summary_completed')}
+                      </div>
+                      <div className="mt-2 text-lg font-semibold">
+                        {run.summary?.completed ?? '--'}
+                      </div>
+                    </div>
+                    <div className="rounded-xl border p-3">
+                      <div className="text-muted-foreground text-xs">
+                        {t('avg_score')}
+                      </div>
+                      <div className="mt-2 text-lg font-semibold">
+                        {typeof run.summary?.avg_score === 'number'
+                          ? run.summary.avg_score.toFixed(2)
+                          : '--'}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="text-muted-foreground flex items-center justify-between text-sm">
+                    <div>
+                      {t('created_at')}:{' '}
+                      {run.created_at ? (
+                        <FormatDate datetime={new Date(run.created_at)} />
+                      ) : (
+                        '--'
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+
+            if (!run.id) {
+              return <React.Fragment key={key}>{content}</React.Fragment>;
+            }
+
+            return (
+              <Link
+                key={key}
+                href={`/workspace/bots/${bot?.id}/evaluation/runs/${run.id}`}
+              >
+                {content}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/src/components/evaluation/server.ts
+++ b/web/src/components/evaluation/server.ts
@@ -1,0 +1,209 @@
+import 'server-only';
+
+import { cookies } from 'next/headers';
+
+import { getLocale } from '@/services/cookies';
+
+import type {
+  BenchmarkDataset,
+  EvaluationPagination,
+  EvaluationRun,
+  EvaluationRunDetailResponse,
+  EvaluationRunItem,
+} from './types';
+
+type FetchState<T> = {
+  payload: T | null;
+  unavailable: boolean;
+  error?: string;
+};
+
+type ListState<T> = FetchState<unknown> & {
+  items: T[];
+  page?: EvaluationPagination;
+};
+
+const API_SERVER_ORIGIN = process.env.API_SERVER_ENDPOINT || 'http://localhost:8000';
+const API_SERVER_BASE_PATH = process.env.API_SERVER_BASE_PATH || '/api/v1';
+const API_ROOT_BASE_PATH = API_SERVER_BASE_PATH.replace(/\/api\/v1\/?$/, '').replace(
+  /\/$/,
+  '',
+);
+const API_V2_BASE_URL = `${API_SERVER_ORIGIN}${API_ROOT_BASE_PATH}/api/v2`;
+
+const buildUrl = (
+  path: string,
+  query?: Record<string, string | number | undefined>,
+) => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const url = new URL(`${API_V2_BASE_URL}${normalizedPath}`);
+
+  Object.entries(query || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    url.searchParams.set(key, String(value));
+  });
+
+  return url.toString();
+};
+
+const extractErrorMessage = (payload: unknown) => {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'detail' in payload &&
+    typeof payload.detail === 'string'
+  ) {
+    return payload.detail;
+  }
+
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'message' in payload &&
+    typeof payload.message === 'string'
+  ) {
+    return payload.message;
+  }
+
+  return undefined;
+};
+
+const getCookieHeader = async () => {
+  const cookieStore = await cookies();
+  return cookieStore
+    .getAll()
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join('; ');
+};
+
+const fetchEvaluationV2 = async <T>(
+  path: string,
+  query?: Record<string, string | number | undefined>,
+): Promise<FetchState<T>> => {
+  const lang = await getLocale();
+  const cookieHeader = await getCookieHeader();
+
+  try {
+    const response = await fetch(buildUrl(path, query), {
+      method: 'GET',
+      cache: 'no-store',
+      headers: {
+        Lang: lang,
+        Cookie: cookieHeader,
+      },
+    });
+
+    if (response.status === 404 || response.status === 405 || response.status === 501) {
+      return {
+        payload: null,
+        unavailable: true,
+      };
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    const payload = contentType.includes('application/json')
+      ? await response.json()
+      : null;
+
+    if (!response.ok) {
+      return {
+        payload: null,
+        unavailable: false,
+        error:
+          extractErrorMessage(payload) ||
+          `Request failed with status ${response.status}`,
+      };
+    }
+
+    return {
+      payload: payload as T,
+      unavailable: false,
+    };
+  } catch (error) {
+    return {
+      payload: null,
+      unavailable: true,
+      error: error instanceof Error ? error.message : 'Network request failed',
+    };
+  }
+};
+
+const extractItems = <T>(payload: unknown, fallbackKeys: string[] = []) => {
+  if (Array.isArray(payload)) {
+    return payload as T[];
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const candidateKeys = ['items', ...fallbackKeys];
+  for (const key of candidateKeys) {
+    const candidate = (payload as Record<string, unknown>)[key];
+    if (Array.isArray(candidate)) {
+      return candidate as T[];
+    }
+  }
+
+  return [];
+};
+
+const extractPage = (payload: unknown): EvaluationPagination | undefined => {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const candidate =
+    (payload as Record<string, unknown>).page ||
+    (payload as Record<string, unknown>).pagination;
+
+  if (!candidate || typeof candidate !== 'object') return undefined;
+  return candidate as EvaluationPagination;
+};
+
+export const listBenchmarkDatasets = async (
+  collectionId: string,
+): Promise<ListState<BenchmarkDataset>> => {
+  const result = await fetchEvaluationV2<unknown>('/benchmark-datasets', {
+    collection_id: collectionId,
+  });
+
+  return {
+    ...result,
+    items: extractItems<BenchmarkDataset>(result.payload, ['datasets']),
+    page: extractPage(result.payload),
+  };
+};
+
+export const listEvaluationRuns = async (
+  botId: string,
+): Promise<ListState<EvaluationRun>> => {
+  const result = await fetchEvaluationV2<unknown>('/evaluation-runs', {
+    bot_id: botId,
+  });
+
+  return {
+    ...result,
+    items: extractItems<EvaluationRun>(result.payload, ['runs']),
+    page: extractPage(result.payload),
+  };
+};
+
+export const getEvaluationRunDetail = async (
+  runId: string,
+): Promise<FetchState<EvaluationRunDetailResponse>> => {
+  return fetchEvaluationV2<EvaluationRunDetailResponse>(
+    `/evaluation-runs/${runId}`,
+  );
+};
+
+export const listEvaluationRunItems = async (
+  runId: string,
+): Promise<ListState<EvaluationRunItem>> => {
+  const result = await fetchEvaluationV2<unknown>(
+    `/evaluation-runs/${runId}/items`,
+  );
+
+  return {
+    ...result,
+    items: extractItems<EvaluationRunItem>(result.payload, ['run_items']),
+    page: extractPage(result.payload),
+  };
+};

--- a/web/src/components/evaluation/status-badge.tsx
+++ b/web/src/components/evaluation/status-badge.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { useTranslations } from 'next-intl';
+
+const toneByStatus: Record<string, string> = {
+  draft: 'border-slate-300 bg-slate-100 text-slate-700',
+  published: 'border-emerald-300 bg-emerald-100 text-emerald-800',
+  archived: 'border-zinc-300 bg-zinc-100 text-zinc-700',
+  queued: 'border-slate-300 bg-slate-100 text-slate-700',
+  pending: 'border-slate-300 bg-slate-100 text-slate-700',
+  running: 'border-sky-300 bg-sky-100 text-sky-800',
+  completed: 'border-emerald-300 bg-emerald-100 text-emerald-800',
+  failed: 'border-rose-300 bg-rose-100 text-rose-800',
+  cancelled: 'border-amber-300 bg-amber-100 text-amber-800',
+};
+
+const fallbackLabel = (status?: string) => {
+  if (!status) return '--';
+  return status
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
+const getStatusLabel = (
+  status: string | undefined,
+  t: ReturnType<typeof useTranslations>,
+) => {
+  if (!status) return '--';
+
+  const key = `status.${status.toLowerCase()}`;
+  try {
+    return t(key);
+  } catch {
+    return fallbackLabel(status);
+  }
+};
+
+export const DatasetVersionStatusBadge = ({
+  status,
+}: {
+  status?: string;
+}) => {
+  const t = useTranslations('page_benchmarks');
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'border px-2.5 py-1 text-xs font-medium',
+        toneByStatus[status?.toLowerCase() || 'draft'],
+      )}
+    >
+      {getStatusLabel(status, t)}
+    </Badge>
+  );
+};
+
+export const EvaluationStatusBadge = ({
+  status,
+}: {
+  status?: string;
+}) => {
+  const t = useTranslations('page_bot_evaluation');
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'border px-2.5 py-1 text-xs font-medium',
+        toneByStatus[status?.toLowerCase() || 'queued'],
+      )}
+    >
+      {getStatusLabel(status, t)}
+    </Badge>
+  );
+};

--- a/web/src/components/evaluation/types.ts
+++ b/web/src/components/evaluation/types.ts
@@ -1,0 +1,126 @@
+export type DatasetVersionStatus = 'draft' | 'published' | 'archived';
+
+export type EvaluationRunStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export type EvaluationRunItemStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export type EvaluationAttemptStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export type BenchmarkDatasetSourceType =
+  | 'manual'
+  | 'import'
+  | 'migrated_from_question_set'
+  | string;
+
+export interface BenchmarkDatasetVersion {
+  id?: string;
+  dataset_id?: string;
+  version?: string;
+  version_name?: string;
+  status?: DatasetVersionStatus;
+  case_count?: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface BenchmarkDataset {
+  id?: string;
+  collection_id?: string;
+  name?: string;
+  description?: string;
+  source_type?: BenchmarkDatasetSourceType;
+  latest_version?: BenchmarkDatasetVersion;
+  version_count?: number;
+  case_count?: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface EvaluationRunConfig {
+  model?: string;
+  judge_mode?: 'none' | 'exact_match' | 'llm_as_judge' | string;
+  concurrency?: number;
+  max_attempts?: number;
+}
+
+export interface EvaluationRunSummary {
+  total?: number;
+  pending?: number;
+  running?: number;
+  completed?: number;
+  failed?: number;
+  cancelled?: number;
+  avg_score?: number;
+}
+
+export interface EvaluationRunProgress {
+  percent?: number;
+  eta_ms?: number;
+}
+
+export interface EvaluationRun {
+  id?: string;
+  bot_id?: string;
+  dataset_version_id?: string;
+  status?: EvaluationRunStatus;
+  config?: EvaluationRunConfig;
+  summary?: EvaluationRunSummary;
+  progress?: EvaluationRunProgress;
+  created_at?: string;
+  updated_at?: string;
+  started_at?: string;
+  finished_at?: string;
+}
+
+export interface EvaluationRunItemAttempt {
+  id?: string;
+  run_item_id?: string;
+  attempt_no?: number;
+  status?: EvaluationAttemptStatus;
+  agent_turn_id?: string;
+  agent_chat_id?: string;
+  score?: number;
+  error?: string;
+  started_at?: string;
+  finished_at?: string;
+}
+
+export interface EvaluationRunItem {
+  id?: string;
+  run_id?: string;
+  case_id?: string;
+  case_key?: string;
+  status?: EvaluationRunItemStatus;
+  best_score?: number;
+  latest_attempt?: EvaluationRunItemAttempt;
+  error?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface EvaluationRunDetailResponse {
+  run?: EvaluationRun;
+  summary?: EvaluationRunSummary;
+  progress?: EvaluationRunProgress;
+}
+
+export interface EvaluationPagination {
+  total?: number;
+  offset?: number;
+  limit?: number;
+}

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -404,6 +404,8 @@
     "empty_title": "No benchmark datasets yet",
     "empty_description": "Create and publish benchmark datasets for this collection to unlock evaluation runs.",
     "no_description": "No description available",
+    "error_title": "Benchmark data could not be loaded",
+    "error_description": "The benchmark endpoint returned an error. Please retry after the backend contract and server state are checked.",
     "not_available_title": "Benchmark APIs are not ready yet",
     "not_available_description": "The frontend route is in place. Data will populate here once the evaluation v2 backend endpoints land.",
     "status": {
@@ -454,6 +456,8 @@
     "empty_detail_description": "The run detail endpoint is reachable, but this run has not returned structured data yet.",
     "empty_items_title": "No run items yet",
     "empty_items_description": "Items will appear after the run is created and the worker starts dispatching attempts.",
+    "error_title": "Evaluation data could not be loaded",
+    "error_description": "The evaluation endpoint returned an error. Please retry after the backend contract and server state are checked.",
     "not_available_title": "Evaluation APIs are not ready yet",
     "not_available_description": "The UI is ready. Data and actions will appear here once the evaluation v2 endpoints are merged.",
     "status": {

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -388,6 +388,83 @@
     "rag_answer": "RAG Answer",
     "judge_reason": "LLM Judge Reasoning"
   },
+  "page_benchmarks": {
+    "metadata": {
+      "title": "Benchmarks",
+      "description": "Curate benchmark datasets for this collection, track ready versions, and prepare published cases for bot evaluations."
+    },
+    "datasets": "Datasets",
+    "ready_datasets": "Ready datasets",
+    "cases": "Cases",
+    "latest_version": "Latest version",
+    "version_count": "Versions",
+    "source_type": "Source",
+    "created_at": "Created",
+    "search_placeholder": "Search benchmark datasets",
+    "empty_title": "No benchmark datasets yet",
+    "empty_description": "Create and publish benchmark datasets for this collection to unlock evaluation runs.",
+    "no_description": "No description available",
+    "not_available_title": "Benchmark APIs are not ready yet",
+    "not_available_description": "The frontend route is in place. Data will populate here once the evaluation v2 backend endpoints land.",
+    "status": {
+      "draft": "Draft",
+      "published": "Published",
+      "archived": "Archived"
+    }
+  },
+  "page_bot_evaluation": {
+    "metadata": {
+      "title": "Evaluation Runs",
+      "description": "Track benchmark runs for this bot, inspect progress, and drill into item-level execution details."
+    },
+    "bot_scope": "Bot scope",
+    "runs": "Runs",
+    "run_detail": "Run detail",
+    "dataset_version": "Dataset version",
+    "progress": "Progress",
+    "avg_score": "Avg. score",
+    "summary_total": "Total",
+    "summary_pending": "Pending",
+    "summary_running": "Running",
+    "summary_completed": "Completed",
+    "summary_failed": "Failed",
+    "summary_cancelled": "Cancelled",
+    "created_at": "Created",
+    "updated_at": "Updated",
+    "items": "Run items",
+    "items_description": "Each item reflects one benchmark case and its latest execution attempt.",
+    "latest_attempt": "Latest attempt",
+    "attempt_label": "Attempt",
+    "case_key": "Case key",
+    "score": "Score",
+    "trace": "Trace",
+    "open_chat": "Open chat",
+    "error": "Error",
+    "actions": "Actions",
+    "status_label": "Status",
+    "cancel_run": "Cancel run",
+    "retry_item": "Retry item",
+    "cancel_success": "Run cancelled",
+    "retry_success": "Retry queued",
+    "action_failed": "Action failed",
+    "search_placeholder": "Search runs, cases, or trace ids",
+    "empty_title": "No evaluation runs yet",
+    "empty_description": "Run a published benchmark dataset against this bot to populate this page.",
+    "empty_detail_title": "Run details are not available yet",
+    "empty_detail_description": "The run detail endpoint is reachable, but this run has not returned structured data yet.",
+    "empty_items_title": "No run items yet",
+    "empty_items_description": "Items will appear after the run is created and the worker starts dispatching attempts.",
+    "not_available_title": "Evaluation APIs are not ready yet",
+    "not_available_description": "The UI is ready. Data and actions will appear here once the evaluation v2 endpoints are merged.",
+    "status": {
+      "queued": "Queued",
+      "pending": "Pending",
+      "running": "Running",
+      "completed": "Completed",
+      "failed": "Failed",
+      "cancelled": "Cancelled"
+    }
+  },
   "page_graph": {
     "metadata": {
       "title": "Knowledge Graph"

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -391,6 +391,83 @@
     "rag_answer": "系统回答",
     "judge_reason": "评测结论"
   },
+  "page_benchmarks": {
+    "metadata": {
+      "title": "Benchmarks",
+      "description": "为当前知识库整理评测数据集、跟踪可运行版本，并为机器人评测准备已发布 case。"
+    },
+    "datasets": "数据集",
+    "ready_datasets": "可运行数据集",
+    "cases": "用例数",
+    "latest_version": "最新版本",
+    "version_count": "版本数",
+    "source_type": "来源",
+    "created_at": "创建时间",
+    "search_placeholder": "搜索 benchmark 数据集",
+    "empty_title": "还没有 benchmark 数据集",
+    "empty_description": "先为这个知识库创建并发布 benchmark 数据集，后续才能发起 evaluation run。",
+    "no_description": "暂无描述",
+    "not_available_title": "Benchmark API 还未就绪",
+    "not_available_description": "前端路由和页面已经准备好，等 evaluation v2 后端接口合入后，这里就会展示真实数据。",
+    "status": {
+      "draft": "草稿",
+      "published": "已发布",
+      "archived": "已归档"
+    }
+  },
+  "page_bot_evaluation": {
+    "metadata": {
+      "title": "Evaluation Runs",
+      "description": "查看这个机器人的 benchmark run、执行进度，以及逐条 item 的运行结果。"
+    },
+    "bot_scope": "机器人范围",
+    "runs": "运行记录",
+    "run_detail": "运行详情",
+    "dataset_version": "数据集版本",
+    "progress": "进度",
+    "avg_score": "平均分",
+    "summary_total": "总数",
+    "summary_pending": "待运行",
+    "summary_running": "运行中",
+    "summary_completed": "已完成",
+    "summary_failed": "失败",
+    "summary_cancelled": "已取消",
+    "created_at": "创建时间",
+    "updated_at": "更新时间",
+    "items": "运行项",
+    "items_description": "每条 item 对应一个 benchmark case，以及它最近一次 attempt 的执行状态。",
+    "latest_attempt": "最近一次尝试",
+    "attempt_label": "尝试",
+    "case_key": "用例键",
+    "score": "分数",
+    "trace": "Trace",
+    "open_chat": "打开会话",
+    "error": "错误",
+    "actions": "操作",
+    "status_label": "状态",
+    "cancel_run": "取消运行",
+    "retry_item": "重试此项",
+    "cancel_success": "已取消该 run",
+    "retry_success": "已加入重试队列",
+    "action_failed": "操作失败",
+    "search_placeholder": "搜索 run、case 或 trace id",
+    "empty_title": "还没有 evaluation run",
+    "empty_description": "等这个机器人开始跑已发布的 benchmark 数据集后，这里就会出现运行记录。",
+    "empty_detail_title": "暂时还没有结构化运行详情",
+    "empty_detail_description": "路由已经打通，但这个 run 还没有返回完整详情数据。",
+    "empty_items_title": "还没有 run item",
+    "empty_items_description": "run 创建后，worker 开始分发 attempt，这里就会逐步出现 item。",
+    "not_available_title": "Evaluation API 还未就绪",
+    "not_available_description": "前端页面已经准备好，等 evaluation v2 接口合入后，这里会自动显示真实数据和操作。",
+    "status": {
+      "queued": "已排队",
+      "pending": "待运行",
+      "running": "运行中",
+      "completed": "已完成",
+      "failed": "失败",
+      "cancelled": "已取消"
+    }
+  },
   "page_graph": {
     "metadata": {
       "title": "知识图谱"

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -407,6 +407,8 @@
     "empty_title": "还没有 benchmark 数据集",
     "empty_description": "先为这个知识库创建并发布 benchmark 数据集，后续才能发起 evaluation run。",
     "no_description": "暂无描述",
+    "error_title": "Benchmark 数据加载失败",
+    "error_description": "Benchmark 接口返回了错误，请先检查后端 contract 和服务状态后再重试。",
     "not_available_title": "Benchmark API 还未就绪",
     "not_available_description": "前端路由和页面已经准备好，等 evaluation v2 后端接口合入后，这里就会展示真实数据。",
     "status": {
@@ -457,6 +459,8 @@
     "empty_detail_description": "路由已经打通，但这个 run 还没有返回完整详情数据。",
     "empty_items_title": "还没有 run item",
     "empty_items_description": "run 创建后，worker 开始分发 attempt，这里就会逐步出现 item。",
+    "error_title": "Evaluation 数据加载失败",
+    "error_description": "Evaluation 接口返回了错误，请先检查后端 contract 和服务状态后再重试。",
     "not_available_title": "Evaluation API 还未就绪",
     "not_available_description": "前端页面已经准备好，等 evaluation v2 接口合入后，这里会自动显示真实数据和操作。",
     "status": {


### PR DESCRIPTION
## Summary
- add evaluation v2 frontend routes for collection benchmarks, bot evaluation runs, and run detail
- add shared evaluation UI components, local frozen-contract types, and server-side /api/v2 data loaders
- expose the new entry points from collection and bot navigation while keeping API-unavailable states graceful

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('web/src/i18n/en-US.json','utf8')); JSON.parse(require('fs').readFileSync('web/src/i18n/zh-CN.json','utf8')); console.log('json ok')"`

## Notes
- `web/node_modules` is not present in this worktree, so local `eslint` / `tsc` could not be executed here.
- frontend data flow follows the frozen `evaluation v2` contract discussed in `#evaluation`.