### PR TITLE
[codex] hard cut legacy history compatibility

### DIFF
--- a/aperag/agent_runtime/schemas.py
+++ b/aperag/agent_runtime/schemas.py
@@ -48,7 +48,7 @@ class UserActivityContext(BaseModel):
     source_name: Optional[str] = None
     keyword: Optional[str] = None
     count: Optional[int] = None
-    target_type: Optional[Literal["knowledge_base", "document", "web", "chat_history"]] = None
+    target_type: Optional[Literal["knowledge_base", "document", "web"]] = None
     scope_label: Optional[str] = None
 
 

--- a/aperag/agent_runtime/services.py
+++ b/aperag/agent_runtime/services.py
@@ -18,7 +18,6 @@ from typing import Any, Optional
 
 from sqlalchemy.exc import IntegrityError
 
-from aperag.agent.agent_history_manager import AgentHistoryManager
 from aperag.agent_runtime.schemas import (
     AgentArtifactEnvelope,
     AgentTimelineEventEnvelope,
@@ -35,7 +34,6 @@ from aperag.db.models import AgentEventActor, AgentTurnStatus, BotType
 from aperag.db.ops import AsyncDatabaseOps, async_db_ops
 from aperag.exceptions import ChatNotFoundException, ResourceNotFoundException, ValidationException
 from aperag.schema import view_models
-from aperag.utils.history import query_chat_messages
 from aperag.utils.utils import utc_now
 
 
@@ -99,7 +97,6 @@ _ACTIVITY_SUBTITLE_KEYS = {
 _KNOWLEDGE_SEARCH_TOOLS = {"list_collections", "search_collection"}
 _WEB_SEARCH_TOOLS = {"search_web", "web_search"}
 _READING_TOOLS = {"read_document", "web_read"}
-_CHAT_HISTORY_TOOLS = {"query_chat_messages"}
 
 
 def _normalize_activity_text(value: Any, *, max_length: int = 160) -> Optional[str]:
@@ -159,8 +156,6 @@ def _infer_target_type(tool_name: Optional[str]) -> Optional[str]:
         return "document" if tool_name == "read_document" else "web"
     if tool_name in _WEB_SEARCH_TOOLS:
         return "web"
-    if tool_name in _CHAT_HISTORY_TOOLS:
-        return "chat_history"
     return None
 
 
@@ -236,8 +231,6 @@ def _infer_tool_activity_intent(tool_name: Optional[str]) -> Optional[UserActivi
     if tool_name in _KNOWLEDGE_SEARCH_TOOLS or tool_name in _WEB_SEARCH_TOOLS:
         return UserActivityIntent.SEARCHING_KNOWLEDGE
     if tool_name in _READING_TOOLS:
-        return UserActivityIntent.READING_SOURCE
-    if tool_name in _CHAT_HISTORY_TOOLS:
         return UserActivityIntent.READING_SOURCE
     return None
 
@@ -614,28 +607,12 @@ class ArtifactService:
 class HistoryWriter:
     def __init__(self, db_ops: AsyncDatabaseOps | None = None):
         self.db_ops = db_ops or async_db_ops
-        self.history_manager = AgentHistoryManager()
 
     async def build_history_context(self, user: str, chat_id: str, limit: int = 8) -> str:
         turns = await self.db_ops.query_recent_agent_turns(user, chat_id, limit=limit)
-        legacy_history = await query_chat_messages(user, chat_id)
-        legacy_lines: list[str] = []
-        legacy_turn_ids: set[str] = set()
-        for turn_parts in legacy_history[-limit:]:
-            turn_ids = {str(part.id) for part in turn_parts if getattr(part, "id", None)}
-            legacy_turn_ids.update(turn_ids)
-            human_texts = [
-                part.data for part in turn_parts if part.role == "human" and part.type == "message" and part.data
-            ]
-            ai_texts = [part.data for part in turn_parts if part.role == "ai" and part.type == "message" and part.data]
-            if human_texts:
-                legacy_lines.append(f"User: {' '.join(human_texts)}")
-            if ai_texts:
-                legacy_lines.append(f"Assistant: {' '.join(ai_texts)}")
-
-        v3_lines: list[str] = []
+        lines: list[str] = []
         for turn in turns:
-            if turn.status != AgentTurnStatus.COMPLETED or turn.id in legacy_turn_ids:
+            if turn.status != AgentTurnStatus.COMPLETED:
                 continue
             artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn.id)
             answer = None
@@ -653,10 +630,9 @@ class HistoryWriter:
             answer_text = _extract_answer_text_from_artifact(answer)
             if not answer_text:
                 continue
-            v3_lines.append(f"User: {turn.input_text}")
-            v3_lines.append(f"Assistant: {answer_text}")
+            lines.append(f"User: {turn.input_text}")
+            lines.append(f"Assistant: {answer_text}")
 
-        lines = legacy_lines + v3_lines
         return "Conversation so far:\n" + "\n".join(lines) if lines else ""
 
     async def commit_completed_turn(
@@ -668,17 +644,7 @@ class HistoryWriter:
         tool_summaries: list[str],
         references: list[ReferenceBundleItem],
     ) -> bool:
-        history = await self.history_manager.get_chat_history(turn.chat_id)
-        return await self.history_manager.save_conversation_turn(
-            message_id=turn.id,
-            trace_id=turn.request_id,
-            history=history,
-            user_query=request.query,
-            ai_response=answer_text,
-            files=[file.model_dump(exclude_none=True) for file in request.files or []],
-            tool_use_list=[{"data": summary} for summary in tool_summaries],
-            tool_references=[item.model_dump(exclude_none=True) for item in references],
-        )
+        return True
 
     async def commit_failed_turn(
         self,
@@ -688,14 +654,4 @@ class HistoryWriter:
         error_message: str,
         tool_summaries: list[str],
     ) -> bool:
-        history = await self.history_manager.get_chat_history(turn.chat_id)
-        return await self.history_manager.save_conversation_turn(
-            message_id=turn.id,
-            trace_id=turn.request_id,
-            history=history,
-            user_query=request.query,
-            ai_response=error_message,
-            files=[file.model_dump(exclude_none=True) for file in request.files or []],
-            tool_use_list=[{"data": summary} for summary in tool_summaries],
-            tool_references=[],
-        )
+        return True

--- a/aperag/db/repositories/agent_runtime.py
+++ b/aperag/db/repositories/agent_runtime.py
@@ -40,6 +40,18 @@ class AsyncAgentRuntimeRepositoryMixin(AsyncRepositoryProtocol):
 
         return await self._execute_query(_query)
 
+    async def query_agent_turns(self, user: str, chat_id: str) -> list[AgentTurn]:
+        async def _query(session):
+            stmt = (
+                select(AgentTurn)
+                .where(AgentTurn.chat_id == chat_id, AgentTurn.user == user)
+                .order_by(AgentTurn.gmt_created.asc())
+            )
+            result = await session.execute(stmt)
+            return result.scalars().all()
+
+        return await self._execute_query(_query)
+
     async def query_agent_turn_by_idempotency(
         self, user: str, chat_id: str, client_idempotency_key: str
     ) -> Optional[AgentTurn]:

--- a/aperag/service/chat_service.py
+++ b/aperag/service/chat_service.py
@@ -30,6 +30,52 @@ from aperag.utils.history import (
 logger = logging.getLogger(__name__)
 
 
+def _artifact_type_value(artifact) -> Optional[str]:
+    if not artifact:
+        return None
+    artifact_type = getattr(artifact, "artifact_type", None)
+    return artifact_type.value if hasattr(artifact_type, "value") else artifact_type
+
+
+def _extract_artifact_text(artifact) -> str:
+    if not artifact or not isinstance(getattr(artifact, "payload", None), dict):
+        return ""
+    return artifact.payload.get("text") or artifact.payload.get("content") or artifact.payload.get("message") or ""
+
+
+def _coerce_feedback(feedback) -> Optional[view_models.Feedback]:
+    if not feedback:
+        return None
+    return view_models.Feedback(type=feedback.type, tag=feedback.tag, message=feedback.message)
+
+
+def _coerce_timestamp(value) -> Optional[float]:
+    return value.timestamp() if value else None
+
+
+def _map_reference_item(item: dict) -> view_models.Reference:
+    return view_models.Reference(
+        score=item.get("score"),
+        text=item.get("snippet") or "",
+        metadata={
+            **(item.get("metadata") or {}),
+            "title": item.get("title"),
+            "source_type": item.get("source_type"),
+            "source_id": item.get("source_id"),
+            "uri": item.get("uri"),
+        },
+    )
+
+
+def _extract_references(artifact) -> list[view_models.Reference]:
+    if not artifact or not isinstance(getattr(artifact, "payload", None), dict):
+        return []
+    items = artifact.payload.get("items")
+    if not isinstance(items, list):
+        return []
+    return [_map_reference_item(item) for item in items if isinstance(item, dict)]
+
+
 class ChatService:
     """Chat service that handles business logic for chats"""
 
@@ -51,6 +97,102 @@ class ChatService:
             created=chat.gmt_created.isoformat(),
             updated=chat.gmt_updated.isoformat(),
         )
+
+    async def _build_v3_chat_history(self, user: str, chat_id: str) -> list[list[view_models.ChatMessage]]:
+        turns = await self.db_ops.query_agent_turns(user, chat_id)
+        feedback_map = {
+            feedback.message_id: _coerce_feedback(feedback)
+            for feedback in await self.db_ops.query_chat_feedbacks(user, chat_id)
+        }
+
+        history: list[list[view_models.ChatMessage]] = []
+        for turn in turns:
+            history.append(
+                [
+                    view_models.ChatMessage(
+                        id=turn.id,
+                        type="message",
+                        role="human",
+                        data=turn.input_text,
+                        timestamp=_coerce_timestamp(turn.gmt_created),
+                    )
+                ]
+            )
+
+            artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn.id)
+            answer_artifact = (
+                next((artifact for artifact in artifacts if artifact.id == turn.answer_artifact_id), None)
+                if turn.answer_artifact_id
+                else None
+            )
+            if not answer_artifact:
+                answer_artifact = next(
+                    (artifact for artifact in artifacts if _artifact_type_value(artifact) == db_models.AgentArtifactType.ANSWER.value),
+                    None,
+                )
+
+            reference_artifact = (
+                next((artifact for artifact in artifacts if artifact.id == turn.reference_bundle_artifact_id), None)
+                if turn.reference_bundle_artifact_id
+                else None
+            )
+            if not reference_artifact:
+                reference_artifact = next(
+                    (
+                        artifact
+                        for artifact in artifacts
+                        if _artifact_type_value(artifact) == db_models.AgentArtifactType.REFERENCE_BUNDLE.value
+                    ),
+                    None,
+                )
+
+            answer_text = _extract_artifact_text(answer_artifact)
+            if not answer_text and turn.status in {
+                db_models.AgentTurnStatus.FAILED,
+                db_models.AgentTurnStatus.CANCELLED,
+            }:
+                answer_text = turn.error_message or ""
+
+            ai_parts: list[view_models.ChatMessage] = []
+            if answer_text:
+                ai_parts.append(
+                    view_models.ChatMessage(
+                        id=turn.id,
+                        type="message",
+                        role="ai",
+                        data=answer_text,
+                        timestamp=_coerce_timestamp(turn.gmt_finished) or _coerce_timestamp(turn.gmt_created),
+                    )
+                )
+            else:
+                ai_parts.append(
+                    view_models.ChatMessage(
+                        id=turn.id,
+                        type="start",
+                        role="ai",
+                        data="",
+                        timestamp=_coerce_timestamp(turn.gmt_created),
+                    )
+                )
+
+            references = _extract_references(reference_artifact)
+            feedback = feedback_map.get(turn.id)
+            if references or feedback:
+                ai_parts.append(
+                    view_models.ChatMessage(
+                        id=turn.id,
+                        type="references",
+                        role="ai",
+                        data="",
+                        references=references,
+                        feedback=feedback,
+                        timestamp=_coerce_timestamp(turn.gmt_finished) or _coerce_timestamp(turn.gmt_created),
+                    )
+                )
+
+            history.append(ai_parts)
+
+        return history
 
     async def create_chat(self, user: str, bot_id: str) -> view_models.Chat:
         # First check if bot exists
@@ -122,15 +264,11 @@ class ChatService:
         return await self.db_ops._execute_query(_execute_paginated_query)
 
     async def get_chat(self, user: str, bot_id: str, chat_id: str) -> view_models.ChatDetails:
-        # Import here to avoid circular imports
-        from aperag.utils.history import query_chat_messages
-
         chat = await self.db_ops.query_chat(user, bot_id, chat_id)
         if chat is None:
             raise ChatNotFoundException(chat_id)
 
-        # Get chat history
-        messages = await query_chat_messages(user, chat_id)
+        messages = await self._build_v3_chat_history(user, chat_id)
 
         # Build response object
         chat_obj = self.build_chat_response(chat)
@@ -184,22 +322,31 @@ class ChatService:
         feedback_message: str = None,
     ) -> dict:
         """Handle message feedback for chat messages"""
