### PR TITLE
[codex] fix LightRAG PG chunk overlap queries

### DIFF
--- a/aperag/db/repositories/lightrag.py
+++ b/aperag/db/repositories/lightrag.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sqlalchemy import select
+from sqlalchemy import String, select
+from sqlalchemy.dialects.postgresql import array as pg_array
 
 from aperag.db.models import (
     LightRAGDocChunksModel,
@@ -21,6 +22,13 @@ from aperag.db.models import (
 )
 from aperag.db.repositories.base import SyncRepositoryProtocol
 from aperag.utils.utils import utc_now
+
+
+def _build_chunk_ids_overlap_clause(column, chunk_ids: list[str]):
+    unique_chunk_ids = [chunk_id for chunk_id in dict.fromkeys(chunk_ids) if chunk_id]
+    if not unique_chunk_ids:
+        return None
+    return column.op("&&")(pg_array(unique_chunk_ids, type_=String()))
 
 
 class LightragRepositoryMixin(SyncRepositoryProtocol):
@@ -172,10 +180,12 @@ class LightragRepositoryMixin(SyncRepositoryProtocol):
         """Query LightRAG VDB entities whose chunk_ids overlap with the given chunk IDs"""
 
         def _query(session):
-            if not chunk_ids:
+            overlap_clause = _build_chunk_ids_overlap_clause(LightRAGVDBEntityModel.chunk_ids, chunk_ids)
+            if overlap_clause is None:
                 return {}
             stmt = select(LightRAGVDBEntityModel).where(
-                LightRAGVDBEntityModel.workspace == workspace, LightRAGVDBEntityModel.chunk_ids.overlap(chunk_ids)
+                LightRAGVDBEntityModel.workspace == workspace,
+                overlap_clause,
             )
             result = session.execute(stmt)
             return {entity.id: entity for entity in result.scalars().all()}
@@ -265,10 +275,12 @@ class LightragRepositoryMixin(SyncRepositoryProtocol):
         """Query LightRAG VDB relations whose chunk_ids overlap with the given chunk IDs"""
 
         def _query(session):
-            if not chunk_ids:
+            overlap_clause = _build_chunk_ids_overlap_clause(LightRAGVDBRelationModel.chunk_ids, chunk_ids)
+            if overlap_clause is None:
                 return {}
             stmt = select(LightRAGVDBRelationModel).where(
-                LightRAGVDBRelationModel.workspace == workspace, LightRAGVDBRelationModel.chunk_ids.overlap(chunk_ids)
+                LightRAGVDBRelationModel.workspace == workspace,
+                overlap_clause,
             )
             result = session.execute(stmt)
             return {relation.id: relation for relation in result.scalars().all()}

--- a/tests/unit_test/graphindex/test_lightrag_pg_chunk_overlap.py
+++ b/tests/unit_test/graphindex/test_lightrag_pg_chunk_overlap.py
@@ -1,0 +1,86 @@
+from sqlalchemy.dialects import postgresql
+
+from aperag.db.repositories.lightrag import LightragRepositoryMixin
+
+
+class _FakeScalarResult:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+
+class _FakeResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return _FakeScalarResult(self._items)
+
+
+class _FakeSession:
+    def __init__(self, items):
+        self._items = items
+        self.captured_stmt = None
+
+    def execute(self, stmt):
+        self.captured_stmt = stmt
+        return _FakeResult(self._items)
+
+
+class _RepoUnderTest(LightragRepositoryMixin):
+    def __init__(self, items):
+        self.session = _FakeSession(items)
+
+    def _execute_query(self, query_func):
+        return query_func(self.session)
+
+    def _execute_transaction(self, operation):
+        raise NotImplementedError
+
+
+class _Entity:
+    def __init__(self, entity_id):
+        self.id = entity_id
+
+
+class _Relation:
+    def __init__(self, relation_id):
+        self.id = relation_id
+
+
+def _compile_postgres(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+def test_query_lightrag_vdb_entity_by_chunk_ids_uses_pg_array_overlap_operator():
+    repo = _RepoUnderTest([_Entity("entity-1")])
+
+    result = repo.query_lightrag_vdb_entity_by_chunk_ids("workspace-1", ["chunk-1", "chunk-2", "chunk-1", ""])
+
+    assert result == {"entity-1": repo.session._items[0]}
+    compiled = _compile_postgres(repo.session.captured_stmt)
+    assert "lightrag_vdb_entity.workspace = %(workspace_1)s" in compiled
+    assert "lightrag_vdb_entity.chunk_ids && ARRAY[" in compiled
+    assert compiled.count("param_") == 2
+
+
+def test_query_lightrag_vdb_relation_by_chunk_ids_uses_pg_array_overlap_operator():
+    repo = _RepoUnderTest([_Relation("relation-1")])
+
+    result = repo.query_lightrag_vdb_relation_by_chunk_ids("workspace-1", ["chunk-a", "chunk-b"])
+
+    assert result == {"relation-1": repo.session._items[0]}
+    compiled = _compile_postgres(repo.session.captured_stmt)
+    assert "lightrag_vdb_relation.workspace = %(workspace_1)s" in compiled
+    assert "lightrag_vdb_relation.chunk_ids && ARRAY[" in compiled
+
+
+def test_query_lightrag_vdb_entity_by_chunk_ids_returns_empty_without_query_for_empty_input():
+    repo = _RepoUnderTest([_Entity("entity-1")])
+
+    result = repo.query_lightrag_vdb_entity_by_chunk_ids("workspace-1", [])
+
+    assert result == {}
+    assert repo.session.captured_stmt is None


### PR DESCRIPTION
## What changed
- replaced the broken ORM `.overlap(...)` calls on `lightrag_vdb_entity.chunk_ids` / `lightrag_vdb_relation.chunk_ids` with an explicit PostgreSQL array-overlap clause
- deduplicated and sanitized `chunk_ids` before building the overlap filter
- added unit coverage for both entity and relation lookups, plus the empty-input fast path

## Why
Local Graph index rebuilds started failing once the graph already contained data. The incremental update/delete path queried existing entity/relation vectors by `chunk_ids`, but the current SQLAlchemy comparator for these array columns did not expose `.overlap(...)`, so the request failed before reaching PostgreSQL.

## Impact
- fixes `LightRAG + PostgreSQL` graph index incremental update/delete for documents after the initial graph build
- keeps the fix scoped to the repository query layer without changing broader graph-index behavior

## Root cause
`aperag/db/repositories/lightrag.py` used `LightRAGVDBEntityModel.chunk_ids.overlap(chunk_ids)` and the same pattern for relations. In the current model setup that comparator does not provide `overlap`, so the graph path crashed with:
`Neither 'InstrumentedAttribute' object nor 'Comparator' object associated with ... chunk_ids has an attribute 'overlap'`

## Validation
- `git diff --check`
- `pytest tests/unit_test/graphindex/test_lightrag_update_and_storage.py tests/unit_test/graphindex/test_lightrag_pg_chunk_overlap.py`
