### PR TITLE
Derive Alibaba rerank URL from provider base URL

### DIFF
--- a/aperag/llm/rerank/rerank_service.py
+++ b/aperag/llm/rerank/rerank_service.py
@@ -45,6 +45,9 @@ class _RankedResult:
 
 
 class RerankService:
+    ALIBABACLOUD_RERANK_PATH = "/api/v1/services/rerank/text-rerank/text-rerank"
+    ALIBABACLOUD_COMPATIBLE_MODE_PATH = "/compatible-mode/v1"
+
     def __init__(
         self,
         rerank_provider: str,
@@ -170,7 +173,9 @@ class RerankService:
                     logger.warning(f"Rerank returned {len(ranked_results)} indices for {len(texts)} documents")
 
                 # Check for invalid indices
-                invalid_rerank_indices = [ranked.index for ranked in ranked_results if ranked.index < 0 or ranked.index >= len(texts)]
+                invalid_rerank_indices = [
+                    ranked.index for ranked in ranked_results if ranked.index < 0 or ranked.index >= len(texts)
+                ]
                 if invalid_rerank_indices:
                     raise RerankError(
                         f"Invalid rerank indices: {invalid_rerank_indices}",
@@ -203,10 +208,18 @@ class RerankService:
             # Convert litellm errors to our custom types
             raise wrap_litellm_error(e, "rerank", self.rerank_provider, self.model) from e
 
+    def _resolve_alibabacloud_rerank_url(self) -> str:
+        base_url = self.api_base.rstrip("/")
+        if base_url.endswith(self.ALIBABACLOUD_RERANK_PATH):
+            return base_url
+        if base_url.endswith(self.ALIBABACLOUD_COMPATIBLE_MODE_PATH):
+            base_url = base_url[: -len(self.ALIBABACLOUD_COMPATIBLE_MODE_PATH)]
+        return f"{base_url}{self.ALIBABACLOUD_RERANK_PATH}"
+
     async def _call_alibabacloud_rerank_api(self, query: str, documents: List[str]) -> dict:
         try:
             async with httpx.AsyncClient(timeout=60.0) as client:
-                url = "https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank"
+                url = self._resolve_alibabacloud_rerank_url()
                 headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
 
                 payload = {

--- a/tests/unit_test/llm/test_rerank_service.py
+++ b/tests/unit_test/llm/test_rerank_service.py
@@ -1,3 +1,4 @@
+import httpx
 import litellm
 import pytest
 
@@ -64,3 +65,76 @@ async def test_async_rerank_accepts_score_alias(monkeypatch):
     assert len(detailed) == 1
     assert detailed[0].original_index == 0
     assert detailed[0].relevance_score == pytest.approx(0.73)
+
+
+@pytest.mark.parametrize(
+    ("configured_base_url", "expected_url"),
+    [
+        (
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank",
+        ),
+        (
+            "https://proxy.example.com/dashscope/compatible-mode/v1",
+            "https://proxy.example.com/dashscope/api/v1/services/rerank/text-rerank/text-rerank",
+        ),
+        (
+            "https://proxy.example.com/dashscope/api/v1/services/rerank/text-rerank/text-rerank",
+            "https://proxy.example.com/dashscope/api/v1/services/rerank/text-rerank/text-rerank",
+        ),
+    ],
+)
+def test_resolve_alibabacloud_rerank_url(configured_base_url, expected_url):
+    service = RerankService(
+        rerank_provider="alibabacloud",
+        rerank_model="gte-rerank-v2",
+        rerank_service_url=configured_base_url,
+        rerank_service_api_key="test-key",
+    )
+
+    assert service._resolve_alibabacloud_rerank_url() == expected_url
+
+
+@pytest.mark.asyncio
+async def test_call_alibabacloud_rerank_api_uses_resolved_base_url(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"output": {"results": [{"index": 1, "relevance_score": 0.88}]}}
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            assert timeout == 60.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers, json):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    service = RerankService(
+        rerank_provider="alibabacloud",
+        rerank_model="gte-rerank-v2",
+        rerank_service_url="https://proxy.example.com/dashscope/compatible-mode/v1",
+        rerank_service_api_key="test-key",
+    )
+
+    response = await service._call_alibabacloud_rerank_api("capital of France", ["Paris", "Tokyo"])
+
+    assert captured["url"] == "https://proxy.example.com/dashscope/api/v1/services/rerank/text-rerank/text-rerank"
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["json"]["model"] == "gte-rerank-v2"
+    assert captured["json"]["parameters"]["top_n"] == 2
+    assert response == {"results": [{"index": 1, "relevance_score": 0.88}]}


### PR DESCRIPTION
## Summary
- keep the AlibabaCloud custom rerank caller instead of forcing a switch back to LiteLLM
- derive the DashScope rerank endpoint from `provider.base_url` instead of hardcoding the public DashScope URL
- add focused tests for compatible-mode base URLs, prefixed proxy base URLs, and exact rerank endpoint passthrough

## Assessment
- current ApeRAG code still has an explicit `_call_alibabacloud_rerank_api()` path
- local LiteLLM package inspection did not show an obvious Alibaba rerank integration to safely hard-cut to
- this PR therefore keeps provider-specific behavior and only fixes the URL contract in the smallest reviewable scope

## Testing
- uv run --extra test pytest tests/unit_test/llm/test_rerank_service.py tests/unit_test/test_llm_views_rerank.py
- uv run --group dev ruff check aperag/llm/rerank/rerank_service.py tests/unit_test/llm/test_rerank_service.py tests/unit_test/test_llm_views_rerank.py
- uv run --group dev ruff format --check aperag/llm/rerank/rerank_service.py tests/unit_test/llm/test_rerank_service.py tests/unit_test/test_llm_views_rerank.py