### PR TITLE
fix(chat): narrow activity completion merge guard

### DIFF
--- a/web/src/components/chat/agent-turn-card.tsx
+++ b/web/src/components/chat/agent-turn-card.tsx
@@ -537,7 +537,8 @@ function findMergeableActivityIndex(
 
   if (
     previous.status === 'running' &&
-    (status === 'completed' || status === 'failed') &&
+    status === 'completed' &&
+    (previous.occurrences || 1) === 1 &&
     serializeUserActivity(previous.userActivity) === serializeUserActivity(activity)
   ) {
     return lastIndex;


### PR DESCRIPTION
## Summary\n- narrow the running -> completed merge guard to only merge a single non-aggregated running item\n- stop folding failed terminal events back into the previous running item\n- keep the fix scoped to agent-turn-card.tsx as a post-merge correctness follow-up\n\n## Validation\n- yarn eslint src/components/chat/agent-turn-card.tsx\n- git diff --check\n\n## Scope\n- web/src/components/chat/agent-turn-card.tsx\n