### PR TITLE
fix(migrations): merge Alembic heads for app startup

### DIFF
--- a/aperag/migration/versions/20260422024500-c1d2e3f4a5b6.py
+++ b/aperag/migration/versions/20260422024500-c1d2e3f4a5b6.py
@@ -1,0 +1,23 @@
+"""merge concurrent app startup migration heads
+
+Revision ID: c1d2e3f4a5b6
+Revises: f17a6b9c2d4e, b7c3d4e5f6a7
+Create Date: 2026-04-22 02:45:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, Sequence[str], None] = ("f17a6b9c2d4e", "b7c3d4e5f6a7")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- add a no-op Alembic merge revision to collapse the current dual heads
- restore `alembic upgrade head` as a valid startup step
- unblock current app startup / compose smoke failures without mixing this repo-level fix into `#1547`

## Root cause
Current code has two Alembic heads:
- `f17a6b9c2d4e`
- `b7c3d4e5f6a7`

Both descend from `a1e2f3d4c5b6`, so `scripts/start-api.sh` fails immediately at:
- `alembic -c aperag/alembic.ini upgrade head`

## Local validation
- `./.venv/bin/alembic -c aperag/alembic.ini heads` -> single head after merge revision
- `./.venv/bin/alembic -c aperag/alembic.ini upgrade head` -> passes
- local `uvicorn aperag.app:app` serves `/health` successfully after the merge revision is present

## Scope
This is a repo-level startup unblocker. It is intentionally kept separate from `#1547` so the graph SQL PR can stay frozen to its own diff scope.
