### PR TITLE
perf(graph): add lightrag chunk lookup indexes

### DIFF
--- a/aperag/db/models.py
+++ b/aperag/db/models.py
@@ -847,6 +847,7 @@ class LightRAGDocChunksModel(Base):
     """LightRAG Document Chunks Storage Model"""
 
     __tablename__ = "lightrag_doc_chunks"
+    __table_args__ = (Index("idx_lightrag_doc_chunks_workspace_doc", "workspace", "full_doc_id"),)
 
     id = Column(String(255), primary_key=True)
     workspace = Column(String(255), primary_key=True)
@@ -864,6 +865,7 @@ class LightRAGVDBEntityModel(Base):
     """LightRAG VDB Entity Storage Model"""
 
     __tablename__ = "lightrag_vdb_entity"
+    __table_args__ = (Index("idx_lightrag_vdb_entity_chunk_ids_gin", "chunk_ids", postgresql_using="gin"),)
 
     id = Column(String(255), primary_key=True)
     workspace = Column(String(255), primary_key=True)
@@ -880,6 +882,7 @@ class LightRAGVDBRelationModel(Base):
     """LightRAG VDB Relation Storage Model"""
 
     __tablename__ = "lightrag_vdb_relation"
+    __table_args__ = (Index("idx_lightrag_vdb_relation_chunk_ids_gin", "chunk_ids", postgresql_using="gin"),)
 
     id = Column(String(255), primary_key=True)
     workspace = Column(String(255), primary_key=True)

--- a/aperag/migration/versions/20260422002000-b7c3d4e5f6a7.py
+++ b/aperag/migration/versions/20260422002000-b7c3d4e5f6a7.py
@@ -16,27 +16,32 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _execute_concurrent_ddl(sql: str) -> None:
+    # These indexes land on live LightRAG tables, so build/drop them without
+    # taking the write-blocking locks of transactional CREATE/DROP INDEX.
+    with op.get_context().autocommit_block():
+        op.execute(sql)
+
+
 def upgrade() -> None:
