### PR TITLE
style(ci): satisfy repo lint gate

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -32,6 +32,7 @@ if settings.otel_enabled:
     )
 
 from fastapi import FastAPI  # noqa: E402
+
 from aperag.exception_handlers import register_exception_handlers
 from aperag.llm.litellm_track import register_custom_llm_track
 from aperag.mcp import mcp_server

--- a/aperag/service/chat_service.py
+++ b/aperag/service/chat_service.py
@@ -127,7 +127,11 @@ class ChatService:
             )
             if not answer_artifact:
                 answer_artifact = next(
-                    (artifact for artifact in artifacts if _artifact_type_value(artifact) == db_models.AgentArtifactType.ANSWER.value),
+                    (
+                        artifact
+                        for artifact in artifacts
+                        if _artifact_type_value(artifact) == db_models.AgentArtifactType.ANSWER.value
+                    ),
                     None,
                 )
 
@@ -334,7 +338,11 @@ class ChatService:
         )
         if not answer_artifact:
             answer_artifact = next(
-                (artifact for artifact in artifacts if _artifact_type_value(artifact) == db_models.AgentArtifactType.ANSWER.value),
+                (
+                    artifact
+                    for artifact in artifacts
+                    if _artifact_type_value(artifact) == db_models.AgentArtifactType.ANSWER.value
+                ),
                 None,
             )
 

--- a/aperag/utils/history.py
+++ b/aperag/utils/history.py
@@ -194,6 +194,7 @@ class RedisChatMessageHistory:
     async def release_redis(self):
         await self.redis_client.close(close_connection_pool=True)
 
+
 def success_response(message_id, data):
     return json.dumps(
         {


### PR DESCRIPTION
## Summary
- fix the current repo lint gate drift in app bootstrap and formatter output
- keep this separate from graph task PRs so task-scoped review objects stay clean

## Validation
- uvx ruff check --no-fix ./aperag
- uvx ruff format --check ./aperag