### PR TITLE
fix(deploy): use release namespace for frontend api endpoint

### DIFF
--- a/deploy/aperag/templates/frontend-deployment.yaml
+++ b/deploy/aperag/templates/frontend-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               protocol: TCP
           env:
             - name: API_SERVER_ENDPOINT
-              value: http://aperag.default.svc.cluster.local:8000
+              value: http://aperag.{{ .Release.Namespace }}.svc.cluster.local:8000
             - name: API_SERVER_BASE_PATH
               value: /api/v1
           {{- with .Values.frontend.resources }}


### PR DESCRIPTION
## Summary
- stop hardcoding the frontend server-side API endpoint to the  namespace
- render the service FQDN using 
- keep the existing  base path unchanged

## Verification
-             - name: API_SERVER_ENDPOINT
              value: http://aperag.demo.svc.cluster.local:8000
- validated the Singapore  deployment end-to-end after applying the same fix: login now reaches  instead of redirecting back to 
