### PR TITLE
fix(chat): hide references after completed answers

### DIFF
--- a/web/src/components/chat/agent-turn-card.tsx
+++ b/web/src/components/chat/agent-turn-card.tsx
@@ -941,6 +941,9 @@ export const AgentTurnCard = ({
       : snapshot.turn.status;
   const displayStatusKey = displayStatus.toLowerCase();
   const showAnswerSection = Boolean(answerText) || terminalStatuses.has(displayStatus);
+  const showReferencesTrigger =
+    references.length > 0 &&
+    !(displayStatus === 'COMPLETED' && Boolean(answerText));
 
   return (
     <div className="flex w-full flex-row gap-3">
@@ -1251,7 +1254,7 @@ export const AgentTurnCard = ({
         </div>
 
         <div className="flex flex-row items-center gap-2">
-          {references.length > 0 && (
+          {showReferencesTrigger && (
             <Sheet>
               <SheetTrigger asChild>
                 <Button variant="ghost" size="sm" className="cursor-pointer">


### PR DESCRIPTION
## Summary
- hide the references trigger once a turn has completed and a final answer is already shown
- keep in-progress and non-completed states unchanged

## Validation
- yarn eslint src/components/chat/agent-turn-card.tsx
- git diff --check

## Scope
- web/src/components/chat/agent-turn-card.tsx only