### PR TITLE
refactor(chat): polish activity stream default view

### DIFF
--- a/web/src/components/chat/agent-turn-card.tsx
+++ b/web/src/components/chat/agent-turn-card.tsx
@@ -476,6 +476,15 @@ function inferUserActivity(
 
 function normalizeTimelineStatus(event: AgentTimelineEventEnvelope) {
   const technicalType = event.technical_type || event.type;
+  const normalized = String(event.status || '').toLowerCase();
+
+  if (technicalType === 'agent.state.changed') {
+    if (normalized === 'failed' || normalized === 'error') return 'failed';
+    if (normalized === 'done' || normalized === 'completed') return 'completed';
+    return 'running';
+  }
+
+  if (technicalType === 'turn.started') return 'running';
   if (
     technicalType === 'tool.started' ||
     technicalType === 'external_action.started'
@@ -486,7 +495,6 @@ function normalizeTimelineStatus(event: AgentTimelineEventEnvelope) {
     technicalType === 'tool.finished' ||
     technicalType === 'external_action.finished'
   ) {
-    const normalized = String(event.status || '').toLowerCase();
     if (normalized === 'failed' || normalized === 'error') return 'failed';
     return 'completed';
   }
@@ -498,7 +506,7 @@ function normalizeTimelineStatus(event: AgentTimelineEventEnvelope) {
   ) {
     return 'failed';
   }
-  return String(event.status || '').toLowerCase() || 'waiting';
+  return normalized || 'waiting';
 }
 
 function serializeUserActivity(activity: UserActivityEnvelope) {
@@ -522,6 +530,14 @@ function findMergeableActivityIndex(
   const previous = entries[lastIndex];
   if (
     previous.status === status &&
+    serializeUserActivity(previous.userActivity) === serializeUserActivity(activity)
+  ) {
+    return lastIndex;
+  }
+
+  if (
+    previous.status === 'running' &&
+    (status === 'completed' || status === 'failed') &&
     serializeUserActivity(previous.userActivity) === serializeUserActivity(activity)
   ) {
     return lastIndex;
@@ -556,12 +572,19 @@ function buildOrderedTimelineItems(
 
     if (mergeableIndex >= 0) {
       const previous = entries[mergeableIndex];
+      const nextOccurrences =
+        previous.status === status
+          ? (previous.occurrences || 1) + 1
+          : previous.occurrences || 1;
       entries[mergeableIndex] = {
         ...previous,
+        status,
         timestamp: event.timestamp,
-        occurrences: (previous.occurrences || 1) + 1,
+        occurrences: nextOccurrences,
         argsPreview: previous.argsPreview || argsPreview,
         resultPreview: resultPreview || previous.resultPreview,
+        rawType: event.type,
+        technicalType: event.technical_type || event.type,
       };
       continue;
     }
@@ -705,20 +728,52 @@ export const AgentTurnCard = ({
     values?: Record<string, string | number | undefined>,
   ) => {
     if (!key) return undefined;
-    return t(
+    const message = t(
       key as never,
       values as never,
     );
+    return message === key ? undefined : message;
   };
 
   const translatePageChat = (
     key: string,
     values?: Record<string, string | number | undefined>,
-  ) =>
-    pageChat(
+  ) => {
+    const message = pageChat(
       key as never,
       values as never,
     );
+    return message === key || message === `page_chat.${key}`
+      ? undefined
+      : message;
+  };
+
+  const getItemStatusLabel = (status: string) => {
+    return (
+      translatePageChat(`activity_stream.item_status.${status}`) ||
+      {
+        waiting: 'Waiting',
+        running: 'In progress',
+        completed: 'Completed',
+        failed: 'Issue',
+      }[status] ||
+      'Waiting'
+    );
+  };
+
+  const getTurnStatusLabel = (statusKey: string) => {
+    return (
+      translatePageChat(`activity_stream.status.${statusKey}`) ||
+      {
+        queued: 'Queued',
+        running: 'Running',
+        completed: 'Completed',
+        failed: 'Failed',
+        cancelled: 'Cancelled',
+      }[statusKey] ||
+      statusKey
+    );
+  };
 
   const answerText = useMemo(
     () => extractAnswerText(snapshot, streamingAnswer, fallbackParts),
@@ -792,7 +847,7 @@ export const AgentTurnCard = ({
             variant={getStatusTone(displayStatus)}
             className="h-5 px-2 text-[10px]"
           >
-            {translatePageChat(`activity_stream.status.${displayStatusKey}`)}
+            {getTurnStatusLabel(displayStatusKey)}
           </Badge>
           {timestamp && (
             <div className="text-muted-foreground text-xs">
@@ -853,11 +908,54 @@ export const AgentTurnCard = ({
                         item.userActivity.detail_key,
                         translationValues,
                       );
-                      const hasExpandableContent =
-                        !!detail ||
+                      const hasDebugContent =
                         !!item.argsPreview ||
                         !!item.resultPreview ||
                         !!item.technicalType;
+
+                      const cardBody = (
+                        <>
+                          <div className="flex flex-wrap items-center gap-1.5">
+                            <div className="text-sm font-medium">
+                              {title}
+                            </div>
+                            <Badge
+                              variant="outline"
+                              className="h-5 rounded-full px-1.5 text-[9px]"
+                            >
+                              {getItemStatusLabel(item.status)}
+                            </Badge>
+                            {item.timestamp && (
+                              <div className="text-muted-foreground text-[10px]">
+                                {format.dateTime(
+                                  new Date(item.timestamp),
+                                  'short',
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          {subtitle && (
+                            <div className="text-muted-foreground mt-1 text-xs">
+                              {subtitle}
+                            </div>
+                          )}
+                          {detail && (
+                            <div className="text-foreground/85 mt-1.5 text-xs">
+                              {detail}
+                            </div>
+                          )}
+                          {(item.occurrences || 1) > 1 && (
+                            <div className="text-muted-foreground mt-1.5 text-[11px]">
+                              {translatePageChat(
+                                'activity_stream.repeated',
+                                {
+                                  count: item.occurrences || 1,
+                                },
+                              )}
+                            </div>
+                          )}
+                        </>
+                      );
 
                       return (
                         <div key={item.key} className="flex gap-2.5">
@@ -876,9 +974,8 @@ export const AgentTurnCard = ({
                           </div>
 
                           <div className="min-w-0 flex-1 pb-3">
-                            {hasExpandableContent ? (
+                            {hasDebugContent ? (
                               <Collapsible
-                                defaultOpen={pending && item.status === 'running'}
                                 className="group/timeline-item"
                               >
                                 <div
@@ -894,47 +991,7 @@ export const AgentTurnCard = ({
                                     >
                                       <ChevronRight className="text-muted-foreground mt-0.5 size-3.5 shrink-0 transition-transform group-data-[state=open]/timeline-item:rotate-90" />
                                       <div className="min-w-0 flex-1">
-                                        <div className="flex flex-wrap items-center gap-1.5">
-                                          <div className="text-sm font-medium">
-                                            {title}
-                                          </div>
-                                          <Badge
-                                            variant="outline"
-                                            className="h-5 rounded-full px-1.5 text-[9px] uppercase"
-                                          >
-                                            {translatePageChat(
-                                              `activity_stream.item_status.${item.status}`,
-                                            )}
-                                          </Badge>
-                                          {item.timestamp && (
-                                            <div className="text-muted-foreground text-[10px]">
-                                              {format.dateTime(
-                                                new Date(item.timestamp),
-                                                'short',
-                                              )}
-                                            </div>
-                                          )}
-                                        </div>
-                                        {subtitle && (
-                                          <div className="text-muted-foreground mt-1 text-xs">
-                                            {subtitle}
-                                          </div>
-                                        )}
-                                        {detail && (
-                                          <div className="text-foreground/85 mt-1.5 text-xs">
-                                            {detail}
-                                          </div>
-                                        )}
-                                        {(item.occurrences || 1) > 1 && (
-                                            <div className="text-muted-foreground mt-1.5 text-[11px]">
-                                              {translatePageChat(
-                                                'activity_stream.repeated',
-                                                {
-                                                  count: item.occurrences || 1,
-                                                },
-                                              )}
-                                            </div>
-                                          )}
+                                        {cardBody}
                                       </div>
                                     </button>
                                   </CollapsibleTrigger>
@@ -987,47 +1044,7 @@ export const AgentTurnCard = ({
                                   styles.card,
                                 )}
                               >
-                                <div className="flex flex-wrap items-center gap-1.5">
-                                  <div className="text-sm font-medium">
-                                    {title}
-                                  </div>
-                                  <Badge
-                                    variant="outline"
-                                    className="h-5 rounded-full px-1.5 text-[9px] uppercase"
-                                  >
-                                    {translatePageChat(
-                                      `activity_stream.item_status.${item.status}`,
-                                    )}
-                                  </Badge>
-                                  {item.timestamp && (
-                                    <div className="text-muted-foreground text-[10px]">
-                                      {format.dateTime(
-                                        new Date(item.timestamp),
-                                        'short',
-                                      )}
-                                    </div>
-                                  )}
-                                </div>
-                                {subtitle && (
-                                  <div className="text-muted-foreground mt-1 text-xs">
-                                    {subtitle}
-                                  </div>
-                                )}
-                                {detail && (
-                                  <div className="text-foreground/85 mt-1.5 text-xs">
-                                    {detail}
-                                  </div>
-                                )}
-                                {(item.occurrences || 1) > 1 && (
-                                    <div className="text-muted-foreground mt-1.5 text-[11px]">
-                                      {translatePageChat(
-                                        'activity_stream.repeated',
-                                        {
-                                          count: item.occurrences || 1,
-                                        },
-                                      )}
-                                    </div>
-                                  )}
+                                {cardBody}
                               </div>
                             )}
                           </div>
@@ -1109,7 +1126,7 @@ export const AgentTurnCard = ({
                   <div className="text-muted-foreground">
                     {pageChat('activity_stream.debug.status')}
                   </div>
-                  <div>{translatePageChat(`activity_stream.status.${displayStatusKey}`)}</div>
+                  <div>{getTurnStatusLabel(displayStatusKey)}</div>
                 </div>
                 {snapshot.turn.error_code && (
                   <div className="grid gap-1">

--- a/web/src/i18n/en-US/activity.json
+++ b/web/src/i18n/en-US/activity.json
@@ -1,45 +1,45 @@
 {
   "thinking": {
-    "title": "Thinking",
-    "subtitle": "Understanding your request and planning the next step."
+    "title": "Understand the question",
+    "subtitle": "Clarifying your goal and deciding what information is needed."
   },
   "searching_knowledge": {
-    "title": "Searching",
-    "subtitle": "Looking through relevant sources for useful information.",
+    "title": "Find relevant sources",
+    "subtitle": "Looking through knowledge bases or the web for information related to your question.",
     "detail": {
-      "keyword": "Keyword: {keyword}",
+      "keyword": "Looking for information about “{keyword}”",
       "source_name": "Source: {sourceName}",
-      "count": "Checking {count} results"
+      "count": "Reviewed {count} results"
     }
   },
   "reading_source": {
-    "title": "Reading",
-    "subtitle": "Reviewing source content before answering.",
+    "title": "Read the sources",
+    "subtitle": "Pulling out the parts that matter most for your question.",
     "detail": {
-      "source_name": "Reading: {sourceName}"
+      "source_name": "Source: {sourceName}"
     }
   },
   "comparing_results": {
-    "title": "Comparing",
-    "subtitle": "Comparing candidate results and deciding what matters most.",
+    "title": "Compare the results",
+    "subtitle": "Sorting through the options to keep the most relevant and reliable information.",
     "detail": {
-      "count": "Comparing {count} results"
+      "count": "Compared {count} results"
     }
   },
   "writing_answer": {
-    "title": "Writing",
-    "subtitle": "Drafting a clear response."
+    "title": "Prepare the answer",
+    "subtitle": "Organizing the information into a final response."
   },
   "waiting": {
-    "title": "Waiting",
-    "subtitle": "Preparing the next step."
+    "title": "Prepare the next step",
+    "subtitle": "Getting ready for what comes next."
   },
   "completed": {
-    "title": "Completed",
-    "subtitle": "The answer is ready."
+    "title": "Answer ready",
+    "subtitle": "Everything needed for the reply has been prepared."
   },
   "error": {
-    "title": "Needs attention",
-    "subtitle": "This run hit a problem before it finished."
+    "title": "Process interrupted",
+    "subtitle": "This run did not finish successfully."
   }
 }

--- a/web/src/i18n/en-US/page_chat.json
+++ b/web/src/i18n/en-US/page_chat.json
@@ -31,8 +31,8 @@
     },
     "item_status": {
       "waiting": "Waiting",
-      "running": "Active",
-      "completed": "Done",
+      "running": "In progress",
+      "completed": "Completed",
       "failed": "Issue"
     },
     "target_type": {

--- a/web/src/i18n/zh-CN/activity.json
+++ b/web/src/i18n/zh-CN/activity.json
@@ -1,45 +1,45 @@
 {
   "thinking": {
-    "title": "思考中",
-    "subtitle": "正在理解你的问题并规划下一步。"
+    "title": "理解问题",
+    "subtitle": "先明确你的目标，再决定需要哪些信息。"
   },
   "searching_knowledge": {
-    "title": "搜索中",
-    "subtitle": "正在查找相关信息来源。",
+    "title": "查找资料",
+    "subtitle": "从知识库或网页中查找和你问题相关的信息。",
     "detail": {
-      "keyword": "关键词：{keyword}",
+      "keyword": "正在查找“{keyword}”相关内容",
       "source_name": "来源：{sourceName}",
-      "count": "正在检查 {count} 条结果"
+      "count": "已查看 {count} 条结果"
     }
   },
   "reading_source": {
-    "title": "读取中",
-    "subtitle": "正在阅读相关内容后再组织回答。",
+    "title": "阅读资料",
+    "subtitle": "提取和你问题最相关的内容。",
     "detail": {
-      "source_name": "正在阅读：{sourceName}"
+      "source_name": "来源：{sourceName}"
     }
   },
   "comparing_results": {
-    "title": "比较中",
-    "subtitle": "正在比较候选结果并筛选关键信息。",
+    "title": "比对结果",
+    "subtitle": "筛选更相关、更可信的信息。",
     "detail": {
-      "count": "正在比较 {count} 条结果"
+      "count": "已比较 {count} 条结果"
     }
   },
   "writing_answer": {
     "title": "整理回答",
-    "subtitle": "正在组织一段清晰的回答。"
+    "subtitle": "把找到的信息组织成最终答复。"
   },
   "waiting": {
-    "title": "准备中",
-    "subtitle": "正在准备下一步。"
+    "title": "准备下一步",
+    "subtitle": "正在准备接下来的处理。"
   },
   "completed": {
-    "title": "已完成",
-    "subtitle": "回答已经准备好了。"
+    "title": "回答已完成",
+    "subtitle": "回答所需的信息已经整理好了。"
   },
   "error": {
-    "title": "需要处理",
-    "subtitle": "本次运行在完成前遇到了问题。"
+    "title": "处理中断",
+    "subtitle": "这次没有顺利完成。"
   }
 }

--- a/web/src/i18n/zh-CN/page_chat.json
+++ b/web/src/i18n/zh-CN/page_chat.json
@@ -32,8 +32,8 @@
     "item_status": {
       "waiting": "等待中",
       "running": "进行中",
-      "completed": "完成",
-      "failed": "异常"
+      "completed": "已完成",
+      "failed": "失败"
     },
     "target_type": {
       "knowledge_base": "知识库",


### PR DESCRIPTION
## Summary
- remove default activity-stream technical leakage from the main view by keeping debug details collapsed
- normalize item lifecycle badges to user-facing running/completed/failed states
- merge adjacent running->completed activity transitions into one logical step and rewrite activity copy as step names

## Validation
- jq empty src/i18n/en-US/activity.json src/i18n/zh-CN/activity.json src/i18n/en-US/page_chat.json src/i18n/zh-CN/page_chat.json
- yarn eslint src/components/chat/agent-turn-card.tsx
- git diff --check

## Scope
- web/src/components/chat/agent-turn-card.tsx
- web/src/i18n/en-US/activity.json
- web/src/i18n/zh-CN/activity.json
- web/src/i18n/en-US/page_chat.json
- web/src/i18n/zh-CN/page_chat.json