### PR TITLE
[codex] harden web search fallback and diagnostics

### DIFF
--- a/aperag/agent/tool_use_message_formatters.py
+++ b/aperag/agent/tool_use_message_formatters.py
@@ -274,6 +274,7 @@ class ToolResultFormatter:
         """Format web search result"""
         query = result.query or ""
         count = len(result.results or [])
+        search_meta = result.meta
 
         # Part 1: Search execution
         if self.language == "zh-CN":
@@ -283,10 +284,28 @@ class ToolResultFormatter:
 
         # Part 2: Results (only if has results)
         if count == 0:
-            if self.language == "zh-CN":
-                results = "没有找到任何网页结果"
+            if search_meta and search_meta.search_status == "unavailable":
+                providers = " -> ".join(search_meta.provider_used or []) or "unknown"
+                backends = ", ".join(search_meta.backend_used or [])
+                error_code = search_meta.error_code or "search_unavailable"
+                if self.language == "zh-CN":
+                    results = f"网页搜索当前不可用（provider：{providers}，错误码：{error_code}）"
+                    if backends:
+                        results += f"\n\n • 后端尝试：{backends}"
+                else:
+                    results = f"Web search was unavailable for this step (provider path: {providers}, error: {error_code})"
+                    if backends:
+                        results += f"\n\n • Backends tried: {backends}"
+            elif search_meta and search_meta.search_status == "disabled":
+                if self.language == "zh-CN":
+                    results = "本轮对话未启用网页搜索"
+                else:
+                    results = "Web search was disabled for this turn"
             else:
-                results = "No web results found"
+                if self.language == "zh-CN":
+                    results = "没有找到任何网页结果"
+                else:
+                    results = "No web results found"
             return f"{execution}\n\n{results}"
         else:
             if self.language == "zh-CN":

--- a/aperag/agent/tool_use_message_formatters.py
+++ b/aperag/agent/tool_use_message_formatters.py
@@ -293,7 +293,9 @@ class ToolResultFormatter:
                     if backends:
                         results += f"\n\n • 后端尝试：{backends}"
                 else:
-                    results = f"Web search was unavailable for this step (provider path: {providers}, error: {error_code})"
+                    results = (
+                        f"Web search was unavailable for this step (provider path: {providers}, error: {error_code})"
+                    )
                     if backends:
                         results += f"\n\n • Backends tried: {backends}"
             elif search_meta and search_meta.search_status == "disabled":

