### PR TITLE
fix(graph): unify lightrag source reference contract

### DIFF
--- a/aperag/graph/lightrag/kg/pg_ops_sync_vector_storage.py
+++ b/aperag/graph/lightrag/kg/pg_ops_sync_vector_storage.py
@@ -42,7 +42,7 @@ import numpy as np
 from ..base import (
     BaseVectorStorage,
 )
-from ..prompt import GRAPH_FIELD_SEP
+from ..source_refs import normalize_source_references
 from ..utils import logger
 
 
@@ -141,13 +141,7 @@ class PGOpsSyncVectorStorage(BaseVectorStorage):
             vector = item.get("__vector__", item.get("content_vector"))
             if hasattr(vector, "tolist"):
                 vector = vector.tolist()
-            chunk_ids = item.get("chunk_ids")
-            if chunk_ids is None:
-                source_id = item.get("source_id")
-                if isinstance(source_id, str) and source_id:
-                    chunk_ids = source_id.split(GRAPH_FIELD_SEP) if GRAPH_FIELD_SEP in source_id else [source_id]
-                else:
-                    chunk_ids = []
+            chunk_ids = normalize_source_references(item.get("chunk_ids"), item.get("source_id"))
             return {
                 "entity_name": item["entity_name"],
                 "content": item["content"],
@@ -161,11 +155,9 @@ class PGOpsSyncVectorStorage(BaseVectorStorage):
                 vector = vector.tolist()
             chunk_ids = item.get("chunk_ids")
             if chunk_ids is None:
-                source_id = item.get("source_id")
-                if isinstance(source_id, str) and source_id:
-                    chunk_ids = source_id.split(GRAPH_FIELD_SEP) if GRAPH_FIELD_SEP in source_id else [source_id]
-                else:
-                    chunk_ids = []
+                chunk_ids = normalize_source_references(item.get("source_id"))
+            else:
+                chunk_ids = normalize_source_references(chunk_ids)
             return {
                 "source_id": item["src_id"],
                 "target_id": item["tgt_id"],

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -80,7 +80,6 @@ from .utils import (
     compute_mdhash_id,
     create_lightrag_logger,
     logger,
-    split_string_by_multi_markers,
 )
 
 

--- a/aperag/graph/lightrag/lightrag.py
+++ b/aperag/graph/lightrag/lightrag.py
@@ -70,6 +70,7 @@ from .operate import (
     merge_nodes_and_edges,
 )
 from .prompt import DEFAULT_ENTITY_TYPES, GRAPH_FIELD_SEP
+from .source_refs import normalize_source_references, serialize_source_references
 from .types import KnowledgeGraph
 from .utils import (
     EmbeddingFunc,
@@ -306,7 +307,7 @@ class LightRAG:
             embedding_func=self.embedding_func,
             cosine_better_than_threshold=self.cosine_better_than_threshold,
             _max_batch_size=self.max_batch_size,
-            meta_fields={"entity_name", "source_id", "content", "file_path"},
+            meta_fields={"entity_name", "source_id", "chunk_ids", "content", "file_path"},
         )
         self.relationships_vdb: BaseVectorStorage = self.vector_db_storage_cls(  # type: ignore
             namespace=NameSpace.VECTOR_STORE_RELATIONSHIPS,
@@ -314,7 +315,7 @@ class LightRAG:
             embedding_func=self.embedding_func,
             cosine_better_than_threshold=self.cosine_better_than_threshold,
             _max_batch_size=self.max_batch_size,
-            meta_fields={"src_id", "tgt_id", "source_id", "content", "file_path"},
+            meta_fields={"src_id", "tgt_id", "source_id", "chunk_ids", "content", "file_path"},
         )
         self.chunks_vdb: BaseVectorStorage = self.vector_db_storage_cls(  # type: ignore
             namespace=NameSpace.VECTOR_STORE_CHUNKS,
@@ -948,6 +949,8 @@ class LightRAG:
                 elif len(new_chunk_ids) != len(old_chunk_ids):
                     updated_entity = dict(entity_data)
                     updated_entity["chunk_ids"] = sorted(new_chunk_ids)
+                    if "source_id" in updated_entity:
+                        updated_entity["source_id"] = serialize_source_references(updated_entity["chunk_ids"])
                     entities_to_update_in_vdb[entity_id] = updated_entity
                     self.lightrag_logger.debug(
                         f"Entity {entity_data.get('entity_name')} chunk_ids updated: {len(old_chunk_ids)} -> {len(new_chunk_ids)}"
@@ -1001,11 +1004,7 @@ class LightRAG:
                 if not node_data or "source_id" not in node_data:
                     continue
 
-                sources = {
-                    source_id
-                    for source_id in split_string_by_multi_markers(node_data["source_id"], [GRAPH_FIELD_SEP])
-                    if source_id
-                }
+                sources = set(normalize_source_references(node_data["source_id"]))
                 if not sources.intersection(chunk_ids):
                     continue
 
@@ -1017,7 +1016,7 @@ class LightRAG:
                     )
                 else:
                     updated_node = dict(node_data)
-                    updated_node["source_id"] = GRAPH_FIELD_SEP.join(sorted(sources))
+                    updated_node["source_id"] = serialize_source_references(sorted(sources))
                     entities_to_update_in_graph[node_label] = updated_node
                     self.lightrag_logger.debug(f"Entity {node_label} source_id will be updated in graph")
 
@@ -1025,11 +1024,7 @@ class LightRAG:
                 if not edge_data or "source_id" not in edge_data:
                     continue
 
-                sources = {
-                    source_id
-                    for source_id in split_string_by_multi_markers(edge_data["source_id"], [GRAPH_FIELD_SEP])
-                    if source_id
-                }
+                sources = set(normalize_source_references(edge_data["source_id"]))
                 if not sources.intersection(chunk_ids):
                     continue
 
@@ -1042,7 +1037,7 @@ class LightRAG:
                     )
                 else:
                     updated_edge = dict(edge_data)
-                    updated_edge["source_id"] = GRAPH_FIELD_SEP.join(sorted(sources))
+                    updated_edge["source_id"] = serialize_source_references(sorted(sources))
                     relationships_to_update_in_graph[(src, tgt)] = updated_edge
                     self.lightrag_logger.debug(f"Relationship {src}-{tgt} source_id will be updated in graph")
 
@@ -1484,6 +1479,7 @@ class LightRAG:
                     "entity_type": merged_entity_data.get("entity_type", "UNKNOWN"),
                     "content": entity_content,
                     "source_id": merged_entity_data.get("source_id", ""),
+                    "chunk_ids": normalize_source_references(merged_entity_data.get("source_id")),
                     "file_path": merged_entity_data.get("file_path", ""),
                 }
             }
