### PR TITLE
fix(i18n): restore activity stream source messages

### DIFF
--- a/web/src/i18n/en-US/activity.json
+++ b/web/src/i18n/en-US/activity.json
@@ -1,0 +1,45 @@
+{
+  "thinking": {
+    "title": "Thinking",
+    "subtitle": "Understanding your request and planning the next step."
+  },
+  "searching_knowledge": {
+    "title": "Searching",
+    "subtitle": "Looking through relevant sources for useful information.",
+    "detail": {
+      "keyword": "Keyword: {keyword}",
+      "source_name": "Source: {sourceName}",
+      "count": "Checking {count} results"
+    }
+  },
+  "reading_source": {
+    "title": "Reading",
+    "subtitle": "Reviewing source content before answering.",
+    "detail": {
+      "source_name": "Reading: {sourceName}"
+    }
+  },
+  "comparing_results": {
+    "title": "Comparing",
+    "subtitle": "Comparing candidate results and deciding what matters most.",
+    "detail": {
+      "count": "Comparing {count} results"
+    }
+  },
+  "writing_answer": {
+    "title": "Writing",
+    "subtitle": "Drafting a clear response."
+  },
+  "waiting": {
+    "title": "Waiting",
+    "subtitle": "Preparing the next step."
+  },
+  "completed": {
+    "title": "Completed",
+    "subtitle": "The answer is ready."
+  },
+  "error": {
+    "title": "Needs attention",
+    "subtitle": "This run hit a problem before it finished."
+  }
+}

--- a/web/src/i18n/en-US/page_chat.json
+++ b/web/src/i18n/en-US/page_chat.json
@@ -18,6 +18,55 @@
 
   "references": "References",
 
+  "activity_stream": {
+    "label": "Activity stream",
+    "empty": "Waiting for activity events...",
+    "repeated": "Repeated {count} times while this step stayed active.",
+    "status": {
+      "queued": "Queued",
+      "running": "Running",
+      "completed": "Completed",
+      "failed": "Failed",
+      "cancelled": "Cancelled"
+    },
+    "item_status": {
+      "waiting": "Waiting",
+      "running": "Active",
+      "completed": "Done",
+      "failed": "Issue"
+    },
+    "target_type": {
+      "knowledge_base": "knowledge base",
+      "document": "document",
+      "web": "web",
+      "chat_history": "chat history"
+    },
+    "debug": {
+      "title": "Debug details",
+      "technical_type": "Technical event",
+      "command_input": "Tool input",
+      "result_summary": "Tool result",
+      "turn_id": "Turn ID",
+      "request_id": "Request ID",
+      "status": "Status",
+      "error_code": "Error code",
+      "error_message": "Error message"
+    }
+  },
+
+  "answer_section": {
+    "failure_details": "Failure details",
+    "run_failed": "Run failed",
+    "cancelled_output": "Cancelled output",
+    "run_cancelled": "Run cancelled",
+    "final_answer": "Final answer",
+    "draft_answer": "Draft answer",
+    "answer": "Answer",
+    "failed_empty": "This run ended before a final answer was produced.",
+    "cancelled_empty": "This run was cancelled before a final answer was produced.",
+    "pending_empty": "The answer will appear here once the activity stream finishes."
+  },
+
   "feedback": {
     "title": "Tell Us What You Think",
 

--- a/web/src/i18n/zh-CN/activity.json
+++ b/web/src/i18n/zh-CN/activity.json
@@ -1,0 +1,45 @@
+{
+  "thinking": {
+    "title": "思考中",
+    "subtitle": "正在理解你的问题并规划下一步。"
+  },
+  "searching_knowledge": {
+    "title": "搜索中",
+    "subtitle": "正在查找相关信息来源。",
+    "detail": {
+      "keyword": "关键词：{keyword}",
+      "source_name": "来源：{sourceName}",
+      "count": "正在检查 {count} 条结果"
+    }
+  },
+  "reading_source": {
+    "title": "读取中",
+    "subtitle": "正在阅读相关内容后再组织回答。",
+    "detail": {
+      "source_name": "正在阅读：{sourceName}"
+    }
+  },
+  "comparing_results": {
+    "title": "比较中",
+    "subtitle": "正在比较候选结果并筛选关键信息。",
+    "detail": {
+      "count": "正在比较 {count} 条结果"
+    }
+  },
+  "writing_answer": {
+    "title": "整理回答",
+    "subtitle": "正在组织一段清晰的回答。"
+  },
+  "waiting": {
+    "title": "准备中",
+    "subtitle": "正在准备下一步。"
+  },
+  "completed": {
+    "title": "已完成",
+    "subtitle": "回答已经准备好了。"
+  },
+  "error": {
+    "title": "需要处理",
+    "subtitle": "本次运行在完成前遇到了问题。"
+  }
+}

--- a/web/src/i18n/zh-CN/page_chat.json
+++ b/web/src/i18n/zh-CN/page_chat.json
@@ -18,6 +18,55 @@
 
   "references": "参考文献",
 
+  "activity_stream": {
+    "label": "活动进度",
+    "empty": "正在等待活动事件...",
+    "repeated": "该步骤保持激活期间重复了 {count} 次。",
+    "status": {
+      "queued": "排队中",
+      "running": "进行中",
+      "completed": "已完成",
+      "failed": "失败",
+      "cancelled": "已取消"
+    },
+    "item_status": {
+      "waiting": "等待中",
+      "running": "进行中",
+      "completed": "完成",
+      "failed": "异常"
+    },
+    "target_type": {
+      "knowledge_base": "知识库",
+      "document": "文档",
+      "web": "网页",
+      "chat_history": "聊天记录"
+    },
+    "debug": {
+      "title": "调试详情",
+      "technical_type": "技术事件",
+      "command_input": "工具输入",
+      "result_summary": "工具结果",
+      "turn_id": "Turn ID",
+      "request_id": "Request ID",
+      "status": "状态",
+      "error_code": "错误码",
+      "error_message": "错误信息"
+    }
+  },
+
+  "answer_section": {
+    "failure_details": "失败详情",
+    "run_failed": "运行失败",
+    "cancelled_output": "已取消输出",
+    "run_cancelled": "运行已取消",
+    "final_answer": "最终回答",
+    "draft_answer": "草稿回答",
+    "answer": "回答",
+    "failed_empty": "本次运行在生成最终回答前就结束了。",
+    "cancelled_empty": "本次运行在生成最终回答前被取消了。",
+    "pending_empty": "活动流结束后，回答会显示在这里。"
+  },
+
   "feedback": {
     "title": "反馈意见",
 


### PR DESCRIPTION
## Summary
- add Activity Stream page_chat keys back to split locale source files
- add missing `activity` namespace source files for both locales
- fix the real source-of-truth used by `i18n:sync` so generated root messages stop dropping these keys

## Validation
- `jq empty web/src/i18n/en-US/page_chat.json web/src/i18n/zh-CN/page_chat.json web/src/i18n/en-US/activity.json web/src/i18n/zh-CN/activity.json`

## Root cause
`request.ts` loads root locale aggregates, but local/dev startup runs `i18n:sync`, which regenerates those aggregates from split source files under `web/src/i18n/<locale>/`. Activity Stream keys had been added to generated root files, but not to the split source files, so startup sync removed them and the UI fell back to raw i18n keys.