### PR TITLE
[codex] fix(graph): cast chunk overlap array to column type

### DIFF
--- a/aperag/db/repositories/lightrag.py
+++ b/aperag/db/repositories/lightrag.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sqlalchemy import String, select
+from sqlalchemy import cast, select
 from sqlalchemy.dialects.postgresql import array as pg_array
 
 from aperag.db.models import (
@@ -28,7 +28,12 @@ def _build_chunk_ids_overlap_clause(column, chunk_ids: list[str]):
     unique_chunk_ids = [chunk_id for chunk_id in dict.fromkeys(chunk_ids) if chunk_id]
     if not unique_chunk_ids:
         return None
-    return column.op("&&")(pg_array(unique_chunk_ids, type_=String()))
+
+    # Keep RHS typed as the same ARRAY element type as the storage column.
+    # PostgreSQL will reject `varchar[] && text[]`, which is exactly what the
+    # current runtime failure is hitting in LightRAG VDB entity/relation lookups.
+    typed_array = cast(pg_array(unique_chunk_ids), column.type)
+    return column.op("&&")(typed_array)
 
 
 class LightragRepositoryMixin(SyncRepositoryProtocol):

--- a/tests/unit_test/graphindex/test_lightrag_pg_chunk_overlap.py
+++ b/tests/unit_test/graphindex/test_lightrag_pg_chunk_overlap.py
@@ -54,7 +54,7 @@ def _compile_postgres(stmt) -> str:
     return str(stmt.compile(dialect=postgresql.dialect()))
 
 
-def test_query_lightrag_vdb_entity_by_chunk_ids_uses_pg_array_overlap_operator():
+def test_query_lightrag_vdb_entity_by_chunk_ids_casts_rhs_to_varchar_array():
     repo = _RepoUnderTest([_Entity("entity-1")])
 
     result = repo.query_lightrag_vdb_entity_by_chunk_ids("workspace-1", ["chunk-1", "chunk-2", "chunk-1", ""])
@@ -62,11 +62,12 @@ def test_query_lightrag_vdb_entity_by_chunk_ids_uses_pg_array_overlap_operator()
     assert result == {"entity-1": repo.session._items[0]}
     compiled = _compile_postgres(repo.session.captured_stmt)
     assert "lightrag_vdb_entity.workspace = %(workspace_1)s" in compiled
-    assert "lightrag_vdb_entity.chunk_ids && ARRAY[" in compiled
+    assert "lightrag_vdb_entity.chunk_ids && CAST(ARRAY[" in compiled
+    assert " AS VARCHAR[])" in compiled
     assert compiled.count("param_") == 2
 
 
-def test_query_lightrag_vdb_relation_by_chunk_ids_uses_pg_array_overlap_operator():
+def test_query_lightrag_vdb_relation_by_chunk_ids_casts_rhs_to_varchar_array():
     repo = _RepoUnderTest([_Relation("relation-1")])
 
     result = repo.query_lightrag_vdb_relation_by_chunk_ids("workspace-1", ["chunk-a", "chunk-b"])
@@ -74,7 +75,8 @@ def test_query_lightrag_vdb_relation_by_chunk_ids_uses_pg_array_overlap_operator
     assert result == {"relation-1": repo.session._items[0]}
     compiled = _compile_postgres(repo.session.captured_stmt)
     assert "lightrag_vdb_relation.workspace = %(workspace_1)s" in compiled
-    assert "lightrag_vdb_relation.chunk_ids && ARRAY[" in compiled
+    assert "lightrag_vdb_relation.chunk_ids && CAST(ARRAY[" in compiled
+    assert " AS VARCHAR[])" in compiled
 
 
 def test_query_lightrag_vdb_entity_by_chunk_ids_returns_empty_without_query_for_empty_input():


### PR DESCRIPTION
## What Changed
- cast the RHS overlap array in `aperag/db/repositories/lightrag.py` to the storage column type before applying PostgreSQL `&&`
- update the focused overlap unit tests to assert the generated SQL now uses `CAST(ARRAY[...] AS VARCHAR[])`

## Why
After `#1519`, the old ORM comparator bug was gone, but the running instance still failed Graph index rebuilds with:
`operator does not exist: character varying[] && text[]`

The LightRAG VDB entity/relation `chunk_ids` columns are `varchar[]`, while `pg_array([...])` was still compiling to `text[]`. PostgreSQL rejects `varchar[] && text[]`, so Graph index rebuilds could still fail on the current instance.

## Impact
- fixes the remaining `chunk_ids` overlap lookup on PostgreSQL for LightRAG VDB entity/relation queries
- keeps the change scoped to the failing query path and its focused unit coverage

## Validation
- `pytest tests/unit_test/graphindex/test_lightrag_pg_chunk_overlap.py -q`
- `python -m py_compile aperag/db/repositories/lightrag.py tests/unit_test/graphindex/test_lightrag_pg_chunk_overlap.py`
- `git diff --check`
- hot-applied the same patch to the current local instance, restarted celery, triggered `rebuild_failed_indexes`, and confirmed the previously failing docs in collection `colba6e3a943b1c9db2` recovered to `GRAPH ACTIVE`
