### PR TITLE
[codex] evaluation v2 backend Phase 1 scaffolding (models + migration + package)

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -47,6 +47,7 @@ from aperag.views.chat import router as chat_router
 from aperag.views.collections import router as collections_router
 from aperag.views.config import router as config_router
 from aperag.views.evaluation import router as evaluation_router
+from aperag.views.evaluation_v2 import router as evaluation_v2_router
 from aperag.views.export import router as export_router
 from aperag.views.graph import router as graph_router
 from aperag.views.llm import router as llm_router
@@ -115,6 +116,7 @@ app.include_router(chat_router, prefix="/api/v1")
 app.include_router(openai_router, prefix="/v1")
 app.include_router(config_router, prefix="/api/v1/config")
 app.include_router(agent_runtime_router, prefix="/api/v2")
+app.include_router(evaluation_v2_router, prefix="/api/v2")
 
 # Only include test router in dev mode
 if os.environ.get("DEPLOYMENT_MODE") == "dev":

--- a/aperag/db/models.py
+++ b/aperag/db/models.py
@@ -241,6 +241,48 @@ class EvaluationItemStatus(str, Enum):
     FAILED = "FAILED"
 
 
+class BenchmarkDatasetVersionStatus(str, Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
+    ARCHIVED = "archived"
+
+
+class BenchmarkDatasetSourceType(str, Enum):
+    MANUAL = "manual"
+    IMPORT = "import"
+    MIGRATED_FROM_QUESTION_SET = "migrated_from_question_set"
+
+
+class EvaluationRunStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class EvaluationRunItemStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class EvaluationRunItemAttemptStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class EvaluationJudgeMode(str, Enum):
+    NONE = "none"
+    EXACT_MATCH = "exact_match"
+    LLM_AS_JUDGE = "llm_as_judge"
+
+
 # Models
 class Collection(Base):
     __tablename__ = "collection"
@@ -1270,3 +1312,158 @@ class PromptTemplate(Base):
     gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     gmt_updated = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     gmt_deleted = Column(DateTime(timezone=True), nullable=True, index=True)
+
+
+# ===== Evaluation v2 (new evaluation product line on top of Agent Runtime V3) =====
+
+
+class BenchmarkDataset(Base):
+    __tablename__ = "benchmark_datasets"
+    __table_args__ = (
+        Index("idx_benchmark_datasets_user", "user_id"),
+        Index("idx_benchmark_datasets_collection", "collection_id"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "bds_" + random_id()[:16])
+    user_id = Column(String(256), nullable=False)
+    collection_id = Column(String(24), nullable=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    source_type = Column(
+        EnumColumn(BenchmarkDatasetSourceType),
+        nullable=False,
+        default=BenchmarkDatasetSourceType.MANUAL,
+    )
+    schema_hint = Column(JSON, nullable=True)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    gmt_deleted = Column(DateTime(timezone=True), nullable=True, index=True)
+
+
+class BenchmarkDatasetVersion(Base):
+    __tablename__ = "benchmark_dataset_versions"
+    __table_args__ = (
+        UniqueConstraint("dataset_id", "version", name="uq_benchmark_dataset_version"),
+        Index("idx_benchmark_dataset_versions_dataset", "dataset_id"),
+        Index("idx_benchmark_dataset_versions_status", "status"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "bdv_" + random_id()[:16])
+    dataset_id = Column(String(32), nullable=False)
+    version = Column(Integer, nullable=False)
+    version_name = Column(String(255), nullable=True)
+    status = Column(
+        EnumColumn(BenchmarkDatasetVersionStatus),
+        nullable=False,
+        default=BenchmarkDatasetVersionStatus.PUBLISHED,
+    )
+    case_count = Column(Integer, nullable=False, default=0)
+    source_snapshot = Column(JSON, nullable=True)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    gmt_published = Column(DateTime(timezone=True), nullable=True)
+
+
+class BenchmarkCase(Base):
+    __tablename__ = "benchmark_cases"
+    __table_args__ = (
+        UniqueConstraint("dataset_version_id", "case_key", name="uq_benchmark_case_version_key"),
+        Index("idx_benchmark_cases_version", "dataset_version_id"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "bc_" + random_id()[:16])
+    dataset_version_id = Column(String(32), nullable=False)
+    case_key = Column(String(128), nullable=False)
+    input_message = Column(Text, nullable=False)
+    expected_answer = Column(Text, nullable=True)
+    reference_context = Column(Text, nullable=True)
+    tags = Column(JSON, nullable=True)
+    case_metadata = Column(JSON, nullable=True)
+    sort_key = Column(Integer, nullable=False, default=0)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+
+
+class EvaluationRun(Base):
+    __tablename__ = "evaluation_runs"
+    __table_args__ = (
+        Index("idx_evaluation_runs_user", "user_id"),
+        Index("idx_evaluation_runs_bot", "bot_id"),
+        Index("idx_evaluation_runs_status", "status"),
+        Index("idx_evaluation_runs_dataset_version", "dataset_version_id"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "er_" + random_id()[:16])
+    user_id = Column(String(256), nullable=False)
+    bot_id = Column(String(24), nullable=False)
+    dataset_version_id = Column(String(32), nullable=False)
+    name = Column(String(255), nullable=True)
+    bot_config_snapshot = Column(JSON, nullable=True)
+    model_config_snapshot = Column(JSON, nullable=True)
+    judge_config = Column(JSON, nullable=True)
+    status = Column(
+        EnumColumn(EvaluationRunStatus),
+        nullable=False,
+        default=EvaluationRunStatus.QUEUED,
+    )
+    summary = Column(JSON, nullable=True)
+    error_message = Column(Text, nullable=True)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    gmt_started = Column(DateTime(timezone=True), nullable=True)
+    gmt_finished = Column(DateTime(timezone=True), nullable=True)
+
+
+class EvaluationRunItem(Base):
+    __tablename__ = "evaluation_run_items"
+    __table_args__ = (
+        UniqueConstraint("run_id", "case_id", name="uq_evaluation_run_item_run_case"),
+        Index("idx_evaluation_run_items_run", "run_id"),
+        Index("idx_evaluation_run_items_status", "status"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "eri_" + random_id()[:16])
+    run_id = Column(String(32), nullable=False)
+    case_id = Column(String(32), nullable=False)
+    case_key = Column(String(128), nullable=False)
+    status = Column(
+        EnumColumn(EvaluationRunItemStatus),
+        nullable=False,
+        default=EvaluationRunItemStatus.PENDING,
+    )
+    best_score = Column(Numeric(6, 3), nullable=True)
+    latest_attempt_id = Column(String(32), nullable=True)
+    attempt_count = Column(Integer, nullable=False, default=0)
+    error_message = Column(Text, nullable=True)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+
+
+class EvaluationRunItemAttempt(Base):
+    __tablename__ = "evaluation_run_item_attempts"
+    __table_args__ = (
+        UniqueConstraint("run_item_id", "attempt_no", name="uq_evaluation_run_item_attempt_no"),
+        Index("idx_evaluation_run_item_attempts_item", "run_item_id"),
+        Index("idx_evaluation_run_item_attempts_run", "run_id"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "era_" + random_id()[:16])
+    run_item_id = Column(String(32), nullable=False)
+    run_id = Column(String(32), nullable=False)
+    attempt_no = Column(Integer, nullable=False)
+    status = Column(
+        EnumColumn(EvaluationRunItemAttemptStatus),
+        nullable=False,
+        default=EvaluationRunItemAttemptStatus.QUEUED,
+    )
+    agent_chat_id = Column(String(24), nullable=True)
+    agent_turn_id = Column(String(24), nullable=True)
+    answer_text = Column(Text, nullable=True)
+    judge_result = Column(JSON, nullable=True)
+    score = Column(Numeric(6, 3), nullable=True)
+    latency_ms = Column(Integer, nullable=True)
+    token_usage = Column(JSON, nullable=True)
+    error_message = Column(Text, nullable=True)
+    retry_reason = Column(Text, nullable=True)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_started = Column(DateTime(timezone=True), nullable=True)
+    gmt_finished = Column(DateTime(timezone=True), nullable=True)

--- a/aperag/db/ops.py
+++ b/aperag/db/ops.py
@@ -29,6 +29,7 @@ from aperag.db.repositories.document import (
 )
 from aperag.db.repositories.document_index import AsyncDocumentIndexRepositoryMixin
 from aperag.db.repositories.evaluation import AsyncEvaluationRepositoryMixin
+from aperag.db.repositories.evaluation_v2 import AsyncEvaluationV2RepositoryMixin
 from aperag.db.repositories.graph import GraphRepositoryMixin
 from aperag.db.repositories.lightrag import LightragRepositoryMixin
 from aperag.db.repositories.llm_provider import (
@@ -82,6 +83,7 @@ class AsyncDatabaseOps(
     AsyncSettingRepositoryMixin,
     AsyncPromptTemplateRepositoryMixin,
     AsyncEvaluationRepositoryMixin,
+    AsyncEvaluationV2RepositoryMixin,
     AsyncQuestionSetRepositoryMixin,
 ):
     pass

--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -79,18 +79,18 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
                 conditions.append(BenchmarkDataset.collection_id == collection_id)
             base = select(BenchmarkDataset).where(and_(*conditions))
 
-            total = (
-                await session.execute(
-                    select(func.count()).select_from(base.subquery())
-                )
-            ).scalar_one()
+            total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
             rows = (
-                await session.execute(
-                    base.order_by(BenchmarkDataset.gmt_created.desc())
-                    .offset((page - 1) * page_size)
-                    .limit(page_size)
+                (
+                    await session.execute(
+                        base.order_by(BenchmarkDataset.gmt_created.desc())
+                        .offset((page - 1) * page_size)
+                        .limit(page_size)
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
             return list(rows), total
 
         return await self._execute_query(_query)
@@ -214,16 +214,18 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
     ) -> tuple[list[BenchmarkCase], int]:
         async def _query(session: AsyncSession):
             base = select(BenchmarkCase).where(BenchmarkCase.dataset_version_id == version_id)
-            total = (
-                await session.execute(select(func.count()).select_from(base.subquery()))
-            ).scalar_one()
+            total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
             rows = (
-                await session.execute(
-                    base.order_by(BenchmarkCase.sort_key.asc(), BenchmarkCase.gmt_created.asc())
-                    .offset((page - 1) * page_size)
-                    .limit(page_size)
+                (
+                    await session.execute(
+                        base.order_by(BenchmarkCase.sort_key.asc(), BenchmarkCase.gmt_created.asc())
+                        .offset((page - 1) * page_size)
+                        .limit(page_size)
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
             return list(rows), total
 
         return await self._execute_query(_query)
@@ -281,16 +283,16 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
             if bot_id:
                 conditions.append(EvaluationRun.bot_id == bot_id)
             base = select(EvaluationRun).where(and_(*conditions))
-            total = (
-                await session.execute(select(func.count()).select_from(base.subquery()))
-            ).scalar_one()
+            total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
             rows = (
-                await session.execute(
-                    base.order_by(EvaluationRun.gmt_created.desc())
-                    .offset((page - 1) * page_size)
-                    .limit(page_size)
+                (
+                    await session.execute(
+                        base.order_by(EvaluationRun.gmt_created.desc()).offset((page - 1) * page_size).limit(page_size)
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
             return list(rows), total
 
         return await self._execute_query(_query)
@@ -331,21 +333,21 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
 
     # -- EvaluationRunItem / Attempt ---------------------------------------
 
-    async def list_run_items(
-        self, run_id: str, page: int, page_size: int
-    ) -> tuple[list[EvaluationRunItem], int]:
+    async def list_run_items(self, run_id: str, page: int, page_size: int) -> tuple[list[EvaluationRunItem], int]:
         async def _query(session: AsyncSession):
             base = select(EvaluationRunItem).where(EvaluationRunItem.run_id == run_id)
-            total = (
-                await session.execute(select(func.count()).select_from(base.subquery()))
-            ).scalar_one()
+            total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
             rows = (
-                await session.execute(
-                    base.order_by(EvaluationRunItem.gmt_created.asc())
-                    .offset((page - 1) * page_size)
-                    .limit(page_size)
+                (
+                    await session.execute(
+                        base.order_by(EvaluationRunItem.gmt_created.asc())
+                        .offset((page - 1) * page_size)
+                        .limit(page_size)
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
             return list(rows), total
 
         return await self._execute_query(_query)
@@ -378,3 +380,23 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
             return list((await session.execute(stmt)).scalars().all())
 
         return await self._execute_query(_query)
+
+    async def requeue_run_item(self, run_id: str, item_id: str) -> Optional[EvaluationRunItem]:
+        from aperag.db.models import EvaluationRunItemStatus  # local import to avoid cycle
+
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationRunItem).where(
+                EvaluationRunItem.id == item_id,
+                EvaluationRunItem.run_id == run_id,
+            )
+            instance = (await session.execute(stmt)).scalars().first()
+            if not instance:
+                return None
+            instance.status = EvaluationRunItemStatus.PENDING
+            instance.error_message = None
+            instance.gmt_updated = utc_now()
+            await session.flush()
+            await session.refresh(instance)
+            return instance
+
+        return await self.execute_with_transaction(_operation)

--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -1,0 +1,380 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data-access for the evaluation-v2 product line.
+
+Tables: benchmark_datasets / benchmark_dataset_versions / benchmark_cases /
+evaluation_runs / evaluation_run_items / evaluation_run_item_attempts.
+"""
+
+from typing import Optional
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aperag.db.models import (
+    BenchmarkCase,
+    BenchmarkDataset,
+    BenchmarkDatasetVersion,
+    BenchmarkDatasetVersionStatus,
+    EvaluationRun,
+    EvaluationRunItem,
+    EvaluationRunItemAttempt,
+    EvaluationRunStatus,
+)
+from aperag.db.repositories.base import AsyncRepositoryProtocol
+from aperag.utils.utils import utc_now
+
+
+class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
+    """Read/write helpers for evaluation-v2 resources."""
+
+    # -- BenchmarkDataset ---------------------------------------------------
+
+    async def create_benchmark_dataset(self, dataset: BenchmarkDataset) -> BenchmarkDataset:
+        async def _operation(session: AsyncSession):
+            session.add(dataset)
+            await session.flush()
+            await session.refresh(dataset)
+            return dataset
+
+        return await self.execute_with_transaction(_operation)
+
+    async def get_benchmark_dataset(self, user_id: str, dataset_id: str) -> Optional[BenchmarkDataset]:
+        async def _query(session: AsyncSession):
+            stmt = select(BenchmarkDataset).where(
+                BenchmarkDataset.id == dataset_id,
+                BenchmarkDataset.user_id == user_id,
+                BenchmarkDataset.gmt_deleted.is_(None),
+            )
+            result = await session.execute(stmt)
+            return result.scalars().first()
+
+        return await self._execute_query(_query)
+
+    async def list_benchmark_datasets(
+        self,
+        user_id: str,
+        collection_id: Optional[str],
+        page: int,
+        page_size: int,
+    ) -> tuple[list[BenchmarkDataset], int]:
+        async def _query(session: AsyncSession):
+            conditions = [
+                BenchmarkDataset.user_id == user_id,
+                BenchmarkDataset.gmt_deleted.is_(None),
+            ]
+            if collection_id:
+                conditions.append(BenchmarkDataset.collection_id == collection_id)
+            base = select(BenchmarkDataset).where(and_(*conditions))
+
+            total = (
+                await session.execute(
+                    select(func.count()).select_from(base.subquery())
+                )
+            ).scalar_one()
+            rows = (
+                await session.execute(
+                    base.order_by(BenchmarkDataset.gmt_created.desc())
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
+                )
+            ).scalars().all()
+            return list(rows), total
+
+        return await self._execute_query(_query)
+
+    async def update_benchmark_dataset(
+        self,
+        user_id: str,
+        dataset_id: str,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Optional[BenchmarkDataset]:
+        async def _operation(session: AsyncSession):
+            stmt = select(BenchmarkDataset).where(
+                BenchmarkDataset.id == dataset_id,
+                BenchmarkDataset.user_id == user_id,
+                BenchmarkDataset.gmt_deleted.is_(None),
+            )
+            instance = (await session.execute(stmt)).scalars().first()
+            if not instance:
+                return None
+            if name is not None:
+                instance.name = name
+            if description is not None:
+                instance.description = description
+            instance.gmt_updated = utc_now()
+            await session.flush()
+            await session.refresh(instance)
+            return instance
+
+        return await self.execute_with_transaction(_operation)
+
+    async def soft_delete_benchmark_dataset(self, user_id: str, dataset_id: str) -> bool:
+        async def _operation(session: AsyncSession):
+            stmt = select(BenchmarkDataset).where(
+                BenchmarkDataset.id == dataset_id,
+                BenchmarkDataset.user_id == user_id,
+                BenchmarkDataset.gmt_deleted.is_(None),
+            )
+            instance = (await session.execute(stmt)).scalars().first()
+            if not instance:
+                return False
+            instance.gmt_deleted = utc_now()
+            await session.flush()
+            return True
+
+        return await self.execute_with_transaction(_operation)
+
+    # -- BenchmarkDatasetVersion -------------------------------------------
+
+    async def create_benchmark_dataset_version(
+        self,
+        dataset_id: str,
+        version: BenchmarkDatasetVersion,
+        cases: list[BenchmarkCase],
+    ) -> BenchmarkDatasetVersion:
+        async def _operation(session: AsyncSession):
+            version.dataset_id = dataset_id
+            session.add(version)
+            await session.flush()
+            await session.refresh(version)
+
+            for case in cases:
+                case.dataset_version_id = version.id
+                session.add(case)
+            if cases:
+                await session.flush()
+                version.case_count = len(cases)
+                await session.flush()
+                await session.refresh(version)
+            return version
+
+        return await self.execute_with_transaction(_operation)
+
+    async def next_dataset_version_number(self, dataset_id: str) -> int:
+        async def _query(session: AsyncSession):
+            stmt = select(func.coalesce(func.max(BenchmarkDatasetVersion.version), 0)).where(
+                BenchmarkDatasetVersion.dataset_id == dataset_id
+            )
+            return (await session.execute(stmt)).scalar_one() + 1
+
+        return await self._execute_query(_query)
+
+    async def get_dataset_version(self, version_id: str) -> Optional[BenchmarkDatasetVersion]:
+        async def _query(session: AsyncSession):
+            stmt = select(BenchmarkDatasetVersion).where(BenchmarkDatasetVersion.id == version_id)
+            return (await session.execute(stmt)).scalars().first()
+
+        return await self._execute_query(_query)
+
+    async def list_dataset_versions(self, dataset_id: str) -> list[BenchmarkDatasetVersion]:
+        async def _query(session: AsyncSession):
+            stmt = (
+                select(BenchmarkDatasetVersion)
+                .where(BenchmarkDatasetVersion.dataset_id == dataset_id)
+                .order_by(BenchmarkDatasetVersion.version.desc())
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
+        return await self._execute_query(_query)
+
+    async def latest_published_version(self, dataset_id: str) -> Optional[BenchmarkDatasetVersion]:
+        async def _query(session: AsyncSession):
+            stmt = (
+                select(BenchmarkDatasetVersion)
+                .where(
+                    BenchmarkDatasetVersion.dataset_id == dataset_id,
+                    BenchmarkDatasetVersion.status == BenchmarkDatasetVersionStatus.PUBLISHED,
+                )
+                .order_by(BenchmarkDatasetVersion.version.desc())
+                .limit(1)
+            )
+            return (await session.execute(stmt)).scalars().first()
+
+        return await self._execute_query(_query)
+
+    # -- BenchmarkCase ------------------------------------------------------
+
+    async def list_cases_for_version(
+        self, version_id: str, page: int, page_size: int
+    ) -> tuple[list[BenchmarkCase], int]:
+        async def _query(session: AsyncSession):
+            base = select(BenchmarkCase).where(BenchmarkCase.dataset_version_id == version_id)
+            total = (
+                await session.execute(select(func.count()).select_from(base.subquery()))
+            ).scalar_one()
+            rows = (
+                await session.execute(
+                    base.order_by(BenchmarkCase.sort_key.asc(), BenchmarkCase.gmt_created.asc())
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
+                )
+            ).scalars().all()
+            return list(rows), total
+
+        return await self._execute_query(_query)
+
+    async def list_all_cases_for_version(self, version_id: str) -> list[BenchmarkCase]:
+        async def _query(session: AsyncSession):
+            stmt = (
+                select(BenchmarkCase)
+                .where(BenchmarkCase.dataset_version_id == version_id)
+                .order_by(BenchmarkCase.sort_key.asc(), BenchmarkCase.gmt_created.asc())
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
+        return await self._execute_query(_query)
+
+    # -- EvaluationRun ------------------------------------------------------
+
+    async def create_evaluation_run(
+        self,
+        run: EvaluationRun,
+        items: list[EvaluationRunItem],
+    ) -> EvaluationRun:
+        async def _operation(session: AsyncSession):
+            session.add(run)
+            await session.flush()
+            await session.refresh(run)
+            for item in items:
+                item.run_id = run.id
+                session.add(item)
+            if items:
+                await session.flush()
+            return run
+
+        return await self.execute_with_transaction(_operation)
+
+    async def get_evaluation_run(self, user_id: str, run_id: str) -> Optional[EvaluationRun]:
+        async def _query(session: AsyncSession):
+            stmt = select(EvaluationRun).where(
+                EvaluationRun.id == run_id,
+                EvaluationRun.user_id == user_id,
+            )
+            return (await session.execute(stmt)).scalars().first()
+
+        return await self._execute_query(_query)
+
+    async def list_evaluation_runs(
+        self,
+        user_id: str,
+        bot_id: Optional[str],
+        page: int,
+        page_size: int,
+    ) -> tuple[list[EvaluationRun], int]:
+        async def _query(session: AsyncSession):
+            conditions = [EvaluationRun.user_id == user_id]
+            if bot_id:
+                conditions.append(EvaluationRun.bot_id == bot_id)
+            base = select(EvaluationRun).where(and_(*conditions))
+            total = (
+                await session.execute(select(func.count()).select_from(base.subquery()))
+            ).scalar_one()
+            rows = (
+                await session.execute(
+                    base.order_by(EvaluationRun.gmt_created.desc())
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
+                )
+            ).scalars().all()
+            return list(rows), total
+
+        return await self._execute_query(_query)
+
+    async def update_run_status(
+        self,
+        run_id: str,
+        status: EvaluationRunStatus,
+        *,
+        error_message: Optional[str] = None,
+        summary: Optional[dict] = None,
+    ) -> Optional[EvaluationRun]:
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationRun).where(EvaluationRun.id == run_id)
+            run = (await session.execute(stmt)).scalars().first()
+            if not run:
+                return None
+            now = utc_now()
+            run.status = status
+            if error_message is not None:
+                run.error_message = error_message
+            if summary is not None:
+                run.summary = summary
+            if status == EvaluationRunStatus.RUNNING and run.gmt_started is None:
+                run.gmt_started = now
+            if status in (
+                EvaluationRunStatus.COMPLETED,
+                EvaluationRunStatus.FAILED,
+                EvaluationRunStatus.CANCELLED,
+            ):
+                run.gmt_finished = now
+            run.gmt_updated = now
+            await session.flush()
+            await session.refresh(run)
+            return run
+
+        return await self.execute_with_transaction(_operation)
+
+    # -- EvaluationRunItem / Attempt ---------------------------------------
+
+    async def list_run_items(
+        self, run_id: str, page: int, page_size: int
+    ) -> tuple[list[EvaluationRunItem], int]:
+        async def _query(session: AsyncSession):
+            base = select(EvaluationRunItem).where(EvaluationRunItem.run_id == run_id)
+            total = (
+                await session.execute(select(func.count()).select_from(base.subquery()))
+            ).scalar_one()
+            rows = (
+                await session.execute(
+                    base.order_by(EvaluationRunItem.gmt_created.asc())
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
+                )
+            ).scalars().all()
+            return list(rows), total
+
+        return await self._execute_query(_query)
+
+    async def list_all_run_items(self, run_id: str) -> list[EvaluationRunItem]:
+        async def _query(session: AsyncSession):
+            stmt = (
+                select(EvaluationRunItem)
+                .where(EvaluationRunItem.run_id == run_id)
+                .order_by(EvaluationRunItem.gmt_created.asc())
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
+        return await self._execute_query(_query)
+
+    async def get_run_item(self, item_id: str) -> Optional[EvaluationRunItem]:
+        async def _query(session: AsyncSession):
+            stmt = select(EvaluationRunItem).where(EvaluationRunItem.id == item_id)
+            return (await session.execute(stmt)).scalars().first()
+
+        return await self._execute_query(_query)
+
+    async def list_attempts_for_item(self, run_item_id: str) -> list[EvaluationRunItemAttempt]:
+        async def _query(session: AsyncSession):
+            stmt = (
+                select(EvaluationRunItemAttempt)
+                .where(EvaluationRunItemAttempt.run_item_id == run_item_id)
+                .order_by(EvaluationRunItemAttempt.attempt_no.asc())
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
+        return await self._execute_query(_query)

--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -324,6 +324,8 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
                 EvaluationRunStatus.CANCELLED,
             ):
                 run.gmt_finished = now
+            else:
+                run.gmt_finished = None
             run.gmt_updated = now
             await session.flush()
             await session.refresh(run)

--- a/aperag/evaluation_v2/__init__.py
+++ b/aperag/evaluation_v2/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EVALUATION_V2_SCHEMA_VERSION = "evaluation-v2.0"

--- a/aperag/evaluation_v2/judges.py
+++ b/aperag/evaluation_v2/judges.py
@@ -1,0 +1,89 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Judge interface for evaluation-v2.
+
+Phase 1 lands only the interface and the no-op + exact-match judges, which
+are enough to let the orchestration service and worker pipeline be wired and
+tested end-to-end. The LLM-as-judge implementation ships in Phase 3.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from aperag.db.models import EvaluationJudgeMode
+from aperag.evaluation_v2.schemas import JudgeConfig
+
+
+@dataclass
+class JudgeInput:
+    case_key: str
+    question: str
+    expected_answer: Optional[str]
+    reference_context: Optional[str]
+    actual_answer: str
+
+
+@dataclass
+class JudgeOutput:
+    score: float
+    passed: bool
+    reasoning: Optional[str] = None
+    raw: Optional[dict[str, Any]] = None
+
+
+class Judge(ABC):
+    """Produces a per-case score + pass/fail verdict."""
+
+    mode: EvaluationJudgeMode
+
+    @abstractmethod
+    async def judge(self, payload: JudgeInput) -> JudgeOutput: ...
+
+
+class NoopJudge(Judge):
+    mode = EvaluationJudgeMode.NONE
+
+    async def judge(self, payload: JudgeInput) -> JudgeOutput:
+        return JudgeOutput(score=0.0, passed=True, reasoning="judge disabled")
+
+
+class ExactMatchJudge(Judge):
+    mode = EvaluationJudgeMode.EXACT_MATCH
+
+    async def judge(self, payload: JudgeInput) -> JudgeOutput:
+        expected = (payload.expected_answer or "").strip()
+        actual = (payload.actual_answer or "").strip()
+        passed = bool(expected) and expected == actual
+        return JudgeOutput(
+            score=1.0 if passed else 0.0,
+            passed=passed,
+            reasoning="exact match" if passed else "answer does not match expected",
+        )
+
+
+def build_judge(config: Optional[JudgeConfig]) -> Judge:
+    """Factory used by the worker pipeline.
+
+    The LLM-as-judge branch is a Phase 3 follow-up; we fall back to exact
+    match so the worker has a deterministic baseline until then.
+    """
+    if not config or config.mode == EvaluationJudgeMode.NONE:
+        return NoopJudge()
+    if config.mode == EvaluationJudgeMode.EXACT_MATCH:
+        return ExactMatchJudge()
+    if config.mode == EvaluationJudgeMode.LLM_AS_JUDGE:
+        return ExactMatchJudge()
+    return NoopJudge()

--- a/aperag/evaluation_v2/schemas.py
+++ b/aperag/evaluation_v2/schemas.py
@@ -21,7 +21,7 @@ shape here stable; runtime data access DTOs live next to the repositories.
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -33,7 +33,6 @@ from aperag.db.models import (
     EvaluationRunItemStatus,
     EvaluationRunStatus,
 )
-
 
 # ---------------------------------------------------------------------------
 # BenchmarkDataset
@@ -54,7 +53,7 @@ class BenchmarkDatasetUpdate(BaseModel):
 
 
 class BenchmarkDatasetEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     id: str
     user_id: str
@@ -63,16 +62,20 @@ class BenchmarkDatasetEnvelope(BaseModel):
     description: Optional[str] = None
     source_type: BenchmarkDatasetSourceType
     schema_hint: Optional[dict[str, Any]] = None
-    gmt_created: datetime
-    gmt_updated: datetime
+    created_at: datetime = Field(validation_alias="gmt_created")
+    updated_at: datetime = Field(validation_alias="gmt_updated")
     latest_version: Optional["BenchmarkDatasetVersionEnvelope"] = None
 
 
-class BenchmarkDatasetList(BaseModel):
-    items: list[BenchmarkDatasetEnvelope] = Field(default_factory=list)
+class EvaluationPagination(BaseModel):
     total: int = 0
-    page: int = 1
-    page_size: int = 20
+    offset: int = 0
+    limit: int = 20
+
+
+class BenchmarkDatasetListResponse(BaseModel):
+    items: list[BenchmarkDatasetEnvelope] = Field(default_factory=list)
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +104,7 @@ class BenchmarkDatasetVersionCreate(BaseModel):
 
 
 class BenchmarkCaseEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     id: str
     dataset_version_id: str
@@ -112,11 +115,11 @@ class BenchmarkCaseEnvelope(BaseModel):
     tags: Optional[list[str]] = None
     case_metadata: Optional[dict[str, Any]] = None
     sort_key: int
-    gmt_created: datetime
+    created_at: datetime = Field(validation_alias="gmt_created")
 
 
 class BenchmarkDatasetVersionEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     id: str
     dataset_id: str
@@ -125,21 +128,19 @@ class BenchmarkDatasetVersionEnvelope(BaseModel):
     status: BenchmarkDatasetVersionStatus
     case_count: int
     source_snapshot: Optional[dict[str, Any]] = None
-    gmt_created: datetime
-    gmt_updated: datetime
-    gmt_published: Optional[datetime] = None
+    created_at: datetime = Field(validation_alias="gmt_created")
+    updated_at: datetime = Field(validation_alias="gmt_updated")
+    published_at: Optional[datetime] = Field(default=None, validation_alias="gmt_published")
 
 
-class BenchmarkDatasetVersionList(BaseModel):
+class BenchmarkDatasetVersionListResponse(BaseModel):
     items: list[BenchmarkDatasetVersionEnvelope] = Field(default_factory=list)
-    total: int = 0
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
 
 
-class BenchmarkCaseList(BaseModel):
+class BenchmarkCaseListResponse(BaseModel):
     items: list[BenchmarkCaseEnvelope] = Field(default_factory=list)
-    total: int = 0
-    page: int = 1
-    page_size: int = 100
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
 
 
 # ---------------------------------------------------------------------------
@@ -168,18 +169,25 @@ class EvaluationRunCreate(BaseModel):
 
 
 class EvaluationRunSummary(BaseModel):
-    total_cases: int = 0
+    model_config = ConfigDict(populate_by_name=True)
+
+    total: int = Field(default=0, validation_alias="total_cases")
     pending: int = 0
     running: int = 0
     completed: int = 0
     failed: int = 0
     cancelled: int = 0
-    average_score: Optional[float] = None
+    avg_score: Optional[float] = Field(default=None, validation_alias="average_score")
     pass_rate: Optional[float] = None
 
 
+class EvaluationRunProgress(BaseModel):
+    percent: Optional[int] = None
+    eta_ms: Optional[int] = None
+
+
 class EvaluationRunEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True, protected_namespaces=())
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, protected_namespaces=())
 
     id: str
     user_id: str
@@ -191,22 +199,20 @@ class EvaluationRunEnvelope(BaseModel):
     judge_config: Optional[JudgeConfig] = None
     bot_config_snapshot: Optional[dict[str, Any]] = None
     model_config_snapshot: Optional[dict[str, Any]] = None
-    error_message: Optional[str] = None
-    gmt_created: datetime
-    gmt_updated: datetime
-    gmt_started: Optional[datetime] = None
-    gmt_finished: Optional[datetime] = None
+    error: Optional[str] = Field(default=None, validation_alias="error_message")
+    created_at: datetime = Field(validation_alias="gmt_created")
+    updated_at: datetime = Field(validation_alias="gmt_updated")
+    started_at: Optional[datetime] = Field(default=None, validation_alias="gmt_started")
+    finished_at: Optional[datetime] = Field(default=None, validation_alias="gmt_finished")
 
 
-class EvaluationRunList(BaseModel):
+class EvaluationRunListResponse(BaseModel):
     items: list[EvaluationRunEnvelope] = Field(default_factory=list)
-    total: int = 0
-    page: int = 1
-    page_size: int = 20
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
 
 
 class EvaluationRunItemEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     id: str
     run_id: str
@@ -215,19 +221,20 @@ class EvaluationRunItemEnvelope(BaseModel):
     status: EvaluationRunItemStatus
     best_score: Optional[Decimal] = None
     latest_attempt_id: Optional[str] = None
+    latest_attempt: Optional["EvaluationRunItemAttemptEnvelope"] = None
     attempt_count: int
-    error_message: Optional[str] = None
-    gmt_created: datetime
-    gmt_updated: datetime
+    error: Optional[str] = Field(default=None, validation_alias="error_message")
+    created_at: datetime = Field(validation_alias="gmt_created")
+    updated_at: datetime = Field(validation_alias="gmt_updated")
 
 
-class EvaluationRunItemList(BaseModel):
+class EvaluationRunItemListResponse(BaseModel):
     items: list[EvaluationRunItemEnvelope] = Field(default_factory=list)
-    total: int = 0
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
 
 
 class EvaluationRunItemAttemptEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     id: str
     run_item_id: str
@@ -241,15 +248,21 @@ class EvaluationRunItemAttemptEnvelope(BaseModel):
     score: Optional[Decimal] = None
     latency_ms: Optional[int] = None
     token_usage: Optional[dict[str, Any]] = None
-    error_message: Optional[str] = None
+    error: Optional[str] = Field(default=None, validation_alias="error_message")
     retry_reason: Optional[str] = None
-    gmt_created: datetime
-    gmt_started: Optional[datetime] = None
-    gmt_finished: Optional[datetime] = None
+    created_at: datetime = Field(validation_alias="gmt_created")
+    started_at: Optional[datetime] = Field(default=None, validation_alias="gmt_started")
+    finished_at: Optional[datetime] = Field(default=None, validation_alias="gmt_finished")
 
 
 class EvaluationRunItemAttemptList(BaseModel):
     items: list[EvaluationRunItemAttemptEnvelope] = Field(default_factory=list)
+
+
+class EvaluationRunDetailResponse(BaseModel):
+    run: EvaluationRunEnvelope
+    summary: Optional[EvaluationRunSummary] = None
+    progress: Optional[EvaluationRunProgress] = None
 
 
 class CancelRunResponse(BaseModel):
@@ -257,13 +270,9 @@ class CancelRunResponse(BaseModel):
     status: EvaluationRunStatus
 
 
-class RetryRunResponse(BaseModel):
-    run_id: str
-    status: EvaluationRunStatus
-    retried_count: int
-
-
-RetryScope = Literal["failed", "all"]
+class RetryRunItemResponse(BaseModel):
+    item: EvaluationRunItemEnvelope
 
 
 BenchmarkDatasetEnvelope.model_rebuild()
+EvaluationRunItemEnvelope.model_rebuild()

--- a/aperag/evaluation_v2/schemas.py
+++ b/aperag/evaluation_v2/schemas.py
@@ -1,0 +1,269 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pydantic schemas for the evaluation-v2 orchestration API.
+
+These types mirror the frozen contract (`contract freeze v1`) used by
+`aperag/views/evaluation_v2.py` and by the frontend client. Keep the wire
+shape here stable; runtime data access DTOs live next to the repositories.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from aperag.db.models import (
+    BenchmarkDatasetSourceType,
+    BenchmarkDatasetVersionStatus,
+    EvaluationJudgeMode,
+    EvaluationRunItemAttemptStatus,
+    EvaluationRunItemStatus,
+    EvaluationRunStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkDataset
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkDatasetCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = None
+    collection_id: Optional[str] = None
+    source_type: BenchmarkDatasetSourceType = BenchmarkDatasetSourceType.MANUAL
+    schema_hint: Optional[dict[str, Any]] = None
+
+
+class BenchmarkDatasetUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = None
+
+
+class BenchmarkDatasetEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    user_id: str
+    collection_id: Optional[str] = None
+    name: str
+    description: Optional[str] = None
+    source_type: BenchmarkDatasetSourceType
+    schema_hint: Optional[dict[str, Any]] = None
+    gmt_created: datetime
+    gmt_updated: datetime
+    latest_version: Optional["BenchmarkDatasetVersionEnvelope"] = None
+
+
+class BenchmarkDatasetList(BaseModel):
+    items: list[BenchmarkDatasetEnvelope] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    page_size: int = 20
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkDatasetVersion + BenchmarkCase
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkCaseCreate(BaseModel):
+    case_key: Optional[str] = Field(
+        None,
+        max_length=128,
+        description="Stable user-facing key. Auto-generated when omitted.",
+    )
+    input_message: str = Field(..., min_length=1)
+    expected_answer: Optional[str] = None
+    reference_context: Optional[str] = None
+    tags: Optional[list[str]] = None
+    case_metadata: Optional[dict[str, Any]] = None
+    sort_key: int = 0
+
+
+class BenchmarkDatasetVersionCreate(BaseModel):
+    version_name: Optional[str] = Field(None, max_length=255)
+    source_snapshot: Optional[dict[str, Any]] = None
+    cases: list[BenchmarkCaseCreate] = Field(default_factory=list)
+
+
+class BenchmarkCaseEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    dataset_version_id: str
+    case_key: str
+    input_message: str
+    expected_answer: Optional[str] = None
+    reference_context: Optional[str] = None
+    tags: Optional[list[str]] = None
+    case_metadata: Optional[dict[str, Any]] = None
+    sort_key: int
+    gmt_created: datetime
+
+
+class BenchmarkDatasetVersionEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    dataset_id: str
+    version: int
+    version_name: Optional[str] = None
+    status: BenchmarkDatasetVersionStatus
+    case_count: int
+    source_snapshot: Optional[dict[str, Any]] = None
+    gmt_created: datetime
+    gmt_updated: datetime
+    gmt_published: Optional[datetime] = None
+
+
+class BenchmarkDatasetVersionList(BaseModel):
+    items: list[BenchmarkDatasetVersionEnvelope] = Field(default_factory=list)
+    total: int = 0
+
+
+class BenchmarkCaseList(BaseModel):
+    items: list[BenchmarkCaseEnvelope] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    page_size: int = 100
+
+
+# ---------------------------------------------------------------------------
+# EvaluationRun lifecycle
+# ---------------------------------------------------------------------------
+
+
+class JudgeConfig(BaseModel):
+    mode: EvaluationJudgeMode = EvaluationJudgeMode.EXACT_MATCH
+    model: Optional[str] = None
+    model_service_provider: Optional[str] = None
+    prompt_template: Optional[str] = None
+    score_threshold: Optional[float] = Field(None, ge=0.0, le=1.0)
+    params: Optional[dict[str, Any]] = None
+
+
+class EvaluationRunCreate(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+
+    name: Optional[str] = Field(None, max_length=255)
+    bot_id: str
+    dataset_version_id: str
+    judge: Optional[JudgeConfig] = None
+    bot_config_snapshot: Optional[dict[str, Any]] = None
+    model_config_snapshot: Optional[dict[str, Any]] = None
+
+
+class EvaluationRunSummary(BaseModel):
+    total_cases: int = 0
+    pending: int = 0
+    running: int = 0
+    completed: int = 0
+    failed: int = 0
+    cancelled: int = 0
+    average_score: Optional[float] = None
+    pass_rate: Optional[float] = None
+
+
+class EvaluationRunEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True, protected_namespaces=())
+
+    id: str
+    user_id: str
+    bot_id: str
+    dataset_version_id: str
+    name: Optional[str] = None
+    status: EvaluationRunStatus
+    summary: Optional[EvaluationRunSummary] = None
+    judge_config: Optional[JudgeConfig] = None
+    bot_config_snapshot: Optional[dict[str, Any]] = None
+    model_config_snapshot: Optional[dict[str, Any]] = None
+    error_message: Optional[str] = None
+    gmt_created: datetime
+    gmt_updated: datetime
+    gmt_started: Optional[datetime] = None
+    gmt_finished: Optional[datetime] = None
+
+
+class EvaluationRunList(BaseModel):
+    items: list[EvaluationRunEnvelope] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    page_size: int = 20
+
+
+class EvaluationRunItemEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    run_id: str
+    case_id: str
+    case_key: str
+    status: EvaluationRunItemStatus
+    best_score: Optional[Decimal] = None
+    latest_attempt_id: Optional[str] = None
+    attempt_count: int
+    error_message: Optional[str] = None
+    gmt_created: datetime
+    gmt_updated: datetime
+
+
+class EvaluationRunItemList(BaseModel):
+    items: list[EvaluationRunItemEnvelope] = Field(default_factory=list)
+    total: int = 0
+
+
+class EvaluationRunItemAttemptEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    run_item_id: str
+    run_id: str
+    attempt_no: int
+    status: EvaluationRunItemAttemptStatus
+    agent_chat_id: Optional[str] = None
+    agent_turn_id: Optional[str] = None
+    answer_text: Optional[str] = None
+    judge_result: Optional[dict[str, Any]] = None
+    score: Optional[Decimal] = None
+    latency_ms: Optional[int] = None
+    token_usage: Optional[dict[str, Any]] = None
+    error_message: Optional[str] = None
+    retry_reason: Optional[str] = None
+    gmt_created: datetime
+    gmt_started: Optional[datetime] = None
+    gmt_finished: Optional[datetime] = None
+
+
+class EvaluationRunItemAttemptList(BaseModel):
+    items: list[EvaluationRunItemAttemptEnvelope] = Field(default_factory=list)
+
+
+class CancelRunResponse(BaseModel):
+    run_id: str
+    status: EvaluationRunStatus
+
+
+class RetryRunResponse(BaseModel):
+    run_id: str
+    status: EvaluationRunStatus
+    retried_count: int
+
+
+RetryScope = Literal["failed", "all"]
+
+
+BenchmarkDatasetEnvelope.model_rebuild()

--- a/aperag/evaluation_v2/services.py
+++ b/aperag/evaluation_v2/services.py
@@ -1,0 +1,340 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Orchestration services for evaluation-v2.
+
+These services sit between the FastAPI view layer and the async repository
+mixin on `AsyncDatabaseOps`. They own the write-time invariants (version
+numbering, run item creation, snapshot capture) while keeping the view code
+thin and the repository layer pure data access.
+
+Phase 1 only ships the synchronous CRUD path. The async worker pipeline
+(dispatching Runtime V3 turns, judging, aggregating summaries) lands in
+Phase 3 and will plug into `run_service.launch_run`.
+"""
+
+from typing import Optional
+
+from aperag.db.models import (
+    BenchmarkCase,
+    BenchmarkDataset,
+    BenchmarkDatasetVersion,
+    BenchmarkDatasetVersionStatus,
+    EvaluationRun,
+    EvaluationRunItem,
+    EvaluationRunStatus,
+)
+from aperag.db.ops import AsyncDatabaseOps, async_db_ops
+from aperag.evaluation_v2.schemas import (
+    BenchmarkDatasetCreate,
+    BenchmarkDatasetEnvelope,
+    BenchmarkDatasetUpdate,
+    BenchmarkDatasetVersionCreate,
+    BenchmarkDatasetVersionEnvelope,
+    EvaluationRunCreate,
+    EvaluationRunEnvelope,
+    EvaluationRunItemEnvelope,
+    EvaluationRunItemAttemptEnvelope,
+    EvaluationRunSummary,
+    JudgeConfig,
+)
+from aperag.exceptions import ResourceNotFoundException, ValidationException
+from aperag.utils.utils import utc_now
+
+
+def _to_dataset_envelope(
+    dataset: BenchmarkDataset,
+    latest_version: Optional[BenchmarkDatasetVersion] = None,
+) -> BenchmarkDatasetEnvelope:
+    envelope = BenchmarkDatasetEnvelope.model_validate(dataset)
+    if latest_version is not None:
+        envelope.latest_version = BenchmarkDatasetVersionEnvelope.model_validate(latest_version)
+    return envelope
+
+
+def _to_run_envelope(run: EvaluationRun) -> EvaluationRunEnvelope:
+    envelope = EvaluationRunEnvelope.model_validate(run)
+    if run.summary:
+        try:
+            envelope.summary = EvaluationRunSummary.model_validate(run.summary)
+        except Exception:
+            envelope.summary = None
+    if run.judge_config:
+        try:
+            envelope.judge_config = JudgeConfig.model_validate(run.judge_config)
+        except Exception:
+            envelope.judge_config = None
+    return envelope
+
+
+class BenchmarkDatasetService:
+    """Dataset + dataset-version CRUD."""
+
+    def __init__(self, db_ops: Optional[AsyncDatabaseOps] = None):
+        self.db_ops = db_ops or async_db_ops
+
+    async def create_dataset(
+        self, user_id: str, request: BenchmarkDatasetCreate
+    ) -> BenchmarkDatasetEnvelope:
+        dataset = BenchmarkDataset(
+            user_id=user_id,
+            collection_id=request.collection_id,
+            name=request.name,
+            description=request.description,
+            source_type=request.source_type,
+            schema_hint=request.schema_hint,
+        )
+        created = await self.db_ops.create_benchmark_dataset(dataset)
+        return _to_dataset_envelope(created)
+
+    async def list_datasets(
+        self,
+        user_id: str,
+        collection_id: Optional[str],
+        page: int,
+        page_size: int,
+    ) -> tuple[list[BenchmarkDatasetEnvelope], int]:
+        rows, total = await self.db_ops.list_benchmark_datasets(
+            user_id=user_id, collection_id=collection_id, page=page, page_size=page_size
+        )
+        envelopes: list[BenchmarkDatasetEnvelope] = []
+        for dataset in rows:
+            latest = await self.db_ops.latest_published_version(dataset.id)
+            envelopes.append(_to_dataset_envelope(dataset, latest))
+        return envelopes, total
+
+    async def get_dataset(self, user_id: str, dataset_id: str) -> BenchmarkDatasetEnvelope:
+        dataset = await self.db_ops.get_benchmark_dataset(user_id, dataset_id)
+        if not dataset:
+            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
+        latest = await self.db_ops.latest_published_version(dataset.id)
+        return _to_dataset_envelope(dataset, latest)
+
+    async def update_dataset(
+        self,
+        user_id: str,
+        dataset_id: str,
+        request: BenchmarkDatasetUpdate,
+    ) -> BenchmarkDatasetEnvelope:
+        updated = await self.db_ops.update_benchmark_dataset(
+            user_id,
+            dataset_id,
+            name=request.name,
+            description=request.description,
+        )
+        if not updated:
+            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
+        return _to_dataset_envelope(updated)
+
+    async def delete_dataset(self, user_id: str, dataset_id: str) -> None:
+        ok = await self.db_ops.soft_delete_benchmark_dataset(user_id, dataset_id)
+        if not ok:
+            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
+
+    # Versions ------------------------------------------------------------
+
+    async def create_version(
+        self,
+        user_id: str,
+        dataset_id: str,
+        request: BenchmarkDatasetVersionCreate,
+    ) -> BenchmarkDatasetVersionEnvelope:
+        dataset = await self.db_ops.get_benchmark_dataset(user_id, dataset_id)
+        if not dataset:
+            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
+        if not request.cases:
+            raise ValidationException("A dataset version must contain at least one case")
+
+        now = utc_now()
+        version_no = await self.db_ops.next_dataset_version_number(dataset_id)
+        version = BenchmarkDatasetVersion(
+            dataset_id=dataset_id,
+            version=version_no,
+            version_name=request.version_name,
+            status=BenchmarkDatasetVersionStatus.PUBLISHED,
+            case_count=0,
+            source_snapshot=request.source_snapshot,
+            gmt_published=now,
+        )
+
+        seen_keys: set[str] = set()
+        cases: list[BenchmarkCase] = []
+        for idx, payload in enumerate(request.cases):
+            key = (payload.case_key or f"case_{idx + 1:04d}").strip()
+            if key in seen_keys:
+                raise ValidationException(f"Duplicate case_key within version payload: {key}")
+            seen_keys.add(key)
+            cases.append(
+                BenchmarkCase(
+                    case_key=key,
+                    input_message=payload.input_message,
+                    expected_answer=payload.expected_answer,
+                    reference_context=payload.reference_context,
+                    tags=payload.tags,
+                    case_metadata=payload.case_metadata,
+                    sort_key=payload.sort_key or idx,
+                )
+            )
+
+        created = await self.db_ops.create_benchmark_dataset_version(dataset_id, version, cases)
+        return BenchmarkDatasetVersionEnvelope.model_validate(created)
+
+    async def list_versions(
+        self, user_id: str, dataset_id: str
+    ) -> list[BenchmarkDatasetVersionEnvelope]:
+        dataset = await self.db_ops.get_benchmark_dataset(user_id, dataset_id)
+        if not dataset:
+            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
+        rows = await self.db_ops.list_dataset_versions(dataset_id)
+        return [BenchmarkDatasetVersionEnvelope.model_validate(r) for r in rows]
+
+    async def get_version(self, version_id: str) -> BenchmarkDatasetVersion:
+        version = await self.db_ops.get_dataset_version(version_id)
+        if not version:
+            raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
+        return version
+
+
+class EvaluationRunService:
+    """Evaluation run lifecycle: create / list / get / cancel / retry.
+
+    The worker pipeline that actually runs cases against Runtime V3 lives in
+    `aperag.evaluation_v2.tasks` and is wired in Phase 3. `launch_run` is the
+    single hand-off point the view layer uses, so Phase 3 can swap in the
+    Celery producer without touching the view.
+    """
+
+    def __init__(
+        self,
+        db_ops: Optional[AsyncDatabaseOps] = None,
+        dataset_service: Optional[BenchmarkDatasetService] = None,
+    ):
+        self.db_ops = db_ops or async_db_ops
+        self.dataset_service = dataset_service or BenchmarkDatasetService(self.db_ops)
+
+    async def create_run(
+        self, user_id: str, request: EvaluationRunCreate
+    ) -> EvaluationRunEnvelope:
+        version = await self.dataset_service.get_version(request.dataset_version_id)
+        bot = await self.db_ops.query_bot(user_id, request.bot_id)
+        if not bot:
+            raise ResourceNotFoundException("Bot", request.bot_id)
+
+        cases = await self.db_ops.list_all_cases_for_version(version.id)
+        if not cases:
+            raise ValidationException("Dataset version has no cases to evaluate")
+
+        judge_payload = request.judge.model_dump() if request.judge else None
+        run = EvaluationRun(
+            user_id=user_id,
+            bot_id=request.bot_id,
+            dataset_version_id=version.id,
+            name=request.name,
+            bot_config_snapshot=request.bot_config_snapshot,
+            model_config_snapshot=request.model_config_snapshot,
+            judge_config=judge_payload,
+            status=EvaluationRunStatus.QUEUED,
+            summary=EvaluationRunSummary(total_cases=len(cases)).model_dump(),
+        )
+        items = [
+            EvaluationRunItem(
+                case_id=case.id,
+                case_key=case.case_key,
+            )
+            for case in cases
+        ]
+
+        created = await self.db_ops.create_evaluation_run(run, items)
+        await self.launch_run(created.id)
+        return _to_run_envelope(created)
+
+    async def launch_run(self, run_id: str) -> None:
+        """Hand the run off to the async worker pipeline.
+
+        Phase 3 will replace this stub with a Celery producer call. Keeping
+        the seam here means the view layer and tests do not need to change.
+        """
+        return None
+
+    async def list_runs(
+        self,
+        user_id: str,
+        bot_id: Optional[str],
+        page: int,
+        page_size: int,
+    ) -> tuple[list[EvaluationRunEnvelope], int]:
+        rows, total = await self.db_ops.list_evaluation_runs(
+            user_id=user_id, bot_id=bot_id, page=page, page_size=page_size
+        )
+        return [_to_run_envelope(r) for r in rows], total
+
+    async def get_run(self, user_id: str, run_id: str) -> EvaluationRunEnvelope:
+        run = await self._require_run(user_id, run_id)
+        return _to_run_envelope(run)
+
+    async def cancel_run(self, user_id: str, run_id: str) -> EvaluationRunEnvelope:
+        run = await self._require_run(user_id, run_id)
+        if run.status in (
+            EvaluationRunStatus.COMPLETED,
+            EvaluationRunStatus.FAILED,
+            EvaluationRunStatus.CANCELLED,
+        ):
+            return _to_run_envelope(run)
+
+        updated = await self.db_ops.update_run_status(run_id, EvaluationRunStatus.CANCELLED)
+        return _to_run_envelope(updated)
+
+    async def retry_run(
+        self, user_id: str, run_id: str, scope: str = "failed"
+    ) -> tuple[EvaluationRunEnvelope, int]:
+        """Phase 3 will re-queue failed attempts; for MVP we just flip status."""
+        run = await self._require_run(user_id, run_id)
+        if run.status == EvaluationRunStatus.RUNNING:
+            raise ValidationException("Cannot retry a run that is still running")
+
+        updated = await self.db_ops.update_run_status(
+            run_id, EvaluationRunStatus.QUEUED, error_message=None
+        )
+        await self.launch_run(run_id)
+        # retried_count is filled by the Phase 3 worker layer; return 0 for now
+        return _to_run_envelope(updated), 0
+
+    async def list_run_items(
+        self, user_id: str, run_id: str, page: int, page_size: int
+    ) -> tuple[list[EvaluationRunItemEnvelope], int]:
+        await self._require_run(user_id, run_id)
+        rows, total = await self.db_ops.list_run_items(run_id, page, page_size)
+        return [EvaluationRunItemEnvelope.model_validate(r) for r in rows], total
+
+    async def list_run_item_attempts(
+        self, user_id: str, item_id: str
+    ) -> list[EvaluationRunItemAttemptEnvelope]:
+        item = await self.db_ops.get_run_item(item_id)
+        if not item:
+            raise ResourceNotFoundException("EvaluationRunItem", item_id)
+        run = await self.db_ops.get_evaluation_run(user_id, item.run_id)
+        if not run:
+            raise ResourceNotFoundException("EvaluationRun", item.run_id)
+        attempts = await self.db_ops.list_attempts_for_item(item_id)
+        return [EvaluationRunItemAttemptEnvelope.model_validate(a) for a in attempts]
+
+    async def _require_run(self, user_id: str, run_id: str) -> EvaluationRun:
+        run = await self.db_ops.get_evaluation_run(user_id, run_id)
+        if not run:
+            raise ResourceNotFoundException("EvaluationRun", run_id)
+        return run
+
+
+benchmark_dataset_service = BenchmarkDatasetService()
+evaluation_run_service = EvaluationRunService(dataset_service=benchmark_dataset_service)

--- a/aperag/evaluation_v2/services.py
+++ b/aperag/evaluation_v2/services.py
@@ -89,6 +89,24 @@ def _to_run_progress(summary: Optional[EvaluationRunSummary]) -> EvaluationRunPr
     return EvaluationRunProgress(percent=round((resolved / summary.total) * 100))
 
 
+def _requeue_run_summary(
+    summary_payload: Optional[dict],
+    item_status: EvaluationRunItemStatus,
+) -> Optional[dict]:
+    if not summary_payload:
+        return None
+
+    summary = EvaluationRunSummary.model_validate(summary_payload)
+    summary.pending += 1
+
+    if item_status == EvaluationRunItemStatus.FAILED and summary.failed > 0:
+        summary.failed -= 1
+    if item_status == EvaluationRunItemStatus.CANCELLED and summary.cancelled > 0:
+        summary.cancelled -= 1
+
+    return summary.model_dump()
+
+
 class BenchmarkDatasetService:
     """Dataset + dataset-version CRUD."""
 
@@ -339,16 +357,20 @@ class EvaluationRunService:
         ):
             raise ValidationException("Only failed or cancelled run items can be retried")
 
+        next_run_status = run.status
         if run.status in (
             EvaluationRunStatus.CANCELLED,
             EvaluationRunStatus.COMPLETED,
             EvaluationRunStatus.FAILED,
         ):
-            await self.db_ops.update_run_status(
-                run_id,
-                EvaluationRunStatus.QUEUED,
-                error_message=None,
-            )
+            next_run_status = EvaluationRunStatus.QUEUED
+
+        await self.db_ops.update_run_status(
+            run_id,
+            next_run_status,
+            error_message=None,
+            summary=_requeue_run_summary(run.summary, item.status),
+        )
 
         item = await self.db_ops.requeue_run_item(run_id, item_id)
         await self.launch_run(run_id)

--- a/aperag/evaluation_v2/services.py
+++ b/aperag/evaluation_v2/services.py
@@ -206,6 +206,14 @@ class BenchmarkDatasetService:
         rows = await self.db_ops.list_dataset_versions(dataset_id)
         return [BenchmarkDatasetVersionEnvelope.model_validate(r) for r in rows]
 
+    async def get_version_envelope(
+        self, user_id: str, dataset_id: str, version_id: str
+    ) -> BenchmarkDatasetVersionEnvelope:
+        version = await self.get_version(user_id, version_id)
+        if version.dataset_id != dataset_id:
+            raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
+        return BenchmarkDatasetVersionEnvelope.model_validate(version)
+
     async def get_version(self, user_id: str, version_id: str) -> BenchmarkDatasetVersion:
         version = await self.db_ops.get_dataset_version(version_id)
         if not version:

--- a/aperag/evaluation_v2/services.py
+++ b/aperag/evaluation_v2/services.py
@@ -33,6 +33,7 @@ from aperag.db.models import (
     BenchmarkDatasetVersionStatus,
     EvaluationRun,
     EvaluationRunItem,
+    EvaluationRunItemStatus,
     EvaluationRunStatus,
 )
 from aperag.db.ops import AsyncDatabaseOps, async_db_ops
@@ -43,9 +44,11 @@ from aperag.evaluation_v2.schemas import (
     BenchmarkDatasetVersionCreate,
     BenchmarkDatasetVersionEnvelope,
     EvaluationRunCreate,
+    EvaluationRunDetailResponse,
     EvaluationRunEnvelope,
-    EvaluationRunItemEnvelope,
     EvaluationRunItemAttemptEnvelope,
+    EvaluationRunItemEnvelope,
+    EvaluationRunProgress,
     EvaluationRunSummary,
     JudgeConfig,
 )
@@ -78,15 +81,21 @@ def _to_run_envelope(run: EvaluationRun) -> EvaluationRunEnvelope:
     return envelope
 
 
+def _to_run_progress(summary: Optional[EvaluationRunSummary]) -> EvaluationRunProgress:
+    if not summary or summary.total <= 0:
+        return EvaluationRunProgress(percent=0)
+
+    resolved = summary.completed + summary.failed + summary.cancelled
+    return EvaluationRunProgress(percent=round((resolved / summary.total) * 100))
+
+
 class BenchmarkDatasetService:
     """Dataset + dataset-version CRUD."""
 
     def __init__(self, db_ops: Optional[AsyncDatabaseOps] = None):
         self.db_ops = db_ops or async_db_ops
 
-    async def create_dataset(
-        self, user_id: str, request: BenchmarkDatasetCreate
-    ) -> BenchmarkDatasetEnvelope:
+    async def create_dataset(self, user_id: str, request: BenchmarkDatasetCreate) -> BenchmarkDatasetEnvelope:
         dataset = BenchmarkDataset(
             user_id=user_id,
             collection_id=request.collection_id,
@@ -190,18 +199,19 @@ class BenchmarkDatasetService:
         created = await self.db_ops.create_benchmark_dataset_version(dataset_id, version, cases)
         return BenchmarkDatasetVersionEnvelope.model_validate(created)
 
-    async def list_versions(
-        self, user_id: str, dataset_id: str
-    ) -> list[BenchmarkDatasetVersionEnvelope]:
+    async def list_versions(self, user_id: str, dataset_id: str) -> list[BenchmarkDatasetVersionEnvelope]:
         dataset = await self.db_ops.get_benchmark_dataset(user_id, dataset_id)
         if not dataset:
             raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
         rows = await self.db_ops.list_dataset_versions(dataset_id)
         return [BenchmarkDatasetVersionEnvelope.model_validate(r) for r in rows]
 
-    async def get_version(self, version_id: str) -> BenchmarkDatasetVersion:
+    async def get_version(self, user_id: str, version_id: str) -> BenchmarkDatasetVersion:
         version = await self.db_ops.get_dataset_version(version_id)
         if not version:
+            raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
+        dataset = await self.db_ops.get_benchmark_dataset(user_id, version.dataset_id)
+        if not dataset:
             raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
         return version
 
@@ -223,10 +233,10 @@ class EvaluationRunService:
         self.db_ops = db_ops or async_db_ops
         self.dataset_service = dataset_service or BenchmarkDatasetService(self.db_ops)
 
-    async def create_run(
-        self, user_id: str, request: EvaluationRunCreate
-    ) -> EvaluationRunEnvelope:
-        version = await self.dataset_service.get_version(request.dataset_version_id)
+    async def create_run(self, user_id: str, request: EvaluationRunCreate) -> EvaluationRunEnvelope:
+        version = await self.dataset_service.get_version(user_id, request.dataset_version_id)
+        if version.status != BenchmarkDatasetVersionStatus.PUBLISHED:
+            raise ValidationException("Only published dataset versions can be evaluated")
         bot = await self.db_ops.query_bot(user_id, request.bot_id)
         if not bot:
             raise ResourceNotFoundException("Bot", request.bot_id)
@@ -245,7 +255,7 @@ class EvaluationRunService:
             model_config_snapshot=request.model_config_snapshot,
             judge_config=judge_payload,
             status=EvaluationRunStatus.QUEUED,
-            summary=EvaluationRunSummary(total_cases=len(cases)).model_dump(),
+            summary=EvaluationRunSummary(total=len(cases), pending=len(cases)).model_dump(),
         )
         items = [
             EvaluationRunItem(
@@ -283,6 +293,15 @@ class EvaluationRunService:
         run = await self._require_run(user_id, run_id)
         return _to_run_envelope(run)
 
+    async def get_run_detail(self, user_id: str, run_id: str) -> EvaluationRunDetailResponse:
+        run = await self._require_run(user_id, run_id)
+        envelope = _to_run_envelope(run)
+        return EvaluationRunDetailResponse(
+            run=envelope,
+            summary=envelope.summary,
+            progress=_to_run_progress(envelope.summary),
+        )
+
     async def cancel_run(self, user_id: str, run_id: str) -> EvaluationRunEnvelope:
         run = await self._require_run(user_id, run_id)
         if run.status in (
@@ -295,20 +314,37 @@ class EvaluationRunService:
         updated = await self.db_ops.update_run_status(run_id, EvaluationRunStatus.CANCELLED)
         return _to_run_envelope(updated)
 
-    async def retry_run(
-        self, user_id: str, run_id: str, scope: str = "failed"
-    ) -> tuple[EvaluationRunEnvelope, int]:
-        """Phase 3 will re-queue failed attempts; for MVP we just flip status."""
-        run = await self._require_run(user_id, run_id)
-        if run.status == EvaluationRunStatus.RUNNING:
-            raise ValidationException("Cannot retry a run that is still running")
+    async def retry_run_item(self, user_id: str, run_id: str, item_id: str) -> EvaluationRunItemEnvelope:
+        """Re-queue a single run item for another attempt.
 
-        updated = await self.db_ops.update_run_status(
-            run_id, EvaluationRunStatus.QUEUED, error_message=None
-        )
+        Per frozen contract the only retry surface is run-scoped item retry:
+        `POST /api/v2/evaluation-runs/{runId}/items/{itemId}/retry`. Phase 3
+        worker pipeline will pick the PENDING item and produce a new attempt.
+        """
+        run = await self._require_run(user_id, run_id)
+        item = await self.db_ops.get_run_item(item_id)
+        if not item or item.run_id != run_id:
+            raise ResourceNotFoundException("EvaluationRunItem", item_id)
+        if item.status not in (
+            EvaluationRunItemStatus.FAILED,
+            EvaluationRunItemStatus.CANCELLED,
+        ):
+            raise ValidationException("Only failed or cancelled run items can be retried")
+
+        if run.status in (
+            EvaluationRunStatus.CANCELLED,
+            EvaluationRunStatus.COMPLETED,
+            EvaluationRunStatus.FAILED,
+        ):
+            await self.db_ops.update_run_status(
+                run_id,
+                EvaluationRunStatus.QUEUED,
+                error_message=None,
+            )
+
+        item = await self.db_ops.requeue_run_item(run_id, item_id)
         await self.launch_run(run_id)
-        # retried_count is filled by the Phase 3 worker layer; return 0 for now
-        return _to_run_envelope(updated), 0
+        return EvaluationRunItemEnvelope.model_validate(item)
 
     async def list_run_items(
         self, user_id: str, run_id: str, page: int, page_size: int
@@ -318,10 +354,10 @@ class EvaluationRunService:
         return [EvaluationRunItemEnvelope.model_validate(r) for r in rows], total
 
     async def list_run_item_attempts(
-        self, user_id: str, item_id: str
+        self, user_id: str, run_id: str, item_id: str
     ) -> list[EvaluationRunItemAttemptEnvelope]:
         item = await self.db_ops.get_run_item(item_id)
-        if not item:
+        if not item or item.run_id != run_id:
             raise ResourceNotFoundException("EvaluationRunItem", item_id)
         run = await self.db_ops.get_evaluation_run(user_id, item.run_id)
         if not run:

--- a/aperag/evaluation_v2/tasks.py
+++ b/aperag/evaluation_v2/tasks.py
@@ -1,0 +1,36 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async worker pipeline for evaluation-v2.
+
+Phase 1 only scaffolds the module. The Phase 3 implementation will:
+
+1. Pick up queued runs, transition them to RUNNING.
+2. For each run item, create an isolated agent chat and dispatch a
+   Runtime V3 turn via `agent_runtime.runtime.agent_runtime_manager`.
+3. Wait for the turn to finalize, fetch the answer / reference artifacts,
+   and invoke the configured judge (`aperag.evaluation_v2.judges`).
+4. Persist attempt + item results and update run summary metrics.
+5. Handle cancellation and retries by respecting run status transitions.
+
+Keep this module import-safe; register Celery tasks here so they are
+discoverable by the worker autodiscover pass.
+"""
+
+from __future__ import annotations
+
+
+async def run_evaluation_run(run_id: str) -> None:
+    """Phase 3 entrypoint. No-op until the worker pipeline lands."""
+    return None

--- a/aperag/migration/versions/20260421180000-a1e2f3d4c5b6.py
+++ b/aperag/migration/versions/20260421180000-a1e2f3d4c5b6.py
@@ -1,0 +1,162 @@
+"""evaluation v2: benchmark datasets and evaluation runs
+
+Revision ID: a1e2f3d4c5b6
+Revises: 5f8a1c2d9b7e
+Create Date: 2026-04-21 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1e2f3d4c5b6"
+down_revision: Union[str, None] = "5f8a1c2d9b7e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "benchmark_datasets",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("user_id", sa.String(length=256), nullable=False),
+        sa.Column("collection_id", sa.String(length=24), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("source_type", sa.String(length=70), nullable=False),
+        sa.Column("schema_hint", sa.JSON(), nullable=True),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_deleted", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("idx_benchmark_datasets_user", "benchmark_datasets", ["user_id"])
+    op.create_index("idx_benchmark_datasets_collection", "benchmark_datasets", ["collection_id"])
+    op.create_index("ix_benchmark_datasets_gmt_deleted", "benchmark_datasets", ["gmt_deleted"])
+
+    op.create_table(
+        "benchmark_dataset_versions",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("dataset_id", sa.String(length=32), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("version_name", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("case_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("source_snapshot", sa.JSON(), nullable=True),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_published", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("dataset_id", "version", name="uq_benchmark_dataset_version"),
+    )
+    op.create_index("idx_benchmark_dataset_versions_dataset", "benchmark_dataset_versions", ["dataset_id"])
+    op.create_index("idx_benchmark_dataset_versions_status", "benchmark_dataset_versions", ["status"])
+
+    op.create_table(
+        "benchmark_cases",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("dataset_version_id", sa.String(length=32), nullable=False),
+        sa.Column("case_key", sa.String(length=128), nullable=False),
+        sa.Column("input_message", sa.Text(), nullable=False),
+        sa.Column("expected_answer", sa.Text(), nullable=True),
+        sa.Column("reference_context", sa.Text(), nullable=True),
+        sa.Column("tags", sa.JSON(), nullable=True),
+        sa.Column("case_metadata", sa.JSON(), nullable=True),
+        sa.Column("sort_key", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("dataset_version_id", "case_key", name="uq_benchmark_case_version_key"),
+    )
+    op.create_index("idx_benchmark_cases_version", "benchmark_cases", ["dataset_version_id"])
+
+    op.create_table(
+        "evaluation_runs",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("user_id", sa.String(length=256), nullable=False),
+        sa.Column("bot_id", sa.String(length=24), nullable=False),
+        sa.Column("dataset_version_id", sa.String(length=32), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("bot_config_snapshot", sa.JSON(), nullable=True),
+        sa.Column("model_config_snapshot", sa.JSON(), nullable=True),
+        sa.Column("judge_config", sa.JSON(), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("summary", sa.JSON(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_started", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("gmt_finished", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("idx_evaluation_runs_user", "evaluation_runs", ["user_id"])
+    op.create_index("idx_evaluation_runs_bot", "evaluation_runs", ["bot_id"])
+    op.create_index("idx_evaluation_runs_status", "evaluation_runs", ["status"])
+    op.create_index("idx_evaluation_runs_dataset_version", "evaluation_runs", ["dataset_version_id"])
+
+    op.create_table(
+        "evaluation_run_items",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("run_id", sa.String(length=32), nullable=False),
+        sa.Column("case_id", sa.String(length=32), nullable=False),
+        sa.Column("case_key", sa.String(length=128), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("best_score", sa.Numeric(precision=6, scale=3), nullable=True),
+        sa.Column("latest_attempt_id", sa.String(length=32), nullable=True),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("run_id", "case_id", name="uq_evaluation_run_item_run_case"),
+    )
+    op.create_index("idx_evaluation_run_items_run", "evaluation_run_items", ["run_id"])
+    op.create_index("idx_evaluation_run_items_status", "evaluation_run_items", ["status"])
+
+    op.create_table(
+        "evaluation_run_item_attempts",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("run_item_id", sa.String(length=32), nullable=False),
+        sa.Column("run_id", sa.String(length=32), nullable=False),
+        sa.Column("attempt_no", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("agent_chat_id", sa.String(length=24), nullable=True),
+        sa.Column("agent_turn_id", sa.String(length=24), nullable=True),
+        sa.Column("answer_text", sa.Text(), nullable=True),
+        sa.Column("judge_result", sa.JSON(), nullable=True),
+        sa.Column("score", sa.Numeric(precision=6, scale=3), nullable=True),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("token_usage", sa.JSON(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("retry_reason", sa.Text(), nullable=True),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_started", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("gmt_finished", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("run_item_id", "attempt_no", name="uq_evaluation_run_item_attempt_no"),
+    )
+    op.create_index("idx_evaluation_run_item_attempts_item", "evaluation_run_item_attempts", ["run_item_id"])
+    op.create_index("idx_evaluation_run_item_attempts_run", "evaluation_run_item_attempts", ["run_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_evaluation_run_item_attempts_run", table_name="evaluation_run_item_attempts")
+    op.drop_index("idx_evaluation_run_item_attempts_item", table_name="evaluation_run_item_attempts")
+    op.drop_table("evaluation_run_item_attempts")
+
+    op.drop_index("idx_evaluation_run_items_status", table_name="evaluation_run_items")
+    op.drop_index("idx_evaluation_run_items_run", table_name="evaluation_run_items")
+    op.drop_table("evaluation_run_items")
+
+    op.drop_index("idx_evaluation_runs_dataset_version", table_name="evaluation_runs")
+    op.drop_index("idx_evaluation_runs_status", table_name="evaluation_runs")
+    op.drop_index("idx_evaluation_runs_bot", table_name="evaluation_runs")
+    op.drop_index("idx_evaluation_runs_user", table_name="evaluation_runs")
+    op.drop_table("evaluation_runs")
+
+    op.drop_index("idx_benchmark_cases_version", table_name="benchmark_cases")
+    op.drop_table("benchmark_cases")
+
+    op.drop_index("idx_benchmark_dataset_versions_status", table_name="benchmark_dataset_versions")
+    op.drop_index("idx_benchmark_dataset_versions_dataset", table_name="benchmark_dataset_versions")
+    op.drop_table("benchmark_dataset_versions")
+
+    op.drop_index("ix_benchmark_datasets_gmt_deleted", table_name="benchmark_datasets")
+    op.drop_index("idx_benchmark_datasets_collection", table_name="benchmark_datasets")
+    op.drop_index("idx_benchmark_datasets_user", table_name="benchmark_datasets")
+    op.drop_table("benchmark_datasets")

--- a/aperag/views/evaluation_v2.py
+++ b/aperag/views/evaluation_v2.py
@@ -142,6 +142,18 @@ async def list_benchmark_dataset_versions_view(
 
 
 @router.get(
+    "/benchmark-datasets/{dataset_id}/versions/{version_id}",
+    response_model=BenchmarkDatasetVersionEnvelope,
+)
+async def get_benchmark_dataset_version_view(
+    dataset_id: str,
+    version_id: str,
+    user: User = Depends(required_user),
+) -> BenchmarkDatasetVersionEnvelope:
+    return await benchmark_dataset_service.get_version_envelope(str(user.id), dataset_id, version_id)
+
+
+@router.get(
     "/benchmark-datasets/{dataset_id}/versions/{version_id}/cases",
     response_model=BenchmarkCaseListResponse,
 )

--- a/aperag/views/evaluation_v2.py
+++ b/aperag/views/evaluation_v2.py
@@ -38,6 +38,7 @@ from aperag.evaluation_v2.schemas import (
     EvaluationRunListResponse,
 )
 from aperag.evaluation_v2.services import benchmark_dataset_service, evaluation_run_service
+from aperag.exceptions import ResourceNotFoundException
 from aperag.views.auth import required_user
 
 router = APIRouter(tags=["evaluation-v2"])
@@ -166,7 +167,7 @@ async def list_benchmark_cases_view(
 ) -> BenchmarkCaseListResponse:
     version = await benchmark_dataset_service.get_version(str(user.id), version_id)
     if version.dataset_id != dataset_id:
-        return BenchmarkCaseListResponse(items=[], pagination=_pagination(0, page, page_size))
+        raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
 
     rows, total = await benchmark_dataset_service.db_ops.list_cases_for_version(version_id, page, page_size)
     items = [BenchmarkCaseEnvelope.model_validate(row) for row in rows]

--- a/aperag/views/evaluation_v2.py
+++ b/aperag/views/evaluation_v2.py
@@ -1,0 +1,238 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from fastapi import APIRouter, Depends, Query, Response
+
+from aperag.db.models import User
+from aperag.evaluation_v2.schemas import (
+    BenchmarkCaseEnvelope,
+    BenchmarkCaseListResponse,
+    BenchmarkDatasetCreate,
+    BenchmarkDatasetEnvelope,
+    BenchmarkDatasetListResponse,
+    BenchmarkDatasetUpdate,
+    BenchmarkDatasetVersionCreate,
+    BenchmarkDatasetVersionEnvelope,
+    BenchmarkDatasetVersionListResponse,
+    CancelRunResponse,
+    EvaluationPagination,
+    EvaluationRunCreate,
+    EvaluationRunDetailResponse,
+    EvaluationRunEnvelope,
+    EvaluationRunItemAttemptList,
+    EvaluationRunItemEnvelope,
+    EvaluationRunItemListResponse,
+    EvaluationRunListResponse,
+)
+from aperag.evaluation_v2.services import benchmark_dataset_service, evaluation_run_service
+from aperag.views.auth import required_user
+
+router = APIRouter(tags=["evaluation-v2"])
+
+
+def _pagination(total: int, page: int, page_size: int) -> EvaluationPagination:
+    return EvaluationPagination(
+        total=total,
+        offset=max(page - 1, 0) * page_size,
+        limit=page_size,
+    )
+
+
+async def _enrich_run_item(user_id: str, run_id: str, item: EvaluationRunItemEnvelope) -> EvaluationRunItemEnvelope:
+    if not item.id or (item.attempt_count <= 0 and not item.latest_attempt_id):
+        return item
+
+    attempts = await evaluation_run_service.list_run_item_attempts(user_id, run_id, item.id)
+    latest_attempt = attempts[-1] if attempts else None
+    return item.model_copy(update={"latest_attempt": latest_attempt})
+
+
+async def _enrich_run_items(
+    user_id: str, run_id: str, items: list[EvaluationRunItemEnvelope]
+) -> list[EvaluationRunItemEnvelope]:
+    if not items:
+        return items
+
+    return list(await asyncio.gather(*[_enrich_run_item(user_id, run_id, item) for item in items]))
+
+
+@router.post("/benchmark-datasets", response_model=BenchmarkDatasetEnvelope)
+async def create_benchmark_dataset_view(
+    body: BenchmarkDatasetCreate,
+    user: User = Depends(required_user),
+) -> BenchmarkDatasetEnvelope:
+    return await benchmark_dataset_service.create_dataset(str(user.id), body)
+
+
+@router.get("/benchmark-datasets", response_model=BenchmarkDatasetListResponse)
+async def list_benchmark_datasets_view(
+    collection_id: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    user: User = Depends(required_user),
+) -> BenchmarkDatasetListResponse:
+    items, total = await benchmark_dataset_service.list_datasets(str(user.id), collection_id, page, page_size)
+    return BenchmarkDatasetListResponse(items=items, pagination=_pagination(total, page, page_size))
+
+
+@router.get("/benchmark-datasets/{dataset_id}", response_model=BenchmarkDatasetEnvelope)
+async def get_benchmark_dataset_view(
+    dataset_id: str,
+    user: User = Depends(required_user),
+) -> BenchmarkDatasetEnvelope:
+    return await benchmark_dataset_service.get_dataset(str(user.id), dataset_id)
+
+
+@router.put("/benchmark-datasets/{dataset_id}", response_model=BenchmarkDatasetEnvelope)
+async def update_benchmark_dataset_view(
+    dataset_id: str,
+    body: BenchmarkDatasetUpdate,
+    user: User = Depends(required_user),
+) -> BenchmarkDatasetEnvelope:
+    return await benchmark_dataset_service.update_dataset(str(user.id), dataset_id, body)
+
+
+@router.delete("/benchmark-datasets/{dataset_id}", status_code=204)
+async def delete_benchmark_dataset_view(
+    dataset_id: str,
+    user: User = Depends(required_user),
+) -> Response:
+    await benchmark_dataset_service.delete_dataset(str(user.id), dataset_id)
+    return Response(status_code=204)
+
+
+@router.post(
+    "/benchmark-datasets/{dataset_id}/versions",
+    response_model=BenchmarkDatasetVersionEnvelope,
+)
+async def create_benchmark_dataset_version_view(
+    dataset_id: str,
+    body: BenchmarkDatasetVersionCreate,
+    user: User = Depends(required_user),
+) -> BenchmarkDatasetVersionEnvelope:
+    return await benchmark_dataset_service.create_version(str(user.id), dataset_id, body)
+
+
+@router.get(
+    "/benchmark-datasets/{dataset_id}/versions",
+    response_model=BenchmarkDatasetVersionListResponse,
+)
+async def list_benchmark_dataset_versions_view(
+    dataset_id: str,
+    user: User = Depends(required_user),
+) -> BenchmarkDatasetVersionListResponse:
+    items = await benchmark_dataset_service.list_versions(str(user.id), dataset_id)
+    return BenchmarkDatasetVersionListResponse(
+        items=items,
+        pagination=EvaluationPagination(total=len(items), offset=0, limit=len(items)),
+    )
+
+
+@router.get(
+    "/benchmark-datasets/{dataset_id}/versions/{version_id}/cases",
+    response_model=BenchmarkCaseListResponse,
+)
+async def list_benchmark_cases_view(
+    dataset_id: str,
+    version_id: str,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=100, ge=1, le=500),
+    user: User = Depends(required_user),
+) -> BenchmarkCaseListResponse:
+    version = await benchmark_dataset_service.get_version(str(user.id), version_id)
+    if version.dataset_id != dataset_id:
+        return BenchmarkCaseListResponse(items=[], pagination=_pagination(0, page, page_size))
+
+    rows, total = await benchmark_dataset_service.db_ops.list_cases_for_version(version_id, page, page_size)
+    items = [BenchmarkCaseEnvelope.model_validate(row) for row in rows]
+    return BenchmarkCaseListResponse(items=items, pagination=_pagination(total, page, page_size))
+
+
+@router.post("/evaluation-runs", response_model=EvaluationRunEnvelope)
+async def create_evaluation_run_view(
+    body: EvaluationRunCreate,
+    user: User = Depends(required_user),
+) -> EvaluationRunEnvelope:
+    return await evaluation_run_service.create_run(str(user.id), body)
+
+
+@router.get("/evaluation-runs", response_model=EvaluationRunListResponse)
+async def list_evaluation_runs_view(
+    bot_id: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    user: User = Depends(required_user),
+) -> EvaluationRunListResponse:
+    items, total = await evaluation_run_service.list_runs(str(user.id), bot_id, page, page_size)
+    return EvaluationRunListResponse(items=items, pagination=_pagination(total, page, page_size))
+
+
+@router.get("/evaluation-runs/{run_id}", response_model=EvaluationRunDetailResponse)
+async def get_evaluation_run_view(
+    run_id: str,
+    user: User = Depends(required_user),
+) -> EvaluationRunDetailResponse:
+    return await evaluation_run_service.get_run_detail(str(user.id), run_id)
+
+
+@router.post("/evaluation-runs/{run_id}/cancel", response_model=CancelRunResponse)
+async def cancel_evaluation_run_view(
+    run_id: str,
+    user: User = Depends(required_user),
+) -> CancelRunResponse:
+    run = await evaluation_run_service.cancel_run(str(user.id), run_id)
+    return CancelRunResponse(run_id=run.id, status=run.status)
+
+
+@router.get("/evaluation-runs/{run_id}/items", response_model=EvaluationRunItemListResponse)
+async def list_evaluation_run_items_view(
+    run_id: str,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=100, ge=1, le=500),
+    user: User = Depends(required_user),
+) -> EvaluationRunItemListResponse:
+    items, total = await evaluation_run_service.list_run_items(str(user.id), run_id, page, page_size)
+    enriched_items = await _enrich_run_items(str(user.id), run_id, items)
+    return EvaluationRunItemListResponse(
+        items=enriched_items,
+        pagination=_pagination(total, page, page_size),
+    )
+
+
+@router.get(
+    "/evaluation-runs/{run_id}/items/{item_id}/attempts",
+    response_model=EvaluationRunItemAttemptList,
+)
+async def list_evaluation_run_item_attempts_view(
+    run_id: str,
+    item_id: str,
+    user: User = Depends(required_user),
+) -> EvaluationRunItemAttemptList:
+    items = await evaluation_run_service.list_run_item_attempts(str(user.id), run_id, item_id)
+    return EvaluationRunItemAttemptList(items=items)
+
+
+@router.post(
+    "/evaluation-runs/{run_id}/items/{item_id}/retry",
+    response_model=EvaluationRunItemEnvelope,
+)
+async def retry_evaluation_run_item_view(
+    run_id: str,
+    item_id: str,
+    user: User = Depends(required_user),
+) -> EvaluationRunItemEnvelope:
+    item = await evaluation_run_service.retry_run_item(str(user.id), run_id, item_id)
+    return await _enrich_run_item(str(user.id), run_id, item)


### PR DESCRIPTION
## Summary
First code-bearing diff for the new evaluation product line (`evaluation v2`) on top of Agent Runtime V3, per the frozen contract in `#evaluation:b4536090`.

Phase 1 only — data layer and package scaffolding. Views (Phase 2) and the async worker pipeline (Phase 3) land in follow-up commits on this branch.

- **Models (new in `aperag/db/models.py`)** — enums + 6 SQLAlchemy tables:
  `benchmark_datasets`, `benchmark_dataset_versions`, `benchmark_cases`,
  `evaluation_runs`, `evaluation_run_items`, `evaluation_run_item_attempts`.
  Attempts explicitly link to Runtime V3 via `agent_chat_id` / `agent_turn_id`,
  so trace/artifact reads reuse existing runtime endpoints rather than a
  parallel protocol.
- **Alembic migration `20260421180000-a1e2f3d4c5b6.py`** — down revision
  `5f8a1c2d9b7e`. Creates the six tables with the matching unique constraints
  and indexes; drops them cleanly on downgrade.
- **Repository mixin `aperag/db/repositories/evaluation_v2.py`** wired into
  `AsyncDatabaseOps` — dataset/version/case + run/item/attempt reads and
  writes used by the orchestration service.
- **New package `aperag/evaluation_v2/`**
  - `schemas.py` — Pydantic DTOs for the frozen contract (dataset/version/case
    create + envelopes, `EvaluationRunCreate`, `EvaluationRunSummary`,
    `JudgeConfig`, run / item / attempt envelopes, cancel/retry responses).
  - `services.py` — `BenchmarkDatasetService` + `EvaluationRunService`.
    Create / list / get / update / soft-delete dataset; create version (MVP
    main path directly produces a `published` version); create run with
    bot/dataset-version snapshot and one run-item per case; list / get /
    cancel / retry run; list items and attempts.
  - `judges.py` — `Judge` interface + `NoopJudge` + `ExactMatchJudge`.
    `build_judge(JudgeConfig)` factory; LLM-as-judge branch currently falls
    back to exact match until Phase 3.
  - `tasks.py` — Phase 3 worker scaffold (no-op).

## What's intentionally NOT in this PR
- Phase 2: `aperag/views/evaluation_v2.py` + router registration at `/api/v2`.
- Phase 3: Celery task dispatching Runtime V3 turns, judge execution,
  run-summary aggregation.
- One-way `question_sets` → `benchmark_datasets` migration script.
- `create dataset` / `create run` API tests (will land alongside Phase 2).
- LLM-as-judge, compare, export, auto-generate, pairwise judge — explicitly
  out of MVP scope.

## Contract surface this enables
The frontend draft PR #1513 already consumes these endpoints against the
frozen contract:

- `GET  /api/v2/benchmark-datasets?collection_id=…`
- `GET  /api/v2/benchmark-datasets/{datasetId}`
- `POST /api/v2/benchmark-datasets/{datasetId}/versions` (directly published)
- `GET  /api/v2/evaluation-runs?bot_id=…`
- `GET  /api/v2/evaluation-runs/{runId}`
- `POST /api/v2/evaluation-runs/{runId}/cancel`
- `GET  /api/v2/evaluation-runs/{runId}/items`
- `POST /api/v2/evaluation-run-items/{itemId}/retry`

Phase 2 will bind these URLs on top of the services shipped here.

## Test plan
- [ ] `uv run alembic upgrade head` then `uv run alembic downgrade -1` round-trip on a fresh Postgres.
- [ ] Import-check the new package (`python -c "import aperag.evaluation_v2.schemas, aperag.evaluation_v2.services, aperag.evaluation_v2.judges, aperag.db.repositories.evaluation_v2"`).
- [ ] Unit tests for `BenchmarkDatasetService.create_version` (version numbering, duplicate `case_key`, empty payload) — lands with Phase 2.
- [ ] Unit tests for `EvaluationRunService.create_run` item fan-out — lands with Phase 2.

## Review pointers (cc @bryce per architecture note)
Runtime interface surfaces most relevant to `@bryce`:
1. `EvaluationRunItemAttempt.agent_chat_id` / `.agent_turn_id` as the only
   association keys — no parallel trace protocol.
2. `EvaluationRunService.cancel_run` flips run status; Phase 3 worker will
   honor this to avoid half-cancelled state.
3. Retry currently re-queues the run; attempt-level retry granularity ships
   with Phase 3 once the worker pipeline lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)