### PR TITLE
Fix rerank response score and index mapping

### DIFF
--- a/aperag/llm/rerank/rerank_service.py
+++ b/aperag/llm/rerank/rerank_service.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+from dataclasses import dataclass
 from typing import List
 
 import httpx
@@ -28,6 +29,19 @@ from aperag.llm.llm_error_types import (
 from aperag.query.query import DocumentWithScore
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RerankResult:
+    original_index: int
+    relevance_score: float
+    document: DocumentWithScore
+
+
+@dataclass(frozen=True)
+class _RankedResult:
+    index: int
+    relevance_score: float
 
 
 class RerankService:
@@ -49,6 +63,17 @@ class RerankService:
         self.max_documents = 1000
 
     async def async_rerank(self, query: str, results: List[DocumentWithScore]) -> List[DocumentWithScore]:
+        ranked_results = await self.async_rerank_with_details(query, results)
+        return [
+            DocumentWithScore(
+                text=ranked.document.text,
+                score=ranked.relevance_score,
+                metadata=ranked.document.metadata,
+            )
+            for ranked in ranked_results
+        ]
+
+    async def async_rerank_with_details(self, query: str, results: List[DocumentWithScore]) -> List[RerankResult]:
         try:
             # Validate inputs
             if not query or not query.strip():
@@ -80,10 +105,18 @@ class RerankService:
                     raise InvalidDocumentError("All documents are empty or invalid", document_count=len(results))
 
             # Call the cached internal method with simple types
-            reranked_indices = await self._rank_texts(query, texts)
+            ranked_results = await self._rank_texts(query, texts)
 
-            # Reconstruct DocumentWithScore objects in the new order
-            reranked_results = [results[i] for i in reranked_indices if 0 <= i < len(results)]
+            # Reconstruct structured results in provider order while preserving original indices and scores.
+            reranked_results = [
+                RerankResult(
+                    original_index=ranked.index,
+                    relevance_score=ranked.relevance_score,
+                    document=results[ranked.index],
+                )
+                for ranked in ranked_results
+                if 0 <= ranked.index < len(results)
+            ]
 
             logger.info(f"Successfully reranked {len(reranked_results)} documents")
             return reranked_results
@@ -96,7 +129,7 @@ class RerankService:
             # Convert litellm errors to our custom types
             raise wrap_litellm_error(e, "rerank", self.rerank_provider, self.model) from e
 
-    async def _rank_texts(self, query: str, texts: List[str]) -> List[int]:
+    async def _rank_texts(self, query: str, texts: List[str]) -> List[_RankedResult]:
         try:
             # Handle different providers
             if self.rerank_provider == "alibabacloud" or "alibabacloud" in self.rerank_provider.lower():
@@ -124,14 +157,20 @@ class RerankService:
 
             # Extract and validate indices
             try:
-                indices = [item["index"] for item in resp["results"]]
+                ranked_results = [
+                    _RankedResult(
+                        index=item["index"],
+                        relevance_score=float(item.get("relevance_score", item.get("score", 0.0))),
+                    )
+                    for item in resp["results"]
+                ]
 
                 # Validate indices
-                if len(indices) != len(texts):
-                    logger.warning(f"Rerank returned {len(indices)} indices for {len(texts)} documents")
+                if len(ranked_results) != len(texts):
+                    logger.warning(f"Rerank returned {len(ranked_results)} indices for {len(texts)} documents")
 
                 # Check for invalid indices
-                invalid_rerank_indices = [idx for idx in indices if idx < 0 or idx >= len(texts)]
+                invalid_rerank_indices = [ranked.index for ranked in ranked_results if ranked.index < 0 or ranked.index >= len(texts)]
                 if invalid_rerank_indices:
                     raise RerankError(
                         f"Invalid rerank indices: {invalid_rerank_indices}",
@@ -143,8 +182,8 @@ class RerankService:
                     )
 
                 # Return the valid indices
-                valid_indices = [idx for idx in indices if 0 <= idx < len(texts)]
-                return valid_indices
+                valid_ranked_results = [ranked for ranked in ranked_results if 0 <= ranked.index < len(texts)]
+                return valid_ranked_results
 
             except (KeyError, IndexError, TypeError) as e:
                 raise RerankError(

--- a/aperag/views/llm.py
+++ b/aperag/views/llm.py
@@ -48,6 +48,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _build_rerank_response_items(reranked_documents, return_documents: bool) -> list[RerankDocument]:
+    response_items = []
+    for ranked_doc in reranked_documents:
+        response_item = RerankDocument(
+            index=ranked_doc.original_index,
+            relevance_score=ranked_doc.relevance_score,
+        )
+
+        if return_documents:
+            doc_content = {"text": ranked_doc.document.text}
+            if ranked_doc.document.metadata:
+                doc_content["metadata"] = ranked_doc.document.metadata
+            response_item.document = doc_content
+
+        response_items.append(response_item)
+
+    return response_items
+
+
 @router.post("/embeddings", response_model=EmbeddingResponse, tags=["llm"])
 @audit(resource_type="llm", api_name="CreateEmbeddings")
 async def create_embeddings(http_request: Request, request: EmbeddingRequest, user: User = Depends(required_user)):
@@ -212,9 +231,10 @@ async def create_rerank(http_request: Request, request: RerankRequest, user: Use
             rerank_service_url=provider_info["base_url"],
             rerank_service_api_key=provider_info["api_key"],
         )
+        rerank_service.validate_configuration()
 
         # Perform reranking
-        reranked_documents = await rerank_service.async_rerank(request.query, input_documents)
+        reranked_documents = await rerank_service.async_rerank_with_details(request.query, input_documents)
 
         # Apply top_k limit
         reranked_documents = reranked_documents[:top_k]
@@ -224,29 +244,10 @@ async def create_rerank(http_request: Request, request: RerankRequest, user: Use
         doc_tokens = sum(len(doc.text.split()) for doc in input_documents)
         total_tokens = query_tokens + doc_tokens
 
-        # Format response
-        rerank_data = []
-        for ranked_doc in reranked_documents:
-            # Find original index
-            original_index = -1
-            for i, orig_doc in enumerate(input_documents):
-                if orig_doc.text == ranked_doc.text:
-                    original_index = i
-                    break
-
-            # Create response item
-            response_item = RerankDocument(
-                index=original_index, relevance_score=ranked_doc.score if hasattr(ranked_doc, "score") else 0.0
-            )
-
-            # Add document content if requested
-            if request.return_documents:
-                doc_content = {"text": ranked_doc.text}
-                if hasattr(ranked_doc, "metadata") and ranked_doc.metadata:
-                    doc_content["metadata"] = ranked_doc.metadata
-                response_item.document = doc_content
-
-            rerank_data.append(response_item)
+        rerank_data = _build_rerank_response_items(
+            reranked_documents,
+            return_documents=bool(request.return_documents),
+        )
 
         return RerankResponse(
             object="list",

--- a/tests/unit_test/llm/test_rerank_service.py
+++ b/tests/unit_test/llm/test_rerank_service.py
@@ -1,0 +1,66 @@
+import litellm
+import pytest
+
+from aperag.llm.rerank.rerank_service import RerankService
+from aperag.query.query import DocumentWithScore
+
+
+@pytest.mark.asyncio
+async def test_async_rerank_preserves_provider_scores_and_duplicate_documents(monkeypatch):
+    async def fake_arerank(**kwargs):
+        assert kwargs["query"] == "duplicate"
+        assert kwargs["documents"] == ["same text", "same text"]
+        return {
+            "results": [
+                {"index": 1, "relevance_score": 0.92},
+                {"index": 0, "relevance_score": 0.41},
+            ]
+        }
+
+    monkeypatch.setattr(litellm, "arerank", fake_arerank)
+
+    service = RerankService(
+        rerank_provider="jina_ai",
+        rerank_model="test-reranker",
+        rerank_service_url="https://example.com",
+        rerank_service_api_key="test-key",
+    )
+    docs = [
+        DocumentWithScore(text="same text", score=0.1, metadata={"id": "first"}),
+        DocumentWithScore(text="same text", score=0.2, metadata={"id": "second"}),
+    ]
+
+    detailed = await service.async_rerank_with_details("duplicate", docs)
+
+    assert [item.original_index for item in detailed] == [1, 0]
+    assert [item.relevance_score for item in detailed] == pytest.approx([0.92, 0.41])
+    assert [item.document.metadata["id"] for item in detailed] == ["second", "first"]
+
+    reranked = await service.async_rerank("duplicate", docs)
+
+    assert [doc.score for doc in reranked] == pytest.approx([0.92, 0.41])
+    assert [doc.metadata["id"] for doc in reranked] == ["second", "first"]
+
+
+@pytest.mark.asyncio
+async def test_async_rerank_accepts_score_alias(monkeypatch):
+    async def fake_arerank(**kwargs):
+        return {"results": [{"index": 0, "score": 0.73}]}
+
+    monkeypatch.setattr(litellm, "arerank", fake_arerank)
+
+    service = RerankService(
+        rerank_provider="jina_ai",
+        rerank_model="test-reranker",
+        rerank_service_url="https://example.com",
+        rerank_service_api_key="test-key",
+    )
+
+    detailed = await service.async_rerank_with_details(
+        "query",
+        [DocumentWithScore(text="hello world", score=0.1, metadata={"id": "doc-1"})],
+    )
+
+    assert len(detailed) == 1
+    assert detailed[0].original_index == 0
+    assert detailed[0].relevance_score == pytest.approx(0.73)

--- a/tests/unit_test/test_llm_views_rerank.py
+++ b/tests/unit_test/test_llm_views_rerank.py
@@ -1,0 +1,24 @@
+from aperag.llm.rerank.rerank_service import RerankResult
+from aperag.query.query import DocumentWithScore
+from aperag.views.llm import _build_rerank_response_items
+
+
+def test_build_rerank_response_items_preserves_original_indices_for_duplicate_texts():
+    reranked_documents = [
+        RerankResult(
+            original_index=1,
+            relevance_score=0.92,
+            document=DocumentWithScore(text="same text", score=0.92, metadata={"id": "second"}),
+        ),
+        RerankResult(
+            original_index=0,
+            relevance_score=0.41,
+            document=DocumentWithScore(text="same text", score=0.41, metadata={"id": "first"}),
+        ),
+    ]
+
+    response_items = _build_rerank_response_items(reranked_documents, return_documents=True)
+
+    assert [item.index for item in response_items] == [1, 0]
+    assert [item.relevance_score for item in response_items] == [0.92, 0.41]
+    assert [item.document["metadata"]["id"] for item in response_items] == ["second", "first"]


### PR DESCRIPTION
## Summary
- preserve provider returned rerank scores instead of dropping them during response construction
- preserve original document indices even when rerank inputs contain duplicate text
- add focused unit coverage for rerank service parsing and view response assembly

## Testing
- uv run --extra test pytest tests/unit_test/llm/test_rerank_service.py tests/unit_test/test_llm_views_rerank.py
- uv run --group dev ruff check aperag/llm/rerank/rerank_service.py aperag/views/llm.py tests/unit_test/llm/test_rerank_service.py tests/unit_test/test_llm_views_rerank.py