-    op.create_index(
-        "idx_lightrag_doc_chunks_workspace_doc",
-        "lightrag_doc_chunks",
-        ["workspace", "full_doc_id"],
+    _execute_concurrent_ddl(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "idx_lightrag_doc_chunks_workspace_doc "
+        "ON lightrag_doc_chunks (workspace, full_doc_id)"
     )
-    op.create_index(
-        "idx_lightrag_vdb_entity_chunk_ids_gin",
-        "lightrag_vdb_entity",
-        ["chunk_ids"],
-        postgresql_using="gin",
+    _execute_concurrent_ddl(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "idx_lightrag_vdb_entity_chunk_ids_gin "
+        "ON lightrag_vdb_entity USING gin (chunk_ids)"
     )
-    op.create_index(
-        "idx_lightrag_vdb_relation_chunk_ids_gin",
-        "lightrag_vdb_relation",
-        ["chunk_ids"],
-        postgresql_using="gin",
+    _execute_concurrent_ddl(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "idx_lightrag_vdb_relation_chunk_ids_gin "
+        "ON lightrag_vdb_relation USING gin (chunk_ids)"
     )
 
 
 def downgrade() -> None:
-    op.drop_index("idx_lightrag_vdb_relation_chunk_ids_gin", table_name="lightrag_vdb_relation")
-    op.drop_index("idx_lightrag_vdb_entity_chunk_ids_gin", table_name="lightrag_vdb_entity")
-    op.drop_index("idx_lightrag_doc_chunks_workspace_doc", table_name="lightrag_doc_chunks")
+    _execute_concurrent_ddl("DROP INDEX CONCURRENTLY IF EXISTS idx_lightrag_vdb_relation_chunk_ids_gin")
+    _execute_concurrent_ddl("DROP INDEX CONCURRENTLY IF EXISTS idx_lightrag_vdb_entity_chunk_ids_gin")
+    _execute_concurrent_ddl("DROP INDEX CONCURRENTLY IF EXISTS idx_lightrag_doc_chunks_workspace_doc")

--- a/aperag/migration/versions/20260422002000-b7c3d4e5f6a7.py
+++ b/aperag/migration/versions/20260422002000-b7c3d4e5f6a7.py
@@ -1,0 +1,42 @@
+"""add lightrag schema indexes for chunk lookups
+
+Revision ID: b7c3d4e5f6a7
+Revises: a1e2f3d4c5b6
+Create Date: 2026-04-22 00:20:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b7c3d4e5f6a7"
+down_revision: Union[str, None] = "a1e2f3d4c5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_lightrag_doc_chunks_workspace_doc",
+        "lightrag_doc_chunks",
+        ["workspace", "full_doc_id"],
+    )
+    op.create_index(
+        "idx_lightrag_vdb_entity_chunk_ids_gin",
+        "lightrag_vdb_entity",
+        ["chunk_ids"],
+        postgresql_using="gin",
+    )
+    op.create_index(
+        "idx_lightrag_vdb_relation_chunk_ids_gin",
+        "lightrag_vdb_relation",
+        ["chunk_ids"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_lightrag_vdb_relation_chunk_ids_gin", table_name="lightrag_vdb_relation")
+    op.drop_index("idx_lightrag_vdb_entity_chunk_ids_gin", table_name="lightrag_vdb_entity")
+    op.drop_index("idx_lightrag_doc_chunks_workspace_doc", table_name="lightrag_doc_chunks")

--- a/tests/unit_test/graphindex/test_lightrag_schema_indexes.py
+++ b/tests/unit_test/graphindex/test_lightrag_schema_indexes.py
@@ -1,0 +1,29 @@
+from aperag.db.models import (
+    LightRAGDocChunksModel,
+    LightRAGVDBEntityModel,
+    LightRAGVDBRelationModel,
+)
+
+
+def _index_map(model):
+    return {index.name: index for index in model.__table__.indexes}
+
+
+def test_lightrag_doc_chunks_has_workspace_full_doc_index():
+    index = _index_map(LightRAGDocChunksModel)["idx_lightrag_doc_chunks_workspace_doc"]
+
+    assert [column.name for column in index.columns] == ["workspace", "full_doc_id"]
+
+
+def test_lightrag_vdb_entity_has_chunk_ids_gin_index():
+    index = _index_map(LightRAGVDBEntityModel)["idx_lightrag_vdb_entity_chunk_ids_gin"]
+
+    assert [column.name for column in index.columns] == ["chunk_ids"]
+    assert index.dialect_options["postgresql"]["using"] == "gin"
+
+
+def test_lightrag_vdb_relation_has_chunk_ids_gin_index():
+    index = _index_map(LightRAGVDBRelationModel)["idx_lightrag_vdb_relation_chunk_ids_gin"]
+
+    assert [column.name for column in index.columns] == ["chunk_ids"]
+    assert index.dialect_options["postgresql"]["using"] == "gin"


### PR DESCRIPTION
## Summary
- add the missing `(workspace, full_doc_id)` index for `lightrag_doc_chunks`
- add explicit GIN indexes for `lightrag_vdb_entity.chunk_ids` and `lightrag_vdb_relation.chunk_ids`
- cover the index declarations with focused metadata tests

## Validation
- uvx ruff check --no-fix aperag/db/models.py aperag/migration/versions/20260422002000-b7c3d4e5f6a7.py tests/unit_test/graphindex/test_lightrag_schema_indexes.py
- uvx ruff format --check aperag/db/models.py aperag/migration/versions/20260422002000-b7c3d4e5f6a7.py tests/unit_test/graphindex/test_lightrag_schema_indexes.py
- ./.venv/bin/pytest tests/unit_test/graphindex/test_lightrag_schema_indexes.py tests/unit_test/graphindex/test_lightrag_pg_chunk_overlap.py -q