@@ -1512,7 +1508,7 @@ class LightRAG:
                     "src_id": src,
                     "tgt_id": tgt,
                     "content": rel_content,
-                    "source_id": edge_data.get("source_id", ""),
+                    "chunk_ids": normalize_source_references(edge_data.get("source_id")),
                     "file_path": edge_data.get("file_path", ""),
                     "keywords": edge_data.get("keywords", ""),
                     "description": edge_data.get("description", ""),
@@ -1580,13 +1576,16 @@ class LightRAG:
             elif strategy == "keep_last":
                 merged_data[key] = values[-1]
             elif strategy == "join_unique":
-                # Handle fields separated by GRAPH_FIELD_SEP
-                unique_items = set()
-                for value in values:
-                    if value:
-                        items = str(value).split(GRAPH_FIELD_SEP)
-                        unique_items.update(item.strip() for item in items if item.strip())
-                merged_data[key] = GRAPH_FIELD_SEP.join(sorted(unique_items))
+                if key == "source_id":
+                    merged_data[key] = serialize_source_references(*values)
+                else:
+                    # Handle fields separated by GRAPH_FIELD_SEP
+                    unique_items = set()
+                    for value in values:
+                        if value:
+                            items = str(value).split(GRAPH_FIELD_SEP)
+                            unique_items.update(item.strip() for item in items if item.strip())
+                    merged_data[key] = GRAPH_FIELD_SEP.join(sorted(unique_items))
             else:
                 # Default: keep first
                 merged_data[key] = values[0]