--- a/aperag/mcp/server.py
+++ b/aperag/mcp/server.py
@@ -415,6 +415,14 @@ async def web_search(
     """
     try:
         api_key = get_api_key()
+        logger.info(
+            "MCP web_search request query=%s source=%s max_results=%s timeout=%s locale=%s",
+            query.strip() if query else "",
+            source.strip() if source else "",
+            max_results,
+            timeout,
+            locale,
+        )
 
         # Build search request
         search_data = {
@@ -441,11 +449,28 @@ async def web_search(
                 try:
                     # Parse response using view model for type safety
                     search_response = WebSearchResponse.model_validate(response.json())
+                    logger.info(
+                        "MCP web_search completed query=%s source=%s status=%s results=%s providers=%s backends=%s fallback=%s",
+                        query.strip() if query else "",
+                        source.strip() if source else "",
+                        search_response.meta.search_status if search_response.meta else "unknown",
+                        len(search_response.results),
+                        search_response.meta.provider_used if search_response.meta else [],
+                        search_response.meta.backend_used if search_response.meta else [],
+                        search_response.meta.fallback_used if search_response.meta else False,
+                    )
                     return search_response.model_dump()
                 except Exception as e:
                     logger.error(f"Failed to parse web search response: {e}")
                     return {"error": "Failed to parse web search response", "details": str(e)}
             else:
+                logger.warning(
+                    "MCP web_search failed status=%s query=%s source=%s body=%s",
+                    response.status_code,
+                    query.strip() if query else "",
+                    source.strip() if source else "",
+                    response.text,
+                )
                 return {"error": f"Web search failed: {response.status_code}", "details": response.text}
     except ValueError as e:
         return {"error": str(e)}
@@ -496,6 +521,13 @@ async def web_read(
     """
     try:
         api_key = get_api_key()
+        logger.info(
+            "MCP web_read request urls=%s timeout=%s locale=%s max_concurrent=%s",
+            len(url_list or []),
+            timeout,
+            locale,
+            max_concurrent,
+        )
 
         # Validate url_list parameter
         if not url_list or len(url_list) == 0:
@@ -520,11 +552,23 @@ async def web_read(
                 try:
                     # Parse response using view model for type safety
                     read_response = WebReadResponse.model_validate(response.json())
+                    logger.info(
+                        "MCP web_read completed urls=%s successful=%s failed=%s",
+                        read_response.total_urls,
+                        read_response.successful,
+                        read_response.failed,
+                    )
                     return read_response.model_dump()
                 except Exception as e:
                     logger.error(f"Failed to parse web read response: {e}")
                     return {"error": "Failed to parse web read response", "details": str(e)}
             else:
+                logger.warning(
+                    "MCP web_read failed status=%s urls=%s body=%s",
+                    response.status_code,
+                    len(url_list or []),
+                    response.text,
+                )
                 return {"error": f"Web read failed: {response.status_code}", "details": response.text}
     except ValueError as e:
         return {"error": str(e)}

--- a/aperag/service/document_service.py
+++ b/aperag/service/document_service.py
@@ -1391,7 +1391,7 @@ class DocumentService:
 
         from aperag.db.ops import async_db_ops as _db_ops
         from aperag.schema.view_models import WebReadRequest
-        from aperag.websearch.reader.reader_service import ReaderService
+        from aperag.websearch.reader.reader_service import read_with_jina_fallback
 
         # Validate URL count
         if len(urls) > 10:
@@ -1401,20 +1401,21 @@ class DocumentService:
 
         # Determine which reader to use based on user's JINA API key
         jina_api_key = await _db_ops.query_provider_api_key("jina", user_id=user_id, need_public=True)
+        logger.info(
+            "Starting fetch-url import collection_id=%s urls=%s jina_configured=%s",
+            collection_id,
+            len(url_strings),
+            bool(jina_api_key),
+        )
 
         web_read_request = WebReadRequest(url_list=url_strings, timeout=30)
 
         try:
-            if jina_api_key:
-                async with ReaderService(provider_name="jina", provider_config={"api_key": jina_api_key}) as svc:
-                    web_response = await svc.read(web_read_request)
-                # Check if JINA returned any successes; fallback if not
-                if not any(r.status == "success" for r in web_response.results):
-                    async with ReaderService(provider_name="trafilatura") as svc:
-                        web_response = await svc.read(web_read_request)
-            else:
-                async with ReaderService(provider_name="trafilatura") as svc:
-                    web_response = await svc.read(web_read_request)
+            web_response = await read_with_jina_fallback(
+                web_read_request,
+                jina_api_key,
+                log_context=f"fetch_url_documents collection_id={collection_id}",
+            )
         except Exception as e:
             logger.error(f"Web read service failed: {e}")
             # Return all URLs as failed
@@ -1427,6 +1428,13 @@ class DocumentService:
                 for u in url_strings
             ]
             return view_models.FetchUrlResponse(results=results, total=len(results), succeeded=0, failed=len(results))
+
+        logger.info(
+            "Fetch-url read stage completed collection_id=%s successful=%s failed=%s",
+            collection_id,
+            web_response.successful,
+            web_response.failed,
+        )
 
         results = []
         for item in web_response.results:
@@ -1458,6 +1466,12 @@ class DocumentService:
 
             try:
                 upload_response = await self.upload_document(user_id, collection_id, virtual_file)
+                logger.info(
+                    "Fetch-url imported successfully collection_id=%s url=%s document_id=%s",
+                    collection_id,
+                    item.url,
+                    upload_response.document_id,
+                )
                 results.append(
                     view_models.FetchUrlResultItem(
                         url=item.url,
@@ -1483,6 +1497,13 @@ class DocumentService:
                 )
 
         succeeded = sum(1 for r in results if r.fetch_status == "success")
+        logger.info(
+            "Fetch-url import completed collection_id=%s total=%s succeeded=%s failed=%s",
+            collection_id,
+            len(results),
+            succeeded,
+            len(results) - succeeded,
+        )
         return view_models.FetchUrlResponse(
             results=results,
             total=len(results),

--- a/aperag/views/web.py
+++ b/aperag/views/web.py
@@ -29,7 +29,7 @@ from aperag.schema.view_models import (
     WebSearchResponse,
 )
 from aperag.views.auth import required_user
-from aperag.websearch.reader.reader_service import ReaderService
+from aperag.websearch.reader.reader_service import ReaderService, read_with_jina_fallback
 from aperag.websearch.search.search_service import SearchService
 
 logger = logging.getLogger(__name__)
@@ -270,30 +270,8 @@ async def _read_with_jina_fallback(request: WebReadRequest, jina_api_key: str) -
     Raises:
         WebReadError: If both JINA and Trafilatura fail
     """
-    # Try JINA first
     try:
-        logger.info("Attempting to read with JINA")
-        async with ReaderService(provider_name="jina", provider_config={"api_key": jina_api_key}) as jina_service:
-            jina_result = await jina_service.read(request)
-
-            # Check if JINA was successful
-            if jina_result and hasattr(jina_result, "results"):
-                successful_count = sum(1 for r in jina_result.results if r.status == "success")
-                if successful_count > 0:
-                    logger.info(f"JINA succeeded: {successful_count}/{jina_result.total_urls} URLs")
-                    return jina_result
-                else:
-                    logger.info("JINA completed but no URLs were successfully processed")
-            else:
-                logger.info("JINA returned empty or invalid result")
-
-    except Exception as e:
-        logger.info(f"JINA failed: {e}")
-
-    # Fallback to Trafilatura
-    logger.info("Falling back to Trafilatura")
-    try:
-        return await _read_with_trafilatura_only(request)
+        return await read_with_jina_fallback(request, jina_api_key, log_context="web_read_endpoint")
     except Exception as e:
         raise WebReadError(f"Both JINA and Trafilatura reading failed. Last error: {str(e)}") from e
 

--- a/aperag/websearch/reader/reader_service.py
+++ b/aperag/websearch/reader/reader_service.py
@@ -5,7 +5,7 @@ Main service class for web content reading functionality with provider abstracti
 """
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from aperag.schema.view_models import WebReadRequest, WebReadResponse, WebReadResultItem
 from aperag.websearch.reader.base_reader import BaseReaderProvider
@@ -261,3 +261,120 @@ class ReaderService:
             ReaderService instance
         """
         return cls(provider_name=provider_name, provider_config=config)
+
+
+def _merge_reader_results(
+    primary_response: WebReadResponse,
+    fallback_response: WebReadResponse,
+    fallback_indexes: list[int],
+) -> WebReadResponse:
+    """Merge fallback results back into the original request order."""
+    merged_results = [result.model_copy(deep=True) for result in primary_response.results]
+
+    fallback_result_count = min(len(fallback_indexes), len(fallback_response.results))
+    if fallback_result_count < len(fallback_indexes):
+        logger.warning(
+            "Reader fallback returned fewer results than expected expected=%s actual=%s",
+            len(fallback_indexes),
+            len(fallback_response.results),
+        )
+
+    for offset in range(fallback_result_count):
+        target_index = fallback_indexes[offset]
+        primary_result = merged_results[target_index]
+        fallback_result = fallback_response.results[offset]
+
+        if primary_result.status == "success":
+            continue
+
+        if fallback_result.status == "success":
+            merged_results[target_index] = fallback_result.model_copy(deep=True)
+            continue
+
+        if not primary_result.error and fallback_result.error:
+            merged_results[target_index] = fallback_result.model_copy(deep=True)
+
+    successful = sum(1 for result in merged_results if result.status == "success")
+    failed = len(merged_results) - successful
+    processing_time = (primary_response.processing_time or 0.0) + (fallback_response.processing_time or 0.0)
+
+    return WebReadResponse(
+        results=merged_results,
+        total_urls=primary_response.total_urls,
+        successful=successful,
+        failed=failed,
+        processing_time=processing_time,
+    )
+
+
+async def read_with_jina_fallback(
+    request: WebReadRequest,
+    jina_api_key: Optional[str],
+    *,
+    log_context: str = "web_read",
+) -> WebReadResponse:
+    """
+    Read web content with JINA preferred and Trafilatura fallback.
+
+    Fallback is applied per URL so partial JINA failures do not force callers to
+    lose recoverable pages.
+    """
+    if not jina_api_key:
+        logger.info("%s using Trafilatura only urls=%s", log_context, len(request.url_list))
+        async with ReaderService(provider_name="trafilatura") as trafilatura_service:
+            response = await trafilatura_service.read(request)
+        logger.info(
+            "%s completed provider=trafilatura successful=%s failed=%s",
+            log_context,
+            response.successful,
+            response.failed,
+        )
+        return response
+
+    try:
+        logger.info("%s using JINA first urls=%s", log_context, len(request.url_list))
+        async with ReaderService(provider_name="jina", provider_config={"api_key": jina_api_key}) as jina_service:
+            jina_response = await jina_service.read(request)
+    except Exception as exc:
+        logger.warning("%s JINA pass crashed error=%s; falling back to Trafilatura", log_context, exc)
+        async with ReaderService(provider_name="trafilatura") as trafilatura_service:
+            fallback_response = await trafilatura_service.read(request)
+        logger.info(
+            "%s completed provider=trafilatura-after-jina-crash successful=%s failed=%s",
+            log_context,
+            fallback_response.successful,
+            fallback_response.failed,
+        )
+        return fallback_response
+
+    fallback_indexes = [index for index, result in enumerate(jina_response.results) if result.status != "success"]
+    if not fallback_indexes:
+        logger.info(
+            "%s completed provider=jina successful=%s failed=%s fallback_used=false",
+            log_context,
+            jina_response.successful,
+            jina_response.failed,
+        )
+        return jina_response
+
+    fallback_urls = [request.url_list[index] for index in fallback_indexes]
+    logger.info(
+        "%s JINA partial failure failed_urls=%s successful=%s failed=%s; retrying with Trafilatura",
+        log_context,
+        len(fallback_urls),
+        jina_response.successful,
+        jina_response.failed,
+    )
+
+    fallback_request = request.model_copy(update={"url_list": fallback_urls})
+    async with ReaderService(provider_name="trafilatura") as trafilatura_service:
+        fallback_response = await trafilatura_service.read(fallback_request)
+
+    merged_response = _merge_reader_results(jina_response, fallback_response, fallback_indexes)
+    logger.info(
+        "%s completed providers=jina,trafilatura successful=%s failed=%s fallback_used=true",
+        log_context,
+        merged_response.successful,
+        merged_response.failed,
+    )
+    return merged_response

--- a/tests/unit_test/chat/test_tool_use_message_formatters.py
+++ b/tests/unit_test/chat/test_tool_use_message_formatters.py
@@ -1,0 +1,46 @@
+from aperag.agent.tool_use_message_formatters import ToolResultFormatter
+from aperag.schema.view_models import WebSearchMeta, WebSearchResponse
+
+
+def test_web_search_formatter_distinguishes_unavailable_from_empty():
+    formatter = ToolResultFormatter(language="en-US")
+    response = WebSearchResponse(
+        query="latest chip news",
+        results=[],
+        total_results=0,
+        search_time=0.2,
+        meta=WebSearchMeta(
+            search_status="unavailable",
+            provider_used=["jina", "duckduckgo"],
+            backend_used=["duckduckgo:auto", "duckduckgo:html"],
+            fallback_used=True,
+            error_code="duckduckgo_unavailable",
+        ),
+    )
+
+    formatted = formatter._format_web_search(response)
+
+    assert "Web search was unavailable for this step" in formatted
+    assert "duckduckgo_unavailable" in formatted
+    assert "duckduckgo:auto" in formatted
+
+
+def test_web_search_formatter_reports_disabled_state():
+    formatter = ToolResultFormatter(language="en-US")
+    response = WebSearchResponse(
+        query="latest chip news",
+        results=[],
+        total_results=0,
+        search_time=0.2,
+        meta=WebSearchMeta(
+            search_status="disabled",
+            provider_used=[],
+            backend_used=[],
+            fallback_used=False,
+            error_code=None,
+        ),
+    )
+
+    formatted = formatter._format_web_search(response)
+
+    assert "Web search was disabled for this turn" in formatted

--- a/tests/unit_test/test_document_service_fetch_url.py
+++ b/tests/unit_test/test_document_service_fetch_url.py
@@ -122,6 +122,72 @@ def test_fetch_url_documents_falls_back_when_jina_returns_no_successes(monkeypat
     assert [call[0] for call in _FakeReaderService.calls] == ["jina", "trafilatura"]
 
 
+def test_fetch_url_documents_falls_back_per_failed_url_when_jina_partially_succeeds(monkeypatch):
+    service = DocumentService()
+    service.upload_document = AsyncMock(
+        side_effect=[
+            view_models.UploadDocumentResponse(
+                document_id="doc-fetch-3a",
+                filename="Primary Title.md",
+                size=14,
+                status="UPLOADED",
+            ),
+            view_models.UploadDocumentResponse(
+                document_id="doc-fetch-3b",
+                filename="Fallback Title.md",
+                size=16,
+                status="UPLOADED",
+            ),
+        ]
+    )
+
+    _FakeReaderService.calls = []
+    _FakeReaderService.plans = [
+        _web_read_response(
+            view_models.WebReadResultItem(
+                url="https://example.com/primary",
+                status="success",
+                title="Primary Title",
+                content="primary markdown",
+            ),
+            view_models.WebReadResultItem(
+                url="https://example.com/fallback",
+                status="error",
+                error="provider timeout",
+                error_code="timeout",
+            ),
+        ),
+        _web_read_response(
+            view_models.WebReadResultItem(
+                url="https://example.com/fallback",
+                status="success",
+                title="Fallback Title",
+                content="fallback markdown",
+            )
+        ),
+    ]
+
+    monkeypatch.setattr("aperag.db.ops.async_db_ops.query_provider_api_key", AsyncMock(return_value="jina-key"))
+    monkeypatch.setattr("aperag.websearch.reader.reader_service.ReaderService", _FakeReaderService)
+
+    response = asyncio.run(
+        service.fetch_url_documents(
+            "user-1",
+            "col-1",
+            ["https://example.com/primary", "https://example.com/fallback"],
+        )
+    )
+
+    assert response.succeeded == 2
+    assert response.failed == 0
+    assert [call[0] for call in _FakeReaderService.calls] == ["jina", "trafilatura"]
+    assert [result.url for result in response.results] == [
+        "https://example.com/primary",
+        "https://example.com/fallback",
+    ]
+    assert [result.fetch_status for result in response.results] == ["success", "success"]
+
+
 def test_fetch_url_documents_reports_upload_failures_per_url(monkeypatch):
     service = DocumentService()
     service.upload_document = AsyncMock(side_effect=RuntimeError("quota exceeded"))

--- a/web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx
@@ -130,12 +130,23 @@ export const UrlImport = ({ onSuccess }: Props) => {
       if (succeeded.length > 0) {
         onSuccess(fetchResults);
       }
-    } catch {
+    } catch (error: unknown) {
+      const detail =
+        typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        typeof (error as { response?: { data?: { detail?: unknown } } }).response?.data?.detail ===
+          'string'
+          ? (error as { response?: { data?: { detail?: string } } }).response?.data?.detail
+          : error instanceof Error
+            ? error.message
+            : 'Request failed';
+
       setResults(
         parseUrls(urlText).map((url) => ({
           url,
           fetch_status: 'error' as const,
-          error: 'Request failed',
+          error: detail || 'Request failed',
         })),
       );
     } finally {


### PR DESCRIPTION
## What changed
- fixed the shared `web_read` fallback path so partial Jina failures retry only failed URLs with Trafilatura instead of giving up after a partial response
- reused that shared fallback in both the chat/web endpoint and Website URL import flow
- added MCP and URL-import stage logs so web search/read failures are easier to trace end to end
- surfaced `unavailable` and `disabled` web-search states in tool-use formatting instead of collapsing them into a generic "no results"
- improved Website URL import UI error reporting to show backend `detail` when available
- added focused regression tests for partial-read fallback and formatter status rendering
- improved local hook bootstrap so future contributors/worktrees are less likely to miss the same CI formatting gate:
  - restored a working `make dev` alias to match existing docs
  - switched hook installation to `core.hooksPath=scripts/hooks`
  - fixed the tracked `scripts/hooks/pre-commit` execute bit so hook install no longer dirties the repo

## Why
There were two correctness/operability gaps in the current web-search chain:
1. multi-URL read requests could lose recoverable pages when Jina partially succeeded, because fallback only ran when Jina produced zero successes overall
2. chat and upload flows hid important diagnostics by flattening provider failures into generic empty-result or request-failed messages

There was also a workflow gap behind the repeated "very small follow-up CI fix" pattern:
- the repo already had a `pre-commit` hook that would catch `make lint`
- but hook installation was easy to miss in new worktrees, and the documented `make dev` entrypoint did not actually exist

## Impact
- chat web-read paths recover more URLs instead of failing partially
- Website URL import is more resilient and easier to debug in private deployments
- tool summaries now distinguish "web search unavailable" from true empty search results
- operators get clearer MCP/import logs for full-chain troubleshooting
- future contributors are more likely to catch `make lint` failures locally before pushing

## Validation
- `./.venv/bin/python -m py_compile aperag/websearch/reader/reader_service.py aperag/views/web.py aperag/service/document_service.py aperag/mcp/server.py aperag/agent/tool_use_message_formatters.py tests/unit_test/test_document_service_fetch_url.py tests/unit_test/chat/test_tool_use_message_formatters.py`
- `./.venv/bin/pytest tests/unit_test/test_document_service_fetch_url.py tests/unit_test/chat/test_tool_use_message_formatters.py tests/unit_test/websearch/test_parallel_search.py -q`
- `cd web && yarn next lint --file 'src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx'`
- `uvx ruff format --check ./aperag`
- `./scripts/install-hooks.sh && git config --get core.hooksPath`
- `make -n dev`
