### PR TITLE
[codex] fix chat collection mention title replacement

### DIFF
--- a/web/src/components/chat/message-parts-user.tsx
+++ b/web/src/components/chat/message-parts-user.tsx
@@ -5,6 +5,59 @@ import { UserRound } from 'lucide-react';
 import { useMemo } from 'react';
 import { MessageTimestamp } from './message-timestamp';
 
+const isMentionBoundary = (value?: string) => {
+  if (!value) return true;
+  return !/[A-Za-z0-9_-]/.test(value);
+};
+
+const replaceCollectionMentions = (
+  rawMessage: string,
+  collectionNameById: Map<string, string>,
+) => {
+  const collectionIds = Array.from(collectionNameById.keys()).sort(
+    (left, right) => right.length - left.length,
+  );
+  if (collectionIds.length === 0) return rawMessage;
+
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < rawMessage.length) {
+    const mentionStart = rawMessage.indexOf('@', cursor);
+    if (mentionStart === -1) {
+      result += rawMessage.slice(cursor);
+      break;
+    }
+
+    result += rawMessage.slice(cursor, mentionStart);
+
+    if (!isMentionBoundary(rawMessage[mentionStart - 1])) {
+      result += '@';
+      cursor = mentionStart + 1;
+      continue;
+    }
+
+    const matchedCollectionId = collectionIds.find((collectionId) => {
+      const mentionEnd = mentionStart + 1 + collectionId.length;
+      return (
+        rawMessage.startsWith(collectionId, mentionStart + 1) &&
+        isMentionBoundary(rawMessage[mentionEnd])
+      );
+    });
+
+    if (!matchedCollectionId) {
+      result += '@';
+      cursor = mentionStart + 1;
+      continue;
+    }
+
+    result += `@${collectionNameById.get(matchedCollectionId) || matchedCollectionId}`;
+    cursor = mentionStart + 1 + matchedCollectionId.length;
+  }
+
+  return result;
+};
+
 export const MessagePartsUser = ({ parts }: { parts: ChatMessage[] }) => {
   const { collections } = useBotContext();
 
@@ -21,12 +74,8 @@ export const MessagePartsUser = ({ parts }: { parts: ChatMessage[] }) => {
         ]),
     );
 
-    const mentionPattern = /(^|\s)@([A-Za-z0-9]{24})(?=\s|$)/g;
-    return rawMessage.replace(mentionPattern, (match, prefix, collectionId) => {
-      const collectionName = collectionNameById.get(collectionId);
-      if (!collectionName) return match;
-      return `${prefix}@${collectionName}`;
-    });
+    // Replace only exact @collection-id mentions that exist in the current bot context.
+    return replaceCollectionMentions(rawMessage, collectionNameById);
   }, [collections, parts]);
 
   return (


### PR DESCRIPTION
## What changed
- replaced the fixed-length collection mention regex in `message-parts-user.tsx`
- now rewrites mentions by matching against the current bot context's real collection-id set
- only exact `@collectionId` mentions are replaced with `@collectionTitle`
- non-mentions or unmatched tokens are preserved as-is

## Why
The previous implementation assumed collection mentions always looked like `@` plus a 24-character alphanumeric id. Real collection ids do not consistently satisfy that assumption, and mentions can also be followed by Chinese text or punctuation. That made the merged implementation miss valid mentions even on the latest `main`.

This follow-up fix avoids guessing identifier shape and instead uses the actual collection ids available in bot context, which is a more reliable short-term approach.

## Validation
- `yarn eslint 'src/components/chat/message-parts-user.tsx'`