@@ -1622,16 +1621,21 @@ class LightRAG:
             elif strategy == "keep_last":
                 merged_data[key] = values[-1]
             elif strategy == "join_unique":
-                # Handle fields separated by GRAPH_FIELD_SEP or commas
-                unique_items = set()
-                for value in values:
-                    if value:
-                        # Try both separators
-                        items = str(value).replace(",", GRAPH_FIELD_SEP).split(GRAPH_FIELD_SEP)
-                        unique_items.update(item.strip() for item in items if item.strip())
-                merged_data[key] = (
-                    ",".join(sorted(unique_items)) if key == "keywords" else GRAPH_FIELD_SEP.join(sorted(unique_items))
-                )
+                if key == "source_id":
+                    merged_data[key] = serialize_source_references(*values)
+                else:
+                    # Handle fields separated by GRAPH_FIELD_SEP or commas
+                    unique_items = set()
+                    for value in values:
+                        if value:
+                            # Try both separators
+                            items = str(value).replace(",", GRAPH_FIELD_SEP).split(GRAPH_FIELD_SEP)
+                            unique_items.update(item.strip() for item in items if item.strip())
+                    merged_data[key] = (
+                        ",".join(sorted(unique_items))
+                        if key == "keywords"
+                        else GRAPH_FIELD_SEP.join(sorted(unique_items))
+                    )
             elif strategy == "max":
                 # For numeric fields like weight
                 try:
@@ -1743,9 +1747,8 @@ class LightRAG:
                 for entity_id, node_data in nodes_data.items():
                     source_id = node_data.get("source_id")
                     if source_id:
-                        chunk_ids = source_id.split(GRAPH_FIELD_SEP) if GRAPH_FIELD_SEP in source_id else [source_id]
                         entity_name = node_data.get("entity_name", entity_id)
-                        for chunk_id in chunk_ids:
+                        for chunk_id in normalize_source_references(source_id):
                             chunk_id = chunk_id.strip()
                             if chunk_id:
                                 chunk_id_to_entities.setdefault(chunk_id, []).append(entity_name)
@@ -1754,12 +1757,11 @@ class LightRAG:
                 for (source_entity_id, target_entity_id), edge_data in edges_data.items():
                     source_id = edge_data.get("source_id")
                     if source_id:
-                        chunk_ids = source_id.split(GRAPH_FIELD_SEP) if GRAPH_FIELD_SEP in source_id else [source_id]
                         source_name = nodes_data.get(source_entity_id, {}).get("entity_name", source_entity_id)
                         target_name = nodes_data.get(target_entity_id, {}).get("entity_name", target_entity_id)
                         edge_tuple = [source_name, target_name]
 
-                        for chunk_id in chunk_ids:
+                        for chunk_id in normalize_source_references(source_id):
                             chunk_id = chunk_id.strip()
                             if chunk_id:
                                 chunk_id_to_edges.setdefault(chunk_id, []).append(edge_tuple)

--- a/aperag/graph/lightrag/operate.py
+++ b/aperag/graph/lightrag/operate.py
@@ -1289,11 +1289,7 @@ async def _find_most_related_text_unit_from_entities(
     knowledge_graph_inst: BaseGraphStorage,
     tokenizer: Tokenizer,
 ):
-    text_units = [
-        normalize_source_references(dp["source_id"])
-        for dp in node_datas
-        if dp["source_id"] is not None
-    ]
+    text_units = [normalize_source_references(dp["source_id"]) for dp in node_datas if dp["source_id"] is not None]
 
     node_names = [dp["entity_name"] for dp in node_datas]
     incident_edges_dict = await knowledge_graph_inst.get_incident_edges_with_data_batch(node_names)
@@ -1633,11 +1629,7 @@ async def _find_related_text_unit_from_relationships(
     text_chunks_db: BaseKVStorage,
     tokenizer: Tokenizer,
 ):
-    text_units = [
-        normalize_source_references(dp["source_id"])
-        for dp in edge_datas
-        if dp["source_id"] is not None
-    ]
+    text_units = [normalize_source_references(dp["source_id"]) for dp in edge_datas if dp["source_id"] is not None]
     all_text_units_lookup = {}
 
     async def fetch_chunk_data(c_id, index):