-        # Get message from Redis history to validate it exists and get context
-        history = RedisChatMessageHistory(chat_id, redis_client=get_async_redis_client())
-        ai_msg = None
-        human_msg = None
-        for message in await history.messages:
-            if message.message_id != message_id:
-                continue
-            if message.role == "ai":
-                ai_msg = message
-            if message.role == "human":
-                human_msg = message
-
-        if not ai_msg:
+        turn = await self.db_ops.query_agent_turn(user, chat_id, message_id)
+        if not turn:
             raise ResourceNotFoundException("AI Message", message_id)
-        if not human_msg:
-            raise ResourceNotFoundException("Human Message", message_id)
+
+        artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn.id)
+        answer_artifact = (
+            next((artifact for artifact in artifacts if artifact.id == turn.answer_artifact_id), None)
+            if turn.answer_artifact_id
+            else None
+        )
+        if not answer_artifact:
+            answer_artifact = next(
+                (artifact for artifact in artifacts if _artifact_type_value(artifact) == db_models.AgentArtifactType.ANSWER.value),
+                None,
+            )
+
+        answer_text = _extract_artifact_text(answer_artifact)
+        if not answer_text and turn.status in {
+            db_models.AgentTurnStatus.FAILED,
+            db_models.AgentTurnStatus.CANCELLED,
+        }:
+            answer_text = turn.error_message or ""
+
+        if not answer_text:
+            raise ResourceNotFoundException("AI Message", message_id)
 
         # Handle feedback state change based on UX design principles
         if feedback_type is None:
