### PR TITLE
[codex] fix frontend api endpoint namespace in chart

### DIFF
--- a/deploy/aperag/templates/frontend-deployment.yaml
+++ b/deploy/aperag/templates/frontend-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               protocol: TCP
           env:
             - name: API_SERVER_ENDPOINT
-              value: http://aperag.default.svc.cluster.local:8000
+              value: http://{{ include "aperag.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8000
             - name: API_SERVER_BASE_PATH
               value: /api/v1
           {{- with .Values.frontend.resources }}


### PR DESCRIPTION
## Summary
- derive frontend `API_SERVER_ENDPOINT` from the Helm release namespace instead of hardcoding `default`
- fixes non-`default` namespace deployments where login succeeds but SSR `/workspace` cannot reach the API service and redirects back to signin
- validated with `helm template aperag deploy/aperag --namespace demo`, which now renders `http://aperag.demo.svc.cluster.local:8000`