--- a/aperag/graph/lightrag/operate.py
+++ b/aperag/graph/lightrag/operate.py
@@ -57,6 +57,7 @@ from .prompt import (
     GRAPH_FIELD_SEP,
     PROMPTS,
 )
+from .source_refs import normalize_source_references, serialize_source_references
 from .types import GraphNodeData, GraphNodeDataDict, MergeSuggestion
 from .utils import (
     LightRAGLogger,
@@ -192,6 +193,7 @@ async def _handle_single_entity_extraction(
         entity_type=entity_type,
         description=entity_description,
         source_id=chunk_key,
+        chunk_ids=[chunk_key],
         file_path=file_path,
     )
 
@@ -233,6 +235,7 @@ async def _handle_single_relationship_extraction(
         description=edge_description,
         keywords=edge_keywords,
         source_id=edge_source_id,
+        chunk_ids=[chunk_key],
         file_path=file_path,
     )
 
@@ -279,7 +282,6 @@ async def _merge_nodes_then_upsert(
 
     # 1. Initialize containers for collecting existing entity data
     already_entity_types = []
-    already_source_ids = []
     already_description = []
     already_file_paths = []
 
@@ -290,8 +292,6 @@ async def _merge_nodes_then_upsert(
         already_entity_types.append(already_node["entity_type"])
 
         # 2.2. Split and collect existing source IDs (multiple IDs separated by GRAPH_FIELD_SEP)
-        already_source_ids.extend(split_string_by_multi_markers(already_node["source_id"], [GRAPH_FIELD_SEP]))
-
         # 2.3. Split and collect existing file paths (multiple paths separated by GRAPH_FIELD_SEP)
         already_file_paths.extend(split_string_by_multi_markers(already_node["file_path"], [GRAPH_FIELD_SEP]))
 
@@ -311,7 +311,12 @@ async def _merge_nodes_then_upsert(
     description = GRAPH_FIELD_SEP.join(sorted(set([dp["description"] for dp in nodes_data] + already_description)))
 
     # 3.3. Merge source IDs, deduplicated
-    source_id = GRAPH_FIELD_SEP.join(set([dp["source_id"] for dp in nodes_data] + already_source_ids))
+    chunk_ids = normalize_source_references(
+        *(dp.get("chunk_ids") for dp in nodes_data),
+        *(dp.get("source_id") for dp in nodes_data),
+        already_node.get("source_id") if already_node else None,
+    )
+    source_id = serialize_source_references(chunk_ids)
 
     # 3.4. Merge file paths, deduplicated
     file_path = GRAPH_FIELD_SEP.join(set([dp["file_path"] for dp in nodes_data] + already_file_paths))
@@ -381,7 +386,6 @@ async def _merge_edges_then_upsert(
         return None
 
     already_weights = []
-    already_source_ids = []
     already_description = []
     already_keywords = []
     already_file_paths = []
@@ -391,10 +395,6 @@ async def _merge_edges_then_upsert(
     if already_edge:
         # Get weight with default 0.0 if missing
         already_weights.append(already_edge.get("weight", 0.0))
-
-        # Get source_id with empty string default if missing or None
-        if already_edge.get("source_id") is not None:
-            already_source_ids.extend(split_string_by_multi_markers(already_edge["source_id"], [GRAPH_FIELD_SEP]))
 
         # Get file_path with empty string default if missing or None
         if already_edge.get("file_path") is not None:
@@ -427,9 +427,12 @@ async def _merge_edges_then_upsert(
     # Join all unique keywords with commas
     keywords = ",".join(sorted(all_keywords))
 
-    source_id = GRAPH_FIELD_SEP.join(
-        set([dp["source_id"] for dp in edges_data if dp.get("source_id")] + already_source_ids)
+    chunk_ids = normalize_source_references(
+        *(dp.get("chunk_ids") for dp in edges_data),
+        *(dp.get("source_id") for dp in edges_data if dp.get("source_id")),
+        already_edge.get("source_id") if already_edge else None,
     )
+    source_id = serialize_source_references(chunk_ids)
     file_path = GRAPH_FIELD_SEP.join(
         set([dp["file_path"] for dp in edges_data if dp.get("file_path")] + already_file_paths)
     )
@@ -587,6 +590,7 @@ async def _merge_nodes_and_edges_impl(
                             "entity_type": entity_data["entity_type"],
                             "content": f"{entity_data['entity_name']}\n{entity_data['description']}",
                             "source_id": entity_data["source_id"],
+                            "chunk_ids": normalize_source_references(entity_data.get("source_id")),
                             "file_path": entity_data.get("file_path", "unknown_source"),
                         }
                     }
@@ -633,7 +637,7 @@ async def _merge_nodes_and_edges_impl(
                             "tgt_id": edge_data["tgt_id"],
                             "keywords": edge_data["keywords"],
                             "content": f"{edge_data['src_id']}\t{edge_data['tgt_id']}\n{edge_data['keywords']}\n{edge_data['description']}",
-                            "source_id": edge_data["source_id"],
+                            "chunk_ids": normalize_source_references(edge_data.get("source_id")),
                             "file_path": edge_data.get("file_path", "unknown_source"),
                         }
                     }

--- a/aperag/graph/lightrag/operate.py
+++ b/aperag/graph/lightrag/operate.py
@@ -1290,7 +1290,7 @@ async def _find_most_related_text_unit_from_entities(
     tokenizer: Tokenizer,
 ):
     text_units = [
-        split_string_by_multi_markers(dp["source_id"], [GRAPH_FIELD_SEP])
+        normalize_source_references(dp["source_id"])
         for dp in node_datas
         if dp["source_id"] is not None
     ]
@@ -1327,7 +1327,7 @@ async def _find_most_related_text_unit_from_entities(
 
     # Add null check for node data
     all_one_hop_text_units_lookup = {
-        k: set(split_string_by_multi_markers(v["source_id"], [GRAPH_FIELD_SEP]))
+        k: set(normalize_source_references(v["source_id"]))
         for k, v in zip(all_one_hop_nodes, all_one_hop_nodes_data)
         if v is not None and "source_id" in v  # Add source_id check
     }
@@ -1634,7 +1634,7 @@ async def _find_related_text_unit_from_relationships(
     tokenizer: Tokenizer,
 ):
     text_units = [
-        split_string_by_multi_markers(dp["source_id"], [GRAPH_FIELD_SEP])
+        normalize_source_references(dp["source_id"])
         for dp in edge_datas
         if dp["source_id"] is not None
     ]

--- a/aperag/graph/lightrag/source_refs.py
+++ b/aperag/graph/lightrag/source_refs.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from .prompt import GRAPH_FIELD_SEP
+from .utils import split_string_by_multi_markers
+
+
+def normalize_source_references(*values: Any) -> list[str]:
+    """Return a deterministic list of chunk/source reference IDs.
+
+    The current graph stack persists the same provenance in two shapes:
+    - graph storage: `source_id` as `GRAPH_FIELD_SEP`-joined string
+    - vector storage: `chunk_ids` as `list[str]`
+
+    This helper gives the codebase one canonical in-memory representation:
+    a sorted, unique `list[str]`.
+    """
+
+    refs: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            refs.extend(split_string_by_multi_markers(value, [GRAPH_FIELD_SEP]))
+            continue
+        if isinstance(value, Iterable):
+            for item in value:
+                if isinstance(item, str):
+                    refs.extend(split_string_by_multi_markers(item, [GRAPH_FIELD_SEP]))
+
+    return sorted(dict.fromkeys(ref for ref in refs if ref))
+
+
+def serialize_source_references(*values: Any) -> str:
+    """Serialize source references back to graph-storage string form."""
+
+    return GRAPH_FIELD_SEP.join(normalize_source_references(*values))
+
+
+def source_references_overlap(source_id: Any, chunk_ids: Any) -> bool:
+    """Return True when graph `source_id` and vector/doc chunk refs overlap."""
+
+    if source_id is None or chunk_ids is None:
+        return False
+
+    source_refs = set(normalize_source_references(source_id))
+    chunk_refs = set(normalize_source_references(chunk_ids))
+    return bool(source_refs.intersection(chunk_refs))

--- a/tests/unit_test/graphindex/test_lightrag_chunk_identity_and_delete_contract.py
+++ b/tests/unit_test/graphindex/test_lightrag_chunk_identity_and_delete_contract.py
@@ -224,10 +224,12 @@ async def test_adelete_by_doc_id_updates_shared_refs_and_deletes_exclusive_refs(
         {
             "ent-shared": {
                 "entity_name": "SharedEntity",
+                "source_id": f"chunk-a{GRAPH_FIELD_SEP}chunk-b",
                 "chunk_ids": ["chunk-a", "chunk-b"],
             },
             "ent-exclusive": {
                 "entity_name": "ExclusiveEntity",
+                "source_id": "chunk-a",
                 "chunk_ids": ["chunk-a"],
             },
         }
@@ -263,6 +265,7 @@ async def test_adelete_by_doc_id_updates_shared_refs_and_deletes_exclusive_refs(
         {
             "ent-shared": {
                 "entity_name": "SharedEntity",
+                "source_id": "chunk-b",
                 "chunk_ids": ["chunk-b"],
             }
         }

--- a/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
+++ b/tests/unit_test/graphindex/test_lightrag_update_and_storage.py
@@ -7,7 +7,13 @@ from aperag.graph.lightrag.base import QueryParam
 from aperag.graph.lightrag.kg.pg_ops_sync_vector_storage import PGOpsSyncVectorStorage
 from aperag.graph.lightrag.lightrag import LightRAG
 from aperag.graph.lightrag.namespace import NameSpace
-from aperag.graph.lightrag.operate import _find_most_related_edges_from_entities, get_high_degree_nodes
+from aperag.graph.lightrag.operate import (
+    _find_most_related_edges_from_entities,
+    get_high_degree_nodes,
+    merge_nodes_and_edges,
+)
+from aperag.graph.lightrag.prompt import GRAPH_FIELD_SEP
+from aperag.graph.lightrag.utils import compute_mdhash_id
 from aperag.graph.lightrag_manager import _process_document_async
 
 
@@ -106,6 +112,101 @@ async def test_pg_vector_upsert_reuses_existing_vector_for_metadata_only_update(
     assert captured["vector_data"]["entity-1"]["chunk_ids"] == ["chunk-a", "chunk-b"]
 
 
+@pytest.mark.asyncio
+async def test_pg_vector_upsert_normalizes_chunk_ids_from_legacy_source_id(monkeypatch):
+    captured = {}
+
+    def _capture_upsert(_workspace, vector_data):
+        captured["vector_data"] = vector_data
+
+    monkeypatch.setattr(
+        "aperag.db.ops.db_ops.upsert_lightrag_vdb_relation",
+        _capture_upsert,
+    )
+
+    storage = PGOpsSyncVectorStorage(
+        namespace=NameSpace.VECTOR_STORE_RELATIONSHIPS,
+        workspace="workspace-1",
+        embedding_func=lambda _batch: None,
+    )
+
+    await storage.upsert(
+        {
+            "rel-1": {
+                "src_id": "Alpha",
+                "tgt_id": "Beta",
+                "content": "Alpha\tBeta\nworks_with\nrelation desc",
+                "content_vector": [0.1, 0.2, 0.3],
+                "source_id": f"chunk-b{GRAPH_FIELD_SEP}chunk-a{GRAPH_FIELD_SEP}chunk-b",
+                "file_path": "/tmp/rel.txt",
+            }
+        }
+    )
+
+    assert captured["vector_data"]["rel-1"]["chunk_ids"] == ["chunk-a", "chunk-b"]
+
+
+@pytest.mark.asyncio
+async def test_merge_nodes_and_edges_upserts_explicit_chunk_ids_to_vector_storage():
+    graph_storage = _FakeGraphStorage()
+    entities_vdb = _FakeEntityVectorStorage()
+    relationships_vdb = _FakeRelationVectorStorage()
+
+    chunk_results = [
+        (
+            {
+                "Alpha": [
+                    {
+                        "entity_name": "Alpha",
+                        "entity_type": "ORG",
+                        "description": "alpha desc",
+                        "source_id": f"chunk-b{GRAPH_FIELD_SEP}chunk-a",
+                        "chunk_ids": ["chunk-b", "chunk-a"],
+                        "file_path": "/tmp/alpha.txt",
+                    }
+                ]
+            },
+            {
+                ("Alpha", "Beta"): [
+                    {
+                        "src_id": "Alpha",
+                        "tgt_id": "Beta",
+                        "description": "relation desc",
+                        "keywords": "works_with",
+                        "weight": 1.0,
+                        "source_id": f"chunk-b{GRAPH_FIELD_SEP}chunk-a",
+                        "chunk_ids": ["chunk-b", "chunk-a"],
+                        "file_path": "/tmp/alpha.txt",
+                    }
+                ]
+            },
+        )
+    ]
+
+    result = await merge_nodes_and_edges(
+        chunk_results=chunk_results,
+        component=["Alpha", "Beta"],
+        workspace="workspace-1",
+        knowledge_graph_inst=graph_storage,
+        entity_vdb=entities_vdb,
+        relationships_vdb=relationships_vdb,
+        llm_model_func=lambda *_args, **_kwargs: None,
+        tokenizer=_FakeTokenizer(),
+        llm_model_max_token_size=2048,
+        summary_to_max_tokens=256,
+        language="zh-CN",
+        force_llm_summary_on_merge=99,
+        lightrag_logger=_FakeLogger(),
+    )
+
+    entity_id = compute_mdhash_id("Alpha", prefix="ent-", workspace="workspace-1")
+    rel_id = compute_mdhash_id("AlphaBeta", prefix="rel-", workspace="workspace-1")
+
+    assert result == {"entity_count": 1, "relation_count": 1}
+    assert entities_vdb.upserts[0][entity_id]["chunk_ids"] == ["chunk-a", "chunk-b"]
+    assert relationships_vdb.upserts[0][rel_id]["chunk_ids"] == ["chunk-a", "chunk-b"]
+
+
 class _FakeGraphStorage:
     def __init__(self, nodes=None, edges_with_data_by_node=None):
         self.nodes = dict(nodes or {})
@@ -130,6 +231,25 @@ class _FakeGraphStorage:
     async def get_incident_edges_with_data_batch(self, node_ids):
         self.calls.append(("get_incident_edges_with_data_batch", tuple(node_ids)))
         return await self.get_nodes_edges_with_data_batch(node_ids)
+
+    async def get_nodes_edges_batch(self, node_ids):
+        self.calls.append(("get_nodes_edges_batch", tuple(node_ids)))
+        return {
+            node_id: [(source, target) for source, target, _edge_data in self.edges_with_data_by_node.get(node_id, [])]
+            for node_id in node_ids
+        }
+
+    async def get_edges_batch(self, edge_pairs):
+        self.calls.append(("get_edges_batch", tuple((edge["src"], edge["tgt"]) for edge in edge_pairs)))
+        all_edges = {}
+        for edges in self.edges_with_data_by_node.values():
+            for edge_source, edge_target, edge_data in edges:
+                all_edges[(edge_source, edge_target)] = dict(edge_data)
+        return {
+            (edge["src"], edge["tgt"]): all_edges[(edge["src"], edge["tgt"])]
+            for edge in edge_pairs
+            if (edge["src"], edge["tgt"]) in all_edges
+        }
 
     async def upsert_node(self, node_id, node_data):
         self.calls.append(("upsert_node", node_id))
@@ -183,15 +303,30 @@ class _FakeGraphStorage:
         self.calls.append(("get_node_ids", limit))
         return list(self.nodes.keys())[:limit] if limit is not None else list(self.nodes.keys())
 
+    async def node_degrees_batch(self, node_ids):
+        self.calls.append(("node_degrees_batch", tuple(node_ids)))
+        degrees = {node_id: 0 for node_id in node_ids}
+        for edges in self.edges_with_data_by_node.values():
+            for edge_source, edge_target, _edge_data in edges:
+                if edge_source in degrees:
+                    degrees[edge_source] += 1
+                if edge_target in degrees:
+                    degrees[edge_target] += 1
+        return degrees
+
 
 class _FakeEntityVectorStorage:
     def __init__(self):
         self.workspace = "workspace-1"
         self.deleted = []
+        self.deleted_entities = []
         self.upserts = []
 
     async def delete(self, ids):
         self.deleted.append(list(ids))
+
+    async def delete_entity(self, entity_name):
+        self.deleted_entities.append(entity_name)
 
     async def upsert(self, data):
         self.upserts.append(data)
@@ -302,6 +437,43 @@ async def test_amerge_entities_uses_batch_graph_primitives_and_batch_delete():
     assert result["entity_name"] == "merged"
 
 
+@pytest.mark.asyncio
+async def test_amerge_nodes_upserts_explicit_chunk_ids_to_vector_storage():
+    rag = LightRAG.__new__(LightRAG)
+    rag.workspace = "workspace-1"
+    rag.lightrag_logger = _FakeLogger()
+    rag.chunk_entity_relation_graph = _FakeGraphStorage(
+        nodes={
+            "A": {"entity_id": "A", "entity_type": "PERSON", "description": "desc A", "source_id": "chunk-b"},
+            "B": {"entity_id": "B", "entity_type": "PERSON", "description": "desc B", "source_id": "chunk-a"},
+            "X": {"entity_id": "X", "entity_type": "ORG", "description": "desc X", "source_id": "chunk-x"},
+            "Y": {"entity_id": "Y", "entity_type": "ORG", "description": "desc Y", "source_id": "chunk-y"},
+        },
+        edges_with_data_by_node={
+            "A": [("A", "X", {"description": "edge ax", "keywords": "k1", "source_id": "chunk-b", "weight": 1})],
+            "B": [("B", "Y", {"description": "edge by", "keywords": "k2", "source_id": "chunk-a", "weight": 2})],
+        },
+    )
+    rag.entities_vdb = _FakeEntityVectorStorage()
+    rag.relationships_vdb = _FakeRelationVectorStorage()
+
+    result = await LightRAG.amerge_nodes(
+        rag,
+        ["A", "B"],
+        {"entity_name": "merged"},
+    )
+
+    merged_entity_id = compute_mdhash_id("merged", prefix="ent-", workspace=rag.workspace)
+
+    assert result["status"] == "success"
+    assert rag.entities_vdb.upserts[0][merged_entity_id]["chunk_ids"] == ["chunk-a", "chunk-b"]
+    assert all(
+        relation_data["chunk_ids"]
+        for upsert_batch in rag.relationships_vdb.upserts
+        for relation_data in upsert_batch.values()
+    )
+
+
 class _FakeHighDegreeGraphStorage:
     async def get_top_degree_nodes(self, limit):
         assert limit == 2
@@ -396,6 +568,12 @@ class _FakeLogger:
         return None
 
     def error(self, *_args, **_kwargs):
+        return None
+
+    def log_entity_merge(self, *_args, **_kwargs):
+        return None
+
+    def log_relation_merge(self, *_args, **_kwargs):
         return None
 
 


### PR DESCRIPTION
## Summary
- add a shared source reference helper so `source_id` normalization no longer lives in ad-hoc split/join call sites
- make entity/relationship vector writes carry explicit `chunk_ids` in the main write path and manual merge path
- keep legacy fallback narrow by only deriving `chunk_ids` from legacy provenance when explicit `chunk_ids` are missing

## Testing
- python3 -m py_compile aperag/graph/lightrag/source_refs.py aperag/graph/lightrag/operate.py aperag/graph/lightrag/lightrag.py aperag/graph/lightrag/kg/pg_ops_sync_vector_storage.py tests/unit_test/graphindex/test_lightrag_update_and_storage.py tests/unit_test/graphindex/test_lightrag_chunk_identity_and_delete_contract.py
- ./.venv/bin/pytest tests/unit_test/graphindex/test_lightrag_update_and_storage.py tests/unit_test/graphindex/test_lightrag_chunk_identity_and_delete_contract.py -q