### PR TITLE
fix(chat): only merge adjacent activity items

### DIFF
--- a/web/src/components/chat/agent-turn-card.tsx
+++ b/web/src/components/chat/agent-turn-card.tsx
@@ -516,15 +516,17 @@ function findMergeableActivityIndex(
   status: string,
   activity: UserActivityEnvelope,
 ) {
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const item = entries[index];
-    if (
-      item.status === status &&
-      serializeUserActivity(item.userActivity) === serializeUserActivity(activity)
-    ) {
-      return index;
-    }
+  const lastIndex = entries.length - 1;
+  if (lastIndex < 0) return -1;
+
+  const previous = entries[lastIndex];
+  if (
+    previous.status === status &&
+    serializeUserActivity(previous.userActivity) === serializeUserActivity(activity)
+  ) {
+    return lastIndex;
   }
+
   return -1;
 }
 


### PR DESCRIPTION
## Summary
- stop activity stream from merging non-adjacent identical user activities
- preserve real step order when the timeline returns to a previous activity later
- keep the fix scoped to timeline merge logic only

## Validation
- `yarn eslint src/components/chat/agent-turn-card.tsx`
- `git diff --check`

## Context
This is the focused follow-up for task `#18` after `#1522` merged.