@@ -215,8 +362,8 @@ class ChatService:
                 feedback_type=feedback_type,
                 feedback_tag=feedback_tag,
                 feedback_message=feedback_message,
-                question=human_msg.get_main_content(),
-                original_answer=ai_msg.get_main_content(),
+                question=turn.input_text,
+                original_answer=answer_text,
             )
             result = {"action": "upserted", "feedback": feedback}
         return result

--- a/aperag/utils/history.py
+++ b/aperag/utils/history.py
@@ -194,54 +194,6 @@ class RedisChatMessageHistory:
     async def release_redis(self):
         await self.redis_client.close(close_connection_pool=True)
 
-
-async def query_chat_messages(user: str, chat_id: str):
-    """
-    Query chat messages from Redis and convert to frontend format.
-
-    Returns:
-        Array of conversation turns, where each turn is an array of message parts
-        格式: [[turn1_parts], [turn2_parts], ...]
-    """
-    from aperag.db.ops import async_db_ops
-    from aperag.schema import view_models
-
-    try:
-        # Get all stored messages (each StoredChatMessage represents one conversation turn)
-        chat_history = RedisChatMessageHistory(chat_id, redis_client=get_async_redis_client())
-        stored_messages = await chat_history.messages
-
-        if not stored_messages:
-            return []
-
-        # Get feedbacks for this chat
-        feedbacks = await async_db_ops.query_chat_feedbacks(user, chat_id)
-        feedback_map = {feedback.message_id: feedback for feedback in feedbacks}
-
-        # Convert each StoredChatMessage (conversation turn) to frontend format
-        conversation_turns = []
-        for stored_message in stored_messages:
-            # Convert this turn to frontend format (returns array of parts)
-            chat_message_list = stored_message.to_frontend_format()
-
-            # Add feedback data if available
-            for chat_msg in chat_message_list:
-                msg_id = chat_msg.id
-                feedback = feedback_map.get(msg_id)
-                if feedback and chat_msg.role == "ai":
-                    chat_msg.feedback = view_models.Feedback(
-                        type=feedback.type, tag=feedback.tag, message=feedback.message
-                    )
-
-            conversation_turns.append(chat_message_list)
-
-        return conversation_turns
-
-    except Exception as e:
-        logger.error(f"Error querying chat messages: {e}")
-        return []
-
-
 def success_response(message_id, data):
     return json.dumps(
         {

--- a/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
+++ b/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
@@ -344,7 +344,7 @@ async def test_agent_runtime_redis_store_turn_claim_renew_and_release(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_history_writer_keeps_legacy_history_and_appends_missing_v3_turns(monkeypatch):
+async def test_history_writer_builds_context_from_v3_turns_only():
     completed_turn = _build_turn(
         id="turn-v3",
         status=AgentTurnStatus.COMPLETED,
@@ -371,20 +371,8 @@ async def test_history_writer_keeps_legacy_history_and_appends_missing_v3_turns(
         )
     )
 
-    legacy_turn = [
-        SimpleNamespace(id="legacy-turn", role="human", type="message", data="old question"),
-        SimpleNamespace(id="legacy-turn", role="ai", type="message", data="old answer"),
-    ]
-
-    async def _fake_query_chat_messages(*_args, **_kwargs):
-        return [legacy_turn]
-
-    monkeypatch.setattr(agent_runtime_services, "query_chat_messages", _fake_query_chat_messages)
-
     context = await writer.build_history_context("user-1", "chat-1")
 
-    assert "User: old question" in context
-    assert "Assistant: old answer" in context
     assert "User: new question" in context
     assert "Assistant: new answer" in context
     assert "missing answer question" not in context

--- a/tests/unit_test/chat/test_chat_service.py
+++ b/tests/unit_test/chat/test_chat_service.py
@@ -1,0 +1,149 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.db.models import AgentTurnStatus
+from aperag.service.chat_service import ChatService
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+class _FakeChatDbOps:
+    def __init__(self):
+        self.chat = SimpleNamespace(
+            id="chat-1",
+            title="Test Chat",
+            bot_id="bot-1",
+            peer_type="system",
+            peer_id=None,
+            gmt_created=_now(),
+            gmt_updated=_now(),
+        )
+        self.turn = SimpleNamespace(
+            id="turn-1",
+            chat_id="chat-1",
+            user="user-1",
+            input_text="What changed?",
+            status=AgentTurnStatus.COMPLETED,
+            answer_artifact_id="artifact-answer",
+            reference_bundle_artifact_id="artifact-refs",
+            error_message=None,
+            gmt_created=_now(),
+            gmt_finished=_now(),
+        )
+        self.answer_artifact = SimpleNamespace(
+            id="artifact-answer",
+            artifact_type="answer",
+            payload={"text": "Here is the answer."},
+        )
+        self.reference_artifact = SimpleNamespace(
+            id="artifact-refs",
+            artifact_type="reference_bundle",
+            payload={
+                "items": [
+                    {
+                        "title": "Doc A",
+                        "snippet": "Reference snippet",
+                        "score": 0.9,
+                        "source_type": "search_collection",
+                        "source_id": "doc-a",
+                        "uri": "https://example.com/doc-a",
+                        "metadata": {"section": "intro"},
+                    }
+                ]
+            },
+        )
+        self.feedback = SimpleNamespace(
+            message_id="turn-1",
+            type="good",
+            tag=None,
+            message=None,
+        )
+        self.feedback_kwargs = None
+
+    async def query_chat(self, user, bot_id, chat_id):
+        if user == "user-1" and bot_id == "bot-1" and chat_id == "chat-1":
+            return self.chat
+        return None
+
+    async def query_agent_turns(self, user, chat_id):
+        if user == "user-1" and chat_id == "chat-1":
+            return [self.turn]
+        return []
+
+    async def query_chat_feedbacks(self, user, chat_id):
+        if user == "user-1" and chat_id == "chat-1":
+            return [self.feedback]
+        return []
+
+    async def query_agent_artifacts_by_turn(self, turn_id):
+        if turn_id == "turn-1":
+            return [self.answer_artifact, self.reference_artifact]
+        return []
+
+    async def query_agent_turn(self, user, chat_id, turn_id):
+        if user == "user-1" and chat_id == "chat-1" and turn_id == "turn-1":
+            return self.turn
+        return None
+
+    async def set_message_feedback_state(self, **kwargs):
+        self.feedback_kwargs = kwargs
+        return {"message_id": kwargs["message_id"], "type": kwargs["feedback_type"]}
+
+    async def remove_message_feedback(self, user, chat_id, message_id):
+        self.feedback_kwargs = {
+            "action": "remove",
+            "user": user,
+            "chat_id": chat_id,
+            "message_id": message_id,
+        }
+        return True
+
+
+@pytest.mark.asyncio
+async def test_get_chat_projects_v3_turn_history():
+    service = ChatService()
+    service.db_ops = _FakeChatDbOps()
+
+    chat = await service.get_chat("user-1", "bot-1", "chat-1")
+
+    assert chat.id == "chat-1"
+    assert chat.history is not None
+    assert len(chat.history) == 2
+
+    user_group, ai_group = chat.history
+    assert user_group[0].role == "human"
+    assert user_group[0].data == "What changed?"
+
+    assert ai_group[0].role == "ai"
+    assert ai_group[0].id == "turn-1"
+    assert ai_group[0].type == "message"
+    assert ai_group[0].data == "Here is the answer."
+
+    assert ai_group[1].type == "references"
+    assert ai_group[1].references is not None
+    assert len(ai_group[1].references) == 1
+    assert ai_group[1].feedback is not None
+    assert ai_group[1].feedback.type == "good"
+
+
+@pytest.mark.asyncio
+async def test_feedback_message_uses_v3_turn_and_artifacts():
+    service = ChatService()
+    service.db_ops = _FakeChatDbOps()
+
+    result = await service.feedback_message(
+        user="user-1",
+        chat_id="chat-1",
+        message_id="turn-1",
+        feedback_type="good",
+        feedback_tag=None,
+        feedback_message=None,
+    )
+
+    assert result["action"] == "upserted"
+    assert service.db_ops.feedback_kwargs["question"] == "What changed?"
+    assert service.db_ops.feedback_kwargs["original_answer"] == "Here is the answer."

--- a/web/src/components/chat/agent-turn-card.tsx
+++ b/web/src/components/chat/agent-turn-card.tsx
@@ -119,7 +119,7 @@ export type UserActivityContext = {
   source_name?: string | null;
   keyword?: string | null;
   count?: number | null;
-  target_type?: 'knowledge_base' | 'document' | 'web' | 'chat_history' | null;
+  target_type?: 'knowledge_base' | 'document' | 'web' | null;
   scope_label?: string | null;
 };
 
@@ -148,7 +148,6 @@ const terminalTimelineItemStatuses = new Set(['completed', 'failed']);
 const knowledgeSearchTools = new Set(['list_collections', 'search_collection']);
 const webSearchTools = new Set(['search_web', 'web_search']);
 const readingTools = new Set(['read_document', 'web_read']);
-const chatHistoryTools = new Set(['query_chat_messages']);
 
 function mapReferenceItem(item: ReferenceBundleItem): Reference {
   return {
@@ -167,7 +166,6 @@ function mapReferenceItem(item: ReferenceBundleItem): Reference {
 function extractAnswerText(
   snapshot: AgentTurnSnapshot,
   streamingAnswer: string,
-  fallbackParts: ChatMessage[],
 ) {
   const answerArtifact = snapshot.artifacts.find(
     (artifact) => artifact.artifact_type === 'answer',
@@ -176,20 +174,14 @@ function extractAnswerText(
     typeof answerArtifact?.payload?.text === 'string'
       ? answerArtifact.payload.text
       : typeof answerArtifact?.payload?.content === 'string'
-        ? answerArtifact.payload.content
-        : '';
+      ? answerArtifact.payload.content
+      : '';
   if (artifactText) return artifactText;
   if (streamingAnswer) return streamingAnswer;
-  return fallbackParts
-    .filter((part) => part.type === 'message')
-    .map((part) => part.data || '')
-    .join('');
+  return '';
 }
 
-function extractReferences(
-  snapshot: AgentTurnSnapshot,
-  fallbackParts: ChatMessage[],
-): Reference[] {
+function extractReferences(snapshot: AgentTurnSnapshot): Reference[] {
   const referenceArtifact = snapshot.artifacts.find(
     (artifact) => artifact.artifact_type === 'reference_bundle',
   );
@@ -199,10 +191,7 @@ function extractReferences(
   if (items.length > 0) {
     return items.map(mapReferenceItem);
   }
-  return (
-    fallbackParts.findLast((part) => Array.isArray(part.references))
-      ?.references || []
-  );
+  return [];
 }
 
 function compactPreview(value: unknown, maxLength = 220) {
@@ -298,7 +287,6 @@ function inferTargetType(
   if (readingTools.has(toolName)) {
     return toolName === 'read_document' ? 'document' : 'web';
   }
-  if (chatHistoryTools.has(toolName)) return 'chat_history';
   return undefined;
 }
 
@@ -393,7 +381,7 @@ function inferActivityIntentFromTool(toolName?: string): UserActivityIntent {
   if (knowledgeSearchTools.has(toolName) || webSearchTools.has(toolName)) {
     return 'searching_knowledge';
   }
-  if (readingTools.has(toolName) || chatHistoryTools.has(toolName)) {
+  if (readingTools.has(toolName)) {
     return 'reading_source';
   }
   return 'waiting';
@@ -884,8 +872,8 @@ export const AgentTurnCard = ({
   };
 
   const answerText = useMemo(
-    () => extractAnswerText(snapshot, streamingAnswer, fallbackParts),
-    [fallbackParts, snapshot, streamingAnswer],
+    () => extractAnswerText(snapshot, streamingAnswer),
+    [snapshot, streamingAnswer],
   );
   const timelineItems = (() => {
     const items = buildDisplayedTimelineItems(
@@ -914,8 +902,8 @@ export const AgentTurnCard = ({
     });
   })();
   const references = useMemo(
-    () => extractReferences(snapshot, fallbackParts),
-    [fallbackParts, snapshot],
+    () => extractReferences(snapshot),
+    [snapshot],
   );
 
   const feedbackParts = useMemo<ChatMessage[]>(() => {

--- a/web/src/components/chat/chat-messages.tsx
+++ b/web/src/components/chat/chat-messages.tsx
@@ -648,8 +648,8 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
           if (!cancelled) {
             mergeSnapshot(snapshot);
           }
-        } catch {
-          // Ignore legacy chat history groups that are not Agent Runtime V3 turns.
+        } catch (error) {
+          console.error('Failed to load historical turn snapshot', turnId, error);
         }
       }
     };


### PR DESCRIPTION
## What Changed
- switched chat details history loading from legacy Redis chat-history reads to V3 turn/artifact projection
- removed legacy history glue from agent runtime context building
- stopped feedback lookup from depending on Redis chat messages
- removed frontend legacy answer/reference fallback and legacy-history-group tolerance
- added focused unit coverage for the new V3-only chat history path

## Why
The user explicitly asked for a hard cut: no legacy chat-history compatibility and no fallback path left in the frontend or backend. This PR is the first cleanup slice for #33, focused on retiring legacy history compatibility across runtime, API, and chat UI.

## User / Developer Impact
- historical chat rendering now comes from Agent Runtime V3 turns and artifacts instead of query_chat_messages
- feedback lookup now uses V3 turn + artifact data directly
- Activity Stream UI no longer falls back to legacy answer/reference parts
- old legacy history compatibility code path is removed from runtime code

## Root Cause
The current chat page and runtime still depended on a legacy Redis chat-history format:
- backend get_chat() still read query_chat_messages
- runtime context mixed legacy_history / legacy_turn_ids into V3 history
- frontend still tolerated legacy chat groups and answer/reference fallback parts

## Validation
- ./.venv/bin/pytest tests/unit_test/agent_runtime/test_agent_runtime_v3.py tests/unit_test/chat/test_chat_service.py -q
- ./.venv/bin/python -m py_compile aperag/agent_runtime/services.py aperag/service/chat_service.py aperag/db/repositories/agent_runtime.py aperag/agent_runtime/schemas.py aperag/utils/history.py tests/unit_test/chat/test_chat_service.py tests/unit_test/agent_runtime/test_agent_runtime_v3.py
- cd web && yarn eslint src/components/chat/agent-turn-card.tsx src/components/chat/chat-messages.tsx

## Follow-up
- #32: retire legacy websocket / old service residue
- final boot-path sweep: remove remaining aperag.agent.* startup/runtime imports before calling the overall hard cut complete