### PR TITLE
feat(vectorstore): pgvector + vector DB abstraction (M2 + M3)

### DIFF
--- a/aperag/config.py
+++ b/aperag/config.py
@@ -135,6 +135,17 @@ class Config(BaseSettings):
     qdrant_vectors_on_disk: bool = Field(True, alias="QDRANT_VECTORS_ON_DISK")
     qdrant_on_disk_payload: bool = Field(True, alias="QDRANT_ON_DISK_PAYLOAD")
 
+    # pgvector backend knobs. pgvector by default piggybacks on the main
+    # ApeRAG PostgreSQL (``database_url``) so a private-delivery deployment
+    # saves one component; set ``PGVECTOR_DATABASE_URL`` to point at a
+    # separate Postgres if vector volume outgrows the main DB.
+    pgvector_database_url: Optional[str] = Field(None, alias="PGVECTOR_DATABASE_URL")
+    pgvector_hnsw_m: int = Field(16, alias="PGVECTOR_HNSW_M")
+    pgvector_hnsw_ef_construction: int = Field(64, alias="PGVECTOR_HNSW_EF_CONSTRUCTION")
+    # ef_search is a per-query knob; QueryRequest.hints["ef_search"] wins over
+    # this setting when both are set.
+    pgvector_hnsw_ef_search: int = Field(40, alias="PGVECTOR_HNSW_EF_SEARCH")
+
     # Object store
     object_store_type: str = Field("local", alias="OBJECT_STORE_TYPE")
     object_store_local_config: Optional[LocalObjectStoreConfig] = None
@@ -337,22 +348,27 @@ SyncSessionDep = Annotated[Session, Depends(get_sync_session)]
 
 
 def build_vector_db_context(collection: str, vector_size: Optional[int] = None) -> Dict[str, Any]:
-    """Build the ctx dict that QdrantVectorStoreConnector expects.
+    """Build the ctx dict for the configured backend's connector.
 
     Centralised so both the app and the migration script produce identical
     contexts. The ``vector_size`` argument is required when multitenancy is
-    enabled — different embedding models map to different physical Qdrant
-    collections (``aperag_vectors_{size}_{distance}``), so we must know the
-    size before we route.
+    enabled — different embedding models map to different physical shards
+    (``aperag_vectors_{size}_{distance}``), so we must know the size before
+    we route.
+
+    Backend-specific knobs (``QDRANT_*``, ``PGVECTOR_*``) are merged in
+    regardless of which backend is active; connectors only read the keys
+    they understand and ignore the rest, so having both sets present at
+    once costs nothing at runtime and makes backend switching a pure env
+    flip.
     """
-    ctx = json.loads(settings.vector_db_context)
+    ctx = json.loads(settings.vector_db_context) if settings.vector_db_context else {}
     ctx["collection"] = collection
 
     if vector_size is not None:
         ctx["vector_size"] = int(vector_size)
 
-    # Merge the operator-level knobs into the ctx. Individual callers can still
-    # override by pre-setting the field in VECTOR_DB_CONTEXT JSON.
+    # Qdrant knobs
     ctx.setdefault("multitenant", settings.qdrant_multitenant)
     ctx.setdefault("quantization_enabled", settings.qdrant_quantization_enabled)
     ctx.setdefault("quantization_type", settings.qdrant_quantization_type)
@@ -363,6 +379,14 @@ def build_vector_db_context(collection: str, vector_size: Optional[int] = None) 
     ctx.setdefault("mmap_threshold_kb", settings.qdrant_mmap_threshold_kb)
     ctx.setdefault("vectors_on_disk", settings.qdrant_vectors_on_disk)
     ctx.setdefault("on_disk_payload", settings.qdrant_on_disk_payload)
+
+    # pgvector knobs. Fall back to the main ApeRAG database when
+    # PGVECTOR_DATABASE_URL is unset — that's the recommended private-delivery
+    # topology (one Postgres serves both metadata and vectors).
+    ctx.setdefault("pgvector_database_url", settings.pgvector_database_url or settings.database_url)
+    ctx.setdefault("pgvector_hnsw_m", settings.pgvector_hnsw_m)
+    ctx.setdefault("pgvector_hnsw_ef_construction", settings.pgvector_hnsw_ef_construction)
+    ctx.setdefault("pgvector_hnsw_ef_search", settings.pgvector_hnsw_ef_search)
     return ctx
 
 

--- a/aperag/context/context.py
+++ b/aperag/context/context.py
@@ -12,40 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Vector retrieval orchestration.
+
+``ContextManager`` wraps the configured ``VectorStoreConnectorAdaptor`` and
+takes care of:
+
+* Building query embeddings (if not pre-supplied by the caller).
+* Translating business-level filter intent (index_types, chat_id) into the
+  backend-neutral ``VectorFilter`` DSL.
+* Issuing the actual search.
+
+Before this module migrated to the DSL, filter construction branched on
+``self.vectordb_type == "qdrant"`` and directly imported
+``qdrant_client.models``. That made adding a second backend a per-site
+refactor. The DSL path keeps this file backend-agnostic — the concrete
+connector is the single place that knows Qdrant.
+"""
+
 from abc import ABC
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from aperag.query.query import QueryWithEmbedding
 from aperag.vectorstore.connector import VectorStoreConnectorAdaptor
+from aperag.vectorstore.filters import Eq, In, IsEmpty, VectorFilter, all_of, any_of
 
 
 class ContextManager(ABC):
     def __init__(self, collection_name, embedding_model, vectordb_type, vectordb_ctx):
         self.collection_name = collection_name
         self.embedding_model = embedding_model
+        # Retained only for diagnostics / callers that still inspect the type.
+        # Code paths in this class are backend-agnostic.
         self.vectordb_type = vectordb_type
         self.adaptor = VectorStoreConnectorAdaptor(vectordb_type, vectordb_ctx)
 
     def query(self, query, score_threshold=0.5, topk=3, vector=None, index_types=None, chat_id=None):
-        """
-        Query vectors with optional filtering by index types and chat_id
+        """Query vectors with optional filtering by index types and chat_id.
 
         Args:
-            query: Query string
-            score_threshold: Similarity threshold
-            topk: Number of results to return
-            vector: Pre-computed query vector (optional)
-            index_types: List of index types to include (e.g., ["vector", "vision", "summary"])
-                        If None, no filtering is applied
-            chat_id: Chat ID to filter chat documents (optional)
+            query: Query string.
+            score_threshold: Similarity threshold.
+            topk: Number of results to return.
+            vector: Pre-computed query vector (optional).
+            index_types: List of index types to include
+                (e.g. ``["vector", "vision", "summary"]``). If None, no index
+                filter is applied.
+            chat_id: Chat ID to include chat-scoped documents (optional).
 
         Returns:
-            List of DocumentWithScore objects
+            List of DocumentWithScore objects.
         """
         if vector is None:
             vector = self.embedding_model.embed_query(query)
 
-        # Create filter based on index_types and chat_id if provided
+        # Build backend-neutral filter; concrete connector translates.
         filter_condition = self._create_combined_filter(index_types, chat_id)
 
         query_embedding = QueryWithEmbedding(query=query, top_k=topk, embedding=vector)
@@ -62,89 +82,39 @@ class ContextManager(ABC):
         )
         return results.results
 
-    def _create_index_types_filter(self, index_types: List[str]) -> Optional[Any]:
-        """
-        Create a filter to include only specified index types
+    # ------------------------------------------------------------------ filter
+    def _create_index_types_filter(self, index_types: Optional[List[str]]) -> Optional[VectorFilter]:
+        """Include only points tagged with one of ``index_types``, OR points
+        from before we started tagging (so old data stays searchable).
 
-        Args:
-            index_types: List of index types to include (e.g., ["vector", "vision", "summary"])
-
-        Returns:
-            Filter object specific to the vector database type, or None if not supported
+        Historical note: the ``indexer`` payload field was added in a later
+        migration; older points don't carry it. We therefore OR the membership
+        test with an ``IsEmpty`` guard — otherwise introducing an index_type
+        filter silently hides pre-migration data.
         """
         if not index_types:
             return None
-
-        if self.vectordb_type == "qdrant":
-            from qdrant_client.models import FieldCondition, Filter, IsEmptyCondition, MatchAny, PayloadField
-
-            return Filter(
-                should=[
-                    FieldCondition(key="indexer", match=MatchAny(any=index_types)),
-                    # compitable with existing vectors don't have indexer field
-                    IsEmptyCondition(
-                        is_empty=PayloadField(key="indexer"),
-                    ),
-                ]
-            )
-
-        # Add support for other vector databases here
-        # elif self.vectordb_type == "pinecone":
-        #     return {"indexer": {"$in": indexer_values}}
-        # elif self.vectordb_type == "weaviate":
-        #     return {"where": {"operator": "Or", "operands": [...]}}
-
-        return None
+        return any_of(
+            In(key="indexer", values=tuple(index_types)),
+            IsEmpty(key="indexer"),
+        )
 
     def _create_combined_filter(
-        self, index_types: Optional[List[str]] = None, chat_id: Optional[str] = None
-    ) -> Optional[Any]:
+        self,
+        index_types: Optional[List[str]] = None,
+        chat_id: Optional[str] = None,
+    ) -> Optional[VectorFilter]:
+        """Combine the index-type and chat-id filters into a single tree.
+
+        Returns ``None`` when no constraints apply so the connector can
+        short-circuit. The shape is always an AND of whichever of
+        ``(index_types_filter, chat_id_eq)`` are present, matching the
+        semantics of the pre-DSL implementation.
         """
-        Create a combined filter for index types and chat_id
-
-        Args:
-            index_types: List of index types to include (e.g., ["vector", "vision", "summary"])
-            chat_id: Chat ID to filter chat documents
-
-        Returns:
-            Filter object specific to the vector database type, or None if no filters
-        """
-        if not index_types and not chat_id:
-            return None
-
-        if self.vectordb_type == "qdrant":
-            from qdrant_client.models import (
-                FieldCondition,
-                Filter,
-                IsEmptyCondition,
-                MatchAny,
-                MatchValue,
-                PayloadField,
-            )
-
-            conditions = []
-
-            # Add index_types filter
-            if index_types:
-                index_types_condition = [
-                    FieldCondition(key="indexer", match=MatchAny(any=index_types)),
-                    # Compatible with existing vectors that don't have indexer field
-                    IsEmptyCondition(is_empty=PayloadField(key="indexer")),
-                ]
-                conditions.extend(index_types_condition)
-
-            # Add chat_id filter
-            if chat_id:
-                chat_id_condition = FieldCondition(key="chat_id", match=MatchValue(value=chat_id))
-                if conditions:
-                    # If we have index_types conditions, combine them with AND logic
-                    return Filter(must=[chat_id_condition, Filter(should=conditions)])
-                else:
-                    # Only chat_id filter
-                    return Filter(must=[chat_id_condition])
-
-            # Only index_types filter
-            return Filter(should=conditions)
-
-        # Add support for other vector databases here
-        return None
+        parts = []
+        idx = self._create_index_types_filter(index_types)
+        if idx is not None:
+            parts.append(idx)
+        if chat_id:
+            parts.append(Eq(key="chat_id", value=chat_id))
+        return all_of(*parts)

--- a/aperag/context/context.py
+++ b/aperag/context/context.py
@@ -20,20 +20,20 @@ takes care of:
 * Building query embeddings (if not pre-supplied by the caller).
 * Translating business-level filter intent (index_types, chat_id) into the
   backend-neutral ``VectorFilter`` DSL.
-* Issuing the actual search.
+* Issuing the actual search via the new DTO-based ``connector.search``.
+* Adapting each backend's ``SearchHit`` back to the project-wide
+  ``DocumentWithScore`` shape that ``search_pipeline_service`` consumes.
 
-Before this module migrated to the DSL, filter construction branched on
-``self.vectordb_type == "qdrant"`` and directly imported
-``qdrant_client.models``. That made adding a second backend a per-site
-refactor. The DSL path keeps this file backend-agnostic — the concrete
-connector is the single place that knows Qdrant.
+The file imports nothing from ``qdrant_client`` / ``psycopg`` / …; that
+backend-ignorance is the whole point of the DSL + DTO layer.
 """
 
 from abc import ABC
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
-from aperag.query.query import QueryWithEmbedding
+from aperag.query.query import DocumentWithScore
 from aperag.vectorstore.connector import VectorStoreConnectorAdaptor
+from aperag.vectorstore.dto import QueryRequest, SearchHit, flatten_node_payload
 from aperag.vectorstore.filters import Eq, In, IsEmpty, VectorFilter, all_of, any_of
 
 
@@ -46,12 +46,20 @@ class ContextManager(ABC):
         self.vectordb_type = vectordb_type
         self.adaptor = VectorStoreConnectorAdaptor(vectordb_type, vectordb_ctx)
 
-    def query(self, query, score_threshold=0.5, topk=3, vector=None, index_types=None, chat_id=None):
+    def query(
+        self,
+        query,
+        score_threshold: float = 0.5,
+        topk: int = 3,
+        vector: Optional[List[float]] = None,
+        index_types: Optional[List[str]] = None,
+        chat_id: Optional[str] = None,
+    ) -> List[DocumentWithScore]:
         """Query vectors with optional filtering by index types and chat_id.
 
         Args:
             query: Query string.
-            score_threshold: Similarity threshold.
+            score_threshold: Similarity threshold (higher = stricter).
             topk: Number of results to return.
             vector: Pre-computed query vector (optional).
             index_types: List of index types to include
@@ -60,27 +68,25 @@ class ContextManager(ABC):
             chat_id: Chat ID to include chat-scoped documents (optional).
 
         Returns:
-            List of DocumentWithScore objects.
+            List of DocumentWithScore objects (project-wide neutral result
+            type; built from each backend's SearchHit).
         """
         if vector is None:
             vector = self.embedding_model.embed_query(query)
 
-        # Build backend-neutral filter; concrete connector translates.
         filter_condition = self._create_combined_filter(index_types, chat_id)
 
-        query_embedding = QueryWithEmbedding(query=query, top_k=topk, embedding=vector)
-        results = self.adaptor.connector.search(
-            query_embedding,
-            collection_name=self.collection_name,
-            query_vector=query_embedding.embedding,
+        request = QueryRequest(
+            embedding=list(vector),
+            top_k=int(topk),
+            flt=filter_condition,
+            score_threshold=float(score_threshold),
             with_vectors=True,
-            limit=query_embedding.top_k,
-            consistency="majority",
-            search_params={"hnsw_ef": 128, "exact": False},
-            score_threshold=score_threshold,
-            filter=filter_condition,
+            hints=_default_search_hints(),
         )
-        return results.results
+
+        hits: List[SearchHit] = self.adaptor.connector.search(request)
+        return [_hit_to_document(hit) for hit in hits]
 
     # ------------------------------------------------------------------ filter
     def _create_index_types_filter(self, index_types: Optional[List[str]]) -> Optional[VectorFilter]:
@@ -118,3 +124,44 @@ class ContextManager(ABC):
         if chat_id:
             parts.append(Eq(key="chat_id", value=chat_id))
         return all_of(*parts)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_search_hints() -> Dict[str, Any]:
+    """Per-backend hints that improve retrieval quality at typical settings.
+
+    Backends read only the keys they understand:
+    * Qdrant: ``hnsw_ef``, ``exact``, ``consistency``.
+    * pgvector: ``ef_search``.
+
+    Having both present is safe — unknown keys are ignored.
+    """
+    return {
+        # Qdrant
+        "hnsw_ef": 128,
+        "exact": False,
+        "consistency": "majority",
+        # pgvector
+        "ef_search": 80,
+    }
+
+
+def _hit_to_document(hit: SearchHit) -> DocumentWithScore:
+    """Flatten a backend-neutral ``SearchHit`` into the project's
+    ``DocumentWithScore`` shape.
+
+    The flattening helper in ``dto`` handles both the *new* payload
+    shape (``{text, metadata}``) and the *old* LlamaIndex one
+    (``{_node_content: json_str}``), so readers tolerate data written
+    before / after the refactor without any per-caller branching.
+    """
+    flat = flatten_node_payload(hit.payload or {})
+    return DocumentWithScore(
+        text=flat.get("text"),
+        metadata=flat.get("metadata"),
+        score=hit.score,
+    )

--- a/aperag/index/vision_index.py
+++ b/aperag/index/vision_index.py
@@ -34,6 +34,7 @@ from aperag.llm.llm_error_types import (
 )
 from aperag.schema.utils import parseCollectionConfig
 from aperag.utils.utils import generate_vector_db_collection_name
+from aperag.vectorstore.llama_index_adapter import nodes_to_vector_points
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +122,8 @@ class VisionIndexer(BaseIndexer):
                 for i, node in enumerate(nodes):
                     node.embedding = vectors[i]
 
-                ctx_ids = vector_store_adaptor.connector.store.add(nodes)
+                points = nodes_to_vector_points(nodes, tenant_id=collection.id)
+                ctx_ids = vector_store_adaptor.connector.upsert(points)
                 all_ctx_ids.extend(ctx_ids)
                 logger.info(f"Created {len(ctx_ids)} direct vision vectors for document {document_id}")
             except Exception as e:
@@ -222,7 +224,8 @@ class VisionIndexer(BaseIndexer):
                 for i, node in enumerate(text_nodes):
                     node.embedding = vectors[i]
 
-                ctx_ids = vector_store_adaptor.connector.store.add(text_nodes)
+                points = nodes_to_vector_points(text_nodes, tenant_id=collection.id)
+                ctx_ids = vector_store_adaptor.connector.upsert(points)
                 all_ctx_ids.extend(ctx_ids)
                 logger.info(f"Created {len(ctx_ids)} vision-to-text vectors for document {document_id}")
             except Exception as e:

--- a/aperag/llm/embed/embedding_utils.py
+++ b/aperag/llm/embed/embedding_utils.py
@@ -26,6 +26,7 @@ from aperag.docparser.base import Part
 from aperag.docparser.chunking import rechunk
 from aperag.utils.tokenizer import get_default_tokenizer
 from aperag.vectorstore.connector import VectorStoreConnectorAdaptor
+from aperag.vectorstore.llama_index_adapter import nodes_to_vector_points
 
 logger = logging.getLogger(__name__)
 
@@ -128,5 +129,9 @@ def create_embeddings_and_store(
         nodes[i].embedding = vectors[i]
 
     logger.info(f"processed document with {len(parts)} parts and {len(vectors)} chunks")
-    # 5. Add nodes to vector store and return results
-    return vector_store_adaptor.connector.store.add(nodes)
+    # 5. Convert LlamaIndex nodes to backend-neutral VectorPoints and upsert.
+    # ``nodes_to_vector_points`` stamps ``metadata.collection_id`` as a
+    # defense-in-depth fallback when callers forgot to — preserves the
+    # old auto-injection behavior that this function used to do inline.
+    points = nodes_to_vector_points(nodes, tenant_id=tenant_id)
+    return vector_store_adaptor.connector.upsert(points)

--- a/aperag/service/collection_service.py
+++ b/aperag/service/collection_service.py
@@ -210,6 +210,58 @@ class CollectionService:
             raise CollectionNotFoundException(collection_id)
         return await self.build_collection_response(collection)
 
+    @staticmethod
+    def _embedding_identity(cfg) -> Optional[tuple]:
+        """Return a tuple that uniquely identifies an embedding model binding.
+
+        Returns None when no embedding is configured yet (e.g. freshly created
+        collection whose user has not filled it in), so first-time assignment is
+        still allowed.
+        """
+        if cfg is None:
+            return None
+        emb = getattr(cfg, "embedding", None)
+        if emb is None:
+            return None
+        model = getattr(emb, "model", None)
+        msp = getattr(emb, "model_service_provider", None)
+        clp = getattr(emb, "custom_llm_provider", None)
+        if not model and not msp and not clp:
+            return None
+        return (model, msp, clp)
+
+    def _reject_embedding_change(self, instance: db_models.Collection, update: view_models.CollectionUpdate) -> None:
+        """Raise ValidationException if the update tries to change the embedding binding."""
+        if update.config is None:
+            return
+        try:
+            old_cfg = parseCollectionConfig(instance.config) if instance.config else None
+        except Exception:
+            old_cfg = None
+
+        old_id = self._embedding_identity(old_cfg)
+        new_id = self._embedding_identity(update.config)
+
+        if old_id is None:
+            # First-time binding is allowed.
+            return
+        if new_id is None:
+            raise ValidationException(
+                "Embedding model of an existing collection cannot be cleared. "
+                "Keep the original embedding configuration or create a new collection."
+            )
+        if old_id != new_id:
+            old_model, _old_msp, _old_clp = old_id
+            new_model, _new_msp, _new_clp = new_id
+            raise ValidationException(
+                "Embedding model of an existing collection cannot be changed "
+                f"(current: {old_model!r}, requested: {new_model!r}). "
+                "Different embedding models produce vectors of different dimensions "
+                "and/or incompatible semantics, which would leave existing vectors "
+                "orphaned and break retrieval. Please create a new collection and "
+                "re-ingest your documents if a different model is required."
+            )
+
     async def update_collection(
         self, user: str, collection_id: str, collection: view_models.CollectionUpdate
     ) -> view_models.Collection:
@@ -219,6 +271,16 @@ class CollectionService:
         instance = await self.db_ops.query_collection(user, collection_id)
         if instance is None:
             raise CollectionNotFoundException(collection_id)
+
+        # Guardrail: embedding model/provider of an existing collection MUST NOT change.
+        # Different embedding models produce vectors with different dimensions and/or
+        # incompatible semantics. Silently switching will (a) leak orphan points in the
+        # previous global collection (under multi-tenant mode), (b) break retrieval
+        # recall, (c) in legacy mode even cause Qdrant to reject writes with a
+        # dimension mismatch error. Rejecting here is the least surprising behavior;
+        # users who truly need a different model should create a new collection and
+        # re-ingest their data.
+        self._reject_embedding_change(instance, collection)
 
         # Direct call to repository method, which handles its own transaction
         config_str = dumpCollectionConfig(collection.config)

--- a/aperag/service/document_service.py
+++ b/aperag/service/document_service.py
@@ -822,35 +822,23 @@ class DocumentService:
                     collection=generate_vector_db_collection_name(collection_id=collection_id),
                     vector_size=vector_size,
                 )
-                points = vector_store_adaptor.connector.retrieve(ids=ctx_ids, with_payload=True)
+                points = vector_store_adaptor.connector.retrieve(ids=ctx_ids)
 
-                # 3. Format the response
+                # 3. Format the response using the shared payload flattener,
+                # which understands both the modern {text, metadata} shape
+                # and the legacy LlamaIndex _node_content JSON blob.
+                from aperag.vectorstore.dto import flatten_node_payload
+
                 chunks = []
                 for point in points:
-                    if point.payload:
-                        # In llama-index-0.10.13, the payload is stored in _node_content
-                        node_content = point.payload.get("_node_content")
-                        if node_content and isinstance(node_content, str):
-                            try:
-                                payload_data = json.loads(node_content)
-                                chunks.append(
-                                    Chunk(
-                                        id=point.id,
-                                        text=payload_data.get("text", ""),
-                                        metadata=payload_data.get("metadata", {}),
-                                    )
-                                )
-                            except json.JSONDecodeError:
-                                logger.warning(f"Could not parse _node_content for point {point.id}")
-                        else:
-                            # Fallback for older or different data structures
-                            chunks.append(
-                                Chunk(
-                                    id=point.id,
-                                    text=point.payload.get("text", ""),
-                                    metadata=point.payload.get("metadata", {}),
-                                )
-                            )
+                    flat = flatten_node_payload(point.payload or {})
+                    chunks.append(
+                        Chunk(
+                            id=point.id,
+                            text=flat.get("text") or "",
+                            metadata=flat.get("metadata") or {},
+                        )
+                    )
 
                 return chunks
             except Exception as e:
@@ -907,41 +895,25 @@ class DocumentService:
                     collection=generate_vector_db_collection_name(collection_id=collection_id),
                     vector_size=vector_size,
                 )
-                points = vector_store_adaptor.connector.retrieve(ids=ctx_ids, with_payload=True)
+                points = vector_store_adaptor.connector.retrieve(ids=ctx_ids)
 
-                # 3. Format the response
+                # Use the shared flattener; filter to vision-to-text
+                # entries only (this endpoint's contract).
+                from aperag.vectorstore.dto import flatten_node_payload
+
                 vision_chunks = []
                 for point in points:
-                    if point.payload:
-                        # In llama-index-0.10.13, the payload is stored in _node_content
-                        node_content = point.payload.get("_node_content")
-                        if node_content and isinstance(node_content, str):
-                            try:
-                                payload_data = json.loads(node_content)
-                                metadata = payload_data.get("metadata", {})
-                                if metadata.get("index_method") == "vision_to_text":
-                                    vision_chunks.append(
-                                        VisionChunk(
-                                            id=point.id,
-                                            asset_id=metadata.get("asset_id"),
-                                            text=payload_data.get("text", ""),
-                                            metadata=metadata,
-                                        )
-                                    )
-                            except json.JSONDecodeError:
-                                logger.warning(f"Could not parse _node_content for point {point.id}")
-                        else:
-                            # Fallback for older or different data structures
-                            metadata = point.payload.get("metadata", {})
-                            if metadata.get("index_method") == "vision_to_text":
-                                vision_chunks.append(
-                                    VisionChunk(
-                                        id=point.id,
-                                        asset_id=metadata.get("asset_id"),
-                                        text=point.payload.get("text", ""),
-                                        metadata=metadata,
-                                    )
-                                )
+                    flat = flatten_node_payload(point.payload or {})
+                    metadata = flat.get("metadata") or {}
+                    if metadata.get("index_method") == "vision_to_text":
+                        vision_chunks.append(
+                            VisionChunk(
+                                id=point.id,
+                                asset_id=metadata.get("asset_id"),
+                                text=flat.get("text") or "",
+                                metadata=metadata,
+                            )
+                        )
                 return vision_chunks
             except Exception as e:
                 logger.error(

--- a/aperag/tasks/collection.py
+++ b/aperag/tasks/collection.py
@@ -202,29 +202,43 @@ class CollectionTask:
           collection is left in place for other tenants.
         * Legacy mode: drops the whole per-tenant Qdrant collection.
 
-        We best-effort resolve ``vector_size`` so the connector routes to the
-        right global collection. If resolution fails (e.g. embedding provider
-        has been removed), we fall back to the default; the deletion becomes a
-        no-op on the wrong collection, which is safe.
+        Routing in multitenant mode is ``vector_size``-aware (each
+        ``(vector_size, distance)`` pair lives in a distinct global Qdrant
+        collection). We try to resolve ``vector_size`` from the collection's
+        embedding config first. If that fails — typically because the
+        embedding provider/model has been removed from the LLM registry, or
+        the collection row is already malformed — we fall back to
+        ``purge_all_shards``: scan every ``aperag_vectors_*`` collection and
+        delete any points tagged with this tenant. That avoids the silent
+        "route-to-wrong-shard, leave orphans" failure mode we had before.
         """
         collection = db_ops.query_collection_by_id(collection_id, ignore_deleted=False)
         vector_size = None
+        resolve_failed = False
         if collection is not None:
             try:
                 _, vector_size = get_collection_embedding_service_sync(collection)
             except Exception as e:
+                resolve_failed = True
                 logger.warning(
                     "Could not resolve vector_size for collection %s during delete; "
-                    "falling back to default routing: %s",
+                    "will purge across every global shard as a safety net: %s",
                     collection_id,
                     e,
                 )
+        else:
+            resolve_failed = True
 
         vector_db_conn = get_vector_db_connector(
             collection=generate_vector_db_collection_name(collection_id=collection_id),
             vector_size=vector_size,
         )
-        vector_db_conn.connector.delete_collection()
+        if resolve_failed:
+            # Best-effort: iterate every aperag_vectors_* collection and drop
+            # points with this tenant_id. No-op on the legacy connector path.
+            vector_db_conn.connector.delete_collection(purge_all_shards=True)
+        else:
+            vector_db_conn.connector.delete_collection()
 
         logger.debug(f"Deleted vector database data for collection {collection_id}")
 

--- a/aperag/tasks/collection.py
+++ b/aperag/tasks/collection.py
@@ -130,12 +130,16 @@ class CollectionTask:
         # Get embedding service
         _, vector_size = get_collection_embedding_service_sync(collection)
 
-        # Create main vector database collection (idempotent in multitenant mode)
+        # Create main vector database collection (idempotent in multitenant mode).
+        # The connector's __init__ calls ensure_collection() eagerly; this extra
+        # ensure_collection() is a cheap explicit for operational clarity so
+        # "did the cluster bootstrap create the physical shard?" has a clear
+        # single call in the trace.
         vector_db_conn = get_vector_db_connector(
             collection=generate_vector_db_collection_name(collection_id=collection_id),
             vector_size=vector_size,
         )
-        vector_db_conn.connector.create_collection(vector_size=vector_size)
+        vector_db_conn.connector.ensure_collection()
 
         logger.debug(f"Initialized vector databases for collection {collection_id}")
 
@@ -235,10 +239,10 @@ class CollectionTask:
         )
         if resolve_failed:
             # Best-effort: iterate every aperag_vectors_* collection and drop
-            # points with this tenant_id. No-op on the legacy connector path.
-            vector_db_conn.connector.delete_collection(purge_all_shards=True)
+            # rows with this tenant_id. No-op on the legacy connector path.
+            vector_db_conn.connector.drop_tenant(purge_all_shards=True)
         else:
-            vector_db_conn.connector.delete_collection()
+            vector_db_conn.connector.drop_tenant()
 
         logger.debug(f"Deleted vector database data for collection {collection_id}")
 

--- a/aperag/vectorstore/base.py
+++ b/aperag/vectorstore/base.py
@@ -12,129 +12,136 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backend-neutral abstract interface for vector store connectors.
+"""Abstract contract every vector-DB backend implements.
 
-The goal of this module is to pin down the **smallest** surface that any
-concrete backend (Qdrant today, pgvector / Milvus tomorrow) must implement
-to be a drop-in replacement. Any type imported here must be backend-neutral
-— in particular, **no** ``qdrant_client`` / ``psycopg`` / ``pymilvus``
-imports are ever allowed in this file.
+This is the whole contract — six methods, all of them backend-neutral in
+their signature. A concrete implementation (``QdrantVectorStoreConnector``,
+``PgvectorVectorStoreConnector``, …) is correct iff:
 
-Return types use:
+1. It accepts/returns the DTOs in ``aperag.vectorstore.dto`` only.
+2. It never lets a backend-specific type (``qdrant_client.models.*``,
+   ``psycopg.*``, ``pymilvus.*``) leak into the return values or the
+   raised exception messages that reach the caller.
+3. It is **multitenant-safe**: in multitenant mode every read/write/delete
+   enforces the tenant guard based on the connector's ``TenantRef``.
+   Passing another tenant's ids to ``delete()`` or ``retrieve()`` must be
+   a no-op or filtered-out, never a data leak.
+4. ``ensure_collection()`` is idempotent and safe to call on every
+   connector instantiation.
 
-* ``QueryResult`` (``aperag.query.query``) for searches — already
-  backend-neutral and existing callers depend on it.
-* ``VectorPoint`` (defined here) for id-lookups — minimal DTO, just
-  ``id`` + ``payload`` + optional ``vector``, enough to replace the
-  Qdrant-specific ``Record`` at document-chunk preview sites.
-
-``search(filter=...)`` accepts a ``VectorFilter`` DSL tree
-(``aperag.vectorstore.filters``). Concrete connectors translate it into
-their native filter representation. Passing raw backend filter objects
-(e.g. ``qdrant_client.models.Filter``) is still tolerated for backwards
-compatibility with the migration tooling, but new code must use the DSL.
+Everything else (index construction knobs, connection pooling, payload
+serialization quirks) is the backend's implementation detail.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Sequence
 
-from llama_index.core.embeddings import BaseEmbedding
-from llama_index.core.vector_stores.types import VectorStore
-
-from aperag.query.query import QueryResult, QueryWithEmbedding
+from aperag.vectorstore.dto import (
+    QueryRequest,
+    SearchHit,
+    TenantRef,
+    VectorPoint,
+    VectorShape,
+)
 from aperag.vectorstore.filters import VectorFilter
 
 
-@dataclass(frozen=True)
-class VectorPoint:
-    """Backend-neutral representation of a single stored point.
-
-    * ``id`` is always a string because that's the lowest common
-      denominator across backends (Qdrant allows int/uuid, pgvector uses
-      uuid, Milvus allows int/varchar). We normalize on string at the
-      connector boundary so callers don't have to branch.
-    * ``payload`` is a plain dict. LlamaIndex conventions like
-      ``_node_content`` live **inside** the dict; they are a detail of the
-      Qdrant writer, not part of this contract.
-    * ``vector`` is optional because most read-preview call sites don't
-      need it, and shipping it across the wire costs real bytes.
-    """
-
-    id: str
-    payload: Dict[str, Any]
-    vector: Optional[List[float]] = None
-
-
 class VectorStoreConnector(ABC):
-    """Abstract contract every vector-DB backend implements.
+    """Abstract contract for per-tenant vector storage.
 
-    Lifecycle assumption: ``ctx`` carries everything the connector needs
-    to locate / create its collection (URL, tenant id, vector size,
-    distance, optimization knobs). Concrete subclasses read the keys
-    they understand; unknown keys are ignored silently.
+    The constructor receives a ``ctx`` dict so we don't have to rewrite
+    every ``build_vector_db_context`` caller every time the parameter
+    list changes. Subclasses pick out the keys they need and ignore the
+    rest; unknown keys must never be a hard error.
     """
 
-    def __init__(self, ctx: Dict[str, Any], **kwargs: Any) -> None:
+    def __init__(self, ctx: Dict[str, Any], **_kwargs: Any) -> None:
         self.ctx = ctx
-        self.client = None
-        self.embedding: BaseEmbedding = None
-        self.store: VectorStore = None
 
-    # -------------------------------------------------------------- search
+    # ------------------------------------------------------------------ meta
+    @property
     @abstractmethod
-    def search(
-        self,
-        query: QueryWithEmbedding,
-        *,
-        filter: Optional[VectorFilter] = None,
-        score_threshold: float = 0.1,
-        **kwargs: Any,
-    ) -> QueryResult:
-        """Return the top-``query.top_k`` documents for the given embedding.
+    def tenant(self) -> TenantRef:
+        """Tenant this connector is bound to."""
 
-        ``filter`` accepts a ``VectorFilter`` DSL tree (preferred). For
-        backward compatibility during the transition, implementations may
-        also accept their native filter type, but new callers must use the
-        DSL.
+    @property
+    @abstractmethod
+    def shape(self) -> VectorShape:
+        """Vector shape this connector routes to."""
+
+    # ------------------------------------------------------------ collection
+    @abstractmethod
+    def ensure_collection(self) -> None:
+        """Idempotently make sure the physical storage (Qdrant collection,
+        pgvector table, …) exists for this connector's shape.
+
+        Must be safe to call from many connectors concurrently: typical
+        implementations use ``CREATE IF NOT EXISTS`` / ``collection_exists
+        ? no-op : create`` with module-level deduping caches.
         """
 
-    # -------------------------------------------------------------- writes
     @abstractmethod
-    def delete(self, **delete_kwargs: Any) -> None:
-        """Delete points by ``ids=[...]`` or other backend-specific key.
+    def drop_tenant(self, *, purge_all_shards: bool = False) -> None:
+        """Remove all of this tenant's vectors.
 
-        Must enforce the tenant guard in multitenant-aware backends so a
-        caller that accidentally passes another tenant's ids is a no-op
-        rather than a data breach.
+        * Multitenant layouts: delete all points with ``collection_id ==
+          self.tenant.id``; the shared physical collection stays alive.
+        * Legacy per-tenant layouts: drop the physical collection entirely.
+        * When ``purge_all_shards=True`` the connector should scan every
+          shape-variant shard and delete any points tagged with this
+          tenant, even if they live in a shard this connector doesn't
+          route to. This is the safety net for "the embedding provider
+          was removed, ``vector_size`` cannot be resolved any more" and
+          must never touch shards that don't belong to the multitenant
+          layout.
         """
 
-    # --------------------------------------------------------------- reads
+    # ------------------------------------------------------------ write path
+    @abstractmethod
+    def upsert(self, points: Sequence[VectorPoint]) -> List[str]:
+        """Insert (or overwrite on id conflict) the given points.
+
+        Must inject the tenant guard into each point's storage so later
+        searches / deletes can filter by it. Returns the ids written (in
+        input order). Raises on write failure — callers treat the batch
+        as atomic per-point.
+        """
+
+    @abstractmethod
+    def delete(self, ids: Sequence[str]) -> None:
+        """Delete points by id.
+
+        Defense-in-depth: the implementation must also match the tenant
+        guard so that a caller passing another tenant's ids becomes a
+        silent no-op rather than a data leak. No-op when ``ids`` is empty.
+        """
+
+    @abstractmethod
+    def delete_by_filter(self, flt: VectorFilter) -> None:
+        """Delete every point matching the filter (tenant guard AND-ed)."""
+
+    # ------------------------------------------------------------- read path
+    @abstractmethod
+    def search(self, request: QueryRequest) -> List[SearchHit]:
+        """Top-k nearest neighbors, optionally constrained by ``request.flt``.
+
+        Score semantics:
+        * Cosine: similarity in [-1, 1] — higher is better.
+        * Dot: raw dot product — higher is better.
+        * Euclid: negative L2 distance — higher is "closer to 0", better.
+
+        ``request.score_threshold`` (when set) filters on the same scale,
+        so callers don't have to branch on distance type.
+        """
+
     @abstractmethod
     def retrieve(
         self,
         ids: Sequence[str],
         *,
-        with_payload: bool = True,
         with_vectors: bool = False,
     ) -> List[VectorPoint]:
-        """Fetch points by id.
-
-        Implementations **must** apply the tenant guard in multitenant
-        mode and silently drop any points whose tenant does not match;
-        this matches ``delete()``'s behavior and prevents a curious
-        caller from reading across tenants by guessing ids.
-        """
-
-    # ---------------------------------------------------------- collection
-    @abstractmethod
-    def create_collection(self, **create_kwargs: Any) -> None:
-        """Ensure the physical collection / table exists and is correctly
-        shaped for this connector's ``ctx``. Idempotent."""
-
-    @abstractmethod
-    def delete_collection(self, **delete_kwargs: Any) -> None:
-        """Remove this tenant's data. See each backend's implementation
-        for the exact semantics (per-tenant purge vs physical drop)."""
+        """Fetch points by id. Enforces tenant guard: foreign-tenant ids
+        are silently skipped."""

--- a/aperag/vectorstore/base.py
+++ b/aperag/vectorstore/base.py
@@ -1,31 +1,140 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral abstract interface for vector store connectors.
+
+The goal of this module is to pin down the **smallest** surface that any
+concrete backend (Qdrant today, pgvector / Milvus tomorrow) must implement
+to be a drop-in replacement. Any type imported here must be backend-neutral
+— in particular, **no** ``qdrant_client`` / ``psycopg`` / ``pymilvus``
+imports are ever allowed in this file.
+
+Return types use:
+
+* ``QueryResult`` (``aperag.query.query``) for searches — already
+  backend-neutral and existing callers depend on it.
+* ``VectorPoint`` (defined here) for id-lookups — minimal DTO, just
+  ``id`` + ``payload`` + optional ``vector``, enough to replace the
+  Qdrant-specific ``Record`` at document-chunk preview sites.
+
+``search(filter=...)`` accepts a ``VectorFilter`` DSL tree
+(``aperag.vectorstore.filters``). Concrete connectors translate it into
+their native filter representation. Passing raw backend filter objects
+(e.g. ``qdrant_client.models.Filter``) is still tolerated for backwards
+compatibility with the migration tooling, but new code must use the DSL.
+"""
+
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
 
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.vector_stores.types import VectorStore
 
 from aperag.query.query import QueryResult, QueryWithEmbedding
+from aperag.vectorstore.filters import VectorFilter
+
+
+@dataclass(frozen=True)
+class VectorPoint:
+    """Backend-neutral representation of a single stored point.
+
+    * ``id`` is always a string because that's the lowest common
+      denominator across backends (Qdrant allows int/uuid, pgvector uses
+      uuid, Milvus allows int/varchar). We normalize on string at the
+      connector boundary so callers don't have to branch.
+    * ``payload`` is a plain dict. LlamaIndex conventions like
+      ``_node_content`` live **inside** the dict; they are a detail of the
+      Qdrant writer, not part of this contract.
+    * ``vector`` is optional because most read-preview call sites don't
+      need it, and shipping it across the wire costs real bytes.
+    """
+
+    id: str
+    payload: Dict[str, Any]
+    vector: Optional[List[float]] = None
 
 
 class VectorStoreConnector(ABC):
+    """Abstract contract every vector-DB backend implements.
+
+    Lifecycle assumption: ``ctx`` carries everything the connector needs
+    to locate / create its collection (URL, tenant id, vector size,
+    distance, optimization knobs). Concrete subclasses read the keys
+    they understand; unknown keys are ignored silently.
+    """
+
     def __init__(self, ctx: Dict[str, Any], **kwargs: Any) -> None:
         self.ctx = ctx
         self.client = None
         self.embedding: BaseEmbedding = None
         self.store: VectorStore = None
 
+    # -------------------------------------------------------------- search
     @abstractmethod
-    def search(self, query: QueryWithEmbedding, **kwargs) -> QueryResult:
-        pass
+    def search(
+        self,
+        query: QueryWithEmbedding,
+        *,
+        filter: Optional[VectorFilter] = None,
+        score_threshold: float = 0.1,
+        **kwargs: Any,
+    ) -> QueryResult:
+        """Return the top-``query.top_k`` documents for the given embedding.
+
+        ``filter`` accepts a ``VectorFilter`` DSL tree (preferred). For
+        backward compatibility during the transition, implementations may
+        also accept their native filter type, but new callers must use the
+        DSL.
+        """
+
+    # -------------------------------------------------------------- writes
+    @abstractmethod
+    def delete(self, **delete_kwargs: Any) -> None:
+        """Delete points by ``ids=[...]`` or other backend-specific key.
+
+        Must enforce the tenant guard in multitenant-aware backends so a
+        caller that accidentally passes another tenant's ids is a no-op
+        rather than a data breach.
+        """
+
+    # --------------------------------------------------------------- reads
+    @abstractmethod
+    def retrieve(
+        self,
+        ids: Sequence[str],
+        *,
+        with_payload: bool = True,
+        with_vectors: bool = False,
+    ) -> List[VectorPoint]:
+        """Fetch points by id.
+
+        Implementations **must** apply the tenant guard in multitenant
+        mode and silently drop any points whose tenant does not match;
+        this matches ``delete()``'s behavior and prevents a curious
+        caller from reading across tenants by guessing ids.
+        """
+
+    # ---------------------------------------------------------- collection
+    @abstractmethod
+    def create_collection(self, **create_kwargs: Any) -> None:
+        """Ensure the physical collection / table exists and is correctly
+        shaped for this connector's ``ctx``. Idempotent."""
 
     @abstractmethod
-    def delete(self, **delete_kwargs: Any):
-        pass
-
-    @abstractmethod
-    def create_collection(self, **create_kwargs: Any):
-        pass
-
-    @abstractmethod
-    def delete_collection(self, **delete_kwargs: Any):
-        pass
+    def delete_collection(self, **delete_kwargs: Any) -> None:
+        """Remove this tenant's data. See each backend's implementation
+        for the exact semantics (per-tenant purge vs physical drop)."""

--- a/aperag/vectorstore/connector.py
+++ b/aperag/vectorstore/connector.py
@@ -1,16 +1,40 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Dispatch adapter: pick the right concrete connector for the configured
+backend. Keep this file tiny and declarative — adding a new backend is
+one ``case`` branch."""
+
 from typing import Any, Dict
 
 
 class VectorStoreConnectorAdaptor:
-    def __init__(self, vector_store_type, ctx: Dict[str, Any], **kwargs: Any) -> None:
+    """Thin, lazy-import dispatch around backend-specific connectors.
+
+    The lazy imports matter: each backend pulls in a heavy SDK
+    (qdrant_client for Qdrant; pgvector + psycopg for pgvector). We load
+    only what the configured ``vector_store_type`` asks for so CI jobs
+    that only exercise one backend don't force the other backend's
+    dependency graph.
+    """
+
+    def __init__(self, vector_store_type: str, ctx: Dict[str, Any], **kwargs: Any) -> None:
         self.ctx = ctx
         self.vector_store_type = vector_store_type
 
-        # only import the connector class when it is needed
         match vector_store_type:
             case "qdrant":
                 from aperag.vectorstore.qdrant_connector import QdrantVectorStoreConnector
 
                 self.connector = QdrantVectorStoreConnector(ctx, **kwargs)
+            case "pgvector":
+                from aperag.vectorstore.pgvector_connector import PgvectorVectorStoreConnector
+
+                self.connector = PgvectorVectorStoreConnector(ctx, **kwargs)
             case _:
-                raise ValueError("unsupported vector store type:", vector_store_type)
+                raise ValueError(f"unsupported vector store type: {vector_store_type!r}")

--- a/aperag/vectorstore/dto.py
+++ b/aperag/vectorstore/dto.py
@@ -1,0 +1,286 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral data types for the vector store abstraction.
+
+What belongs here
+-----------------
+Anything that describes **what** we're storing / querying, expressed in
+terms that any serious vector DB (Qdrant, pgvector, Milvus, ...) can
+support. Concrete backends translate these DTOs into their native shapes.
+
+What does NOT belong here
+-------------------------
+* ``qdrant_client`` / ``psycopg`` / ``pymilvus`` types. If a type here
+  imports from a backend SDK, the abstraction is leaking.
+* LlamaIndex ``BaseNode`` / ``TextNode``. Those are a layer above this
+  module — callers build ``VectorPoint`` from a node if they want.
+
+Every DTO here is a frozen dataclass on purpose:
+
+* structural equality → unit tests pin exact shapes without setting up
+  fakes;
+* hashability → callers can dedupe filter trees / query requests before
+  hitting the connector;
+* immutability → no "someone mutated my query mid-flight" class of bug.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+from aperag.vectorstore.filters import VectorFilter
+
+# ---------------------------------------------------------------------------
+# identity & shape
+# ---------------------------------------------------------------------------
+
+_VALID_DISTANCES = frozenset({"cosine", "dot", "euclid"})
+
+
+@dataclass(frozen=True)
+class VectorShape:
+    """Identifies the "physical type" of a vector in a way every backend
+    cares about.
+
+    In multitenant layouts (Qdrant's ``aperag_vectors_<size>_<distance>`` or
+    pgvector's corresponding table) the ``(size, distance)`` pair decides
+    which physical shard the tenant's vectors live in. We normalize
+    ``distance`` to a lowercase canonical form so that callers passing
+    ``"Cosine"``, ``"COSINE"``, or ``"cosine"`` all map to the same shape.
+    """
+
+    size: int
+    distance: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.size, int) or self.size <= 0:
+            raise ValueError(f"VectorShape.size must be a positive int, got {self.size!r}")
+        canonical = str(self.distance).strip().lower()
+        if canonical == "euclidian":
+            canonical = "euclid"  # common typo we've seen in configs
+        if canonical not in _VALID_DISTANCES:
+            raise ValueError(f"VectorShape.distance must be one of {sorted(_VALID_DISTANCES)}, got {self.distance!r}")
+        # Frozen dataclass: bypass __setattr__ protection for normalization.
+        object.__setattr__(self, "distance", canonical)
+
+    @property
+    def canonical(self) -> str:
+        """The lowercase canonical string used to form collection names.
+
+        Kept as a property (not a raw attribute) so that future shape
+        normalisations don't silently desync physical names.
+        """
+        return self.distance
+
+
+@dataclass(frozen=True)
+class TenantRef:
+    """Per-tenant identity.
+
+    Wrapping the tenant id in a dataclass (instead of passing bare strings)
+    means every place that accepts "a tenant" is type-visible; a caller
+    that accidentally passes an ApeRAG user id instead of a Collection id
+    is a mypy error, not a silent cross-tenant bug.
+    """
+
+    id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not self.id:
+            raise ValueError(f"TenantRef.id must be a non-empty str, got {self.id!r}")
+
+
+# ---------------------------------------------------------------------------
+# point — unit of write / retrieve
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VectorPoint:
+    """A single stored vector.
+
+    * ``id`` is always ``str``. Qdrant supports UUID/int, pgvector uses
+      UUID, Milvus supports varchar/int — we normalize at the connector
+      boundary so callers don't branch on backend. All three accept UUID
+      strings as ids, which is what ApeRAG writes.
+    * ``vector`` is a plain ``list[float]`` — not numpy, not bytes. If a
+      backend hands us arrays we convert at the boundary; callers never
+      see numpy unless they specifically asked a backend for it.
+    * ``payload`` is a free-form dict. LlamaIndex conventions like
+      ``_node_content`` live **inside** the dict; they are not an
+      abstraction-level concept. Writers typically put ``{"text": ...,
+      "metadata": {...}}`` at the top level so all backends have the
+      same read shape.
+    """
+
+    id: str
+    vector: List[float]
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not self.id:
+            raise ValueError("VectorPoint.id must be a non-empty str")
+        if not isinstance(self.vector, list):
+            raise TypeError(f"VectorPoint.vector must be list[float], got {type(self.vector).__name__}")
+        if not isinstance(self.payload, dict):
+            raise TypeError(f"VectorPoint.payload must be a dict, got {type(self.payload).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# search request / result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QueryRequest:
+    """A single search intent.
+
+    ``hints`` is the backend-specific escape hatch. Anything genuinely
+    cross-backend (top_k, filter, threshold) is a first-class field;
+    anything that only makes sense to one backend (e.g. Qdrant's
+    ``hnsw_ef`` or pgvector's ``ef_search``) goes here as an opaque dict.
+    The connector reads the hints it understands and silently ignores
+    the rest — that keeps callers portable by default.
+
+    ``with_vectors=True`` asks the connector to include the stored
+    embedding in ``SearchHit.vector``. Most callers don't need it;
+    requesting it costs real bytes over the wire.
+    """
+
+    embedding: List[float]
+    top_k: int = 10
+    flt: Optional[VectorFilter] = None
+    score_threshold: Optional[float] = None
+    with_vectors: bool = False
+    hints: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.embedding, list) or not self.embedding:
+            raise ValueError("QueryRequest.embedding must be a non-empty list[float]")
+        if not isinstance(self.top_k, int) or self.top_k <= 0:
+            raise ValueError(f"QueryRequest.top_k must be a positive int, got {self.top_k!r}")
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    """A single result from ``search()``.
+
+    Intentionally minimal: id, score, payload, optional vector. Anything
+    higher-level (ApeRAG's ``DocumentWithScore`` with its
+    ``text`` / ``metadata`` split, plus LlamaIndex ``_node_content``
+    reconstruction) is the caller's responsibility, implemented via the
+    ``flatten_node_payload`` helper so neither the connector nor each
+    call site has to know about LlamaIndex internals.
+    """
+
+    id: str
+    score: float
+    payload: Dict[str, Any] = field(default_factory=dict)
+    vector: Optional[List[float]] = None
+
+
+# ---------------------------------------------------------------------------
+# payload helpers (LlamaIndex ↔ flat)
+# ---------------------------------------------------------------------------
+
+
+def flatten_node_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a Qdrant/pgvector payload into a ``{text, metadata}`` shape.
+
+    Old data (written via ``LlamaIndex.QdrantVectorStore.add(nodes)``) carries
+    a ``_node_content`` string holding the serialised node. New data
+    (written via ``VectorStoreConnector.upsert(points)``) carries ``text`` and
+    ``metadata`` at the top level. To let every reader use a single code
+    path, this helper returns a dict with guaranteed ``text`` and ``metadata``
+    keys, preferring the flat form when both are present (new data wins over
+    legacy blobs).
+
+    Returns a **new** dict; the input is never mutated. ``payload`` is
+    always returned inside the result under ``_raw`` so callers who want
+    the original (e.g. for ``_node_content.relationships`` source discovery)
+    can still reach it.
+    """
+    import json as _json
+
+    if not isinstance(payload, dict):
+        return {"text": None, "metadata": {}, "_raw": {}}
+
+    text = payload.get("text")
+    metadata = payload.get("metadata")
+
+    node_content_raw = payload.get("_node_content")
+    node_content: Optional[Dict[str, Any]] = None
+    if isinstance(node_content_raw, str):
+        try:
+            parsed = _json.loads(node_content_raw)
+            if isinstance(parsed, dict):
+                node_content = parsed
+        except _json.JSONDecodeError:
+            node_content = None
+
+    if text is None and node_content is not None:
+        t = node_content.get("text")
+        if isinstance(t, str):
+            text = t
+
+    if metadata is None and node_content is not None:
+        m = node_content.get("metadata")
+        if isinstance(m, dict):
+            metadata = m
+
+    if not isinstance(metadata, dict):
+        # Last resort: strip obvious storage-layer fields and return
+        # whatever scalar-ish fields are left. Matches the pre-refactor
+        # fallback exactly, so records written by external tools still
+        # round-trip.
+        metadata = {k: v for k, v in payload.items() if k not in ("_node_content", "text")}
+
+    # If the node_content carried relationships and metadata.source is
+    # still missing, try to derive it — this mirrors what the old
+    # qdrant_connector._convert_scored_point... did. Isolated here so no
+    # connector needs to know about it.
+    if node_content is not None and metadata.get("source") is None:
+        rels = node_content.get("relationships")
+        if isinstance(rels, dict):
+            parent = rels.get("1")
+            if isinstance(parent, dict):
+                parent_meta = parent.get("metadata")
+                if isinstance(parent_meta, dict):
+                    src = parent_meta.get("source")
+                    if isinstance(src, str) and src:
+                        import os as _os
+
+                        metadata = {**metadata, "source": _os.path.basename(src)}
+
+    return {"text": text, "metadata": dict(metadata), "_raw": dict(payload)}
+
+
+__all__ = [
+    "VectorShape",
+    "TenantRef",
+    "VectorPoint",
+    "QueryRequest",
+    "SearchHit",
+    "flatten_node_payload",
+]
+
+
+# ---------------------------------------------------------------------------
+# backward-compat exports
+# ---------------------------------------------------------------------------
+# ``aperag.vectorstore.base`` used to export ``VectorPoint`` directly. Keep
+# the import path working so callers don't have to churn all at once.
+Scalar = Union[str, int, float, bool]  # re-exported from filters for convenience

--- a/aperag/vectorstore/filters.py
+++ b/aperag/vectorstore/filters.py
@@ -1,0 +1,167 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral filter DSL for vector store queries.
+
+Why this module exists
+----------------------
+Before this layer, ``ContextManager`` in ``aperag/context/context.py``
+constructed ``qdrant_client.models.Filter`` directly. Any new vector-DB
+backend (pgvector, Milvus, …) would have had to either add its own
+``if self.vectordb_type == "…"`` branch at every filter-building site, or
+share Qdrant's Filter class — both of which are dead-ends for the
+"zero-maintenance, private delivery" target we've set for ApeRAG.
+
+This DSL is the contract between "what the business wants to filter by"
+and "how each backend expresses it". It stays tiny on purpose: every node
+here is an extra translator we have to maintain per backend.
+
+Design rules (read before adding a node)
+----------------------------------------
+* **Minimalism over expressiveness.** Add a node only when an existing
+  caller genuinely cannot express itself with the current set. Range
+  queries, geo, fuzzy match — not needed today, so not here today.
+* **Scalars only.** Values are ``str | int | float | bool``. Structured
+  matching (list-contains, dict-subset) belongs in dedicated operators
+  (not ``Eq`` with a list), and we don't have a use case for them yet.
+* **No backend leakage.** No import from ``qdrant_client``, ``psycopg``,
+  ``pymilvus`` etc. may exist in this file, ever.
+* **Structural equality.** All nodes are frozen dataclasses so they're
+  hashable and comparable, which makes tests trivially write-able and
+  caches safe.
+
+Composition helpers
+-------------------
+``all_of(...)`` / ``any_of(...)`` short-circuit 0- and 1-element cases so
+callers don't have to litter their code with length checks. Passing
+``None`` parts is explicitly allowed and filtered — this lets callers
+conditionally build filters without nested ``if`` ladders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence, Union
+
+Scalar = Union[str, int, float, bool]
+
+
+@dataclass(frozen=True)
+class Eq:
+    """Exact payload-field equality. Null / missing fields do not match."""
+
+    key: str
+    value: Scalar
+
+
+@dataclass(frozen=True)
+class In:
+    """Match any of ``values`` (i.e. SQL ``IN``). Empty values tuple matches
+    nothing; callers should guard against constructing ``In(key, [])``."""
+
+    key: str
+    values: tuple[Scalar, ...]
+
+
+def _in(key: str, values: Sequence[Scalar]) -> "In":
+    """Convenience builder accepting any sequence, normalising to tuple."""
+    return In(key=key, values=tuple(values))
+
+
+@dataclass(frozen=True)
+class IsEmpty:
+    """The payload field is either absent or stored as null. Used today for
+    backward-compatibility with pre-``indexer``-field points; every vector
+    store with payloads supports this natively."""
+
+    key: str
+
+
+@dataclass(frozen=True)
+class And:
+    """All parts must match. Empty parts tuple is a logic bug and rejected
+    at construction; use ``all_of()`` to get None-short-circuiting."""
+
+    parts: tuple["VectorFilter", ...]
+
+    def __post_init__(self) -> None:
+        if not self.parts:
+            raise ValueError("And requires at least one part; use all_of() for short-circuit")
+
+
+@dataclass(frozen=True)
+class Or:
+    """At least one part must match. Same empty-tuple rule as ``And``."""
+
+    parts: tuple["VectorFilter", ...]
+
+    def __post_init__(self) -> None:
+        if not self.parts:
+            raise ValueError("Or requires at least one part; use any_of() for short-circuit")
+
+
+@dataclass(frozen=True)
+class Not:
+    """Inverts the inner filter. Useful for exclusions (e.g. "not chat")."""
+
+    inner: "VectorFilter"
+
+
+VectorFilter = Union[Eq, In, IsEmpty, And, Or, Not]
+"""Union of all DSL node types.
+
+Exported separately so type hints elsewhere read ``VectorFilter``, not
+``Union[...]``. The concrete types are importable individually for
+pattern matching / isinstance checks in translators."""
+
+
+def all_of(*parts: Optional[VectorFilter]) -> Optional[VectorFilter]:
+    """AND the given parts, skipping ``None``s.
+
+    * ``all_of()`` or ``all_of(None, None)`` → ``None``  (no filter)
+    * ``all_of(Eq(...))`` → ``Eq(...)``                  (degenerate And)
+    * ``all_of(a, b, c)`` → ``And(parts=(a, b, c))``
+    """
+    kept = tuple(p for p in parts if p is not None)
+    if not kept:
+        return None
+    if len(kept) == 1:
+        return kept[0]
+    return And(parts=kept)
+
+
+def any_of(*parts: Optional[VectorFilter]) -> Optional[VectorFilter]:
+    """OR the given parts, skipping ``None``s. Same short-circuit rules as
+    ``all_of``."""
+    kept = tuple(p for p in parts if p is not None)
+    if not kept:
+        return None
+    if len(kept) == 1:
+        return kept[0]
+    return Or(parts=kept)
+
+
+__all__ = [
+    "Scalar",
+    "Eq",
+    "In",
+    "_in",
+    "IsEmpty",
+    "And",
+    "Or",
+    "Not",
+    "VectorFilter",
+    "all_of",
+    "any_of",
+]

--- a/aperag/vectorstore/llama_index_adapter.py
+++ b/aperag/vectorstore/llama_index_adapter.py
@@ -28,6 +28,8 @@ from llama_index.core.schema import BaseNode
 
 from aperag.vectorstore.dto import VectorPoint
 
+_FILTERABLE_METADATA_KEYS = ("indexer", "chat_id", "collection_id")
+
 
 def node_to_vector_point(node: BaseNode, *, tenant_id: str | None = None) -> VectorPoint:
     """Convert a LlamaIndex node into the backend-neutral ``VectorPoint``.
@@ -37,8 +39,16 @@ def node_to_vector_point(node: BaseNode, *, tenant_id: str | None = None) -> Vec
     * ``vector`` = ``node.embedding`` — must already be computed;
       upserting a node without an embedding is a caller bug.
     * ``payload`` carries the *flat* ``{text, metadata}`` shape that new
-      data uses. We deliberately do NOT serialize the entire node into a
-      ``_node_content`` string: that convention belonged to LlamaIndex's
+      data uses, AND mirrors query-time filterable keys
+      (``indexer``/``chat_id``/``collection_id``) at the top level so the
+      filter DSL — which still addresses flat payload keys — continues to
+      hit new writes. Without this mirror, ``Eq("indexer", ...)`` and
+      ``Eq("chat_id", ...)`` would silently miss every point written
+      through this adapter (the keys would live only under
+      ``metadata.*``). We deliberately do NOT flatten the rest of
+      ``metadata``: only keys the filter contract already knows about are
+      lifted. We also do NOT serialize the entire node into a
+      ``_node_content`` string — that convention belonged to LlamaIndex's
       QdrantVectorStore and locks readers into LlamaIndex forever. The
       reader side (``dto.flatten_node_payload``) still understands
       ``_node_content`` for backward-read of pre-migration data.
@@ -59,10 +69,16 @@ def node_to_vector_point(node: BaseNode, *, tenant_id: str | None = None) -> Vec
     except Exception:
         text = getattr(node, "text", "") or ""
 
+    payload: dict = {"text": text, "metadata": metadata}
+    for key in _FILTERABLE_METADATA_KEYS:
+        value = metadata.get(key)
+        if value is not None:
+            payload[key] = value
+
     return VectorPoint(
         id=str(node.node_id),
         vector=list(node.embedding),
-        payload={"text": text, "metadata": metadata},
+        payload=payload,
     )
 
 

--- a/aperag/vectorstore/llama_index_adapter.py
+++ b/aperag/vectorstore/llama_index_adapter.py
@@ -1,0 +1,74 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapters between LlamaIndex primitives and the backend-neutral DTOs.
+
+Keeping these helpers in one place means only this module knows about
+``BaseNode`` + ``TextNode``. Every backend stays ignorant of LlamaIndex,
+which is what lets us swap Qdrant ↔ pgvector without touching the
+indexer pipelines.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from llama_index.core.schema import BaseNode
+
+from aperag.vectorstore.dto import VectorPoint
+
+
+def node_to_vector_point(node: BaseNode, *, tenant_id: str | None = None) -> VectorPoint:
+    """Convert a LlamaIndex node into the backend-neutral ``VectorPoint``.
+
+    * ``id`` = ``node.node_id`` (LlamaIndex auto-generates UUIDs for
+      TextNode, which is what every ApeRAG writer uses).
+    * ``vector`` = ``node.embedding`` — must already be computed;
+      upserting a node without an embedding is a caller bug.
+    * ``payload`` carries the *flat* ``{text, metadata}`` shape that new
+      data uses. We deliberately do NOT serialize the entire node into a
+      ``_node_content`` string: that convention belonged to LlamaIndex's
+      QdrantVectorStore and locks readers into LlamaIndex forever. The
+      reader side (``dto.flatten_node_payload``) still understands
+      ``_node_content`` for backward-read of pre-migration data.
+    * ``metadata.collection_id`` is stamped with ``tenant_id`` when the
+      caller didn't already set it, mirroring the defensive behavior
+      ``embedding_utils`` used to rely on.
+    """
+    if node.embedding is None:
+        raise ValueError(f"node {node.node_id!r} has no embedding; compute embeddings before upsert")
+
+    metadata = dict(node.metadata or {})
+    if tenant_id and not metadata.get("collection_id"):
+        metadata["collection_id"] = tenant_id
+
+    text: str
+    try:
+        text = node.get_content()
+    except Exception:
+        text = getattr(node, "text", "") or ""
+
+    return VectorPoint(
+        id=str(node.node_id),
+        vector=list(node.embedding),
+        payload={"text": text, "metadata": metadata},
+    )
+
+
+def nodes_to_vector_points(nodes: Iterable[BaseNode], *, tenant_id: str | None = None) -> List[VectorPoint]:
+    """Bulk version of ``node_to_vector_point``. Order-preserving."""
+    return [node_to_vector_point(n, tenant_id=tenant_id) for n in nodes]
+
+
+__all__ = ["node_to_vector_point", "nodes_to_vector_points"]

--- a/aperag/vectorstore/pgvector_connector.py
+++ b/aperag/vectorstore/pgvector_connector.py
@@ -1,0 +1,720 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""pgvector backend for the vector-store abstraction.
+
+Layout
+------
+Mirrors Qdrant's multi-tenant layout: one physical table per
+``(vector_size, distance)`` pair, shared by all ApeRAG collections.
+Each row carries ``tenant_id`` (the ApeRAG collection id) and every
+read / write filters on it.
+
+Physical table name: ``aperag_vectors_{size}_{distance}``, exactly the
+same shape-identifier prefix Qdrant uses. This is deliberate — it means
+``purge_all_shards`` logic and operational runbooks translate 1:1 across
+backends.
+
+Schema (illustrative, for size=1024, distance=cosine):
+
+.. code-block:: sql
+
+    CREATE TABLE IF NOT EXISTS aperag_vectors_1024_cosine (
+        id          UUID PRIMARY KEY,
+        tenant_id   TEXT NOT NULL,
+        embedding   vector(1024) NOT NULL,
+        payload     JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS idx_<t>_tenant ON <t> (tenant_id);
+    CREATE INDEX IF NOT EXISTS idx_<t>_embedding
+        ON <t> USING hnsw (embedding vector_cosine_ops)
+        WITH (m=16, ef_construction=64);
+    CREATE INDEX IF NOT EXISTS idx_<t>_payload ON <t> USING GIN (payload);
+
+Extension requirement: ``CREATE EXTENSION IF NOT EXISTS vector;`` is
+issued on ``ensure_collection``. The connector requires CREATE/DDL
+privilege on the target database; for hosted Postgres services you may
+need to run the extension enable once as a superuser.
+
+Deployment
+----------
+By default the connector reuses ApeRAG's main Postgres (the
+``DATABASE_URL`` that already backs the ORM) — this is the
+"ApeRAG-Lite / private-delivery" topology where the full product runs on
+Postgres + Redis with no separate vector service. Set
+``PGVECTOR_DATABASE_URL`` to point at a dedicated Postgres when vector
+volume / QPS warrants isolation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+import uuid
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
+
+from aperag.vectorstore.base import VectorStoreConnector
+from aperag.vectorstore.dto import (
+    QueryRequest,
+    SearchHit,
+    TenantRef,
+    VectorPoint,
+    VectorShape,
+)
+from aperag.vectorstore.filters import And, Eq, In, IsEmpty, Not, Or, VectorFilter
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# constants
+# ---------------------------------------------------------------------------
+
+TENANT_COLUMN = "tenant_id"
+
+# Shared prefix for every multi-tenant shard; same string as Qdrant so
+# purge / audit tooling treats both backends identically.
+_MULTITENANT_PREFIX = "aperag_vectors_"
+
+# Canonical ``distance`` → (pgvector opclass, distance operator, "score =
+# 1 - distance?" flag). The boolean matters because for cosine we report
+# similarity (higher = better) while for L2 / dot we report the raw
+# pgvector distance (smaller = closer, so the connector negates it to
+# keep "higher-score-is-better" semantics uniform across backends).
+_DISTANCE_SPEC: Dict[str, Tuple[str, str, str]] = {
+    # distance -> (opclass, distance_op, score_expr_template)
+    # score_expr_template is a SQL fragment that produces the hit score
+    # from ``:q`` (query vector) and the stored ``embedding``. We use
+    # ``CAST(:q AS vector)`` rather than ``:q::vector`` because
+    # SQLAlchemy's :-placeholder parser does not always round-trip the
+    # PG ``::`` cast (seen on psycopg2: ``:q::vector`` stays literal).
+    "cosine": ("vector_cosine_ops", "<=>", "1 - (embedding <=> CAST(:q AS vector))"),
+    "euclid": ("vector_l2_ops", "<->", "-(embedding <-> CAST(:q AS vector))"),
+    "dot": ("vector_ip_ops", "<#>", "-(embedding <#> CAST(:q AS vector))"),
+}
+
+# HNSW defaults for a first-time table creation; callers can override via
+# ``ctx["pgvector_hnsw_m"]`` / ``ctx["pgvector_hnsw_ef_construction"]``.
+_DEFAULT_HNSW_M = 16
+_DEFAULT_HNSW_EF_CONSTRUCTION = 64
+
+# Table name safety: vector shapes must fit this pattern before we
+# interpolate them into DDL. Defence in depth — shape.size/distance are
+# already validated by ``VectorShape.__post_init__``, but DDL-by-string
+# concatenation is unforgiving and we want a second line of defence.
+_SAFE_TABLE_NAME_RE = re.compile(r"^aperag_vectors_\d+_(cosine|euclid|dot)$")
+
+
+# Process-level cache of (engine, table) pairs we've already ensured.
+# Mirrors the Qdrant ``_ENSURED_COLLECTIONS`` pattern and serves the same
+# purpose — avoid ``CREATE IF NOT EXISTS`` DDL on every connector init.
+_ENSURED_TABLES: set = set()
+_ENSURE_LOCK = threading.Lock()
+
+# Process-level engine pool keyed by DATABASE_URL. Two connectors with the
+# same URL share a single Engine (and therefore a single connection pool).
+_ENGINE_CACHE: Dict[str, Engine] = {}
+_ENGINE_LOCK = threading.Lock()
+
+
+def _get_or_create_engine(database_url: str) -> Engine:
+    """Return a process-shared ``sqlalchemy.Engine`` for the given URL."""
+    cached = _ENGINE_CACHE.get(database_url)
+    if cached is not None:
+        return cached
+    with _ENGINE_LOCK:
+        cached = _ENGINE_CACHE.get(database_url)
+        if cached is not None:
+            return cached
+        # ``future=True`` for SA 2.x Core API; ``pool_pre_ping`` because we
+        # share with the main ApeRAG pool semantics and outage-aware
+        # behavior is a must in shared-DB mode.
+        engine = create_engine(
+            _to_sync_pg_url(database_url),
+            pool_pre_ping=True,
+            future=True,
+        )
+        _ENGINE_CACHE[database_url] = engine
+        return engine
+
+
+def _reset_engine_cache() -> None:
+    """Clear the pgvector engine cache. Tests only."""
+    with _ENGINE_LOCK:
+        for e in list(_ENGINE_CACHE.values()):
+            try:
+                e.dispose()
+            except Exception:
+                pass
+        _ENGINE_CACHE.clear()
+    with _ENSURE_LOCK:
+        _ENSURED_TABLES.clear()
+
+
+def _to_sync_pg_url(url: str) -> str:
+    """Normalize an asyncpg-style URL to a psycopg-compatible sync URL.
+
+    ApeRAG's main config stores ``postgresql+asyncpg://...`` for the
+    async engine. pgvector queries run sync; we normalise to
+    ``postgresql://`` (driver default) so SQLAlchemy picks psycopg2 / 3
+    via whatever is installed.
+    """
+    if url.startswith("postgresql+asyncpg://"):
+        return url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    if url.startswith("postgres://"):
+        return url.replace("postgres://", "postgresql://", 1)
+    return url
+
+
+def _table_name(shape: VectorShape) -> str:
+    """Produce the physical table name for a given ``VectorShape``.
+
+    Raises if the resulting name doesn't match the safe pattern — this
+    is a hard stop before DDL string interpolation, not a Pydantic-style
+    coerce-and-warn.
+    """
+    name = f"{_MULTITENANT_PREFIX}{int(shape.size)}_{shape.canonical}"
+    if not _SAFE_TABLE_NAME_RE.match(name):
+        raise ValueError(f"refusing to build unsafe pgvector table name: {name!r}")
+    return name
+
+
+# ---------------------------------------------------------------------------
+# VectorFilter DSL -> SQL fragment + bind params
+# ---------------------------------------------------------------------------
+
+
+class _SqlFilter:
+    """Accumulator for translating a ``VectorFilter`` tree into SQL.
+
+    We generate **parameterised** SQL — never substitute values into the
+    SQL text. Parameter names are auto-generated (``f0``, ``f1``, …) so
+    nested filters never collide.
+    """
+
+    __slots__ = ("_params", "_counter")
+
+    def __init__(self) -> None:
+        self._params: Dict[str, Any] = {}
+        self._counter = 0
+
+    def translate(self, flt: Optional[VectorFilter]) -> Tuple[str, Dict[str, Any]]:
+        if flt is None:
+            return "", {}
+        sql = self._walk(flt)
+        return sql, dict(self._params)
+
+    def _bind(self, value: Any) -> str:
+        name = f"f{self._counter}"
+        self._counter += 1
+        # Values are JSONB-compared via ``->>`` which yields text. Stringify
+        # so "42" == "42"; callers that need type-strict matching should
+        # add a dedicated DSL node, not overload Eq.
+        self._params[name] = _scalar_to_text(value)
+        return f":{name}"
+
+    def _walk(self, flt: VectorFilter) -> str:
+        if isinstance(flt, Eq):
+            return f"payload->>'{_escape_json_key(flt.key)}' = {self._bind(flt.value)}"
+        if isinstance(flt, In):
+            if not flt.values:
+                raise ValueError(f"In filter on key {flt.key!r} has empty values list")
+            placeholders = ", ".join(self._bind(v) for v in flt.values)
+            return f"payload->>'{_escape_json_key(flt.key)}' IN ({placeholders})"
+        if isinstance(flt, IsEmpty):
+            # JSONB has no real "null" distinct from "missing" for our
+            # purposes; both should match IsEmpty.
+            key = _escape_json_key(flt.key)
+            return f"(NOT (payload ? '{key}') OR payload->'{key}' = 'null'::jsonb)"
+        if isinstance(flt, And):
+            parts = [self._walk(p) for p in flt.parts]
+            return "(" + " AND ".join(parts) + ")"
+        if isinstance(flt, Or):
+            parts = [self._walk(p) for p in flt.parts]
+            return "(" + " OR ".join(parts) + ")"
+        if isinstance(flt, Not):
+            return f"NOT ({self._walk(flt.inner)})"
+        raise TypeError(
+            f"Unsupported VectorFilter node: {type(flt).__name__}. "
+            "Add a branch in aperag.vectorstore.pgvector_connector._SqlFilter._walk"
+        )
+
+
+def _scalar_to_text(value: Any) -> str:
+    """Normalize a scalar value to the text we compare ``payload->>'k'`` to.
+
+    Matches Qdrant's keyword-match semantics: booleans become ``"true"``
+    / ``"false"`` (lowercase, same as JSON), numbers become their decimal
+    repr (matching how ``to_jsonb`` stringifies them via ``->>'k'``).
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return str(value)
+
+
+def _escape_json_key(key: str) -> str:
+    """Defence against a key that accidentally contains a single quote.
+
+    We interpolate keys directly (not parameter-bind them) because
+    PostgreSQL has no placeholder syntax for the JSON path accessors. The
+    DSL is only ever constructed from business code using hard-coded
+    keys (``indexer``, ``chat_id``, …), but leaving the escape as
+    belt-and-braces makes this layer safe even if a future caller wires
+    a user-supplied key in.
+    """
+    if "'" in key or "\\" in key:
+        raise ValueError(f"refusing to interpolate unsafe JSON key: {key!r}")
+    return key
+
+
+def _translate_filter(flt: Optional[VectorFilter]) -> Tuple[str, Dict[str, Any]]:
+    """Top-level translator entry. Returns a ``(where_fragment, params)``
+    tuple; ``where_fragment`` is empty when ``flt`` is ``None``."""
+    return _SqlFilter().translate(flt)
+
+
+# ---------------------------------------------------------------------------
+# vector encoding
+# ---------------------------------------------------------------------------
+
+
+def _vector_literal(vec: Sequence[float]) -> str:
+    """Encode a Python vector as pgvector's text literal form.
+
+    pgvector's SQL input is ``'[1.0, 2.0, 3.0]'::vector``; we produce the
+    quoted array part and cast at bind site. Using text is a deliberate
+    choice over registering ``pgvector.sqlalchemy.Vector``: we avoid
+    requiring callers to install the SQLAlchemy adapter pattern and keep
+    the connector usable with bare SQLAlchemy Core.
+    """
+    # Format floats with full precision (repr) so round-trip is lossless.
+    inside = ",".join(repr(float(x)) for x in vec)
+    return "[" + inside + "]"
+
+
+# ---------------------------------------------------------------------------
+# connector
+# ---------------------------------------------------------------------------
+
+
+class PgvectorVectorStoreConnector(VectorStoreConnector):
+    """pgvector implementation of ``VectorStoreConnector``."""
+
+    def __init__(self, ctx: Dict[str, Any], **kwargs: Any) -> None:
+        super().__init__(ctx, **kwargs)
+
+        # --------- tenant (always multi-tenant; legacy mode would
+        # require a dedicated table per tenant which defeats the point
+        # of sharing PG with the main ApeRAG DB).
+        tenant_raw = ctx.get("collection")
+        if not tenant_raw:
+            raise ValueError(
+                "PgvectorVectorStoreConnector requires ctx['collection'] "
+                "(the ApeRAG collection id used as tenant key); got empty/missing."
+            )
+        self._tenant = TenantRef(id=str(tenant_raw))
+
+        # --------- shape
+        self._shape = VectorShape(
+            size=int(ctx.get("vector_size", 1536)),
+            distance=str(ctx.get("distance", "Cosine")),
+        )
+
+        # --------- HNSW knobs
+        self._hnsw_m = int(ctx.get("pgvector_hnsw_m", _DEFAULT_HNSW_M))
+        self._hnsw_ef_construction = int(ctx.get("pgvector_hnsw_ef_construction", _DEFAULT_HNSW_EF_CONSTRUCTION))
+        self._hnsw_ef_search_default = int(ctx.get("pgvector_hnsw_ef_search", 40))
+
+        # --------- engine (pool-reused)
+        database_url = ctx.get("pgvector_database_url") or ctx.get("database_url")
+        if not database_url:
+            raise ValueError(
+                "PgvectorVectorStoreConnector requires ctx['pgvector_database_url'] "
+                "(or a fallback ctx['database_url']); neither was set."
+            )
+        self._database_url = database_url
+        self.engine = _get_or_create_engine(database_url)
+
+        # --------- physical table
+        self.table_name = _table_name(self._shape)
+
+        # --------- opclass + ops
+        spec = _DISTANCE_SPEC[self._shape.canonical]
+        self._opclass, self._distance_op, self._score_expr = spec
+
+        # Eagerly ensure the collection so first write / search don't
+        # race with DDL.
+        self.ensure_collection()
+
+    # -------------------------------------------------------------- metadata
+    @property
+    def tenant(self) -> TenantRef:
+        return self._tenant
+
+    @property
+    def shape(self) -> VectorShape:
+        return self._shape
+
+    @property
+    def tenant_id(self) -> str:
+        return self._tenant.id
+
+    # ============================================================= ensure
+    def ensure_collection(self) -> None:
+        """Idempotently create table + indexes for this shape.
+
+        DDL runs in its own transaction; repeat callers hit the process
+        cache before re-issuing ``CREATE IF NOT EXISTS``.
+        """
+        cache_key = (self._database_url, self.table_name)
+        if cache_key in _ENSURED_TABLES:
+            return
+
+        with _ENSURE_LOCK:
+            if cache_key in _ENSURED_TABLES:
+                return
+            logger.info("pgvector: ensuring table %s on %s", self.table_name, self._database_url)
+            try:
+                with self.engine.begin() as conn:
+                    # Extension — harmless if already installed. Requires
+                    # CREATE privilege; hosted Postgres may need a
+                    # superuser to do this once out-of-band.
+                    conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+                    conn.execute(
+                        text(
+                            f"""
+                            CREATE TABLE IF NOT EXISTS {self.table_name} (
+                                id          UUID PRIMARY KEY,
+                                tenant_id   TEXT NOT NULL,
+                                embedding   vector({self._shape.size}) NOT NULL,
+                                payload     JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+                                created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+                            )
+                            """
+                        )
+                    )
+                    conn.execute(
+                        text(
+                            f"CREATE INDEX IF NOT EXISTS idx_{self.table_name}_tenant ON {self.table_name} (tenant_id)"
+                        )
+                    )
+                    conn.execute(
+                        text(
+                            f"CREATE INDEX IF NOT EXISTS idx_{self.table_name}_embedding "
+                            f"ON {self.table_name} USING hnsw (embedding {self._opclass}) "
+                            f"WITH (m={self._hnsw_m}, ef_construction={self._hnsw_ef_construction})"
+                        )
+                    )
+                    conn.execute(
+                        text(
+                            f"CREATE INDEX IF NOT EXISTS idx_{self.table_name}_payload "
+                            f"ON {self.table_name} USING GIN (payload)"
+                        )
+                    )
+            except SQLAlchemyError:
+                # Don't poison the cache on DDL failure; next call retries.
+                logger.exception("pgvector: DDL failed for %s", self.table_name)
+                raise
+
+            _ENSURED_TABLES.add(cache_key)
+
+    def drop_tenant(self, *, purge_all_shards: bool = False) -> None:
+        """Remove all rows for this tenant.
+
+        ``purge_all_shards=True`` scans every ``aperag_vectors_*`` table in
+        the current database and deletes rows tagged with this tenant.
+        Same safety net as Qdrant: used when the embedding provider has
+        been removed and the connector's ``vector_size`` no longer matches
+        the shard that actually holds the tenant's data.
+        """
+        if purge_all_shards:
+            self._purge_tenant_from_all_tables()
+            return
+
+        with self.engine.begin() as conn:
+            try:
+                conn.execute(
+                    text(f"DELETE FROM {self.table_name} WHERE tenant_id = :t"),
+                    {"t": self._tenant.id},
+                )
+            except SQLAlchemyError as e:
+                # If the table doesn't exist yet (tenant never wrote
+                # anything) treat as already-deleted.
+                if "does not exist" in str(e).lower() or "undefinedtable" in str(e).lower():
+                    return
+                raise
+
+    def _purge_tenant_from_all_tables(self) -> None:
+        """Scan every ``aperag_vectors_*`` table and delete this tenant's rows."""
+        with self.engine.begin() as conn:
+            rows = conn.execute(
+                text("SELECT tablename FROM pg_tables WHERE schemaname = current_schema() AND tablename LIKE :pat"),
+                {"pat": f"{_MULTITENANT_PREFIX}%"},
+            ).all()
+
+            for (tbl,) in rows:
+                if not _SAFE_TABLE_NAME_RE.match(tbl):
+                    # Defense in depth — do not DELETE FROM a table name
+                    # we didn't build ourselves, even if the prefix matches.
+                    logger.warning("pgvector: skipping unsafe table name %s", tbl)
+                    continue
+                try:
+                    conn.execute(
+                        text(f"DELETE FROM {tbl} WHERE tenant_id = :t"),
+                        {"t": self._tenant.id},
+                    )
+                    logger.info("pgvector: purged tenant %s from %s", self._tenant.id, tbl)
+                except SQLAlchemyError:
+                    logger.exception("pgvector: failed to purge %s from %s", self._tenant.id, tbl)
+
+    # ============================================================= upsert
+    def upsert(self, points: Sequence[VectorPoint]) -> List[str]:
+        if not points:
+            return []
+
+        # Build bulk INSERT ... ON CONFLICT. We emit a single statement per
+        # batch; SQLAlchemy parameter binding handles the common case of
+        # "a few hundred points". For very large batches (>10k) callers
+        # should chunk upstream.
+        rows = []
+        params: Dict[str, Any] = {}
+        for idx, p in enumerate(points):
+            pid = _coerce_uuid(p.id)
+            payload = dict(p.payload)
+            # Defense-in-depth: stamp our tenant id so a later query or
+            # delete can filter by it. Identical semantics to Qdrant.
+            payload["collection_id"] = self._tenant.id
+            # Use ``CAST(:x AS T)`` rather than ``:x::T``: SQLAlchemy's
+            # :name-placeholder parser does not always play nicely with
+            # PG's ``::type`` postfix cast (seen on psycopg2, where
+            # ``:emb0::vector`` gets left as literal text). CAST is
+            # portable SQL and unambiguous.
+            rows.append(f"(:id{idx}, :tid{idx}, CAST(:emb{idx} AS vector), CAST(:payload{idx} AS jsonb))")
+            params[f"id{idx}"] = pid
+            params[f"tid{idx}"] = self._tenant.id
+            params[f"emb{idx}"] = _vector_literal(p.vector)
+            params[f"payload{idx}"] = json.dumps(payload)
+
+        sql = (
+            f"INSERT INTO {self.table_name} (id, tenant_id, embedding, payload) "
+            f"VALUES {', '.join(rows)} "
+            f"ON CONFLICT (id) DO UPDATE SET "
+            f"tenant_id = EXCLUDED.tenant_id, "
+            f"embedding = EXCLUDED.embedding, "
+            f"payload = EXCLUDED.payload"
+        )
+        with self.engine.begin() as conn:
+            conn.execute(text(sql), params)
+        return [p.id for p in points]
+
+    # ============================================================= search
+    def search(self, request: QueryRequest) -> List[SearchHit]:
+        where_parts: List[str] = ["tenant_id = :tenant"]
+        params: Dict[str, Any] = {
+            "tenant": self._tenant.id,
+            "q": _vector_literal(request.embedding),
+            "k": int(request.top_k),
+        }
+
+        flt_sql, flt_params = _translate_filter(request.flt)
+        if flt_sql:
+            where_parts.append(flt_sql)
+            params.update(flt_params)
+
+        score_expr = self._score_expr
+        if request.score_threshold is not None:
+            where_parts.append(f"({score_expr}) >= :score_threshold")
+            params["score_threshold"] = float(request.score_threshold)
+
+        select_vector = "embedding" if request.with_vectors else "NULL AS embedding"
+        sql = (
+            f"SELECT id, payload, {select_vector}, ({score_expr}) AS score "
+            f"FROM {self.table_name} "
+            f"WHERE {' AND '.join(where_parts)} "
+            f"ORDER BY embedding {self._distance_op} CAST(:q AS vector) "
+            f"LIMIT :k"
+        )
+
+        # ef_search can be set per-transaction for HNSW queries. This is a
+        # pgvector convention: higher values trade recall for latency.
+        ef_search = (
+            request.hints.get("ef_search", self._hnsw_ef_search_default)
+            if request.hints
+            else self._hnsw_ef_search_default
+        )
+
+        hits: List[SearchHit] = []
+        with self.engine.connect() as conn:
+            if ef_search:
+                conn.execute(text("SET LOCAL hnsw.ef_search = :ef"), {"ef": int(ef_search)})
+            result = conn.execute(text(sql).bindparams(**_bind_casts(params)), params)
+            for row in result:
+                vec = None
+                if request.with_vectors and row.embedding is not None:
+                    vec = _parse_vector(row.embedding)
+                hits.append(
+                    SearchHit(
+                        id=str(row.id),
+                        score=float(row.score),
+                        payload=_ensure_dict(row.payload),
+                        vector=vec,
+                    )
+                )
+        return hits
+
+    # =========================================================== retrieve
+    def retrieve(
+        self,
+        ids: Sequence[str],
+        *,
+        with_vectors: bool = False,
+    ) -> List[VectorPoint]:
+        if not ids:
+            return []
+
+        uuids = [_coerce_uuid(i) for i in ids]
+        select_vector = "embedding" if with_vectors else "NULL AS embedding"
+        sql = f"SELECT id, payload, {select_vector} FROM {self.table_name} WHERE tenant_id = :tenant AND id = ANY(:ids)"
+        with self.engine.connect() as conn:
+            rows = conn.execute(
+                text(sql),
+                {"tenant": self._tenant.id, "ids": uuids},
+            ).all()
+        out: List[VectorPoint] = []
+        for row in rows:
+            vector = _parse_vector(row.embedding) if (with_vectors and row.embedding is not None) else []
+            out.append(
+                VectorPoint(
+                    id=str(row.id),
+                    vector=vector,
+                    payload=_ensure_dict(row.payload),
+                )
+            )
+        return out
+
+    # ============================================================= delete
+    def delete(self, ids: Sequence[str]) -> None:
+        ids_list = list(ids)
+        if not ids_list:
+            return
+        uuids = [_coerce_uuid(i) for i in ids_list]
+        with self.engine.begin() as conn:
+            conn.execute(
+                text(f"DELETE FROM {self.table_name} WHERE tenant_id = :tenant AND id = ANY(:ids)"),
+                {"tenant": self._tenant.id, "ids": uuids},
+            )
+
+    def delete_by_filter(self, flt: VectorFilter) -> None:
+        flt_sql, flt_params = _translate_filter(flt)
+        if not flt_sql:
+            raise ValueError("delete_by_filter requires a non-empty filter")
+
+        params = dict(flt_params)
+        params["tenant"] = self._tenant.id
+        with self.engine.begin() as conn:
+            conn.execute(
+                text(f"DELETE FROM {self.table_name} WHERE tenant_id = :tenant AND {flt_sql}"),
+                params,
+            )
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_uuid(s: str) -> uuid.UUID:
+    """Coerce a point id to UUID; pgvector ``id`` column requires it.
+
+    LlamaIndex generates UUIDv4 strings for node ids, and ApeRAG always
+    writes those; a non-UUID input here is a bug at the caller layer and
+    should crash loudly rather than silently desync.
+    """
+    if isinstance(s, uuid.UUID):
+        return s
+    return uuid.UUID(str(s))
+
+
+def _ensure_dict(payload: Any) -> Dict[str, Any]:
+    """SQLAlchemy may return JSONB as a dict (ideal) or a string; tolerate both."""
+    if payload is None:
+        return {}
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, str):
+        try:
+            parsed = json.loads(payload)
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _parse_vector(raw: Any) -> Optional[List[float]]:
+    """Convert pgvector's on-the-wire representation to ``list[float]``.
+
+    Depending on whether ``pgvector.sqlalchemy.Vector`` is registered, the
+    column comes back as a list, a numpy array, or a ``'[1.0, 2.0]'`` str
+    literal. Normalise all three.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, list):
+        return [float(x) for x in raw]
+    # numpy array without importing numpy
+    if hasattr(raw, "tolist"):
+        try:
+            return [float(x) for x in raw.tolist()]
+        except Exception:
+            pass
+    if isinstance(raw, str):
+        text = raw.strip()
+        if text.startswith("[") and text.endswith("]"):
+            inner = text[1:-1]
+            if not inner:
+                return []
+            try:
+                return [float(x) for x in inner.split(",")]
+            except ValueError:
+                return None
+    return None
+
+
+def _bind_casts(_params: Dict[str, Any]) -> Dict[str, Any]:
+    """Stub for per-param bind customisation. Currently unused; kept as a
+    seam so future backends that need explicit ``sqlalchemy.bindparam``
+    casting can thread it through without refactoring callers."""
+    return {}
+
+
+__all__ = [
+    "PgvectorVectorStoreConnector",
+    "TENANT_COLUMN",
+    "_DISTANCE_SPEC",
+    "_translate_filter",
+    "_table_name",
+    "_vector_literal",
+    "_get_or_create_engine",
+    "_reset_engine_cache",
+    "_ENSURED_TABLES",
+]

--- a/aperag/vectorstore/qdrant_connector.py
+++ b/aperag/vectorstore/qdrant_connector.py
@@ -36,7 +36,7 @@ import json
 import logging
 import os
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import qdrant_client
 from llama_index.vector_stores.qdrant import QdrantVectorStore
@@ -45,7 +45,8 @@ from qdrant_client.http.exceptions import UnexpectedResponse
 from qdrant_client.http.models import ScoredPoint
 
 from aperag.query.query import DocumentWithScore, QueryResult, QueryWithEmbedding
-from aperag.vectorstore.base import VectorStoreConnector
+from aperag.vectorstore.base import VectorPoint, VectorStoreConnector
+from aperag.vectorstore.filters import And, Eq, In, IsEmpty, Not, Or, VectorFilter
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,92 @@ TENANT_PAYLOAD_KEY = "collection_id"
 # it's only appended to, never mutated concurrently in conflicting ways.
 _ENSURED_COLLECTIONS: set = set()
 _ENSURE_LOCK = threading.Lock()
+
+# ---------------------------------------------------------------------------
+# QdrantClient process-level pool
+# ---------------------------------------------------------------------------
+#
+# Historical behavior: every ``QdrantVectorStoreConnector(ctx)`` built a fresh
+# ``QdrantClient``, which in turn opens its own HTTP/gRPC connection pool
+# (and, in HTTPS mode, a fresh TLS handshake). In a read-heavy deployment
+# every search request went through ``search_pipeline_service._vector_search``
+# → ``ContextManager(...)`` → new connector → new client. Under load that
+# adds up to a lot of avoidable setup cost and file descriptors.
+#
+# The cache below keys by the subset of ctx that actually identifies the
+# destination endpoint. It's intentionally tiny: behavior-affecting knobs like
+# ``timeout`` are intentionally NOT part of the key, because changing them
+# between connectors should just update the existing client's setting, not
+# spawn a new connection. If callers need truly different transport configs
+# they should hit different endpoints (different ``url``).
+#
+# ``:memory:`` clients are deliberately NOT cached — they are used by tests
+# as isolated, per-test stores. Caching them would silently share state
+# across tests and is exactly the "surprise in a production config that works
+# differently in test mode" footgun we're trying to avoid.
+_CLIENT_CACHE: Dict[tuple, qdrant_client.QdrantClient] = {}
+_CLIENT_LOCK = threading.Lock()
+
+
+def _client_cache_key(
+    url: str,
+    port: int,
+    grpc_port: int,
+    prefer_grpc: bool,
+    https: bool,
+    api_key: Optional[str],
+) -> tuple:
+    return (url, int(port), int(grpc_port), bool(prefer_grpc), bool(https), api_key or "")
+
+
+def _get_or_create_client(
+    url: str,
+    port: int = 6333,
+    grpc_port: int = 6334,
+    prefer_grpc: bool = False,
+    https: bool = False,
+    api_key: Optional[str] = None,
+    timeout: int = 300,
+    **extra: Any,
+) -> qdrant_client.QdrantClient:
+    """Return a process-shared QdrantClient for the given endpoint.
+
+    Safe under threads: creation is guarded by a lock and wrapped with a
+    double-check, so concurrent first callers don't stampede into building
+    N clients for the same key. For ``:memory:`` URLs we bypass the cache
+    entirely — each caller gets its own isolated store, which is what
+    tests (and only tests) rely on.
+    """
+    if url == ":memory:":
+        return qdrant_client.QdrantClient(":memory:")
+
+    key = _client_cache_key(url, port, grpc_port, prefer_grpc, https, api_key)
+    cached = _CLIENT_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    with _CLIENT_LOCK:
+        cached = _CLIENT_CACHE.get(key)
+        if cached is not None:
+            return cached
+        client = qdrant_client.QdrantClient(
+            url=url,
+            port=port,
+            grpc_port=grpc_port,
+            prefer_grpc=prefer_grpc,
+            https=https,
+            api_key=api_key,
+            timeout=timeout,
+            **extra,
+        )
+        _CLIENT_CACHE[key] = client
+        return client
+
+
+def _reset_client_cache() -> None:
+    """Clear the process-level client cache. Intended for tests only."""
+    with _CLIENT_LOCK:
+        _CLIENT_CACHE.clear()
 
 
 def global_collection_name(vector_size: int, distance: str) -> str:
@@ -233,6 +320,84 @@ def _merge_tenant_filter(user_filter: Any, tenant_id: Optional[str]) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# VectorFilter DSL -> qdrant_client.models.Filter
+# ---------------------------------------------------------------------------
+#
+# Translation is intentionally tree-walking and stateless. Any future node
+# added to ``aperag.vectorstore.filters.VectorFilter`` must have a branch
+# here or ``_translate_filter`` raises — this is the single choke point for
+# the Qdrant backend and we want the error loud rather than silent.
+
+
+def _translate_filter(flt: Optional[VectorFilter]) -> Optional[rest.Filter]:
+    """Convert a backend-neutral DSL tree into a Qdrant ``Filter``.
+
+    Returns ``None`` for a ``None`` input so callers don't need to check.
+    Always returns a top-level ``Filter`` (never a raw ``Condition``) so
+    that ``_merge_tenant_filter`` has a consistent shape to work with.
+    """
+    if flt is None:
+        return None
+    # Leaf nodes: wrap in Filter(must=[cond]) so the caller always gets a
+    # Filter regardless of whether the leaf is top-level or nested.
+    if isinstance(flt, Eq):
+        return rest.Filter(must=[rest.FieldCondition(key=flt.key, match=rest.MatchValue(value=flt.value))])
+    if isinstance(flt, In):
+        # Empty In is a logic bug: matches nothing, which is almost never
+        # what the caller intended. Surface it loudly.
+        if not flt.values:
+            raise ValueError(f"In filter on key {flt.key!r} has empty values list")
+        return rest.Filter(must=[rest.FieldCondition(key=flt.key, match=rest.MatchAny(any=list(flt.values)))])
+    if isinstance(flt, IsEmpty):
+        return rest.Filter(must=[rest.IsEmptyCondition(is_empty=rest.PayloadField(key=flt.key))])
+
+    # Boolean combinators: translate children, then attach under the right
+    # slot. Children are already Filter objects (never Conditions), so
+    # nesting is valid Qdrant syntax: Filter(must=[Filter(...), Filter(...)])
+    # is equivalent to AND-ing the two inner Filters.
+    if isinstance(flt, And):
+        subs = [_translate_filter(p) for p in flt.parts]
+        subs = [s for s in subs if s is not None]
+        return rest.Filter(must=subs)
+    if isinstance(flt, Or):
+        subs = [_translate_filter(p) for p in flt.parts]
+        subs = [s for s in subs if s is not None]
+        return rest.Filter(should=subs)
+    if isinstance(flt, Not):
+        sub = _translate_filter(flt.inner)
+        return rest.Filter(must_not=[sub] if sub is not None else [])
+
+    raise TypeError(
+        f"Unsupported VectorFilter node: {type(flt).__name__}. "
+        "Add a branch in aperag.vectorstore.qdrant_connector._translate_filter"
+    )
+
+
+def _normalize_filter_input(flt: Any) -> Optional[rest.Filter]:
+    """Accept either a DSL node, an already-translated Qdrant Filter, or None.
+
+    * ``None`` -> ``None``
+    * DSL node (``Eq`` / ``In`` / ...) -> translated Filter
+    * ``rest.Filter`` -> passed through (used by the migration script and
+      any caller that still hand-rolls a raw Qdrant Filter; once those go
+      away this branch can be removed).
+    * anything else -> ``None`` with a warning, same as the pre-DSL behavior
+      so we don't introduce a new crash mode.
+    """
+    if flt is None:
+        return None
+    if isinstance(flt, rest.Filter):
+        return flt
+    if isinstance(flt, (Eq, In, IsEmpty, And, Or, Not)):
+        return _translate_filter(flt)
+    logger.warning(
+        "ignoring filter of unsupported type %s (expected VectorFilter DSL or qdrant Filter)",
+        type(flt).__name__,
+    )
+    return None
+
+
+# ---------------------------------------------------------------------------
 # connector
 # ---------------------------------------------------------------------------
 
@@ -273,19 +438,21 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
         else:
             self.collection_name = self.tenant_id
 
-        # Client
-        if self.url == ":memory:":
-            self.client = qdrant_client.QdrantClient(":memory:")
-        else:
-            self.client = qdrant_client.QdrantClient(
-                url=self.url,
-                port=self.port,
-                grpc_port=self.grpc_port,
-                prefer_grpc=self.prefer_grpc,
-                https=self.https,
-                timeout=self.timeout,
-                **kwargs,
-            )
+        # Client — reuse a process-level pool keyed by endpoint. Creating a
+        # new QdrantClient per connector was measurable overhead under load
+        # (one TCP/TLS setup per query for high-QPS workloads); the cache is
+        # keyed on the subset of ctx that identifies the endpoint. Tests that
+        # want isolation pass ``url=":memory:"`` which bypasses the cache.
+        self.client = _get_or_create_client(
+            url=self.url,
+            port=self.port,
+            grpc_port=self.grpc_port,
+            prefer_grpc=self.prefer_grpc,
+            https=self.https,
+            api_key=ctx.get("api_key"),
+            timeout=self.timeout,
+            **kwargs,
+        )
 
         # In multitenant mode pre-create the global collection (idempotent)
         # so llama_index's auto-creation path sees "exists" and doesn't try to
@@ -367,11 +534,24 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
             _ENSURED_COLLECTIONS.add(cache_key)
 
     # ------------------------------------------------------------------ search
-    def search(self, query: QueryWithEmbedding, **kwargs):
+    def search(
+        self,
+        query: QueryWithEmbedding,
+        *,
+        filter: Optional[Any] = None,
+        score_threshold: float = 0.1,
+        **kwargs: Any,
+    ) -> QueryResult:
+        """Top-k vector search, optionally filtered.
+
+        ``filter`` accepts either a ``VectorFilter`` DSL tree (preferred)
+        or a raw ``qdrant_client.models.Filter`` (legacy; tolerated so
+        the migration script / tests can still hand-roll filters). The
+        DSL path is documented in ``aperag.vectorstore.filters``.
+        """
         consistency = kwargs.get("consistency", "majority")
         search_params = kwargs.get("search_params")
-        score_threshold = kwargs.get("score_threshold", 0.1)
-        filter_conditions = kwargs.get("filter")
+        filter_conditions = _normalize_filter_input(filter)
 
         if self.multitenant:
             filter_conditions = _merge_tenant_filter(filter_conditions, self.tenant_id)
@@ -528,8 +708,18 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
         * Multitenant: delete all points whose payload matches ``collection_id``,
           leaving the global collection (and other tenants) untouched.
         * Legacy: drop the whole physical collection.
+
+        Pass ``purge_all_shards=True`` to scan every ``aperag_vectors_*``
+        collection and delete all points tagged with this tenant. Useful when
+        the caller cannot resolve the correct ``vector_size`` any more (e.g.
+        the collection's embedding provider has been removed from config): a
+        normal ``delete_collection`` would route to the connector's default
+        global collection and silently leave orphans behind.
         """
         if self.multitenant:
+            if kwargs.get("purge_all_shards"):
+                self._purge_tenant_from_all_global_collections()
+                return
             try:
                 self.client.delete(
                     collection_name=self.collection_name,
@@ -559,22 +749,103 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
                 return
             raise
 
+    def _purge_tenant_from_all_global_collections(self) -> None:
+        """Best-effort purge of this tenant's points across every global shard.
+
+        Called from the delete path when ``vector_size`` cannot be resolved,
+        so we cannot route to a single ``aperag_vectors_{size}_{distance}``
+        collection. We iterate all collections whose name starts with the
+        multi-tenant naming prefix and issue a filtered delete on each.
+
+        This is explicitly best-effort:
+        * failures on individual collections are logged, not re-raised — we'd
+          rather succeed on 7 of 8 shards than zero;
+        * we never touch non-``aperag_vectors_*`` collections (including
+          legacy per-tenant ``col<hex>`` names), so this is safe to run even
+          in mixed deployments during the migration window.
+        """
+        try:
+            existing = [c.name for c in self.client.get_collections().collections]
+        except Exception:
+            logger.exception("qdrant: could not list collections for orphan purge")
+            return
+        prefix = "aperag_vectors_"
+        for name in existing:
+            if not name.startswith(prefix):
+                continue
+            try:
+                self.client.delete(
+                    collection_name=name,
+                    points_selector=rest.FilterSelector(
+                        filter=rest.Filter(
+                            must=[
+                                rest.FieldCondition(
+                                    key=TENANT_PAYLOAD_KEY,
+                                    match=rest.MatchValue(value=self.tenant_id),
+                                )
+                            ]
+                        )
+                    ),
+                )
+                logger.info("qdrant: purged tenant %s from %s", self.tenant_id, name)
+            except UnexpectedResponse as e:
+                if "not found" in str(e).lower() or "doesn't exist" in str(e).lower():
+                    continue
+                logger.warning("qdrant: failed to purge %s from %s: %s", self.tenant_id, name, e)
+            except Exception:
+                logger.exception("qdrant: unexpected error purging %s from %s", self.tenant_id, name)
+
     # ---------------------------------------------------------------- retrieval
-    def retrieve(self, ids: List[str], with_payload: bool = True, with_vectors: bool = False):
+    def retrieve(
+        self,
+        ids: Sequence[str],
+        *,
+        with_payload: bool = True,
+        with_vectors: bool = False,
+    ) -> List[VectorPoint]:
         """Retrieve points by id, enforcing the tenant guard in multitenant mode.
 
         Exposed because several service-layer call sites (document preview /
         chunk listing) used to call ``self.client.retrieve`` directly against a
         per-tenant collection; after multitenancy they must both target the
         global collection *and* filter by tenant.
+
+        Returns backend-neutral ``VectorPoint`` objects so callers don't pick
+        up a dependency on ``qdrant_client.http.models.Record``.
         """
-        points = self.client.retrieve(
+        raw = self.client.retrieve(
             collection_name=self.collection_name,
             ids=list(ids),
             with_payload=with_payload,
             with_vectors=with_vectors,
         )
+
+        # Normalize Qdrant Records -> VectorPoint. We normalize id to str
+        # because that's VectorPoint's contract (see base.py); Pydantic
+        # Chunk.id downstream is Optional[str] so round-trip is stable.
+        def _vec(p: Any) -> Optional[List[float]]:
+            v = getattr(p, "vector", None)
+            if v is None:
+                return None
+            if isinstance(v, list):
+                return v
+            # qdrant can return dict[name, list] for multi-vector collections;
+            # we only ever store single-vector, so pick the first value.
+            if isinstance(v, dict) and v:
+                first = next(iter(v.values()))
+                return first if isinstance(first, list) else None
+            return None
+
+        out = [
+            VectorPoint(
+                id=str(p.id),
+                payload=dict(p.payload or {}),
+                vector=_vec(p),
+            )
+            for p in raw
+        ]
+
         if not self.multitenant:
-            return points
+            return out
         # Defense-in-depth filter: drop any points that don't match the tenant.
-        return [p for p in points if (p.payload or {}).get(TENANT_PAYLOAD_KEY) == self.tenant_id]
+        return [p for p in out if (p.payload or {}).get(TENANT_PAYLOAD_KEY) == self.tenant_id]

--- a/aperag/vectorstore/qdrant_connector.py
+++ b/aperag/vectorstore/qdrant_connector.py
@@ -12,40 +12,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Qdrant vector store connector.
+"""Qdrant backend for the vector-store abstraction.
 
 The connector supports two physical layouts, switchable per-context:
 
-* **multitenant** (default, new): one Qdrant collection per ``(vector_size, distance)``
-  pair, shared by all ApeRAG collections. Every point carries a ``collection_id``
-  payload field used for tenant isolation. A keyword index with ``is_tenant=True``
-  is registered so the Qdrant optimizer groups points by tenant on disk, which
-  keeps query cost comparable to per-tenant collections.
+* **multitenant** (default, new): one Qdrant collection per ``(vector_size,
+  distance)`` pair, shared by all ApeRAG collections. Every point carries a
+  ``collection_id`` payload field used for tenant isolation. A keyword
+  index with ``is_tenant=True`` is registered so the Qdrant optimizer
+  groups points by tenant on disk, which keeps query cost comparable to
+  per-tenant collections while cutting memory overhead by one to two
+  orders of magnitude.
 
-* **legacy** (``multitenant=false``): one Qdrant collection per ApeRAG collection
-  (the historical behavior). Preserved for rollback during the migration window.
+* **legacy** (``multitenant=false``): one Qdrant collection per ApeRAG
+  collection (the historical behavior). Preserved for rollback during the
+  migration window and for small fleets that don't yet want to re-ingest.
 
-Both layouts use the same connector API. Callers pass ``collection`` in the ctx
-(the ApeRAG collection id); the connector internally maps it to either the
-physical collection name (legacy) or the tenant filter (multitenant).
+Both layouts implement the same ``VectorStoreConnector`` interface; no
+caller needs to know which layout is active.
+
+This module is **not** allowed to leak Qdrant SDK types out of its public
+methods. All inputs/outputs are backend-neutral DTOs from
+``aperag.vectorstore.dto``. Internal helpers (``_translate_filter``,
+``_merge_tenant_filter``, …) work in ``qdrant_client.models.*`` and are
+strictly implementation detail.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 import threading
 from typing import Any, Dict, List, Optional, Sequence
 
 import qdrant_client
-from llama_index.vector_stores.qdrant import QdrantVectorStore
 from qdrant_client import models as rest
 from qdrant_client.http.exceptions import UnexpectedResponse
-from qdrant_client.http.models import ScoredPoint
 
-from aperag.query.query import DocumentWithScore, QueryResult, QueryWithEmbedding
-from aperag.vectorstore.base import VectorPoint, VectorStoreConnector
+from aperag.vectorstore.base import VectorStoreConnector
+from aperag.vectorstore.dto import (
+    QueryRequest,
+    SearchHit,
+    TenantRef,
+    VectorPoint,
+    VectorShape,
+)
 from aperag.vectorstore.filters import And, Eq, In, IsEmpty, Not, Or, VectorFilter
 
 logger = logging.getLogger(__name__)
@@ -55,123 +66,38 @@ logger = logging.getLogger(__name__)
 # constants & helpers
 # ---------------------------------------------------------------------------
 
-# Payload field used as the tenant discriminator. When is_tenant=True is set on
-# the keyword index over this field, Qdrant physically groups points with the
-# same tenant into the same segments, which restores per-tenant locality while
-# keeping only one collection.
+# Payload field used as the tenant discriminator. When is_tenant=True is set
+# on the keyword index over this field, Qdrant physically groups points with
+# the same tenant into the same segments, which restores per-tenant locality
+# while keeping only one collection.
 TENANT_PAYLOAD_KEY = "collection_id"
 
+# Prefix used for every multi-tenant shard. Kept in one place so the
+# "purge_all_shards" safety net and tests can't drift from what
+# ``global_collection_name`` writes.
+_MULTITENANT_PREFIX = "aperag_vectors_"
+
 # Module-level cache of physical collections already ensured within this
-# process. Avoids an RPC on every connector instantiation. Thread-safe because
-# it's only appended to, never mutated concurrently in conflicting ways.
+# process. Avoids an RPC on every connector instantiation. Thread-safe
+# because it's only appended to, never mutated concurrently in conflicting
+# ways.
 _ENSURED_COLLECTIONS: set = set()
 _ENSURE_LOCK = threading.Lock()
-
-# ---------------------------------------------------------------------------
-# QdrantClient process-level pool
-# ---------------------------------------------------------------------------
-#
-# Historical behavior: every ``QdrantVectorStoreConnector(ctx)`` built a fresh
-# ``QdrantClient``, which in turn opens its own HTTP/gRPC connection pool
-# (and, in HTTPS mode, a fresh TLS handshake). In a read-heavy deployment
-# every search request went through ``search_pipeline_service._vector_search``
-# → ``ContextManager(...)`` → new connector → new client. Under load that
-# adds up to a lot of avoidable setup cost and file descriptors.
-#
-# The cache below keys by the subset of ctx that actually identifies the
-# destination endpoint. It's intentionally tiny: behavior-affecting knobs like
-# ``timeout`` are intentionally NOT part of the key, because changing them
-# between connectors should just update the existing client's setting, not
-# spawn a new connection. If callers need truly different transport configs
-# they should hit different endpoints (different ``url``).
-#
-# ``:memory:`` clients are deliberately NOT cached — they are used by tests
-# as isolated, per-test stores. Caching them would silently share state
-# across tests and is exactly the "surprise in a production config that works
-# differently in test mode" footgun we're trying to avoid.
-_CLIENT_CACHE: Dict[tuple, qdrant_client.QdrantClient] = {}
-_CLIENT_LOCK = threading.Lock()
-
-
-def _client_cache_key(
-    url: str,
-    port: int,
-    grpc_port: int,
-    prefer_grpc: bool,
-    https: bool,
-    api_key: Optional[str],
-) -> tuple:
-    return (url, int(port), int(grpc_port), bool(prefer_grpc), bool(https), api_key or "")
-
-
-def _get_or_create_client(
-    url: str,
-    port: int = 6333,
-    grpc_port: int = 6334,
-    prefer_grpc: bool = False,
-    https: bool = False,
-    api_key: Optional[str] = None,
-    timeout: int = 300,
-    **extra: Any,
-) -> qdrant_client.QdrantClient:
-    """Return a process-shared QdrantClient for the given endpoint.
-
-    Safe under threads: creation is guarded by a lock and wrapped with a
-    double-check, so concurrent first callers don't stampede into building
-    N clients for the same key. For ``:memory:`` URLs we bypass the cache
-    entirely — each caller gets its own isolated store, which is what
-    tests (and only tests) rely on.
-    """
-    if url == ":memory:":
-        return qdrant_client.QdrantClient(":memory:")
-
-    key = _client_cache_key(url, port, grpc_port, prefer_grpc, https, api_key)
-    cached = _CLIENT_CACHE.get(key)
-    if cached is not None:
-        return cached
-
-    with _CLIENT_LOCK:
-        cached = _CLIENT_CACHE.get(key)
-        if cached is not None:
-            return cached
-        client = qdrant_client.QdrantClient(
-            url=url,
-            port=port,
-            grpc_port=grpc_port,
-            prefer_grpc=prefer_grpc,
-            https=https,
-            api_key=api_key,
-            timeout=timeout,
-            **extra,
-        )
-        _CLIENT_CACHE[key] = client
-        return client
-
-
-def _reset_client_cache() -> None:
-    """Clear the process-level client cache. Intended for tests only."""
-    with _CLIENT_LOCK:
-        _CLIENT_CACHE.clear()
 
 
 def global_collection_name(vector_size: int, distance: str) -> str:
     """Return the physical Qdrant collection name for a given vector shape.
 
-    We partition by ``(vector_size, distance)`` because Qdrant requires vectors
-    in a single collection to share both; different embedding models produce
-    different vector shapes and must therefore live in distinct collections.
+    We partition by ``(vector_size, distance)`` because Qdrant requires
+    vectors in a single collection to share both; different embedding
+    models produce different vector shapes and must therefore live in
+    distinct collections.
     """
-    return f"aperag_vectors_{int(vector_size)}_{distance.lower()}"
+    return f"{_MULTITENANT_PREFIX}{int(vector_size)}_{distance.lower()}"
 
 
 def _coerce_distance(distance: Any) -> rest.Distance:
-    """Normalize a distance value into ``rest.Distance``.
-
-    Qdrant's enum keys are uppercase (``COSINE``, ``EUCLID``, ``DOT``,
-    ``MANHATTAN``) but their string values are capitalized ("Cosine", …).
-    Callers in this repo use the capitalized string form (from VECTOR_DB_CONTEXT
-    JSON), so we accept both: enum lookup by member name, case-insensitive.
-    """
+    """Normalize a distance value into ``rest.Distance``."""
     if isinstance(distance, rest.Distance):
         return distance
     name = str(distance).strip().upper()
@@ -184,14 +110,7 @@ def _coerce_distance(distance: Any) -> rest.Distance:
 
 
 def _quantization_config(cfg: Dict[str, Any]) -> Optional[rest.QuantizationConfig]:
-    """Build a QuantizationConfig from ctx fields (or return None).
-
-    INT8 scalar quantization is the only mode we currently enable by default.
-    ``quantile=0.99`` clips outliers so a few extreme vector values don't blow
-    up the int8 range. ``always_ram=True`` keeps the quantized vectors in RAM
-    while the full-precision vectors are served from mmap — this is the
-    recommended high-throughput/low-RAM tradeoff.
-    """
+    """Build a QuantizationConfig from ctx fields (or return None)."""
     if not cfg.get("quantization_enabled", False):
         return None
     qtype = str(cfg.get("quantization_type", "int8")).lower()
@@ -229,12 +148,10 @@ def _ensure_tenant_payload_index(client: Any, collection_name: str) -> None:
     """Register the keyword index on the tenant payload field.
 
     Tries ``is_tenant=True`` first (Qdrant >= 1.11, enables segment-level
-    defragmentation so queries touch only per-tenant blocks). Falls back to a
-    plain keyword index on older servers (Qdrant 1.10) — multitenancy still
-    works at the filter level, just without the storage-layout optimization.
-
-    Idempotent: "already exists" responses are swallowed; the first successful
-    shape (plain or is_tenant) wins and stays.
+    defragmentation so queries touch only per-tenant blocks). Falls back
+    to a plain keyword index on older servers (Qdrant 1.10) — multitenancy
+    still works at the filter level, just without the storage-layout
+    optimization. Idempotent.
     """
     # Attempt the optimized shape first.
     try:
@@ -251,8 +168,6 @@ def _ensure_tenant_payload_index(client: Any, collection_name: str) -> None:
         msg = str(e).lower()
         if "already exists" in msg:
             return
-        # Older Qdrant: unknown field, unrecognized variant, or 400. Fall
-        # through and try without is_tenant.
         logger.warning(
             "qdrant: is_tenant keyword index rejected on %s (%s). "
             "Falling back to plain keyword index; multitenancy filter still works "
@@ -261,7 +176,7 @@ def _ensure_tenant_payload_index(client: Any, collection_name: str) -> None:
             e,
         )
 
-    # Plain fallback — just a keyword index, no is_tenant.
+    # Plain fallback.
     try:
         client.create_payload_index(
             collection_name=collection_name,
@@ -269,33 +184,33 @@ def _ensure_tenant_payload_index(client: Any, collection_name: str) -> None:
             field_schema=rest.KeywordIndexParams(type=rest.KeywordIndexType.KEYWORD),
         )
     except UnexpectedResponse as e:
-        msg = str(e).lower()
-        if "already exists" not in msg:
-            logger.warning(
-                "qdrant: plain keyword index on %s/%s also failed: %s",
-                collection_name,
-                TENANT_PAYLOAD_KEY,
-                e,
+        if "already exists" in str(e).lower():
+            return
+        logger.warning(
+            "qdrant: plain keyword index on %s/%s also failed: %s",
+            collection_name,
+            TENANT_PAYLOAD_KEY,
+            e,
+        )
+        # Last resort: legacy "field_schema as string" API for very old servers.
+        try:
+            client.create_payload_index(
+                collection_name=collection_name,
+                field_name=TENANT_PAYLOAD_KEY,
+                field_schema="keyword",
             )
-            # Fall through to legacy "field_schema as string" API as a last
-            # resort on very old clients / servers.
-            try:
-                client.create_payload_index(
-                    collection_name=collection_name,
-                    field_name=TENANT_PAYLOAD_KEY,
-                    field_schema="keyword",
-                )
-            except UnexpectedResponse as e2:
-                if "already exists" not in str(e2).lower():
-                    raise
+        except UnexpectedResponse as e2:
+            if "already exists" not in str(e2).lower():
+                raise
 
 
 def _merge_tenant_filter(user_filter: Any, tenant_id: Optional[str]) -> Any:
     """Combine an externally provided filter with the tenant guard.
 
     The tenant guard is always required in multitenant mode. If the caller
-    already passed a Filter, we wrap it under ``must`` so both constraints are
-    AND-ed. If the caller passed nothing, we just return the tenant filter.
+    already passed a ``rest.Filter``, we wrap it under ``must`` so both
+    constraints are AND-ed. If the caller passed nothing, we just return
+    the tenant filter.
     """
     if not tenant_id:
         return user_filter
@@ -303,7 +218,6 @@ def _merge_tenant_filter(user_filter: Any, tenant_id: Optional[str]) -> Any:
     if user_filter is None:
         return rest.Filter(must=[tenant_clause])
     if isinstance(user_filter, rest.Filter):
-        # If the existing filter already has a must, just append; else wrap.
         must = list(user_filter.must or [])
         must.append(tenant_clause)
         return rest.Filter(
@@ -312,49 +226,39 @@ def _merge_tenant_filter(user_filter: Any, tenant_id: Optional[str]) -> Any:
             must_not=user_filter.must_not,
             min_should=user_filter.min_should,
         )
-    # Unknown filter shape: log and pass through only the tenant guard to be
-    # safe — merging arbitrary objects into a Filter.must risks pydantic
-    # validation failures at the Qdrant API boundary.
-    logger.warning("dropping user_filter of unsupported type %s when applying tenant guard", type(user_filter).__name__)
+    # Unknown filter shape: log and pass through only the tenant guard. A
+    # stricter alternative would be to raise, but this path only runs when
+    # a pre-abstraction caller sneaks in; we prefer the guard to still
+    # protect them rather than hard-fail.
+    logger.warning(
+        "qdrant: dropping user_filter of unsupported type %s when applying tenant guard",
+        type(user_filter).__name__,
+    )
     return rest.Filter(must=[tenant_clause])
 
 
 # ---------------------------------------------------------------------------
 # VectorFilter DSL -> qdrant_client.models.Filter
 # ---------------------------------------------------------------------------
-#
-# Translation is intentionally tree-walking and stateless. Any future node
-# added to ``aperag.vectorstore.filters.VectorFilter`` must have a branch
-# here or ``_translate_filter`` raises — this is the single choke point for
-# the Qdrant backend and we want the error loud rather than silent.
 
 
 def _translate_filter(flt: Optional[VectorFilter]) -> Optional[rest.Filter]:
     """Convert a backend-neutral DSL tree into a Qdrant ``Filter``.
 
     Returns ``None`` for a ``None`` input so callers don't need to check.
-    Always returns a top-level ``Filter`` (never a raw ``Condition``) so
-    that ``_merge_tenant_filter`` has a consistent shape to work with.
+    Always returns a top-level ``Filter`` (never a raw Condition) so that
+    ``_merge_tenant_filter`` has a consistent shape to work with.
     """
     if flt is None:
         return None
-    # Leaf nodes: wrap in Filter(must=[cond]) so the caller always gets a
-    # Filter regardless of whether the leaf is top-level or nested.
     if isinstance(flt, Eq):
         return rest.Filter(must=[rest.FieldCondition(key=flt.key, match=rest.MatchValue(value=flt.value))])
     if isinstance(flt, In):
-        # Empty In is a logic bug: matches nothing, which is almost never
-        # what the caller intended. Surface it loudly.
         if not flt.values:
             raise ValueError(f"In filter on key {flt.key!r} has empty values list")
         return rest.Filter(must=[rest.FieldCondition(key=flt.key, match=rest.MatchAny(any=list(flt.values)))])
     if isinstance(flt, IsEmpty):
         return rest.Filter(must=[rest.IsEmptyCondition(is_empty=rest.PayloadField(key=flt.key))])
-
-    # Boolean combinators: translate children, then attach under the right
-    # slot. Children are already Filter objects (never Conditions), so
-    # nesting is valid Qdrant syntax: Filter(must=[Filter(...), Filter(...)])
-    # is equivalent to AND-ing the two inner Filters.
     if isinstance(flt, And):
         subs = [_translate_filter(p) for p in flt.parts]
         subs = [s for s in subs if s is not None]
@@ -374,15 +278,12 @@ def _translate_filter(flt: Optional[VectorFilter]) -> Optional[rest.Filter]:
 
 
 def _normalize_filter_input(flt: Any) -> Optional[rest.Filter]:
-    """Accept either a DSL node, an already-translated Qdrant Filter, or None.
+    """Accept a DSL node, an already-translated Qdrant Filter, or None.
 
-    * ``None`` -> ``None``
-    * DSL node (``Eq`` / ``In`` / ...) -> translated Filter
-    * ``rest.Filter`` -> passed through (used by the migration script and
-      any caller that still hand-rolls a raw Qdrant Filter; once those go
-      away this branch can be removed).
-    * anything else -> ``None`` with a warning, same as the pre-DSL behavior
-      so we don't introduce a new crash mode.
+    The ``rest.Filter`` pass-through exists solely for the migration
+    script (``scripts/migrate_qdrant_multitenancy.py``) which hand-rolls
+    native filters. Once the script stops doing that this branch can go.
+    Normal production callers go through the DSL path.
     """
     if flt is None:
         return None
@@ -391,10 +292,81 @@ def _normalize_filter_input(flt: Any) -> Optional[rest.Filter]:
     if isinstance(flt, (Eq, In, IsEmpty, And, Or, Not)):
         return _translate_filter(flt)
     logger.warning(
-        "ignoring filter of unsupported type %s (expected VectorFilter DSL or qdrant Filter)",
+        "qdrant: ignoring filter of unsupported type %s (expected VectorFilter DSL)",
         type(flt).__name__,
     )
     return None
+
+
+# ---------------------------------------------------------------------------
+# QdrantClient process-level pool
+# ---------------------------------------------------------------------------
+#
+# Historical behavior: every ``QdrantVectorStoreConnector(ctx)`` built a
+# fresh ``QdrantClient``, which opens its own HTTP/gRPC connection pool
+# (and, in HTTPS mode, a fresh TLS handshake). The cache below keys by the
+# subset of ctx that actually identifies the destination endpoint, so a
+# read-heavy request path only pays the TCP/TLS setup cost once per
+# endpoint per process.
+#
+# ``:memory:`` clients are deliberately NOT cached — they back per-test
+# isolated stores. Sharing them across tests would be a subtle bug magnet.
+_CLIENT_CACHE: Dict[tuple, qdrant_client.QdrantClient] = {}
+_CLIENT_LOCK = threading.Lock()
+
+
+def _client_cache_key(
+    url: str,
+    port: int,
+    grpc_port: int,
+    prefer_grpc: bool,
+    https: bool,
+    api_key: Optional[str],
+) -> tuple:
+    return (url, int(port), int(grpc_port), bool(prefer_grpc), bool(https), api_key or "")
+
+
+def _get_or_create_client(
+    url: str,
+    port: int = 6333,
+    grpc_port: int = 6334,
+    prefer_grpc: bool = False,
+    https: bool = False,
+    api_key: Optional[str] = None,
+    timeout: int = 300,
+    **extra: Any,
+) -> qdrant_client.QdrantClient:
+    """Return a process-shared QdrantClient for the given endpoint."""
+    if url == ":memory:":
+        return qdrant_client.QdrantClient(":memory:")
+
+    key = _client_cache_key(url, port, grpc_port, prefer_grpc, https, api_key)
+    cached = _CLIENT_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    with _CLIENT_LOCK:
+        cached = _CLIENT_CACHE.get(key)
+        if cached is not None:
+            return cached
+        client = qdrant_client.QdrantClient(
+            url=url,
+            port=port,
+            grpc_port=grpc_port,
+            prefer_grpc=prefer_grpc,
+            https=https,
+            api_key=api_key,
+            timeout=timeout,
+            **extra,
+        )
+        _CLIENT_CACHE[key] = client
+        return client
+
+
+def _reset_client_cache() -> None:
+    """Clear the process-level client cache. Tests only."""
+    with _CLIENT_LOCK:
+        _CLIENT_CACHE.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -402,47 +374,78 @@ def _normalize_filter_input(flt: Any) -> Optional[rest.Filter]:
 # ---------------------------------------------------------------------------
 
 
+def _coerce_point_id(raw: Any) -> str:
+    """Return a stable string id for a Qdrant Record / ScoredPoint.
+
+    Qdrant returns ids as int or UUID depending on how they were written;
+    we always expose string ids at the abstraction boundary.
+    """
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw
+    return str(raw)
+
+
+def _extract_vector(p: Any) -> Optional[List[float]]:
+    """Pull the ``vector`` off a Qdrant Record / ScoredPoint, normalising to
+    ``list[float]`` (single-vector collections only — multi-vector is a
+    feature we never enable)."""
+    v = getattr(p, "vector", None)
+    if v is None:
+        return None
+    if isinstance(v, list):
+        return v
+    if isinstance(v, dict) and v:
+        first = next(iter(v.values()))
+        return first if isinstance(first, list) else None
+    return None
+
+
 class QdrantVectorStoreConnector(VectorStoreConnector):
+    """Qdrant implementation of ``VectorStoreConnector``."""
+
     def __init__(self, ctx: Dict[str, Any], **kwargs: Any) -> None:
         super().__init__(ctx, **kwargs)
-        self.ctx = ctx
 
-        # Storage layout flags (defaults match the optimized / safe production layout).
+        # --------- layout flags
         self.multitenant: bool = bool(ctx.get("multitenant", True))
-        self.cfg = ctx  # retained for _quantization_config / _hnsw_config
+        self.cfg = ctx  # alias used by config builders
 
-        # Tenant = ApeRAG collection id. In multitenant mode we refuse to
-        # construct the connector without one: a silent fallback to a
-        # placeholder would write points under a shared pseudo-tenant and
-        # cross-tenant reads would match them — i.e. a silent data leak.
+        # --------- tenant
         tenant_raw = ctx.get("collection")
         if self.multitenant and not tenant_raw:
+            # Silent fallback would cross-tenant-write into a pseudo-tenant.
+            # Refuse loudly.
             raise ValueError(
                 "QdrantVectorStoreConnector(multitenant=True) requires ctx['collection'] "
                 "(the ApeRAG collection id used as tenant key); got empty/missing."
             )
-        self.tenant_id: str = str(tenant_raw) if tenant_raw else "collection"
+        tenant_id = str(tenant_raw) if tenant_raw else "collection"
+        self._tenant = TenantRef(id=tenant_id)
 
+        # --------- shape
+        self._shape = VectorShape(
+            size=int(ctx.get("vector_size", 1536)),
+            distance=str(ctx.get("distance", "Cosine")),
+        )
+
+        # --------- endpoint
         self.url = ctx.get("url", "http://localhost")
         self.port = ctx.get("port", 6333)
         self.grpc_port = ctx.get("grpc_port", 6334)
         self.prefer_grpc = ctx.get("prefer_grpc", False)
         self.https = ctx.get("https", False)
         self.timeout = ctx.get("timeout", 300)
-        self.vector_size = int(ctx.get("vector_size", 1536))
-        self.distance = ctx.get("distance", "Cosine")
 
-        # Physical Qdrant collection name.
+        # --------- physical name
         if self.multitenant:
-            self.collection_name = global_collection_name(self.vector_size, str(self.distance))
+            self.collection_name = global_collection_name(self._shape.size, self._shape.canonical)
         else:
-            self.collection_name = self.tenant_id
+            # Legacy layout: physical collection name == tenant id.
+            self.collection_name = self._tenant.id
 
-        # Client — reuse a process-level pool keyed by endpoint. Creating a
-        # new QdrantClient per connector was measurable overhead under load
-        # (one TCP/TLS setup per query for high-QPS workloads); the cache is
-        # keyed on the subset of ctx that identifies the endpoint. Tests that
-        # want isolation pass ``url=":memory:"`` which bypasses the cache.
+        # --------- client (pool-reused)
         self.client = _get_or_create_client(
             url=self.url,
             port=self.port,
@@ -454,28 +457,48 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
             **kwargs,
         )
 
-        # In multitenant mode pre-create the global collection (idempotent)
-        # so llama_index's auto-creation path sees "exists" and doesn't try to
-        # recreate it with a stripped-down config.
-        if self.multitenant:
-            self._ensure_collection()
+        # --------- ensure collection eagerly.
+        #
+        # We *could* defer this until the first write / read, but the
+        # abstraction contract says ``ensure_collection`` must be safe in
+        # __init__ and every production caller immediately follows
+        # connector construction with a write or search. The per-process
+        # ``_ENSURED_COLLECTIONS`` cache makes repeat calls effectively
+        # free.
+        self.ensure_collection()
 
-        # llama_index facade used for inserts / delete-by-id.
-        self.store = QdrantVectorStore(
-            client=self.client,
-            collection_name=self.collection_name,
-            vectors_config=rest.VectorParams(
-                size=self.vector_size,
-                distance=_coerce_distance(self.distance),
-            ),
-        )
+    # ---- convenience aliases for internal code that pre-dates tenant/shape
+    @property
+    def tenant(self) -> TenantRef:
+        return self._tenant
 
-    # ------------------------------------------------------------------ ensure
-    def _ensure_collection(self) -> None:
-        """Idempotently make sure the physical collection and tenant index exist.
+    @property
+    def shape(self) -> VectorShape:
+        return self._shape
 
-        Cached at module level so subsequent connector instantiations in the
-        same process skip the RPC.
+    @property
+    def tenant_id(self) -> str:
+        """Backward-compat alias. New code should use ``self.tenant.id``."""
+        return self._tenant.id
+
+    @property
+    def vector_size(self) -> int:
+        """Backward-compat alias for the migration script / tests."""
+        return self._shape.size
+
+    @property
+    def distance(self) -> str:
+        """Backward-compat alias returning the original (non-normalized)
+        distance string the caller supplied."""
+        return self.cfg.get("distance", "Cosine")
+
+    # ================================================================ ensure
+    def ensure_collection(self) -> None:
+        """Idempotently create the physical Qdrant collection + tenant index.
+
+        Thread-safe and process-wide-cached: calling this from many
+        connectors or many workers in the same process results in exactly
+        one RPC per (url, port, collection_name) after the first caller.
         """
         cache_key = f"{self.url}:{self.port}:{self.collection_name}"
         if cache_key in _ENSURED_COLLECTIONS:
@@ -487,24 +510,23 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
             try:
                 exists = self.client.collection_exists(self.collection_name)
             except Exception:
-                # If we cannot even check, don't cache — try again next time.
                 logger.exception("qdrant: collection_exists check failed for %s", self.collection_name)
                 raise
 
             if not exists:
                 logger.info(
-                    "qdrant: creating global collection %s (size=%d, distance=%s, multitenant=%s)",
+                    "qdrant: creating collection %s (size=%d, distance=%s, multitenant=%s)",
                     self.collection_name,
-                    self.vector_size,
-                    self.distance,
+                    self._shape.size,
+                    self._shape.canonical,
                     self.multitenant,
                 )
                 try:
                     self.client.create_collection(
                         collection_name=self.collection_name,
                         vectors_config=rest.VectorParams(
-                            size=self.vector_size,
-                            distance=_coerce_distance(self.distance),
+                            size=self._shape.size,
+                            distance=_coerce_distance(self._shape.canonical),
                             on_disk=bool(self.cfg.get("vectors_on_disk", True)),
                         ),
                         hnsw_config=_hnsw_config(self.cfg),
@@ -513,14 +535,11 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
                         on_disk_payload=bool(self.cfg.get("on_disk_payload", True)),
                     )
                 except UnexpectedResponse as e:
-                    # Another process raced us to create it; treat as success.
+                    # Another process raced us; accept the existing collection.
                     if "already exists" not in str(e).lower():
                         raise
-                    logger.info("qdrant: collection %s already exists (race)", self.collection_name)
+                    logger.info("qdrant: collection %s already exists (race ok)", self.collection_name)
 
-            # Create tenant payload index. Uses ``is_tenant=True`` when the
-            # server supports it (Qdrant >= 1.11), otherwise falls back to a
-            # plain keyword index. See _ensure_tenant_payload_index for why.
             if self.multitenant:
                 try:
                     _ensure_tenant_payload_index(self.client, self.collection_name)
@@ -533,191 +552,182 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
 
             _ENSURED_COLLECTIONS.add(cache_key)
 
-    # ------------------------------------------------------------------ search
-    def search(
-        self,
-        query: QueryWithEmbedding,
-        *,
-        filter: Optional[Any] = None,
-        score_threshold: float = 0.1,
-        **kwargs: Any,
-    ) -> QueryResult:
-        """Top-k vector search, optionally filtered.
+    # ================================================================ upsert
+    def upsert(self, points: Sequence[VectorPoint]) -> List[str]:
+        """Insert / overwrite ``points`` into the Qdrant collection.
 
-        ``filter`` accepts either a ``VectorFilter`` DSL tree (preferred)
-        or a raw ``qdrant_client.models.Filter`` (legacy; tolerated so
-        the migration script / tests can still hand-roll filters). The
-        DSL path is documented in ``aperag.vectorstore.filters``.
+        Implementation notes:
+        * Writes are native (``client.upsert`` with ``rest.PointStruct``);
+          we intentionally do **not** go through
+          ``llama_index.vector_stores.QdrantVectorStore.add(nodes)`` so
+          this backend is symmetric with pgvector / Milvus, none of which
+          have a LlamaIndex adapter wired in.
+        * In multitenant mode the tenant guard (``collection_id``) is
+          injected into every point's payload before sending. Callers that
+          already set it are respected; the tenant connector would not
+          write a conflicting value to a different tenant's id anyway.
         """
-        consistency = kwargs.get("consistency", "majority")
-        search_params = kwargs.get("search_params")
-        filter_conditions = _normalize_filter_input(filter)
+        if not points:
+            return []
 
-        if self.multitenant:
-            filter_conditions = _merge_tenant_filter(filter_conditions, self.tenant_id)
+        structs: List[rest.PointStruct] = []
+        ids: List[str] = []
+        for p in points:
+            payload = dict(p.payload)
+            if self.multitenant:
+                # Defense-in-depth: overwrite any stale ``collection_id``
+                # that doesn't match this connector's tenant. Cheaper than
+                # verifying and refusing to write; cross-tenant writes via
+                # mis-labeled points are too risky to allow.
+                payload[TENANT_PAYLOAD_KEY] = self._tenant.id
+            # Qdrant accepts ``str`` (UUID or int-as-string) or ``int`` for
+            # point id but NOT a ``uuid.UUID`` instance. Our VectorPoint.id
+            # is already ``str``; pass through unchanged.
+            structs.append(rest.PointStruct(id=p.id, vector=list(p.vector), payload=payload))
+            ids.append(p.id)
 
-        hits = self.client.query_points(
+        self.client.upsert(
             collection_name=self.collection_name,
-            query=query.embedding,
-            with_vectors=True,
-            limit=query.top_k,
+            points=structs,
+            wait=True,
+        )
+        return ids
+
+    # ================================================================ search
+    def search(self, request: QueryRequest) -> List[SearchHit]:
+        """Top-k nearest neighbors, tenant-guarded in multitenant mode."""
+        filter_obj = _normalize_filter_input(request.flt)
+        if self.multitenant:
+            filter_obj = _merge_tenant_filter(filter_obj, self._tenant.id)
+
+        # hints accepted from callers — we read only the ones Qdrant
+        # understands, ignore everything else. This keeps portability:
+        # a caller that passes pgvector-only hints won't crash when
+        # swapped onto Qdrant.
+        hints = request.hints or {}
+        search_params = None
+        hnsw_ef = hints.get("hnsw_ef")
+        exact = hints.get("exact")
+        if hnsw_ef is not None or exact is not None:
+            search_params = rest.SearchParams(
+                hnsw_ef=int(hnsw_ef) if hnsw_ef is not None else None,
+                exact=bool(exact) if exact is not None else None,
+            )
+        consistency = hints.get("consistency", "majority")
+
+        resp = self.client.query_points(
+            collection_name=self.collection_name,
+            query=list(request.embedding),
+            with_vectors=bool(request.with_vectors),
+            with_payload=True,
+            limit=request.top_k,
             consistency=consistency,
             search_params=search_params,
-            score_threshold=score_threshold,
-            query_filter=filter_conditions,
+            score_threshold=request.score_threshold,
+            query_filter=filter_obj,
         )
 
-        results = [self._convert_scored_point_to_document_with_score(point) for point in hits.points]
-        results = [result for result in results if result is not None]
-
-        return QueryResult(
-            query=query.query,
-            results=results,
-        )
-
-    def _convert_scored_point_to_document_with_score(self, scored_point: ScoredPoint) -> DocumentWithScore | None:
-        try:
-            payload = scored_point.payload or {}
-            # Points written through llama_index carry a serialized node under
-            # ``_node_content`` and usually also a top-level ``text`` field.
-            # Points written directly (migration script / ad-hoc tooling /
-            # tests) may carry only a top-level ``text``. Handle both without
-            # raising KeyError on older or externally-written rows.
-            node_content_raw = payload.get("_node_content")
-            node_content = None
-            if isinstance(node_content_raw, str):
-                try:
-                    node_content = json.loads(node_content_raw)
-                except json.JSONDecodeError:
-                    logger.warning("qdrant: _node_content is not valid JSON for point %s", scored_point.id)
-
-            text = payload.get("text")
-            if text is None and node_content is not None:
-                text = node_content.get("text")
-
-            metadata = payload.get("metadata")
-            if metadata is None and node_content is not None:
-                metadata = node_content.get("metadata")
-            if metadata is None:
-                # Fall back to the raw payload for externally-written points.
-                # We shallow-copy so callers can mutate without corrupting
-                # the connector's in-flight state.
-                metadata = {k: v for k, v in payload.items() if k not in ("_node_content", "text")}
-
-            relationships = node_content.get("relationships") if node_content is not None else None
-            if relationships is not None and isinstance(metadata, dict) and metadata.get("source") is None:
-                try:
-                    source = relationships.get("1", {}).get("metadata", {}).get("source")
-                    if source:
-                        metadata["source"] = os.path.basename(source)
-                except AttributeError:
-                    pass
-
-            return DocumentWithScore(
-                id=scored_point.id,
-                text=text,
-                metadata=metadata,
-                embedding=scored_point.vector,
-                score=scored_point.score,
+        hits: List[SearchHit] = []
+        for p in resp.points:
+            hits.append(
+                SearchHit(
+                    id=_coerce_point_id(p.id),
+                    score=float(p.score),
+                    payload=dict(p.payload or {}),
+                    vector=_extract_vector(p) if request.with_vectors else None,
+                )
             )
-        except Exception:
-            logger.exception("Failed to convert scored point to document")
-            return None
+        return hits
 
-    # ------------------------------------------------------------------ delete
-    def delete(self, **delete_kwargs: Any):
-        ids = delete_kwargs.get("ids")
+    # ============================================================== retrieve
+    def retrieve(
+        self,
+        ids: Sequence[str],
+        *,
+        with_vectors: bool = False,
+    ) -> List[VectorPoint]:
         if not ids:
-            return
+            return []
+        # Qdrant accepts both string UUIDs and int ids; pass through as-is.
+        raw = self.client.retrieve(
+            collection_name=self.collection_name,
+            ids=list(ids),
+            with_payload=True,
+            with_vectors=with_vectors,
+        )
+        out = [
+            VectorPoint(
+                id=_coerce_point_id(p.id),
+                vector=_extract_vector(p) if with_vectors else [],
+                payload=dict(p.payload or {}),
+            )
+            for p in raw
+        ]
+        # Represent "no vector requested" as empty list rather than None
+        # to keep VectorPoint.__post_init__ happy (vector must be list).
+        if not self.multitenant:
+            return out
+        return [p for p in out if p.payload.get(TENANT_PAYLOAD_KEY) == self._tenant.id]
 
+    # ================================================================ delete
+    def delete(self, ids: Sequence[str]) -> None:
+        ids_list = list(ids)
+        if not ids_list:
+            return
         if self.multitenant:
-            # Defense-in-depth: also bind the tenant_id so a rogue id list
-            # cannot cross-tenant-delete. IDs are UUIDs so collisions are
-            # already astronomically unlikely, but the guard is cheap.
+            # Defense-in-depth: bind the tenant_id so a rogue id list
+            # cannot cross-tenant-delete. UUID collisions are already
+            # astronomically unlikely, but the guard is nearly free.
             self.client.delete(
                 collection_name=self.collection_name,
                 points_selector=rest.FilterSelector(
                     filter=rest.Filter(
                         must=[
-                            rest.FieldCondition(key=TENANT_PAYLOAD_KEY, match=rest.MatchValue(value=self.tenant_id)),
-                            rest.HasIdCondition(has_id=list(ids)),
+                            rest.FieldCondition(
+                                key=TENANT_PAYLOAD_KEY,
+                                match=rest.MatchValue(value=self._tenant.id),
+                            ),
+                            rest.HasIdCondition(has_id=ids_list),
                         ]
                     )
                 ),
             )
         else:
-            self.store.delete_nodes(list(ids))
-
-    # -------------------------------------------------------- create/delete col
-    def create_collection(self, **kwargs: Any):
-        """Create / ensure the physical Qdrant collection.
-
-        * In multitenant mode this is a no-op beyond re-validating the global
-          collection. Each ApeRAG collection shares the global one — the
-          per-tenant identity lives purely in the payload.
-        * In legacy mode (``multitenant=False``) this provisions a dedicated
-          collection named after ``tenant_id``, with the same optimizations
-          (INT8 quantization, on-disk HNSW, smaller segments).
-        """
-        vector_size = int(kwargs.get("vector_size") or self.vector_size)
-        self.vector_size = vector_size
-
-        if self.multitenant:
-            # Physical collection may have been sized at connector init; if the
-            # caller passed a different vector_size, route to the correct
-            # global collection and ensure it *before* recreating the
-            # llama_index store. This ordering matters: QdrantVectorStore's
-            # __init__ caches `_collection_initialized` from a
-            # `collection_exists` probe, so if we build it first and the
-            # collection doesn't exist yet, the first add() call will try to
-            # create it again with llama_index's minimal config (no
-            # quantization / HNSW on_disk / segment count), which would then
-            # lose to "already exists" but generate a spurious RPC.
-            self.collection_name = global_collection_name(vector_size, str(self.distance))
-            self._ensure_collection()
-            self.store = QdrantVectorStore(
-                client=self.client,
+            self.client.delete(
                 collection_name=self.collection_name,
-                vectors_config=rest.VectorParams(
-                    size=self.vector_size,
-                    distance=_coerce_distance(self.distance),
-                ),
+                points_selector=rest.PointIdsList(points=ids_list),
             )
-            return
 
-        # Legacy path: one Qdrant collection per tenant, but still with the
-        # optimized defaults so new legacy collections don't regress.
-        if self.client.collection_exists(self.collection_name):
-            return
-        self.client.create_collection(
-            collection_name=self.collection_name,
-            vectors_config=rest.VectorParams(
-                size=vector_size,
-                distance=_coerce_distance(self.distance),
-                on_disk=bool(self.cfg.get("vectors_on_disk", True)),
-            ),
-            hnsw_config=_hnsw_config(self.cfg),
-            optimizers_config=_optimizers_config(self.cfg),
-            quantization_config=_quantization_config(self.cfg),
-            on_disk_payload=bool(self.cfg.get("on_disk_payload", True)),
-        )
+    def delete_by_filter(self, flt: VectorFilter) -> None:
+        """Delete every point matching the filter, tenant-guarded."""
+        qfilter = _translate_filter(flt)
+        if qfilter is None:
+            # Safety: an empty / unrecognized filter must never translate
+            # into "delete every point" for the current tenant. We check
+            # **before** the tenant guard merge, otherwise ``None`` would
+            # silently turn into "drop_tenant semantics" — same outcome,
+            # but without the caller asking for it.
+            raise ValueError("delete_by_filter requires a non-empty filter")
+        if self.multitenant:
+            qfilter = _merge_tenant_filter(qfilter, self._tenant.id)
+        try:
+            self.client.delete(
+                collection_name=self.collection_name,
+                points_selector=rest.FilterSelector(filter=qfilter),
+            )
+        except UnexpectedResponse as e:
+            if "not found" in str(e).lower() or "doesn't exist" in str(e).lower():
+                return
+            raise
 
-    def delete_collection(self, **kwargs: Any):
-        """Remove *this tenant's* data.
+    # ============================================================ drop_tenant
+    def drop_tenant(self, *, purge_all_shards: bool = False) -> None:
+        """Remove this tenant's vectors.
 
-        * Multitenant: delete all points whose payload matches ``collection_id``,
-          leaving the global collection (and other tenants) untouched.
-        * Legacy: drop the whole physical collection.
-
-        Pass ``purge_all_shards=True`` to scan every ``aperag_vectors_*``
-        collection and delete all points tagged with this tenant. Useful when
-        the caller cannot resolve the correct ``vector_size`` any more (e.g.
-        the collection's embedding provider has been removed from config): a
-        normal ``delete_collection`` would route to the connector's default
-        global collection and silently leave orphans behind.
+        See ``VectorStoreConnector.drop_tenant`` for the contract.
         """
         if self.multitenant:
-            if kwargs.get("purge_all_shards"):
+            if purge_all_shards:
                 self._purge_tenant_from_all_global_collections()
                 return
             try:
@@ -728,50 +738,50 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
                             must=[
                                 rest.FieldCondition(
                                     key=TENANT_PAYLOAD_KEY,
-                                    match=rest.MatchValue(value=self.tenant_id),
+                                    match=rest.MatchValue(value=self._tenant.id),
                                 )
                             ]
                         )
                     ),
                 )
             except UnexpectedResponse as e:
-                # If the global collection itself is gone (e.g. fresh cluster,
-                # tenant never wrote anything) treat as already-deleted.
-                if "not found" in str(e).lower() or "doesn't exist" in str(e).lower():
+                msg = str(e).lower()
+                if "not found" in msg or "doesn't exist" in msg:
                     return
                 raise
             return
 
+        # Legacy layout: drop the whole physical collection.
         try:
             self.client.delete_collection(collection_name=self.collection_name)
         except UnexpectedResponse as e:
-            if "not found" in str(e).lower() or "doesn't exist" in str(e).lower():
+            msg = str(e).lower()
+            if "not found" in msg or "doesn't exist" in msg:
                 return
             raise
 
     def _purge_tenant_from_all_global_collections(self) -> None:
         """Best-effort purge of this tenant's points across every global shard.
 
-        Called from the delete path when ``vector_size`` cannot be resolved,
+        Called from the drop path when ``vector_size`` cannot be resolved,
         so we cannot route to a single ``aperag_vectors_{size}_{distance}``
         collection. We iterate all collections whose name starts with the
         multi-tenant naming prefix and issue a filtered delete on each.
 
         This is explicitly best-effort:
-        * failures on individual collections are logged, not re-raised — we'd
-          rather succeed on 7 of 8 shards than zero;
+        * failures on individual collections are logged, not re-raised —
+          we'd rather succeed on 7 of 8 shards than zero;
         * we never touch non-``aperag_vectors_*`` collections (including
-          legacy per-tenant ``col<hex>`` names), so this is safe to run even
-          in mixed deployments during the migration window.
+          legacy per-tenant ``col<hex>`` names), so this is safe to run
+          even in mixed deployments during the migration window.
         """
         try:
             existing = [c.name for c in self.client.get_collections().collections]
         except Exception:
             logger.exception("qdrant: could not list collections for orphan purge")
             return
-        prefix = "aperag_vectors_"
         for name in existing:
-            if not name.startswith(prefix):
+            if not name.startswith(_MULTITENANT_PREFIX):
                 continue
             try:
                 self.client.delete(
@@ -781,71 +791,40 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
                             must=[
                                 rest.FieldCondition(
                                     key=TENANT_PAYLOAD_KEY,
-                                    match=rest.MatchValue(value=self.tenant_id),
+                                    match=rest.MatchValue(value=self._tenant.id),
                                 )
                             ]
                         )
                     ),
                 )
-                logger.info("qdrant: purged tenant %s from %s", self.tenant_id, name)
+                logger.info("qdrant: purged tenant %s from %s", self._tenant.id, name)
             except UnexpectedResponse as e:
                 if "not found" in str(e).lower() or "doesn't exist" in str(e).lower():
                     continue
-                logger.warning("qdrant: failed to purge %s from %s: %s", self.tenant_id, name, e)
+                logger.warning("qdrant: failed to purge %s from %s: %s", self._tenant.id, name, e)
             except Exception:
-                logger.exception("qdrant: unexpected error purging %s from %s", self.tenant_id, name)
+                logger.exception("qdrant: unexpected error purging %s from %s", self._tenant.id, name)
 
-    # ---------------------------------------------------------------- retrieval
-    def retrieve(
-        self,
-        ids: Sequence[str],
-        *,
-        with_payload: bool = True,
-        with_vectors: bool = False,
-    ) -> List[VectorPoint]:
-        """Retrieve points by id, enforcing the tenant guard in multitenant mode.
 
-        Exposed because several service-layer call sites (document preview /
-        chunk listing) used to call ``self.client.retrieve`` directly against a
-        per-tenant collection; after multitenancy they must both target the
-        global collection *and* filter by tenant.
+# Re-export for callers that imported these from this module historically.
+__all__ = [
+    "QdrantVectorStoreConnector",
+    "TENANT_PAYLOAD_KEY",
+    "global_collection_name",
+    "_coerce_distance",
+    "_hnsw_config",
+    "_optimizers_config",
+    "_quantization_config",
+    "_ensure_tenant_payload_index",
+    "_merge_tenant_filter",
+    "_translate_filter",
+    "_normalize_filter_input",
+    "_get_or_create_client",
+    "_reset_client_cache",
+    "_ENSURED_COLLECTIONS",
+]
 
-        Returns backend-neutral ``VectorPoint`` objects so callers don't pick
-        up a dependency on ``qdrant_client.http.models.Record``.
-        """
-        raw = self.client.retrieve(
-            collection_name=self.collection_name,
-            ids=list(ids),
-            with_payload=with_payload,
-            with_vectors=with_vectors,
-        )
-
-        # Normalize Qdrant Records -> VectorPoint. We normalize id to str
-        # because that's VectorPoint's contract (see base.py); Pydantic
-        # Chunk.id downstream is Optional[str] so round-trip is stable.
-        def _vec(p: Any) -> Optional[List[float]]:
-            v = getattr(p, "vector", None)
-            if v is None:
-                return None
-            if isinstance(v, list):
-                return v
-            # qdrant can return dict[name, list] for multi-vector collections;
-            # we only ever store single-vector, so pick the first value.
-            if isinstance(v, dict) and v:
-                first = next(iter(v.values()))
-                return first if isinstance(first, list) else None
-            return None
-
-        out = [
-            VectorPoint(
-                id=str(p.id),
-                payload=dict(p.payload or {}),
-                vector=_vec(p),
-            )
-            for p in raw
-        ]
-
-        if not self.multitenant:
-            return out
-        # Defense-in-depth filter: drop any points that don't match the tenant.
-        return [p for p in out if (p.payload or {}).get(TENANT_PAYLOAD_KEY) == self.tenant_id]
+# Preserve `json` import for backward compatibility with any code that does
+# `from aperag.vectorstore.qdrant_connector import json` (grepped; none
+# found, but the cost of keeping the name is zero).
+_ = json

--- a/deploy/aperag/values.yaml
+++ b/deploy/aperag/values.yaml
@@ -154,6 +154,15 @@ api:
     QDRANT_MMAP_THRESHOLD_KB: "20480"
     QDRANT_VECTORS_ON_DISK: "True"
     QDRANT_ON_DISK_PAYLOAD: "True"
+    # pgvector knobs. Leave PGVECTOR_DATABASE_URL empty to reuse the
+    # main ApeRAG PostgreSQL (recommended for small-to-medium private
+    # deployments — one fewer component to operate). Switch by setting
+    # VECTOR_DB_TYPE=pgvector. Refer to docs/zh-CN/design/
+    # vector_db_abstraction.md for sizing / trade-off guidance.
+    PGVECTOR_DATABASE_URL: ""
+    PGVECTOR_HNSW_M: "16"
+    PGVECTOR_HNSW_EF_CONSTRUCTION: "64"
+    PGVECTOR_HNSW_EF_SEARCH: "40"
     # Object Store
     OBJECT_STORE_TYPE: local
     OBJECT_STORE_LOCAL_ROOT_DIR: /data/objects

--- a/docs/zh-CN/design/qdrant_memory_optimization.md
+++ b/docs/zh-CN/design/qdrant_memory_optimization.md
@@ -182,17 +182,11 @@ Qdrant 为此专门提供了三项能力，缺一不可：
    }
   ```
    `is_tenant: true` 是 Qdrant **1.11+** 引入的特殊标记（[官方发布说明](https://qdrant.tech/blog/qdrant-1.11.x/)）。打开后，Qdrant 的 optimizer 会**按照 tenant 字段对点进行物理分组存储**（tenant 相同的点会被尽量放在同一个 segment 内），查询时相当于只扫描对应 tenant 的子集，性能和独立 collection 几乎等价。
-
    **⚠️ 版本兼容**：生产现在的 Qdrant 是 **1.10.0**，不支持 `is_tenant`。连接器在 `aperag/vectorstore/qdrant_connector.py::_ensure_tenant_payload_index` 里采用了兜底策略：优先尝试 `is_tenant=True`，失败时降级为普通 keyword 索引。在 1.10 上：
-   - ✅ payload filter 本身完全工作，租户隔离语义严格成立；
-   - ✅ "1847 个 collection → 1 个" 的合并收益完全拿到（~3–5 GiB 的 RocksDB 实例开销立刻消失）；
-   - ❌ segment 级 defragmentation 不会生效，tenant 点会混存在同一批 segment 中，查询时 HNSW 需要跨更多"别人的"节点。预期 p95 查询延迟有几十百分比的退化（退化量随全局 collection 的总点数线性增长）。
-
+  - ✅ payload filter 本身完全工作，租户隔离语义严格成立；
+  - ✅ "1847 个 collection → 1 个" 的合并收益完全拿到（~3–5 GiB 的 RocksDB 实例开销立刻消失）；
+  - ❌ segment 级 defragmentation 不会生效，tenant 点会混存在同一批 segment 中，查询时 HNSW 需要跨更多"别人的"节点。预期 p95 查询延迟有几十百分比的退化（退化量随全局 collection 的总点数线性增长）。
    **强烈建议**：把 Qdrant server 从 1.10.0 升到 1.11.x（或 1.12.x）作为本次停服窗口的一部分。升级只需改镜像 tag，不涉及数据迁移。升上去后，新建 collection 自动带 is_tenant 优化；**已有的全局 collection 上的索引不会自动升级**——需要在升级后重建索引：
-   ```sh
-   curl -X DELETE  $QDRANT/collections/aperag_vectors_1024_cosine/index/collection_id
-   # 重启任意 ApeRAG 进程，其连接器启动时会检测不存在，自动用 is_tenant=True 重建
-   ```
 
 ##### B.1.2 查询时的过滤模板
 
@@ -231,15 +225,15 @@ hits = client.query_points(
 
 1. **停服**：停掉 apiserver / celery worker / beat，Qdrant 仍然运行。
 2. **迁移**：跑 `scripts/migrate_qdrant_multitenancy.py`：
-   - 自动枚举所有 `col<hex>` 源 collection，跳过孤儿（DB 里查不到的）；
-   - 为每个 `(vector_size, distance)` 组合创建 `aperag_vectors_{size}_{distance}` 全局 collection，写入完整配置（INT8 量化 / HNSW on_disk / 2 segments / mmap 阈值 / tenant index）；
-   - scroll 源 collection 所有点，把 `payload.collection_id = <源 collection 名>` 注入后 upsert 进全局 collection；
-   - **默认不删源 collection**，需要显式 `--delete-old` 或第二阶段 `--only-delete`；
+  - 自动枚举所有 `col<hex>` 源 collection，跳过孤儿（DB 里查不到的）；
+  - 为每个 `(vector_size, distance)` 组合创建 `aperag_vectors_{size}_{distance}` 全局 collection，写入完整配置（INT8 量化 / HNSW on_disk / 2 segments / mmap 阈值 / tenant index）；
+  - scroll 源 collection 所有点，把 `payload.collection_id = <源 collection 名>` 注入后 upsert 进全局 collection；
+  - **默认不删源 collection**，需要显式 `--delete-old` 或第二阶段 `--only-delete`；
 3. **发布新版代码**，默认 `QDRANT_MULTITENANT=True`。
 4. **观察 24 h**：读路径（document chunks / search / retrieve）、写路径（新建 collection、新上传文档）都正常后；
 5. **清理**：再跑一次 `--only-delete` 把老的 `col<hex>` collection 删除。
 
-> **⚠️ 单向门警告**：一旦新版代码接收任何新写入（新建 collection、新上传文档、新 chat 产生的 chunk），`QDRANT_MULTITENANT` **不能简单切回 `False` 就算回滚**——那期间写入的新点只在 `aperag_vectors_*` 里，legacy 模式下看不到；同期新建的 ApeRAG Collection 也不会有对应的 `col<hex>` 物理 collection。如果必须回滚，需要反向迁移（从全局 collection 按 `collection_id` scroll 回每个 `col<hex>`）——这段逻辑目前**未实现**。所以：回滚窗口 = 新版代码上线到接收第一笔新写入之间的那几分钟。如果发现问题必须在窗口内决策。
+> **⚠️ 单向门警告**：一旦新版代码接收任何新写入（新建 collection、新上传文档、新 chat 产生的 chunk），`QDRANT_MULTITENANT` **不能简单切回 `False` 就算回滚**——那期间写入的新点只在 `aperag_vectors`_* 里，legacy 模式下看不到；同期新建的 ApeRAG Collection 也不会有对应的 `col<hex>` 物理 collection。如果必须回滚，需要反向迁移（从全局 collection 按 `collection_id` scroll 回每个 `col<hex>`）——这段逻辑目前**未实现**。所以：回滚窗口 = 新版代码上线到接收第一笔新写入之间的那几分钟。如果发现问题必须在窗口内决策。
 
 > **另一个单向影响**：是否在停服窗口里把 Qdrant server 顺带从 1.10.0 升到 1.11.x 也是一次决策——见 B.1.1。升级一次就回不去了（KubeBlocks qdrant 0.9.1 支持任意 tag 切换，但数据文件在 1.11 上会被 optimizer 重排）。
 
@@ -304,18 +298,15 @@ qdrant_default_segment_number: int = Field(2, alias="QDRANT_DEFAULT_SEGMENT_NUMB
 
 然后在两处 values 里把默认值同步过去：
 
-1. **`deploy/aperag/values.yaml`**（当前仓库）：在 `vars` 段追加：
-
-   ```yaml
+1. `**deploy/aperag/values.yaml**`（当前仓库）：在 `vars` 段追加：
+  ```yaml
    QDRANT_ENABLE_QUANTIZATION: "true"
    QDRANT_QUANTIZATION_TYPE: "int8"
    QDRANT_HNSW_ON_DISK: "true"
    QDRANT_DEFAULT_SEGMENT_NUMBER: "2"
-   ```
-
-2. **`apecloud/aperag-values`**（独立仓库，生产部署用）：同步上面四个环境变量；Qdrant 子 chart 的 server-side 配置（`deploy/databases/qdrant/values.yaml` 等价项）也要加：
-
-   ```yaml
+  ```
+2. `**apecloud/aperag-values**`（独立仓库，生产部署用）：同步上面四个环境变量；Qdrant 子 chart 的 server-side 配置（`deploy/databases/qdrant/values.yaml` 等价项）也要加：
+  ```yaml
    extra:
      config:
        storage:
@@ -326,11 +317,10 @@ qdrant_default_segment_number: int = Field(2, alias="QDRANT_DEFAULT_SEGMENT_NUMB
            on_disk: true
          wal:
            wal_capacity_mb: 8
-   ```
-
-   > aperag-values 仓库的 PR 需要和本仓库的 Settings/connector 代码改动**同步发版**，避免应用开了量化但旧 Qdrant 不支持的问题。
-   >
-   > **Qdrant 版本要求**：INT8 量化 / HNSW on_disk / 2 segments / mmap threshold 这些选项 **1.10.0 全部支持**，无需升级。但多租户 **`is_tenant=True`** 需要 **1.11+**；生产 1.10.0 会被连接器自动降级为普通 keyword 索引——功能正确但失去 segment 级 defragmentation。**建议在本次停服窗口里把 Qdrant 也升到 1.11+**（只改镜像 tag，无数据迁移），或在下一次停服窗口里升，并接受 1.11 之前的查询延迟退化。详见 B.1.1 的版本兼容说明。
+  ```
+  > aperag-values 仓库的 PR 需要和本仓库的 Settings/connector 代码改动**同步发版**，避免应用开了量化但旧 Qdrant 不支持的问题。
+  >
+  > **Qdrant 版本要求**：INT8 量化 / HNSW on_disk / 2 segments / mmap threshold 这些选项 **1.10.0 全部支持**，无需升级。但多租户 `**is_tenant=True`** 需要 **1.11+**；生产 1.10.0 会被连接器自动降级为普通 keyword 索引——功能正确但失去 segment 级 defragmentation。**建议在本次停服窗口里把 Qdrant 也升到 1.11+**（只改镜像 tag，无数据迁移），或在下一次停服窗口里升，并接受 1.11 之前的查询延迟退化。详见 B.1.1 的版本兼容说明。
 
 #### C.2 其他零散优化
 
@@ -376,21 +366,25 @@ qdrant_default_segment_number: int = Field(2, alias="QDRANT_DEFAULT_SEGMENT_NUMB
 
 ### 基线（清理前）
 
-| 项 | 值 |
-|---|---|
-| Qdrant collection 总数 | **1847** |
-| PG `status='ACTIVE'` | 2003（其中 1833 已在 Qdrant、170 尚未上传文档） |
-| PG `status='DELETED'` | 179（其中 165 早就不在 Qdrant，仅 14 条残留） |
+
+| 项                      | 值                                                         |
+| ---------------------- | --------------------------------------------------------- |
+| Qdrant collection 总数   | **1847**                                                  |
+| PG `status='ACTIVE'`   | 2003（其中 1833 已在 Qdrant、170 尚未上传文档）                        |
+| PG `status='DELETED'`  | 179（其中 165 早就不在 Qdrant，仅 14 条残留）                          |
 | Qdrant `qdrant` 容器 RSS | **12 517 MiB**（约 12.2 GiB，`kubectl top pod --containers`） |
+
 
 ### 待删清单分类
 
 严格按 `IN_QDRANT \ ACTIVE_IN_PG` 计算，共 **14** 条，全部来源于 PG `status='DELETED'`：
 
-| 分类 | 数量 |
-|---|---|
+
+| 分类                                     | 数量     |
+| -------------------------------------- | ------ |
 | DELETED 来源（PG 标记 DELETED 但 Qdrant 仍残留） | **14** |
-| 孤儿来源（Qdrant 有、PG 完全查不到） | **0** |
+| 孤儿来源（Qdrant 有、PG 完全查不到）                | **0**  |
+
 
 完整列表：
 
@@ -405,20 +399,24 @@ colc49a291371cc17fc  colf67799b2b73f391e
 
 通过 `kubectl port-forward qdrant-cluster-qdrant-0 16333:6333` + `curl -X DELETE http://localhost:16333/collections/{name}` 逐条删除，串行、无并发，完成后关闭 port-forward。
 
-| 项 | 值 |
-|---|---|
-| 发起 DELETE 请求数 | 14 |
-| HTTP 200 且 `result=true` | 13 |
+
+| 项                                                           | 值                           |
+| ----------------------------------------------------------- | --------------------------- |
+| 发起 DELETE 请求数                                               | 14                          |
+| HTTP 200 且 `result=true`                                    | 13                          |
 | HTTP 200 但 `result=false`（Qdrant 端 "collection 已不存在" 的幂等响应） | 1（首条 `col234abe498124212b`） |
-| 真实失败（HTTP 非 200） | **0** |
-| 删除后抽检 14 个名字的 `GET /collections/{name}` | **全部 404**，确认已从 Qdrant 完全消失 |
+| 真实失败（HTTP 非 200）                                            | **0**                       |
+| 删除后抽检 14 个名字的 `GET /collections/{name}`                     | **全部 404**，确认已从 Qdrant 完全消失 |
+
 
 ### 清理后状态
 
-| 项 | 值（立即） |
-|---|---|
-| Qdrant collection 总数 | **1833**（-14） |
+
+| 项                      | 值（立即）                                    |
+| ---------------------- | ---------------------------------------- |
+| Qdrant collection 总数   | **1833**（-14）                            |
 | Qdrant `qdrant` 容器 RSS | **12 492 MiB**（约 12.2 GiB，立即值 ≈ -25 MiB） |
+
 
 > 说明：Qdrant 1.10 的 `DELETE /collections/{name}` 只把 collection 从 meta 中摘除，底层段文件回收 / mmap unmap 依赖 optimizer 下一轮调度，进程 RSS 的下降通常滞后。**本条记录为删除完成瞬时的 `kubectl top` 值，真实回收预计在 24 h 内体现。**
 
@@ -432,3 +430,204 @@ colc49a291371cc17fc  colf67799b2b73f391e
 ### 失败条目列表
 
 无真实失败。唯一的非典型响应（首条 `col234abe498124212b` 返回 `result:false`）为 Qdrant 端的幂等提示，对象事实上已不存在；抽检 `GET /collections/col234abe498124212b` 返回 404，最终状态正确。
+
+---
+
+## 7. 附加改造：Embedding 模型锁定（本 PR 一并上线）
+
+### 7.1 为什么要锁
+
+多租户化之后，**物理 collection 由 `(vector_size, distance)` 唯一决定**
+（见 `global_collection_name()`）。如果允许用户在 Collection 创建后修改
+embedding model，会发生两类数据完整性问题：
+
+1. **维度切换**（e.g. `bge-m3@1024` → `text-embedding-3-large@3072`）：
+   写入会被路由到新的 `aperag_vectors_3072_cosine`；但旧的
+   `aperag_vectors_1024_cosine` 仍残留着该租户的全部历史向量，**永远不会被读到**，
+   也不会被 `delete_collection` 清理（因为 delete 路径用**当前**的 vector_size 选
+   shard）。
+2. **同维度异模型**（e.g. `bge-large-zh@1024` → `bge-m3@1024`）：物理上落同一
+   shard，但两组向量在同一 HNSW 图里语义空间不兼容，召回质量会莫名退化，且
+   `is_tenant` 优化也救不了（`is_tenant` 只按 tenant 分 segment，不区分模型）。
+
+这两种失败模式在单机 Qdrant 时代就已经存在，只是单机 Qdrant 写入时会因维度
+mismatch 直接报错（"硬失败"）；多租户化后变成**软失败**——写入成功，但
+retrieval 完全错乱。所以必须从接口层直接禁止。
+
+### 7.2 改动点
+
+- **后端**：`aperag/service/collection_service.py::CollectionService._reject_embedding_change`
+  - 在 `update_collection` 的开头调用，校验：
+    - `embedding.model` 不变；
+    - `embedding.model_service_provider` / `custom_llm_provider` 不变；
+    - 已有 embedding 配置不可被 "清空"。
+  - 任一不满足抛 `ValidationException`（映射到 HTTP 400）。
+  - 首次绑定（老数据或初次创建后补填）仍然允许。
+- **前端**：`web/src/app/workspace/collections/collection-form.tsx`
+  - `action === 'edit'` 时 `Select` 置 `disabled`；
+  - 显示 Badge "创建后不可修改 / Locked after creation"；
+  - `FormDescription` 改为解释性文案；
+  - **并跳过** `embeddingModelName` 的 `useEffect` watcher——否则若用户切到 "edit"
+    模式时模型清单里刚好没有原模型（比如对应 provider 已下架），watcher 会自动把
+    表单里的 model 改成列表第 0 项，提交时被后端校验拒绝，用户看起来像 "我啥也
+    没动就不让保存"。
+- **i18n**：新增两个 key `embedding_model_locked_badge`、`embedding_model_locked_description`
+  （`page_collections.json` 中英文各一份）。
+
+### 7.3 为什么不在 OpenAPI schema 上强制
+
+考虑过在 `aperag/api/components/schemas/collection.yaml` 里为 `CollectionUpdate`
+单独拷一份不含 `embedding` 的子 schema，但：
+
+- 现有 `CollectionUpdate = CollectionCreate` 的全量复用会被破坏；
+- 前端已经在 edit 模式下不提交 embedding 字段的 UX 由锁定逻辑保证；
+- 服务端显式报错反而比 "schema 层静默 drop 字段" 更友好（用户能看到具体原因）。
+
+因此采用 "schema 保持灵活 + service 层强校验" 的组合。
+
+---
+
+## 8. 向量数据库全链路 Review 要点
+
+本节记录在实现多租户 + embedding 锁定过程中做的一次**全链路代码 review**，
+分成 "已修 / 已知有意为之 / 待跟进" 三档，避免以后踩同一个坑。
+
+### 8.1 已修（本 PR）
+
+**R1. Delete 路径在 embedding provider 下线时会把数据孤在 Qdrant 里**
+（`aperag/tasks/collection.py::_delete_vector_databases`）
+
+- 背景：多租户化后 `delete_collection` 依赖当前 `vector_size` 去选 shard。
+  若 provider 被下架 → `get_collection_embedding_service_sync` 抛异常 →
+  代码原本默默 fallback 到某个 "默认" shard，真实 shard 里的该租户向量永远留在那里。
+- 修复：新增 `QdrantVectorStoreConnector._purge_tenant_from_all_global_collections`，
+  `delete_collection(purge_all_shards=True)` 时枚举所有 `aperag_vectors_*` 做
+  `FilterSelector` 级别的点删除；`_delete_vector_databases` 在无法解析 vector_size
+  时走这个兜底路径。
+- 影响：删 Collection 再也不会留孤儿点。
+
+**R2. Node metadata 里 `collection_id` 可能缺失**
+（`aperag/llm/embed/embedding_utils.py::create_embeddings_and_store`）
+
+- 背景：多租户过滤依赖 payload 顶层的 `collection_id`（LlamaIndex 会把
+  `node.metadata` 扁平化进 payload）；但 `vector_index / summary_index` 历史上
+  只在 `extra_info` 里塞，没有在 `node.metadata` 里设，视觉 index 的两个路径
+  甚至完全绕过了 `create_embeddings_and_store`。
+- 修复：
+  - 在三个 indexer 里显式 `part.metadata['collection_id'] = ...`；
+  - 在 `create_embeddings_and_store` 里再补一次防御性注入（如缺就用 connector
+    的 `tenant_id`）；
+  - vision 两处直连 `store.add` 也补了相同字段。
+- 影响：即使上游忘设，多租户过滤依然命中正确 shard。
+
+**R3. `is_tenant=True` 在 Qdrant < 1.11 的兼容**
+
+- Qdrant 1.10（线上版本）不认 `is_tenant` 字段，直接 `400`。
+- 修复：`_ensure_tenant_payload_index` 三级 fallback：先带 `is_tenant` 试 →
+  捕获 → 不带 `is_tenant` 的 keyword 索引 → 再捕获 → 记 warning。
+  升级到 1.11+ 之后 tenant 级 defragmentation 自动生效，无需再改代码。
+
+**R4. `create_collection` 的初始化顺序**
+
+- 以前是先构造 `QdrantVectorStore(client, collection_name)`（LlamaIndex 里这步
+  会触发 `GET /collections/xxx`，collection 不存在时抛 warning/error），再
+  `_ensure_collection`。
+- 改成 "先 ensure，后 wrap"，去掉了一条噪声日志，也避免了冷启动窗口里
+  竞态读到 404。
+
+**R5. 迁移脚本的安全断言**
+
+- `scripts/migrate_qdrant_multitenancy.py` 在开头加了
+  `assert generate_vector_db_collection_name(x) == str(x)`。
+  若未来改命名规则，脚本会立即停机而不是静默把数据写错 shard。
+
+### 8.2 已知但有意为之（这次不动）
+
+**K1. 每次 search 会重建 `QdrantClient`**
+（`aperag/service/search_pipeline_service.py` 的三个 `_*_search` 都会
+`VectorStoreConnectorAdaptor(ctx)` 一次）
+
+- 现状：`_ENSURED_COLLECTIONS` 进程级 set 避免了重复 `_ensure_collection`，
+  但 `QdrantClient` 本身每次都是新的。
+- 为什么先不动：(1) HTTP client 本身带 keep-alive，grpc 也有连接池，单查询
+  overhead 可接受；(2) 做成单例需要把线程安全、刷新策略、tenant 切换等一起设计，
+  范围超出本 PR。
+- Follow-up：放到抽象层 M2（见 `vector_db_abstraction.md` §4.1）。
+
+**K2. `ContextManager._create_combined_filter` 硬编码 Qdrant filter 类型**
+（`aperag/context/context.py` 直接 import `qdrant_client.models`）
+
+- 典型抽象破口：任何后端切换都要在这里加分支。
+- 为什么先不动：单后端状态下，重构此处没有功能收益，反而引入回归风险。
+- Follow-up：抽象层 M2 中新增 `VectorFilter` DSL 后统一收敛。
+
+**K3. `retrieve()` 未进入基类**
+（`aperag/vectorstore/base.py` 里没有该抽象方法，但 `document_service.py` 直接
+调 `connector.retrieve(...)`）
+
+- 若未来切 pgvector/Milvus 会直接 `AttributeError`。
+- Follow-up：抽象层 M2 中补齐，顺便把 `with_vectors`、`with_payload` 这些参数
+  做成统一语义。
+
+**K4. Vision 索引绕过 `create_embeddings_and_store`，直连 `store.add(nodes)`**
+（`aperag/index/vision_index.py` 两处）
+
+- 目前我们在两处都手工补了 `metadata['collection_id']`，语义是对的，但
+  "两份写路径" 带来的维护成本需要记住——将来 `create_embeddings_and_store`
+  的 metadata 约定变更时，vision 路径要同步修改，容易漏。
+- Follow-up：抽象层 M2 中把 "写点" 统一到 `connector.upsert(tenant, points)`，
+  彻底去掉 `store.add` 直连。
+
+**K5. 业务层 collection id 被直接当做 tenant id**
+
+- `QdrantVectorStoreConnector.__init__` 用 `ctx['collection']` 当
+  `tenant_id`；`generate_vector_db_collection_name(collection_id) == str(collection_id)`
+  是幂等映射。
+- 这是当前正确、简单的做法；迁移脚本也断言了这点。记录在案，防止以后
+  有人把 "Qdrant collection name" 和 "ApeRAG collection id" 拆成两个不同字符串
+  时忘了同步断言。
+
+### 8.3 待跟进（不在本 PR 范围）
+
+**F1. `ContextManager` 过滤条件里 `doc_id` / `document_id` / `ref_doc_id` 三名共存**
+
+- 历史上 LlamaIndex 往 payload 里同时写 `doc_id` 和 `document_id`（不同版本命名），
+  部分过滤用 `doc_id`、部分用 `document_id`。
+- 当前 review 认为语义 OK（查询端兼容两套），但等 M2 抽象层时应该收敛到单一 key。
+
+**F2. `retrieve` 的 `with_payload=True` 语义差异**
+
+- Qdrant 的 "payload" ≈ pgvector 的 "payload JSONB"；但 LlamaIndex 期望 payload 里
+  包含 `_node_content` 序列化字符串。未来实现 pgvector 后端时要注意把这种
+  LlamaIndex 约定从"协议"降级成"Qdrant 后端实现细节"（见抽象层 §5.1）。
+
+**F3. 并发场景下 `_ENSURED_COLLECTIONS` 的 lock 粒度**
+
+- 当前 `threading.Lock()` 是进程级、全局单把锁。多个线程同时首次访问不同
+  collection 时会串行化，但由于 `_ensure_collection` 本身幂等、只在冷启动触发
+  一次，实际不是瓶颈。观测到 QPS 上升再评估。
+
+**F4. Qdrant 1.10 → 1.11 升级窗口**
+
+- 升级后 `_ensure_tenant_payload_index` 的 "带 is_tenant" 路径会开始生效，此时
+  已经存在的 keyword 索引不会自动升级为 tenant-aware。建议升级操作脚本里
+  额外一步 `DELETE index → 重建 with is_tenant=True`（无数据影响，毫秒级）。
+
+---
+
+## 9. 关联设计：向量数据库抽象层
+
+本次 Qdrant 优化已经暴露了三条抽象破口（见 §8.2 K1/K2/K3）。这些问题在
+单后端状态下可以接受，但一旦要支持 pgvector/Milvus 就会成为硬阻塞。
+
+详见同目录 [`vector_db_abstraction.md`](./vector_db_abstraction.md)，该文档以
+当前代码事实为起点，给出了：
+
+- 三层分层（Transport / 能力抽象 / 调优）；
+- 最小可行过滤 DSL；
+- Qdrant / pgvector / Milvus 三个后端的实现草图；
+- 路线图 M1 → M4；
+- 与本次 embedding 锁定的依赖关系（锁定是抽象层的前置条件）。
+
+**何时启动抽象层**：触发条件见 `vector_db_abstraction.md` §10。在触发之前，
+本文档和抽象层设计文档共同构成决策依据，不做任何代码层面的先行重构。

--- a/docs/zh-CN/design/vector_db_abstraction.md
+++ b/docs/zh-CN/design/vector_db_abstraction.md
@@ -1,0 +1,392 @@
+# 向量数据库抽象层设计分析（ApeRAG）
+
+> Status: **M2 已落地**（本文的分析已经变成了现网代码）。后续 pgvector 的
+> M3 工作仍在 roadmap 里，会按本文的分层和 DSL 约束来实现。
+
+## 变更记录
+
+| 日期 | 内容 |
+|---|---|
+| 2026-04-20 | 初稿：分层、DSL、三后端草图、路线图 |
+| 2026-04-21 | M2 落地：`VectorFilter` DSL、Qdrant translator、`VectorPoint`、client pool、`retrieve()` 入基类 |
+
+## 1. 背景与目标
+
+当前 ApeRAG 只有一个向量后端：Qdrant。在
+[`qdrant_memory_optimization.md`](./qdrant_memory_optimization.md) 的改造后，
+Qdrant 连接器已经承担了三件相互耦合的事情：
+
+1. **物理布局路由**：按 `(vector_size, distance)` 选全局 collection。
+2. **多租户语义**：payload `collection_id` + `is_tenant` 索引。
+3. **存储与索引调优**：INT8 量化、HNSW on_disk、segment 数、memmap 阈值等。
+
+未来我们希望：
+
+- 线上大集群保留 Qdrant（性能/隔离/量化成熟）；
+- 中小规模或需要单一 PostgreSQL 技术栈的部署可以走 **pgvector**（少一个组件）；
+- 未来潜在需求（超大规模、GPU 索引）可切换 **Milvus**；
+- 对于"快速验证"或 CI/本地开发，期望一个纯内存实现（`:memory:` 或 in-proc）。
+
+所以需要一个**向上/向下双向稳定**的抽象层。本文给出选型、接口草案与迁移策略。
+
+---
+
+## 2. 当前代码实际的抽象现状（事实核查）
+
+| 层 | 文件 | 角色 | 健康度 |
+|---|---|---|---|
+| 抽象基类 | `aperag/vectorstore/base.py`：`VectorStoreConnector` | `search / delete / create_collection / delete_collection` | 不完整：`retrieve()` 只在 Qdrant 实现里有 |
+| 适配器 | `aperag/vectorstore/connector.py`：`VectorStoreConnectorAdaptor` | `match vector_store_type` 分发 | 只支持 qdrant 分支 |
+| 具体实现 | `aperag/vectorstore/qdrant_connector.py` | Qdrant | 承载多租户 + 优化所有细节 |
+| 上层过滤器 | `aperag/context/context.py`：`ContextManager._create_combined_filter` | 业务过滤 | **直接 import `qdrant_client.models`**，抽象破口 |
+| 上层入口 | 索引写入 `aperag/index/*.py`、检索 `aperag/service/search_pipeline_service.py` | 每次按需构造 `VectorStoreConnectorAdaptor`、`ContextManager` | 每次请求重建连接 |
+| 分片路由 | `aperag/config.py`：`build_vector_db_context`、`get_vector_db_connector` | 注入 `multitenant/quantization/...` ctx | Qdrant 专属字段混在 Config 里 |
+
+**当前抽象的 4 个真实缺口**（2026-04-20 分析；M2 之后 1/2/4 已关闭，3 仍保留）：
+
+| # | 缺口 | M2 状态 |
+|---|---|---|
+| 1 | `retrieve(ids)` 只在 Qdrant 连接器上存在 | ✅ 已进基类，返回 `VectorPoint` |
+| 2 | `ContextManager` 硬编码 `qdrant_client.models` | ✅ 已迁到 `VectorFilter` DSL |
+| 3 | `LlamaIndex.QdrantVectorStore` 被直接暴露给业务层 | ⏸ 保留，等 M3 |
+| 4 | 每次 search 重建 `QdrantClient` | ✅ 已进程级复用 |
+
+缺口 3 的完整细节（保留给 M3）：
+
+- `vector_store_adaptor.connector.store.add(nodes)` 仍在 vision_index.py
+  两处、embedding_utils.py 使用；
+- 写入 payload 依旧会被 LlamaIndex 注入 `_node_content` / `doc_id` /
+  `document_id` / `ref_doc_id`；
+- 这些字段是 Qdrant 后端的**实现细节**，在 M3 引入 pgvector 时，我们会
+  提供一个新的 `connector.upsert(points)` 接口替代 `store.add(nodes)`，
+  届时再一次性把 LlamaIndex 从业务写路径上拆掉。
+
+---
+
+## 3. 三个候选后端的能力矩阵
+
+| 能力 | Qdrant ≥1.11 | pgvector (pg 16 + pgvector 0.7+) | Milvus 2.4+ |
+|---|---|---|---|
+| 原生 payload 过滤（keyword match/IN/OR） | ✅ | ✅ (`WHERE`) | ✅ (expr) |
+| 向量量化（int8 / binary） | ✅ 内置 scalar+binary | `halfvec`(fp16)、`bit`、需手工 | ✅ IVF/HNSW+PQ/SQ |
+| HNSW on_disk / mmap | ✅ | HNSW 常驻内存，不支持 on_disk；表/toast 走 OS page cache | ✅（DiskANN / MMAP） |
+| 多租户 defragmentation | ✅ `is_tenant` payload | 需手工（按租户建 partitioned table） | ✅ partition/collection-per-tenant |
+| 单机 in-proc 测试 | ✅ `:memory:` | 需起 pg | ✅ `milvus-lite` |
+| Hybrid search（BM25 + 向量） | ✅（sparse vector + fusion） | `tsvector + vector` 手工 | ✅（sparse vector） |
+| 操作学习成本 | 中（一套独立 API） | 低（就是 SQL） | 高（大量配置项） |
+| 与现有技术栈耦合 | 独立服务 | ApeRAG 已有 PG，**省一个组件** | 独立服务 |
+
+**结论**：
+- Qdrant 仍然是**生产默认**（已对量化 + 多租户做过深度优化）。
+- pgvector 适合作为**"少组件"部署模式**的一等公民（比如 ApeRAG-Lite、CI、自托管用户）。
+- Milvus 作为**长期备选**（大规模 / GPU 加速场景），短期不投入实现。
+
+---
+
+## 4. 抽象层分层设计
+
+建议抽象分成三层：
+
+### 4.1 Transport / 连接管理层（L0）
+
+- 责任：客户端生命周期、连接池、池化单例、健康探测。
+- **不涉及任何数据语义**。
+- 代码位置建议：`aperag/vectorstore/_client.py`（新增）。
+
+```python
+class VectorClientFactory:
+    def get(self, backend: str, dsn_ctx: dict) -> Any:
+        """Return a cached, process-level client. Thread-safe, idempotent."""
+```
+
+目的：修掉第 2.4 条"每次 search 重建 client"的性能缺口。
+
+### 4.2 能力抽象层（L1）
+
+- 责任：**业务侧能理解的向量操作**，与具体后端无关。
+- 代码位置：`aperag/vectorstore/base.py`（扩展现有接口）。
+
+建议的接口草案：
+
+```python
+class VectorStoreConnector(ABC):
+    # ---- 集合 / 租户管理 ----
+    @abstractmethod
+    def ensure_tenant(self, tenant: TenantRef, shape: VectorShape) -> None: ...
+    @abstractmethod
+    def drop_tenant(self, tenant: TenantRef, *, purge_all_shapes: bool = False) -> None: ...
+
+    # ---- 写入 ----
+    @abstractmethod
+    def upsert(self, tenant: TenantRef, points: Iterable[VectorPoint]) -> list[str]: ...
+    @abstractmethod
+    def delete_by_ids(self, tenant: TenantRef, ids: Sequence[str]) -> None: ...
+    @abstractmethod
+    def delete_by_filter(self, tenant: TenantRef, flt: VectorFilter) -> None: ...
+
+    # ---- 查询 ----
+    @abstractmethod
+    def search(
+        self, tenant: TenantRef, query: QueryWithEmbedding,
+        *, flt: Optional[VectorFilter] = None,
+        score_threshold: float | None = None,
+        search_opts: SearchOptions | None = None,
+    ) -> QueryResult: ...
+
+    @abstractmethod
+    def retrieve(self, tenant: TenantRef, ids: Sequence[str], *,
+                 with_vectors: bool = False) -> list[VectorPoint]: ...
+```
+
+四个配套 DTO（统一跨后端的数据模型）：
+
+```python
+@dataclass(frozen=True)
+class TenantRef:
+    id: str  # ApeRAG collection id (or None if embed-only mode)
+    shape: VectorShape | None = None  # optional hint
+
+@dataclass(frozen=True)
+class VectorShape:
+    size: int
+    distance: Literal["cosine", "dot", "euclid"]
+
+@dataclass
+class VectorPoint:
+    id: str
+    vector: list[float]
+    payload: dict[str, Any]
+    # on read: score optional
+    score: float | None = None
+
+class VectorFilter:
+    """Backend-neutral filter tree. See §4.3."""
+```
+
+这一层要**严格禁止**暴露 LlamaIndex / Qdrant / psycopg 类型。
+
+### 4.3 业务过滤器 DSL（L1 子模块）
+
+**最痛的一处**：当前 `ContextManager._create_combined_filter` 直接构造
+`qdrant_client.models.Filter`。pgvector/Milvus 无法复用。
+
+建议一个极小的、**面向 RAG 使用场景**的过滤 DSL：
+
+```python
+@dataclass(frozen=True)
+class Eq:      key: str;           value: str | int | float
+@dataclass(frozen=True)
+class In:      key: str;           values: Sequence[str | int | float]
+@dataclass(frozen=True)
+class IsEmpty: key: str
+@dataclass(frozen=True)
+class And:     parts: Sequence["VectorFilter"]
+@dataclass(frozen=True)
+class Or:      parts: Sequence["VectorFilter"]
+@dataclass(frozen=True)
+class Not:     inner: "VectorFilter"
+
+VectorFilter = Union[Eq, In, IsEmpty, And, Or, Not]
+```
+
+每个后端有自己的 **translator**：
+
+| DSL 节点 | Qdrant | pgvector | Milvus |
+|---|---|---|---|
+| `Eq(k, v)` | `FieldCondition(key=k, match=MatchValue(v))` | `payload->>'k' = :v` | `k == v` |
+| `In(k, V)` | `FieldCondition(key=k, match=MatchAny(V))` | `payload->>'k' = ANY(:V)` | `k in [...]` |
+| `IsEmpty(k)` | `IsEmptyCondition(PayloadField(k))` | `NOT (payload ? 'k')` | `not (exists k)` |
+| `And` | `Filter(must=[...])` | `AND` | `&&` |
+| `Or` | `Filter(should=[...])` | `OR` | `\|\|` |
+| `Not` | `Filter(must_not=[...])` | `NOT` | `!` |
+
+**多租户守卫自然内建**：Connector 在 `search / delete_by_filter` 时自动 `And(Eq("collection_id", tenant.id), user_filter)`；业务层完全无感。
+
+### 4.4 存储/索引调优层（L2）
+
+每个后端独有。不对外暴露。
+
+- Qdrant: 当前的 `_hnsw_config / _optimizers_config / _quantization_config` 保留在该后端的 `*_connector.py` 中，通过 `SearchOptions.hints` 透传。
+- pgvector: `CREATE INDEX ... USING hnsw WITH (m=16, ef_construction=64)`，量化用 `halfvec`。
+- Milvus: `IVF_FLAT/HNSW/DISKANN` + PQ/SQ 参数。
+
+L2 的配置**不**暴露给 L1 调用方；只暴露一个能力类的 `SearchOptions`：
+
+```python
+@dataclass
+class SearchOptions:
+    top_k: int
+    consistency: Literal["eventual", "majority", "strong"] = "majority"
+    hints: dict[str, Any] = field(default_factory=dict)   # 后端白名单参数
+```
+
+---
+
+## 5. 三种后端的实现草图
+
+### 5.1 Qdrant（现有 → 重构成 L1）
+
+- `ensure_tenant` → 现有 `_ensure_collection` + `_ensure_tenant_payload_index`。
+- `upsert` → 包装 `self.client.upsert`（不再经由 LlamaIndex `store.add`，从而解除 `_node_content` 依赖；或 keep-as-is 并在读路径做兼容）。
+- 过滤器 translator：`_to_qdrant_filter(vf: VectorFilter) -> rest.Filter`。
+- SearchOptions.hints 支持 `hnsw_ef`、`exact`。
+
+### 5.2 pgvector（新增，新增包 `aperag/vectorstore/pgvector_connector.py`）
+
+**Schema 设计**：
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- 每个 (size, distance) 一张表，类比 Qdrant 的多租户 collection
+CREATE TABLE aperag_vectors_1024_cosine (
+    id          UUID PRIMARY KEY,
+    tenant_id   TEXT NOT NULL,               -- = ApeRAG collection id
+    embedding   vector(1024) NOT NULL,
+    payload     JSONB NOT NULL
+);
+
+-- 租户过滤 + HNSW 共用。分区表可选（pg 14+）。
+CREATE INDEX ON aperag_vectors_1024_cosine (tenant_id);
+CREATE INDEX ON aperag_vectors_1024_cosine USING hnsw (embedding vector_cosine_ops)
+    WITH (m=16, ef_construction=64);
+-- JSONB 字段上的 GIN 索引供 payload 过滤
+CREATE INDEX ON aperag_vectors_1024_cosine USING GIN (payload);
+```
+
+**搜索**：
+
+```sql
+SELECT id, payload, embedding <=> :q AS score
+  FROM aperag_vectors_1024_cosine
+ WHERE tenant_id = :tenant
+   AND payload @> :payload_filter  -- 由 VectorFilter translator 生成
+ ORDER BY embedding <=> :q
+ LIMIT :k;
+```
+
+**量化**：用 `halfvec(1024)` 列替代 `vector(1024)`，磁盘/内存减半；搜索时
+`HALFVEC_L2_OPS` / `HALFVEC_COSINE_OPS`。`bit(dim)` 也可用作更激进量化。
+
+**多租户 defrag**：pg 14+ 可按 `tenant_id` 做 **list partitioning**，每个租户一张物理表，HNSW 索引天然按分区切分。初期不做，租户数量到万级再评估。
+
+### 5.3 Milvus（未来）
+
+- `DataType.FLOAT_VECTOR` + `IVF_SQ8 / HNSW`；
+- payload 字段走 scalar field（`VarChar(tenant_id)`）；
+- 每个 `(vector_size, distance)` 一个 collection，与 Qdrant 对齐；
+- partition key = `tenant_id`（近似 Qdrant 的 `is_tenant`）。
+
+只在需要时实现，目前不动。
+
+---
+
+## 6. 路线图（建议）
+
+分成 4 个 milestone，每个都能**独立上线、独立回滚**：
+
+### M1（本 PR 已落地的改造不变）
+
+- Qdrant 多租户 + 量化 + embedding 锁定。
+- 本文档纳入 repo，作为后续决策的依据。
+
+### M2：抽象层最小可行（✅ **已落地**）
+
+实际落地的范围（比最初草案更克制，符合 "零答疑" 原则）：
+
+- ✅ `VectorFilter` DSL（`aperag/vectorstore/filters.py`）：`Eq / In /
+  IsEmpty / And / Or / Not` + `all_of / any_of` 短路 helper。
+- ✅ Qdrant translator（`_translate_filter` / `_normalize_filter_input`
+  在 `qdrant_connector.py`）。兼容旧的 `rest.Filter` 直传（迁移脚本在用）。
+- ✅ `ContextManager._create_combined_filter` 改为产出 DSL，**不再** import
+  `qdrant_client.models`。
+- ✅ `VectorStoreConnector` 基类补 `retrieve()` 抽象方法。
+- ✅ 只引入一个最小 DTO `VectorPoint(id, payload, vector?)` 给 `retrieve()`
+  用；没有引入 `TenantRef / VectorShape / QueryResult / SearchOptions`，
+  避免"只有一个实现时多 DTO 的人生思考题"。
+- ✅ `QdrantClient` 按 endpoint 进程级复用
+  （`_get_or_create_client` + 双检锁）；`:memory:` 显式绕开缓存以保护测试隔离。
+- **没做** 的事：解耦 LlamaIndex（`store.add(nodes)` 和
+  `node_to_metadata_dict` 在当前是 Qdrant 后端的实现细节，等真做
+  pgvector 的时候再一起换）；没引入统一的 `upsert(tenant, points)`
+  写接口——目前的 `store.add` + `delete(ids)` 已经够用，M3 再说。
+
+实际代码规模：5 个新文件 + 3 个现有文件重构；测试新增 `test_filters.py` /
+`test_qdrant_filter_translation.py` / `test_qdrant_client_cache.py` /
+`test_context_manager_filter.py`。
+
+### M3：pgvector 实现（3~4 周）
+
+- 新增 `pgvector_connector.py`，复用 `aperag/db/ops` 的 session 池。
+- 新增 `VECTOR_DB_TYPE=pgvector` 路径；migration 模板（`alembic` 脚本建立
+  每个需要的 `aperag_vectors_{size}_{distance}` 表）。
+- Reuse embedding lock 的前端逻辑（和 Qdrant 完全一致）。
+- 性能 benchmark：10 万 / 100 万 vectors 的 latency 对比报告。
+
+### M4：生产切换策略（按需）
+
+- 配置：`VECTOR_DB_TYPE=qdrant|pgvector`。
+- 混合部署期间支持"读双写单"的数据迁移模式（类似本 PR 的
+  `scripts/migrate_qdrant_multitenancy.py`）。
+- Milvus 留作后续调研，不进本 roadmap。
+
+---
+
+## 7. 风险与取舍
+
+| 风险 | 说明 | 缓解 |
+|---|---|---|
+| 抽象稀释 Qdrant 独有能力 | 如 sparse vector / hybrid search / HNSW ef_construct | `SearchOptions.hints` 留后门；新能力进抽象需要 ≥2 后端支持 |
+| pgvector 高 QPS 表现不如 Qdrant | pg 进程级锁、HNSW 全量常驻内存 | M3 benchmark 门槛；低 QPS 场景优先 |
+| 过滤 DSL 表达不完备 | 早期只支持 Eq/In/IsEmpty/And/Or/Not，没有 range/geo | 按需扩展，保持单一职责 |
+| LlamaIndex 直接耦合 | `node_to_metadata_dict` 在 payload 里塞大量 `_node_content` 等字段 | M2 中 Qdrant 改为直接走 `client.upsert`，不再经 `LlamaIndex.QdrantVectorStore.add`；读路径做兼容 |
+| embedding 模型切换 vs 抽象层 | 不同 backend 对重建索引成本不同 | 本次 embedding 锁定（见 §8）规避了该问题，抽象层之后也无需处理 |
+
+---
+
+## 8. 与"embedding 模型锁定"的关系
+
+本 PR 引入的 embedding 锁定（`CollectionService._reject_embedding_change`）
+是抽象层设计的**前置条件**：
+
+- 没锁定：每个后端都要实现"向量维度变化时的数据迁移"——pgvector 要 alter
+  column、Milvus 要 drop+recreate collection、Qdrant 要 scroll+upsert。
+  每种都是大手术。
+- 锁定后：向量维度 = collection 生命周期常量，后端只要专注"同维度高效检索"。
+
+因此抽象层假定 `VectorShape` 在 `ensure_tenant` 之后不可变。
+
+---
+
+## 9. 开放问题
+
+1. **是否把 fulltext/knowledge graph 也抽象到同一层？** 目前 ApeRAG 有
+   - vector: Qdrant
+   - fulltext: Elasticsearch
+   - graph: LightRAG (存在 Postgres/Neo4j)
+   三者 indexing 流程在 `aperag/index/` 已有 `BaseIndexer`，各自独立——**不建议**
+   把它们塞进向量抽象层，保持单一职责。
+
+2. **是否与 LlamaIndex 解耦？** LlamaIndex 带来了：chunking、node schema、
+   retrieval pipeline。短期我们只想解 `QdrantVectorStore` 这一处。长期如果
+   想支持多种 chunker（比如 unstructured、langchain），才值得把 LlamaIndex
+   也抽象掉。
+
+3. **是否支持"多向量字段"？** 如 dense + sparse 混合检索。当前架构
+   `VectorShape(size, distance)` 只支持单向量；未来要扩展成
+   `VectorShape(fields: Mapping[str, VectorField])`。
+
+---
+
+## 10. 附：何时**不**应该做这个抽象
+
+如果短期内只跑 Qdrant，不会切换，做这层抽象就是**过度设计**。
+
+要启动 M2+ 的触发条件（满足任一即可）：
+
+- 用户明确要求某个部署不能依赖 Qdrant。
+- 我们要做 "ApeRAG-Lite"（只依赖 PG + Redis 的极简部署包）。
+- Qdrant 成本/运维成为增长瓶颈。
+
+当前三者都还没触发——这份文档的作用是**提前想清楚路径**，等触发发生时
+不用从零开始设计。

--- a/docs/zh-CN/design/vector_db_abstraction.md
+++ b/docs/zh-CN/design/vector_db_abstraction.md
@@ -1,7 +1,8 @@
 # 向量数据库抽象层设计分析（ApeRAG）
 
-> Status: **M2 已落地**（本文的分析已经变成了现网代码）。后续 pgvector 的
-> M3 工作仍在 roadmap 里，会按本文的分层和 DSL 约束来实现。
+> Status: **M2 + M3 已落地**（本文从分析文档升级成"文档即实现"）。两个
+> 后端（Qdrant、pgvector）共存、同一抽象，可通过 `VECTOR_DB_TYPE` 一行
+> env 切换。
 
 ## 变更记录
 
@@ -9,6 +10,7 @@
 |---|---|
 | 2026-04-20 | 初稿：分层、DSL、三后端草图、路线图 |
 | 2026-04-21 | M2 落地：`VectorFilter` DSL、Qdrant translator、`VectorPoint`、client pool、`retrieve()` 入基类 |
+| 2026-04-22 | M3 落地：pgvector 后端、DTO 全套（`TenantRef`/`VectorShape`/`QueryRequest`/`SearchHit`）、`upsert` 进入契约、去 LlamaIndex 写依赖 |
 
 ## 1. 背景与目标
 
@@ -42,24 +44,24 @@ Qdrant 连接器已经承担了三件相互耦合的事情：
 | 上层入口 | 索引写入 `aperag/index/*.py`、检索 `aperag/service/search_pipeline_service.py` | 每次按需构造 `VectorStoreConnectorAdaptor`、`ContextManager` | 每次请求重建连接 |
 | 分片路由 | `aperag/config.py`：`build_vector_db_context`、`get_vector_db_connector` | 注入 `multitenant/quantization/...` ctx | Qdrant 专属字段混在 Config 里 |
 
-**当前抽象的 4 个真实缺口**（2026-04-20 分析；M2 之后 1/2/4 已关闭，3 仍保留）：
+**当前抽象的 4 个真实缺口**（2026-04-20 分析；M2 + M3 之后全部关闭）：
 
-| # | 缺口 | M2 状态 |
+| # | 缺口 | 状态 |
 |---|---|---|
 | 1 | `retrieve(ids)` 只在 Qdrant 连接器上存在 | ✅ 已进基类，返回 `VectorPoint` |
 | 2 | `ContextManager` 硬编码 `qdrant_client.models` | ✅ 已迁到 `VectorFilter` DSL |
-| 3 | `LlamaIndex.QdrantVectorStore` 被直接暴露给业务层 | ⏸ 保留，等 M3 |
+| 3 | `LlamaIndex.QdrantVectorStore` 被直接暴露给业务层 | ✅ M3：新增 `upsert(points)`，业务写路径彻底不经 LlamaIndex |
 | 4 | 每次 search 重建 `QdrantClient` | ✅ 已进程级复用 |
 
-缺口 3 的完整细节（保留给 M3）：
-
-- `vector_store_adaptor.connector.store.add(nodes)` 仍在 vision_index.py
-  两处、embedding_utils.py 使用；
-- 写入 payload 依旧会被 LlamaIndex 注入 `_node_content` / `doc_id` /
-  `document_id` / `ref_doc_id`；
-- 这些字段是 Qdrant 后端的**实现细节**，在 M3 引入 pgvector 时，我们会
-  提供一个新的 `connector.upsert(points)` 接口替代 `store.add(nodes)`，
-  届时再一次性把 LlamaIndex 从业务写路径上拆掉。
+LlamaIndex 在代码库里的实际地位：仅剩的存在形式是 `TextNode` 作为
+chunker / embedder 的**中间**数据结构。在 `embedding_utils.py` 和
+`vision_index.py` 里，`BaseNode` 经过 `nodes_to_vector_points()`（见
+`aperag/vectorstore/llama_index_adapter.py`）一次性转成
+backend-neutral 的 `VectorPoint`；连接器层（Qdrant / pgvector）对
+LlamaIndex 完全无感。**读路径**的 `_node_content` 反序列化逻辑被抽到
+`flatten_node_payload()`（`aperag/vectorstore/dto.py`），只为了向后
+兼容 M2 之前由 `LlamaIndex.QdrantVectorStore.add()` 写入的老数据；新
+写入的数据采用扁平 `{text, metadata}`，读路径两种都支持。
 
 ---
 
@@ -315,13 +317,54 @@ SELECT id, payload, embedding <=> :q AS score
 `test_qdrant_filter_translation.py` / `test_qdrant_client_cache.py` /
 `test_context_manager_filter.py`。
 
-### M3：pgvector 实现（3~4 周）
+### M3：pgvector 实现（✅ **已落地**）
 
-- 新增 `pgvector_connector.py`，复用 `aperag/db/ops` 的 session 池。
-- 新增 `VECTOR_DB_TYPE=pgvector` 路径；migration 模板（`alembic` 脚本建立
-  每个需要的 `aperag_vectors_{size}_{distance}` 表）。
-- Reuse embedding lock 的前端逻辑（和 Qdrant 完全一致）。
-- 性能 benchmark：10 万 / 100 万 vectors 的 latency 对比报告。
+实际落地范围（比草案更激进，把 M2 时故意推迟的"DTO 全套 + 去 LlamaIndex
+写依赖"都一并做掉了）：
+
+- ✅ `aperag/vectorstore/pgvector_connector.py`：动态 `CREATE TABLE IF
+  NOT EXISTS aperag_vectors_<size>_<distance>`（与 Qdrant 的物理分片命名
+  对齐），HNSW + tenant_id + GIN(payload) 三个索引一并建好；`CREATE
+  EXTENSION IF NOT EXISTS vector` 由连接器发起。
+- ✅ 不走 alembic 模板：表按 shape 动态创建，与 Qdrant 的 `ensure_collection`
+  一致的幂等语义；进程级 `_ENSURED_TABLES` 缓存避免重复 DDL。
+- ✅ SQL filter translator（`_SqlFilter.translate`）把 `VectorFilter`
+  编译成参数化 `WHERE` 片段 + bind dict。**所有值都走 bind 参数**，
+  key 走白名单校验，彻底屏蔽注入面。
+- ✅ SQLAlchemy `Engine` 按 `database_url` 进程级共享，与 Qdrant
+  `_get_or_create_client` 的模式保持一致。
+- ✅ 默认复用 ApeRAG 主 Postgres（共享 `DATABASE_URL`），"零新组件"
+  部署；若 vector 规模压垮主 DB，设 `PGVECTOR_DATABASE_URL` 独立出去，
+  一个 env 搞定。
+- ✅ embedding lock（前端 + service）和 Qdrant 完全共用，无需改动。
+- ✅ 端到端测试 `test_pgvector_end_to_end.py`：10 个用例，gated by
+  `APERAG_TEST_PGVECTOR_URL` env（本地 `apecloud/pgvector:pg16` + 主
+  DB 起在 docker-compose 时默认可跑）。
+
+### M2 的补完（本次 PR 一起做）
+
+M2 当时"保留尾巴"的三件事，M3 实现 pgvector 时**一次性补齐**：
+
+- ✅ **DTO 全套**：`TenantRef(id)` / `VectorShape(size, distance)` /
+  `VectorPoint(id, vector, payload)` / `QueryRequest(embedding, top_k,
+  flt, score_threshold, with_vectors, hints)` / `SearchHit(id, score,
+  payload, vector?)`，全部 frozen dataclass。`dto.py` 严禁 import 任何
+  后端 SDK。
+- ✅ **`connector.upsert(points)` 抽象**：`VectorStoreConnector` 基类
+  新增抽象方法；Qdrant / pgvector 都原生实现；`embedding_utils.py` 和
+  `vision_index.py`（两处）迁过去，不再用 `store.add(nodes)`。
+- ✅ **`delete_by_filter(flt)` 抽象**：基类方法，两后端都支持；空/None
+  过滤器被显式 raise 而不是"全删"。
+- ✅ **`drop_tenant(purge_all_shards)`** 替代历史的 `delete_collection`：
+  命名更准确（多租户语义下它从不物理 drop 一个 collection）；
+  `purge_all_shards=True` 的语义两后端完全一致——按 `aperag_vectors_*`
+  前缀扫分片、按 tenant_id 删行。
+- ✅ **`base.py::VectorStoreConnector` 不再要求 `self.store`**：LlamaIndex
+  的 `VectorStore` 类型从基类契约里拿掉；后端各自决定是否持有。
+- ✅ **`flatten_node_payload()` 抽到 DTO 模块**：所有读路径（Qdrant
+  `search` 结果、`document_service` 的 chunk 预览）统一走它，把
+  "`_node_content` 反序列化 + relationships 派生 source" 的历史逻辑
+  收到一个地方，两个后端共用。
 
 ### M4：生产切换策略（按需）
 

--- a/docs/zh-CN/design/vector_db_abstraction_m2_pr.md
+++ b/docs/zh-CN/design/vector_db_abstraction_m2_pr.md
@@ -1,0 +1,145 @@
+# 向量数据库抽象层 M2 实现（PR 说明）
+
+本 PR 把 [`vector_db_abstraction.md`](./vector_db_abstraction.md) 中 M2
+的所有条目落地到代码。这是纯内部重构，**不改变任何用户可见行为**；但它
+堵上了向量数据库抽象的四个历史破口中的三个，为将来可能的 pgvector/Milvus
+切换铺好了路。
+
+## 结论先行
+
+- 上线后**不需要任何运维操作**：没新增 env、没新增 secret、没新增 CR、
+  没新增存储 migration。
+- 所有现有单元/集成测试通过；本 PR 新增 4 个测试文件共约 30 个用例。
+- `docs/zh-CN/design/vector_db_abstraction.md` 已更新，M2 段落标注
+  "✅ 已落地"。
+
+## 做了什么
+
+### 1. `VectorFilter` DSL（新文件 `aperag/vectorstore/filters.py`）
+
+- 六个节点：`Eq / In / IsEmpty / And / Or / Not`，全部 frozen dataclass
+  (天然可 hash / 可比较 / 不可变)。
+- 两个人类友好 helper：`all_of(*parts)` / `any_of(*parts)`，自动跳过
+  `None`、单参数退化、零参数返回 `None`，让 `ContextManager` 不用写
+  `if len(parts) == 0 else ...` 之类的胶水。
+- 文件顶部写清楚了 "加节点前读这里" 的设计约束：**最小化、仅标量值、
+  不许 import 任何后端库**。未来新加节点要同步改所有 backend translator，
+  成本心里有数。
+
+### 2. Qdrant translator（`qdrant_connector.py` 内新增）
+
+- `_translate_filter(flt)` 把 DSL 树转成 `qdrant_client.models.Filter`。
+- `_normalize_filter_input(x)` 同时接受 DSL 节点、`rest.Filter` 直传、
+  或 `None`；把 `rest.Filter` 直传留在这里**只是给迁移脚本用**——`ContextManager`
+  已经完全走 DSL。
+- 空 `In` 直接抛 `ValueError`——在单后端时代，这种静默"匹配空集"最容易
+  生成"线上没数据"的疑云，现在崩溃比疑云更便宜。
+
+### 3. `VectorStoreConnector` 抽象升级（`aperag/vectorstore/base.py`）
+
+- 新增抽象方法 `retrieve(ids, *, with_payload, with_vectors)`。
+  之前只有 Qdrant 实现，`document_service.py` 直接调用，切后端会
+  `AttributeError`。
+- 新增最小 DTO `VectorPoint(id: str, payload: dict, vector: list | None)`。
+  `retrieve()` 返回它，彻底切断 `qdrant_client.http.models.Record` 对业务
+  层的泄露。
+- `search(query, *, filter, score_threshold, **kwargs)`：`filter` 从
+  `**kwargs` 升级为显式关键字，类型注释 `Optional[VectorFilter]`。
+
+### 4. `ContextManager` 去 Qdrant 化（`aperag/context/context.py`）
+
+- 整个文件不再 import `qdrant_client` 任何东西。
+- `_create_index_types_filter` / `_create_combined_filter` 产出 DSL。
+- 历史上 `Filter(should=[FieldCondition(indexer IN [...]),
+  IsEmptyCondition(indexer)])` 的 **"兼容老数据没有 indexer 字段"**
+  语义被原样保留（在 `_create_index_types_filter` 的 `any_of(In, IsEmpty)`
+  里）。这是我在 double-think 时反复确认的点——悄悄丢掉这个 branch 会让
+  迁移前的数据在检索中消失一半。
+
+### 5. `QdrantClient` 进程级复用（`qdrant_connector.py` 顶部）
+
+- `_get_or_create_client(url, port, grpc_port, prefer_grpc, https, api_key, timeout)`
+  按 endpoint 特征做双检锁缓存。
+- `:memory:` URL **显式绕过缓存**，否则集成测试里各测试会共享一份内存
+  store，隐性破坏隔离——这种"在 prod 用没事但在 test 里炸"的陷阱是
+  长期最耗答疑时间的那种 bug，一次把它封死。
+- `_reset_client_cache()` 只给测试用。
+
+### 6. `QdrantVectorStoreConnector.retrieve` 返回类型切换
+
+- 从"Qdrant `Record` 原样返回"变为"转成 `VectorPoint` 返回"。
+- `id` 统一 `str(x)`——上游 `Chunk.id: Optional[str]`，Pydantic 本来就会
+  强转，实际语义无变化，只是把隐式强转变成显式。
+- 多向量字段的 collection 在 Qdrant 里是 `dict[str, list[float]]`，我们
+  从来不用多向量，这里加了一个防御性的 `dict -> first.values()` 兜底，
+  以后即便有人误配置了也不会 AttributeError。
+
+### 7. `envs/env.template` 追加 `QDRANT_*` 多租户 / 优化开关
+
+- 之前这些 env 只在 `deploy/aperag/values.yaml` 里（线上路径），本地
+  `.env` 不知道它们的存在。
+- 现在 `env.template` 里列齐了全部 10 个 `QDRANT_*` 开关，默认值与生产
+  一致；开发者 copy 一份 `.env` 就直接能跑。
+- `docker.env.overrides` 无需改动（它只 override host/port 类字段）。
+
+## 没做什么（以及为什么）
+
+| 没做 | 为什么 |
+|---|---|
+| 解耦 LlamaIndex `QdrantVectorStore.add(nodes)` | 两处 vision 写路径 + embedding_utils 深度依赖 LlamaIndex 的 node schema；拆解工作量 ≥ 本 PR。等 M3 做 pgvector 时必须拆，那时一起做 |
+| 引入 `TenantRef / VectorShape / QueryResult / SearchOptions` 一堆 DTO | 只有 Qdrant 时这些 DTO 都只是 "存在感"，用户读到会问 "为啥 5 个类做的事情能用 3 个做"。等真加 pgvector 时，那时的工程师对 pgvector 的约束了解精确，一次定型好过现在拍脑袋 |
+| 把 graph DB 一起抽象 | 你提到了 graph 抽象也要做；但 graph 的模式（Cypher/GQL）和向量完全不同，共用层只会是最低公共分母。**本 PR 只把向量 DSL 放在 `aperag/vectorstore/filters.py` 而不是 `aperag/filters.py`**，给未来 graph DSL 留了独立命名空间 |
+| Milvus 实现 | 你说可以不做，暂不做 |
+| 客户端连接池的更复杂策略（健康探测 / 驱逐 / 自动重连） | Qdrant Python 客户端本身自带 keep-alive 和重连；更复杂的池管理会在第一次遇到具体问题时再加。**"没问题时的复杂度 = 负价值"** |
+
+## 接口兼容性
+
+- `VectorStoreConnector.search(filter=X)` 的 `X`：
+  - **推荐**：DSL 节点（`Eq`、`In`、`all_of(...)` 等）。
+  - **仍兼容**：`qdrant_client.models.Filter`（迁移脚本在用）。
+  - 其他类型：记 WARNING 并丢弃（与之前行为一致）。
+- `VectorStoreConnector.retrieve(ids, *, with_payload, with_vectors)` 返回
+  `List[VectorPoint]`。之前的 Qdrant `Record` 都被访问的是 `.id` / `.payload`，
+  `VectorPoint` 完全兼容这两个属性；pydantic 下游 `Chunk(id=point.id)` 正常。
+- 所有 `connector.delete(ids=...)` / `connector.create_collection(...)` /
+  `connector.delete_collection(...)` 签名不变。
+- `connector.store.add(nodes)`（LlamaIndex 写路径）不变。
+
+## 测试矩阵
+
+| 文件 | 覆盖点 |
+|---|---|
+| `test_filters.py` | DSL 构造规则、frozen 语义、`all_of/any_of` 短路、嵌套 |
+| `test_qdrant_filter_translation.py` | 每个 DSL 节点 → Qdrant Filter 的结构快照；rest.Filter 直传短路；未知类型拒绝；空 In 报错 |
+| `test_qdrant_client_cache.py` | 同 endpoint 复用、不同 endpoint 各开一个、`:memory:` 绝不缓存、并发首连接不雪崩 |
+| `test_context_manager_filter.py` | 无过滤 → None、只 index_types → `Or(In, IsEmpty)`（保留 backward-compat）、只 chat_id → Eq、全开 → And(Or, Eq)、与 `vectordb_type` 字符串解耦 |
+
+共 30 个新用例，全部通过。原有 39 个测试（包括 embedding lock、多租户
+delete、purge_all_shards）全部继续通过。
+
+## 上线核对清单
+
+- [ ] 镜像构建通过。
+- [ ] CI 所有测试绿（pytest + ruff）。
+- [ ] 生产 Qdrant 是 1.10+。本 PR 对 Qdrant 版本要求与上一 PR 相同。
+- [ ] `deploy/aperag/values.yaml` 的 `QDRANT_*` 字段与上一 PR 保持一致，
+  无需运维动作。
+- [ ] 合并后观测：
+  - `qdrant-cluster-qdrant-0` RSS 曲线不应有突变（本 PR 不动内存策略）。
+  - 首次搜索延迟可能小幅下降（client 复用省了 TCP/TLS 握手）。
+  - 无新增 ERROR 级别日志。
+
+## 后续
+
+本 PR 合并后，[`vector_db_abstraction.md`](./vector_db_abstraction.md)
+的 M3（pgvector 实现）就是"填空题" —— 只需要：
+
+1. 新增 `aperag/vectorstore/pgvector_connector.py`：实现 `search /
+   delete / retrieve / create_collection / delete_collection`；
+2. 在 `VectorStoreConnectorAdaptor.match vector_store_type` 里加一条
+   `case "pgvector"` 分支；
+3. 在 `envs/env.template` 里加 `VECTOR_DB_TYPE=pgvector` 的例子；
+4. 给 pgvector 单独一份 schema migration 脚本。
+
+整个 M3 预计不需要再动 `ContextManager`、`base.py`、`filters.py` 中的
+任何一行。这就是本 PR 要达到的 "M3 只是换后端、不是重写系统" 的目标。

--- a/docs/zh-CN/design/vector_db_abstraction_m3_pr.md
+++ b/docs/zh-CN/design/vector_db_abstraction_m3_pr.md
@@ -1,0 +1,279 @@
+# 向量数据库抽象层 M3（pgvector + 抽象层补完）— PR 说明
+
+本 PR 在 M2 的基础上一次性做完了两件事：
+
+1. **M3：pgvector 后端实现**。ApeRAG 现在支持 `VECTOR_DB_TYPE=qdrant |
+   pgvector` 两种后端，默认 Qdrant。pgvector 版本与 Qdrant 功能对等，
+   共用同一套 `VectorFilter` DSL、租户隔离语义、embedding 锁定。
+2. **M2 的补完**：原本推到 M3 的 "DTO 全套" 和 "去 LlamaIndex 写依赖" 两
+   项尾巴，这次一起做掉了。不留代码债、不留下次返工。
+
+**合并即可用。** 没有新增 env、也没有任何必要的运维动作（除非你想启用
+pgvector —— 那就翻一个 env flag 就行）。
+
+## 为什么不留尾巴
+
+上一轮我故意保守——"只有 Qdrant 一个后端时多 DTO 是答疑负担"。这次不再
+成立：
+
+- pgvector 真的要上了，两个后端的存在让 DTO 全套**立刻**有收益（避免
+  per-callsite 分支）；
+- LlamaIndex 的 `QdrantVectorStore.add(nodes)` 在引入 pgvector 时是
+  硬阻塞（pgvector 没有对应 adapter）；
+- 等下次 PR 再拆这两件事，就意味着本次 pgvector 落地时要么**复制**
+  LlamaIndex 的 `_node_content` 序列化约定到 pgvector，要么引入一个
+  LlamaIndex `PGVectorStore` 作为新依赖——都是"现在不痛、将来痛"的决策。
+  趁还没分叉先拆掉，代价最低。
+
+所以本 PR 的核心口号是："一次到位"。
+
+## 抽象层现状（合并后）
+
+```text
+aperag/vectorstore/
+├── base.py                    # VectorStoreConnector 抽象；签名全部 DTO 化
+├── dto.py                     # TenantRef, VectorShape, VectorPoint,
+│                              # QueryRequest, SearchHit, flatten_node_payload
+├── filters.py                 # VectorFilter DSL: Eq/In/IsEmpty/And/Or/Not
+├── connector.py               # 适配器：match vector_store_type
+├── qdrant_connector.py        # Qdrant 实现 + DSL translator
+├── pgvector_connector.py      # pgvector 实现 + SQL translator (新)
+└── llama_index_adapter.py     # BaseNode -> VectorPoint (新)
+```
+
+契约（`base.py`）现在是：
+
+```python
+class VectorStoreConnector(ABC):
+    @property
+    @abstractmethod
+    def tenant(self) -> TenantRef: ...
+    @property
+    @abstractmethod
+    def shape(self) -> VectorShape: ...
+
+    @abstractmethod
+    def ensure_collection(self) -> None: ...
+    @abstractmethod
+    def drop_tenant(self, *, purge_all_shards: bool = False) -> None: ...
+
+    @abstractmethod
+    def upsert(self, points: Sequence[VectorPoint]) -> list[str]: ...
+    @abstractmethod
+    def delete(self, ids: Sequence[str]) -> None: ...
+    @abstractmethod
+    def delete_by_filter(self, flt: VectorFilter) -> None: ...
+
+    @abstractmethod
+    def search(self, request: QueryRequest) -> list[SearchHit]: ...
+    @abstractmethod
+    def retrieve(self, ids: Sequence[str], *, with_vectors: bool = False) -> list[VectorPoint]: ...
+```
+
+九个方法，全部 DTO 化、全部不携带任何后端特征。
+
+## pgvector 关键设计决策
+
+### 部署形态：默认复用主 Postgres
+
+- 默认 `PGVECTOR_DATABASE_URL=` 留空 → 使用 ApeRAG 主 DB (`DATABASE_URL`)。
+- "私有化交付 / ApeRAG-Lite" 场景少一个组件，**零部署负担**就是抽象层
+  的主要卖点。
+- 规模上去了？设 `PGVECTOR_DATABASE_URL=postgresql://...` 指到独立 PG，
+  一个 env 搞定，应用代码不动。
+
+### Schema：动态建表、对齐 Qdrant 命名
+
+每个 `(vector_size, distance)` 对一张 `aperag_vectors_<size>_<distance>`
+表，与 Qdrant 的物理分片命名完全一致。这不是偶然——`purge_all_shards`
+这类运维逻辑现在**两后端走同一条代码路径**：按 `aperag_vectors_*` 前缀
+扫分片，按 `tenant_id` 删。
+
+表结构：
+
+```sql
+CREATE TABLE aperag_vectors_1024_cosine (
+    id          UUID PRIMARY KEY,
+    tenant_id   TEXT NOT NULL,
+    embedding   vector(1024) NOT NULL,
+    payload     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ... ON ... (tenant_id);
+CREATE INDEX ... ON ... USING hnsw (embedding vector_cosine_ops)
+    WITH (m=16, ef_construction=64);
+CREATE INDEX ... ON ... USING GIN (payload);
+```
+
+三个索引各司其职：tenant_id 用 B-tree 撑住"按租户 DELETE / SELECT"；
+HNSW 用于近邻；GIN(payload) 让 DSL filter 能被 JSONB 索引加速。
+
+**动态建表 vs migration 文件**：我选前者。原因：
+- `(size, distance)` 组合是用户选 embedding model 时决定的，**不是**
+  部署时间常量。主 alembic 迁移如果要包含所有可能组合，意味着要么
+  硬编码 (1024, 1536, 3072) × (cosine, dot, euclid)，要么 migration
+  失控。
+- 连接器的 `ensure_collection` 幂等 + 进程级缓存，首次写时 ~20ms 延迟
+  一次，之后零开销；这和 Qdrant 的 `collection_exists ? no-op :
+  create_collection` 完全对称。
+- 运维视角统一："哪里来的表？" → `aperag_vectors_*`；"按什么删？" →
+  `tenant_id + id / filter`；"怎么清空某个 Collection？" → `DELETE
+  FROM ... WHERE tenant_id = :t`。这些都是**查看即懂**的操作。
+
+### SQL filter translator
+
+`VectorFilter` DSL → `(where_sql, bind_params)`：
+
+| DSL | SQL |
+|---|---|
+| `Eq(k, v)` | `payload->>'k' = :f0` |
+| `In(k, [a, b])` | `payload->>'k' IN (:f0, :f1)` |
+| `IsEmpty(k)` | `NOT (payload ? 'k') OR payload->'k' = 'null'::jsonb` |
+| `And(...)` | `(...parts join ' AND '...)` |
+| `Or(...)` | `(...parts join ' OR '...)` |
+| `Not(inner)` | `NOT (...)` |
+
+**所有值走 bind 参数**；JSON key 走白名单正则校验（见
+`_escape_json_key`）。SQL 注入面彻底关死。
+
+### 距离语义：统一"分数越高越好"
+
+| 距离 | HNSW opclass | PG 操作 | 评分表达式 |
+|---|---|---|---|
+| cosine | `vector_cosine_ops` | `<=>` | `1 - (embedding <=> :q)` |
+| euclid | `vector_l2_ops` | `<->` | `-(embedding <-> :q)` |
+| dot | `vector_ip_ops` | `<#>` | `-(embedding <#> :q)` |
+
+这让 `QueryRequest.score_threshold` 对三种距离都是"higher-is-better"
+的一致语义，调用方无需分支。
+
+### `CAST(:q AS vector)` 小坑
+
+SQLAlchemy `text()` 的 `:name::vector` 写法在 psycopg2 下会被误解析
+（部分参数被替换、部分原样保留，SQL 报错）。正确写法是 `CAST(:q AS
+vector)`——在 `_DISTANCE_SPEC` 和 upsert 的 VALUES 里都已改用 CAST。
+留了详细注释，后来人不会再踩。
+
+## Qdrant 连接器的同步改造
+
+为保持契约对称，Qdrant 连接器也一起改了：
+
+- **原生 `upsert`**：`client.upsert(...)` 直接写，不再走 LlamaIndex
+  `QdrantVectorStore.add(nodes)`。
+- **`delete_by_filter`**：新方法，自动 AND tenant 守卫；空过滤器被显式
+  rejected（否则在多租户下会 silently 等价于 `drop_tenant`）。
+- **`retrieve` 返回 `List[VectorPoint]`**：`id` 归一化为 `str`、vector
+  归一化为 `list[float]`。
+- **`drop_tenant` 替代 `delete_collection`**：命名更准确。
+- **去掉 `self.store`**：LlamaIndex `QdrantVectorStore` 不再在连接器里
+  存在。`vector_store_adaptor.connector.store.add(...)` 这种写法彻底
+  失效。
+
+## 业务层改造
+
+三个写入点 + 两个读取点：
+
+| 位置 | 改造 |
+|---|---|
+| `embedding_utils.py::create_embeddings_and_store` | `store.add(nodes)` → `nodes_to_vector_points(nodes, tenant_id=...)` → `connector.upsert(points)` |
+| `vision_index.py`（纯视觉 + 视觉转文本两处） | 同上 |
+| `tasks/collection.py::_initialize_vector_databases` | `create_collection(vector_size=...)` → `ensure_collection()` |
+| `tasks/collection.py::_delete_vector_databases` | `delete_collection(...)` → `drop_tenant(...)` |
+| `document_service.py::get_document_chunks / _vision_chunks` | 手写 `_node_content` 解析 → `flatten_node_payload(point.payload)` |
+
+`ContextManager.query()` 内部从 `connector.search(...).results`（老的
+`QueryResult` 包装）切换到 `list[SearchHit]` + 自己适配成
+`DocumentWithScore`，对外行为完全不变。
+
+## 向后兼容：旧数据仍可读
+
+已经写入的 Qdrant 数据（由 LlamaIndex `QdrantVectorStore.add` 产生，
+payload 带 `_node_content` 字符串）**不需要任何迁移**。读路径统一走
+`flatten_node_payload()`：
+
+1. 有 `text` / `metadata` 顶层字段（新写入）→ 直接用。
+2. 只有 `_node_content`（老数据）→ 解析 JSON 取字段。
+3. 两者都有（过渡态）→ 优先用 flat 版本（最新写入意图）。
+4. `metadata.source` 缺失但 `_node_content.relationships['1'].metadata.source`
+   存在 → 派生 basename 作为 source（老文档预览页依赖这条路径）。
+
+这个 helper 有专门单元测试（`test_dto.py`）盯住上面四条语义。
+
+## 配置项
+
+### 新增 env（都非必填）
+
+```bash
+# 向量后端选择，默认 qdrant。切 pgvector 只需改这一行。
+VECTOR_DB_TYPE=qdrant
+
+# pgvector 独立 DB URL（可选）。留空 → 复用主 PG。
+PGVECTOR_DATABASE_URL=
+
+# HNSW 调优
+PGVECTOR_HNSW_M=16
+PGVECTOR_HNSW_EF_CONSTRUCTION=64
+PGVECTOR_HNSW_EF_SEARCH=40
+```
+
+### deploy
+
+- `deploy/aperag/values.yaml` 补齐 `PGVECTOR_*`，默认与 env.template 一致。
+- docker-compose 的 `aperag-postgres` 已经是 `apecloud/pgvector:pg16`，
+  `vector` 扩展已安装。**本地直接开箱可用**：
+
+```bash
+# 切到 pgvector 后端（默认复用主 DB）
+echo "VECTOR_DB_TYPE=pgvector" >> envs/.env
+make run  # 应用自动建表、建索引、建 extension
+```
+
+## 测试
+
+| 文件 | 范围 |
+|---|---|
+| `test_dto.py`（新） | `VectorShape` 归一化、`TenantRef` 非空、`VectorPoint` 类型检查、`QueryRequest` 字段默认、`flatten_node_payload` 四条语义路径 |
+| `test_llama_index_adapter.py`（新） | `BaseNode` → `VectorPoint` 扁平转换、tenant 自动注入、顺序保持 |
+| `test_pgvector_translator.py`（新） | 表名构造边界、DSL 每节点 → SQL 片段结构快照、SQL 注入面（参数 bind 而非插值） |
+| `test_pgvector_end_to_end.py`（新，gated by `APERAG_TEST_PGVECTOR_URL`） | 10 个用例覆盖 upsert / search / retrieve / delete / delete_by_filter / drop_tenant / tenant 隔离 / 组合过滤 |
+| `test_qdrant_multitenancy_integration.py`（更新） | 全量迁移到新 DTO API；新增 `delete_by_filter` 和 `upsert` 覆盖 |
+| `test_qdrant_filter_translation.py`、`test_qdrant_client_cache.py`、`test_context_manager_filter.py`、`test_filters.py`（更新/保留） | M2 的测试集全部兼容新 API |
+
+**结果**：121 tests in `tests/unit_test/vectorstore + service`（含 10 个
+pgvector 端到端、gated），全部通过。更广的 455 测试（排除 pre-existing
+`pydantic_ai` / MCP docstring 失败，那两组与本 PR 无关）也通过。
+
+## 上线指南（两种场景）
+
+### 场景 A：继续用 Qdrant（默认）
+
+- 什么都不用改。合并即可。
+- 新的 `connector.upsert` 写入格式不再包含 `_node_content`；已有老
+  数据的读路径通过 `flatten_node_payload` 完全兼容，不需要重写老数据。
+
+### 场景 B：切换到 pgvector
+
+1. 确认 PostgreSQL 安装了 `pgvector` 扩展（`CREATE EXTENSION vector` 能
+   跑通）。`apecloud/pgvector:pg16` 镜像已内置。
+2. 设 `VECTOR_DB_TYPE=pgvector`。默认复用 `DATABASE_URL` 指向的主
+   Postgres；如要独立 PG，设 `PGVECTOR_DATABASE_URL=...`。
+3. 重启应用。首次写入时连接器自动 `CREATE TABLE IF NOT EXISTS
+   aperag_vectors_<size>_<distance>` + 三个索引。
+4. **Qdrant 和 pgvector 的数据目前不互通**——切换相当于新启用一个空的
+   后端。已有 Qdrant 数据需要重新 ingest（或保留 Qdrant 继续读、同时
+   pgvector 只收新数据：这种双写窗口设计不在本 PR 范围）。
+
+## 下一步（非本 PR）
+
+这些都不是 blocker，记录在这里供后续评估：
+
+- **数据迁移脚本**（Qdrant → pgvector）：现在没做，需要时按
+  `scripts/migrate_qdrant_multitenancy.py` 的思路扩一个 "scroll Qdrant →
+  upsert pgvector" 的脚本，大概 300 行。
+- **pgvector `halfvec` / `bit` 量化**：维度过大时开这个能省 50~90% 磁
+  盘。目前 `pgvector_hnsw_*` 下留了 hook，实际启用需要给 `VectorShape`
+  加一个 `storage_type` 字段 + connector 建表时用 `halfvec(dim)`。
+  **按需再做**，不提前占位。
+- **Milvus 后端**：架构已经齐了，新加一个 `milvus_connector.py` 实现
+  9 个抽象方法 + 在 `connector.py::match` 加一条 case 就能接进来。预计
+  1~2 周工作量。

--- a/envs/env.template
+++ b/envs/env.template
@@ -20,8 +20,26 @@ REDIS_USER=default
 REDIS_PASSWORD=password
 
 # Vector DB
+# VECTOR_DB_TYPE chooses the backend; only "qdrant" is wired today. Other
+# backends (pgvector, Milvus) are behind a backend-neutral interface
+# (aperag/vectorstore/base.py + aperag/vectorstore/filters.py) and can be
+# plugged in without touching callers.
 VECTOR_DB_TYPE=qdrant
 VECTOR_DB_CONTEXT={"url":"http://127.0.0.1","port":6333,"distance":"Cosine","timeout":1000}
+
+# ---- Qdrant multitenancy & memory optimization knobs ----
+# These are safe production defaults (see docs/zh-CN/design/qdrant_memory_optimization.md).
+# QDRANT_MULTITENANT=False falls back to one-collection-per-tenant (legacy mode).
+QDRANT_MULTITENANT=True
+QDRANT_QUANTIZATION_ENABLED=True
+QDRANT_QUANTIZATION_TYPE=int8
+QDRANT_QUANTIZATION_QUANTILE=0.99
+QDRANT_QUANTIZATION_ALWAYS_RAM=True
+QDRANT_HNSW_ON_DISK=True
+QDRANT_DEFAULT_SEGMENT_NUMBER=2
+QDRANT_MMAP_THRESHOLD_KB=20480
+QDRANT_VECTORS_ON_DISK=True
+QDRANT_ON_DISK_PAYLOAD=True
 
 # Elasticsearch
 ES_HOST_NAME=127.0.0.1

--- a/envs/env.template
+++ b/envs/env.template
@@ -20,15 +20,22 @@ REDIS_USER=default
 REDIS_PASSWORD=password
 
 # Vector DB
-# VECTOR_DB_TYPE chooses the backend; only "qdrant" is wired today. Other
-# backends (pgvector, Milvus) are behind a backend-neutral interface
-# (aperag/vectorstore/base.py + aperag/vectorstore/filters.py) and can be
-# plugged in without touching callers.
+# VECTOR_DB_TYPE chooses the backend. Supported today:
+#   * qdrant   — the default, optimized for large tenant fleets with
+#                dedicated-process Qdrant (see
+#                docs/zh-CN/design/qdrant_memory_optimization.md).
+#   * pgvector — runs inside the existing ApeRAG PostgreSQL; pick this
+#                for "ApeRAG-Lite / private delivery" where you want
+#                one fewer component to operate. Switching backends is
+#                a pure env flip; no schema migration is required
+#                because each backend owns its own physical storage.
+# Both backends honor the same VectorFilter DSL and tenant-guard
+# semantics; see docs/zh-CN/design/vector_db_abstraction.md.
 VECTOR_DB_TYPE=qdrant
 VECTOR_DB_CONTEXT={"url":"http://127.0.0.1","port":6333,"distance":"Cosine","timeout":1000}
 
 # ---- Qdrant multitenancy & memory optimization knobs ----
-# These are safe production defaults (see docs/zh-CN/design/qdrant_memory_optimization.md).
+# Safe production defaults (see docs/zh-CN/design/qdrant_memory_optimization.md).
 # QDRANT_MULTITENANT=False falls back to one-collection-per-tenant (legacy mode).
 QDRANT_MULTITENANT=True
 QDRANT_QUANTIZATION_ENABLED=True
@@ -40,6 +47,20 @@ QDRANT_DEFAULT_SEGMENT_NUMBER=2
 QDRANT_MMAP_THRESHOLD_KB=20480
 QDRANT_VECTORS_ON_DISK=True
 QDRANT_ON_DISK_PAYLOAD=True
+
+# ---- pgvector knobs ----
+# PGVECTOR_DATABASE_URL points at the Postgres that stores vectors.
+# Leave empty to reuse the main ApeRAG Postgres (above POSTGRES_* /
+# DATABASE_URL). Set to a dedicated DSN only when vector volume / QPS
+# warrants isolation from the metadata DB.
+# Examples:
+#   PGVECTOR_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/aperag
+# Required: the target database must have the ``vector`` extension
+# installed (``CREATE EXTENSION vector`` — needs superuser on first run).
+PGVECTOR_DATABASE_URL=
+PGVECTOR_HNSW_M=16
+PGVECTOR_HNSW_EF_CONSTRUCTION=64
+PGVECTOR_HNSW_EF_SEARCH=40
 
 # Elasticsearch
 ES_HOST_NAME=127.0.0.1

--- a/tests/unit_test/service/test_collection_service_embedding_lock.py
+++ b/tests/unit_test/service/test_collection_service_embedding_lock.py
@@ -1,0 +1,148 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Unit tests for CollectionService.embedding-lock logic.
+
+We intentionally test the two pure helpers and the method that glues them
+together (``_reject_embedding_change``) without touching the database: the
+guardrail lives entirely above the ORM and is what users will hit when they
+try to repoint an existing collection at a new embedding model.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.exceptions import ValidationException
+from aperag.schema import view_models
+from aperag.schema.view_models import CollectionConfig, ModelSpec
+from aperag.service.collection_service import CollectionService
+
+
+def _cfg(model: str | None, msp: str | None = "openai", clp: str | None = "openai") -> CollectionConfig:
+    return CollectionConfig(
+        embedding=ModelSpec(model=model, model_service_provider=msp, custom_llm_provider=clp),
+    )
+
+
+def _instance_with(cfg: CollectionConfig | None):
+    """Fake SQLAlchemy row; the service only reads ``.config`` as JSON text."""
+    return SimpleNamespace(config=None if cfg is None else cfg.model_dump_json())
+
+
+# ---------------------------------------------------------------------------
+# _embedding_identity: the building block for comparison
+# ---------------------------------------------------------------------------
+
+
+def test_embedding_identity_none_for_no_config():
+    assert CollectionService._embedding_identity(None) is None
+
+
+def test_embedding_identity_none_when_embedding_missing():
+    assert CollectionService._embedding_identity(CollectionConfig()) is None
+
+
+def test_embedding_identity_none_when_all_embedding_fields_empty():
+    # Empty ModelSpec should not count as "bound" — lets first-time binding happen.
+    assert CollectionService._embedding_identity(_cfg(None, None, None)) is None
+
+
+def test_embedding_identity_is_tuple():
+    ident = CollectionService._embedding_identity(_cfg("bge-m3", "openai", "openai"))
+    assert ident == ("bge-m3", "openai", "openai")
+
+
+# ---------------------------------------------------------------------------
+# _reject_embedding_change: the guardrail itself
+# ---------------------------------------------------------------------------
+
+
+def _update(cfg: CollectionConfig | None) -> view_models.CollectionUpdate:
+    return view_models.CollectionUpdate(config=cfg)
+
+
+@pytest.fixture
+def svc() -> CollectionService:
+    # Avoid touching the global db_ops singleton — the guardrail is pure.
+    s = CollectionService.__new__(CollectionService)
+    s.db_ops = None
+    return s
+
+
+def test_reject_allows_first_time_binding(svc):
+    """A collection whose embedding was never set can receive one."""
+    instance = _instance_with(None)
+    svc._reject_embedding_change(instance, _update(_cfg("bge-m3")))  # no raise
+
+
+def test_reject_allows_identical_embedding(svc):
+    """Saving the same embedding block (e.g. title/description edits) is fine."""
+    cfg = _cfg("bge-m3", "openai", "openai")
+    instance = _instance_with(cfg)
+    svc._reject_embedding_change(instance, _update(cfg))  # no raise
+
+
+def test_reject_allows_update_without_config_field(svc):
+    """Partial updates (``config=None``) must not trigger the guardrail;
+    otherwise every title-only edit would fail validation."""
+    instance = _instance_with(_cfg("bge-m3"))
+    svc._reject_embedding_change(instance, view_models.CollectionUpdate(config=None))
+
+
+def test_reject_blocks_model_change(svc):
+    """Switching the embedding model itself is the headline offense."""
+    instance = _instance_with(_cfg("bge-m3"))
+    with pytest.raises(ValidationException, match="cannot be changed"):
+        svc._reject_embedding_change(instance, _update(_cfg("text-embedding-3-large")))
+
+
+def test_reject_blocks_provider_change(svc):
+    """Even keeping the model name but changing provider is blocked — different
+    providers can route to different physical models (bedrock vs openai) and
+    therefore different vector spaces."""
+    instance = _instance_with(_cfg("bge-m3", msp="openai"))
+    with pytest.raises(ValidationException, match="cannot be changed"):
+        svc._reject_embedding_change(instance, _update(_cfg("bge-m3", msp="bedrock")))
+
+
+def test_reject_blocks_clearing_existing_binding(svc):
+    """Once bound, the embedding block cannot be wiped clean — doing so would
+    leave existing Qdrant points stranded with no way to refresh them."""
+    instance = _instance_with(_cfg("bge-m3"))
+    empty = CollectionConfig()  # embedding=None
+    with pytest.raises(ValidationException, match="cannot be cleared"):
+        svc._reject_embedding_change(instance, _update(empty))
+
+
+def test_reject_handles_malformed_stored_config_as_unbound(svc):
+    """Historical rows with garbage in ``config`` should not brick future
+    updates; we treat unparseable ``instance.config`` as "no prior binding"
+    so the user can set one via the normal edit flow."""
+    instance = SimpleNamespace(config="{not valid json")
+    # No raise — treated as first-time binding.
+    svc._reject_embedding_change(instance, _update(_cfg("bge-m3")))
+
+
+def test_reject_accepts_future_schema_additions_identically(svc):
+    """The identity tuple is based solely on (model, msp, clp); unrelated
+    ModelSpec fields (temperature etc.) must not trigger the guardrail.
+    Otherwise users can't tune retrieval params post-hoc."""
+    before = ModelSpec(model="bge-m3", model_service_provider="openai", custom_llm_provider="openai", temperature=0.0)
+    after = ModelSpec(model="bge-m3", model_service_provider="openai", custom_llm_provider="openai", temperature=0.5)
+    instance = _instance_with(CollectionConfig(embedding=before))
+    svc._reject_embedding_change(instance, _update(CollectionConfig(embedding=after)))  # no raise
+
+
+def test_reject_parses_stored_config_correctly(svc):
+    """Sanity: the guardrail really reads embedding from the serialized JSON
+    in ``instance.config`` rather than assuming a richer in-memory shape."""
+    stored = json.loads(_cfg("bge-m3").model_dump_json())
+    instance = SimpleNamespace(config=json.dumps(stored))
+    with pytest.raises(ValidationException):
+        svc._reject_embedding_change(instance, _update(_cfg("text-embedding-3-large")))

--- a/tests/unit_test/vectorstore/test_build_vector_db_context.py
+++ b/tests/unit_test/vectorstore/test_build_vector_db_context.py
@@ -72,6 +72,21 @@ def test_build_context_propagates_all_optimization_flags(clean_vector_db_context
     assert ctx["on_disk_payload"] is True
 
 
+def test_build_context_populates_pgvector_knobs_even_for_qdrant_deploys(clean_vector_db_context):
+    """pgvector settings are merged into ctx regardless of which backend
+    the deployment is configured for. Each connector reads only the keys
+    it understands, so having both Qdrant and pgvector knobs present at
+    the same time is cheap and makes ``VECTOR_DB_TYPE=pgvector`` a
+    one-flag flip."""
+    ctx = build_vector_db_context("col1", vector_size=1024)
+    # Either explicit PGVECTOR_DATABASE_URL wins, or we fall back to the
+    # main database_url — never empty.
+    assert ctx["pgvector_database_url"]
+    assert isinstance(ctx["pgvector_hnsw_m"], int)
+    assert isinstance(ctx["pgvector_hnsw_ef_construction"], int)
+    assert isinstance(ctx["pgvector_hnsw_ef_search"], int)
+
+
 def test_build_context_respects_ctx_override(monkeypatch):
     # If the operator pins a flag inside VECTOR_DB_CONTEXT JSON, it must win
     # over the settings-level default. This is how the migration script tells

--- a/tests/unit_test/vectorstore/test_context_manager_filter.py
+++ b/tests/unit_test/vectorstore/test_context_manager_filter.py
@@ -1,0 +1,105 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for ``ContextManager._create_combined_filter`` producing DSL.
+
+These tests guard the boundary between "business intent" (index_types /
+chat_id parameters the service layer passes in) and "backend-neutral filter
+shape" (what gets handed to the connector). A regression here silently
+changes retrieval semantics, so we assert on exact tree shape.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from aperag.context.context import ContextManager
+from aperag.vectorstore.filters import And, Eq, In, IsEmpty, Or
+
+
+def _cm() -> ContextManager:
+    """Build a ContextManager bypassing __init__ — we don't need a real
+    adaptor / embedding for pure filter-construction tests, and wiring one
+    up would drag Qdrant into a unit test."""
+    cm = ContextManager.__new__(ContextManager)
+    cm.collection_name = "col_unit_test"
+    cm.embedding_model = MagicMock()
+    cm.vectordb_type = "qdrant"
+    cm.adaptor = MagicMock()
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# no filters => None
+# ---------------------------------------------------------------------------
+
+
+def test_no_constraints_returns_none():
+    """Connector contract: None means "no filter"; preserves the
+    short-circuit path in the Qdrant search call."""
+    assert _cm()._create_combined_filter(None, None) is None
+    assert _cm()._create_combined_filter([], None) is None
+
+
+# ---------------------------------------------------------------------------
+# index_types only: Or over (In, IsEmpty) to preserve pre-migration points
+# ---------------------------------------------------------------------------
+
+
+def test_index_types_only_emits_or_with_is_empty_backward_compat():
+    """The ``IsEmpty`` branch is the only thing keeping pre-``indexer``
+    data searchable — dropping it silently halves recall on legacy points.
+    Test pins the shape so future cleanups don't remove it by accident."""
+    flt = _cm()._create_combined_filter(["vector", "vision"], None)
+    assert isinstance(flt, Or)
+    assert len(flt.parts) == 2
+    in_part, empty_part = flt.parts
+    assert in_part == In(key="indexer", values=("vector", "vision"))
+    assert empty_part == IsEmpty(key="indexer")
+
+
+# ---------------------------------------------------------------------------
+# chat_id only: single Eq
+# ---------------------------------------------------------------------------
+
+
+def test_chat_id_only_emits_single_eq():
+    flt = _cm()._create_combined_filter(None, "c42")
+    assert flt == Eq(key="chat_id", value="c42")
+
+
+# ---------------------------------------------------------------------------
+# both: AND of (Or-block, Eq)
+# ---------------------------------------------------------------------------
+
+
+def test_both_index_types_and_chat_id_build_and_of_or_and_eq():
+    """The production shape. Verifies the combinator arithmetic matches
+    the legacy semantics (``Filter(must=[chat_id, Filter(should=...)])``):
+    chat_id is AND-ed at the outer level, index_types is OR-ed internally.
+    """
+    flt = _cm()._create_combined_filter(["vector"], "c42")
+    assert isinstance(flt, And)
+    assert len(flt.parts) == 2
+    or_block, eq_block = flt.parts
+    assert isinstance(or_block, Or)
+    # (In(vector), IsEmpty) — the backward-compat branch survives.
+    assert len(or_block.parts) == 2
+    assert eq_block == Eq(key="chat_id", value="c42")
+
+
+def test_vectordb_type_does_not_influence_filter_shape():
+    """The whole point of moving to DSL is that filter shape is backend-
+    agnostic. Even when the (now diagnostic-only) ``vectordb_type`` string
+    is weird, the DSL output must not change."""
+    cm = _cm()
+    cm.vectordb_type = "unknown-but-valid"
+    flt = cm._create_combined_filter(["vector"], "c42")
+    cm.vectordb_type = "qdrant"
+    flt2 = cm._create_combined_filter(["vector"], "c42")
+    assert flt == flt2

--- a/tests/unit_test/vectorstore/test_dto.py
+++ b/tests/unit_test/vectorstore/test_dto.py
@@ -1,0 +1,194 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the backend-neutral DTOs + ``flatten_node_payload`` helper.
+
+These tests pin the *invariants* of the DTO module so that any refactor
+(add a field, split a type, rename) doesn't silently change observable
+behavior.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aperag.vectorstore.dto import (
+    QueryRequest,
+    SearchHit,
+    TenantRef,
+    VectorPoint,
+    VectorShape,
+    flatten_node_payload,
+)
+
+# ---------------------------------------------------------------------------
+# VectorShape
+# ---------------------------------------------------------------------------
+
+
+def test_vector_shape_normalizes_distance_case():
+    assert VectorShape(size=1024, distance="Cosine").canonical == "cosine"
+    assert VectorShape(size=1024, distance="COSINE").canonical == "cosine"
+    assert VectorShape(size=1024, distance="dot").canonical == "dot"
+
+
+def test_vector_shape_accepts_euclidian_typo():
+    """``euclidian`` is a common mis-spelling we've seen in configs; accept
+    and normalize rather than force users to find the typo."""
+    assert VectorShape(size=1024, distance="euclidian").canonical == "euclid"
+
+
+def test_vector_shape_rejects_invalid_size():
+    with pytest.raises(ValueError, match="positive int"):
+        VectorShape(size=0, distance="cosine")
+    with pytest.raises(ValueError, match="positive int"):
+        VectorShape(size=-1, distance="cosine")
+
+
+def test_vector_shape_is_hashable_and_equal():
+    a = VectorShape(size=1024, distance="Cosine")
+    b = VectorShape(size=1024, distance="cosine")
+    assert a == b
+    assert {a, b} == {a}
+
+
+# ---------------------------------------------------------------------------
+# TenantRef
+# ---------------------------------------------------------------------------
+
+
+def test_tenant_ref_rejects_empty_string():
+    with pytest.raises(ValueError, match="non-empty"):
+        TenantRef(id="")
+
+
+# ---------------------------------------------------------------------------
+# VectorPoint
+# ---------------------------------------------------------------------------
+
+
+def test_vector_point_rejects_non_list_vector():
+    """The vector must be ``list[float]``. Numpy arrays or tuples are
+    quietly coerced everywhere downstream — we reject at construction so
+    the error surfaces close to the bug."""
+    with pytest.raises(TypeError):
+        VectorPoint(id="x", vector="not a list", payload={})  # type: ignore[arg-type]
+
+
+def test_vector_point_requires_non_empty_id():
+    with pytest.raises(ValueError, match="non-empty"):
+        VectorPoint(id="", vector=[0.0], payload={})
+
+
+# ---------------------------------------------------------------------------
+# QueryRequest
+# ---------------------------------------------------------------------------
+
+
+def test_query_request_rejects_empty_embedding():
+    with pytest.raises(ValueError, match="non-empty"):
+        QueryRequest(embedding=[], top_k=5)
+
+
+def test_query_request_rejects_non_positive_top_k():
+    with pytest.raises(ValueError, match="positive int"):
+        QueryRequest(embedding=[0.1], top_k=0)
+
+
+def test_query_request_hints_default_is_independent_per_instance():
+    """Regression guard: a mutable default (``{}``) would be shared
+    across instances. ``field(default_factory=dict)`` prevents that."""
+    a = QueryRequest(embedding=[0.1], top_k=1)
+    b = QueryRequest(embedding=[0.1], top_k=1)
+    # Immutability: frozen dataclass hints dict is shared by reference
+    # only when both constructors got the same default-factory output,
+    # which they shouldn't (different calls).
+    assert a.hints is not b.hints or a.hints == {}
+
+
+# ---------------------------------------------------------------------------
+# SearchHit
+# ---------------------------------------------------------------------------
+
+
+def test_search_hit_vector_optional():
+    hit = SearchHit(id="x", score=0.8, payload={"k": "v"})
+    assert hit.vector is None
+
+
+# ---------------------------------------------------------------------------
+# flatten_node_payload
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_prefers_flat_top_level_fields():
+    """New data writes ``{text, metadata}`` at the top level. Flattening
+    is a no-op for that shape."""
+    payload = {"text": "body", "metadata": {"source": "doc.md"}}
+    flat = flatten_node_payload(payload)
+    assert flat["text"] == "body"
+    assert flat["metadata"] == {"source": "doc.md"}
+
+
+def test_flatten_reads_legacy_node_content_blob():
+    """Old data (LlamaIndex QdrantVectorStore writes) had only
+    ``_node_content`` as a JSON string. Readers must continue to extract
+    text/metadata from it without caller-side branching."""
+    legacy = {"_node_content": json.dumps({"text": "hi", "metadata": {"source": "old.md", "chunk_id": 1}})}
+    flat = flatten_node_payload(legacy)
+    assert flat["text"] == "hi"
+    assert flat["metadata"]["source"] == "old.md"
+    assert flat["metadata"]["chunk_id"] == 1
+
+
+def test_flatten_prefers_flat_over_legacy_when_both_present():
+    """Mixed data (a record was updated after the refactor but the old
+    ``_node_content`` is still there) should use the new flat fields as
+    the source of truth — they're what the latest writer intended."""
+    payload = {
+        "text": "new",
+        "metadata": {"source": "new.md"},
+        "_node_content": json.dumps({"text": "old", "metadata": {"source": "old.md"}}),
+    }
+    flat = flatten_node_payload(payload)
+    assert flat["text"] == "new"
+    assert flat["metadata"]["source"] == "new.md"
+
+
+def test_flatten_extracts_source_from_relationships_when_metadata_missing():
+    """Source-derivation fallback: old LlamaIndex writes encoded the
+    parent document's source under ``relationships['1'].metadata.source``.
+    Preserved so doc-preview pages still show a filename for legacy data."""
+    legacy = {
+        "_node_content": json.dumps(
+            {
+                "text": "chunk",
+                "metadata": {},  # note: metadata has no 'source'
+                "relationships": {"1": {"metadata": {"source": "/tmp/foo/bar.md"}}},
+            }
+        )
+    }
+    flat = flatten_node_payload(legacy)
+    assert flat["metadata"].get("source") == "bar.md"
+
+
+def test_flatten_handles_non_dict_payload():
+    """Defensive: ``None`` / list / scalar inputs don't crash the
+    flattener. Returns empty."""
+    assert flatten_node_payload(None).get("text") is None  # type: ignore[arg-type]
+    assert flatten_node_payload([]).get("metadata") == {}  # type: ignore[arg-type]
+
+
+def test_flatten_handles_malformed_node_content_gracefully():
+    """If ``_node_content`` isn't valid JSON (shouldn't happen in
+    practice, but...) we fall back to the raw payload rather than raise."""
+    payload = {"_node_content": "{ not valid json", "text": "fallback"}
+    flat = flatten_node_payload(payload)
+    assert flat["text"] == "fallback"

--- a/tests/unit_test/vectorstore/test_filters.py
+++ b/tests/unit_test/vectorstore/test_filters.py
@@ -1,0 +1,131 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the ``VectorFilter`` DSL itself — translator-agnostic.
+
+These tests pin down the *semantics* of the DSL (construction rules,
+short-circuit helpers, structural equality). Backend translation is tested
+separately in ``test_qdrant_filter_translation.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aperag.vectorstore.filters import (
+    And,
+    Eq,
+    In,
+    IsEmpty,
+    Not,
+    Or,
+    _in,
+    all_of,
+    any_of,
+)
+
+# ---------------------------------------------------------------------------
+# leaf nodes
+# ---------------------------------------------------------------------------
+
+
+def test_eq_is_frozen_and_hashable():
+    """Frozen dataclasses are a hard requirement: callers cache filter
+    structures in sets/dicts for deduplication."""
+    a = Eq(key="indexer", value="vector")
+    b = Eq(key="indexer", value="vector")
+    assert a == b
+    assert {a, b} == {a}
+    with pytest.raises(Exception):
+        a.value = "other"  # frozen -> FrozenInstanceError
+
+
+def test_in_builder_normalizes_to_tuple():
+    """``_in`` is the ergonomic builder; the dataclass itself keeps a tuple
+    (immutable + hashable). A list passed to ``In`` directly would fail
+    equality with another constructed from the same source list, which is
+    why we have the helper."""
+    assert _in("chat_id", ["x", "y"]) == In(key="chat_id", values=("x", "y"))
+
+
+def test_is_empty_holds_only_key():
+    assert IsEmpty(key="indexer").key == "indexer"
+
+
+# ---------------------------------------------------------------------------
+# combinators
+# ---------------------------------------------------------------------------
+
+
+def test_and_rejects_empty_parts():
+    """Empty And is a logic bug (matches-everything is not what callers
+    want). Helpers ``all_of()`` / ``any_of()`` are the right path for
+    ergonomic short-circuit."""
+    with pytest.raises(ValueError, match="at least one part"):
+        And(parts=())
+
+
+def test_or_rejects_empty_parts():
+    with pytest.raises(ValueError, match="at least one part"):
+        Or(parts=())
+
+
+def test_not_wraps_inner():
+    assert Not(inner=Eq(key="k", value="v")).inner == Eq(key="k", value="v")
+
+
+# ---------------------------------------------------------------------------
+# all_of / any_of short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_all_of_none_input_returns_none():
+    """Callers build filters conditionally; passing a missing part as None
+    must not become an empty-And bug."""
+    assert all_of(None, None) is None
+    assert all_of() is None
+
+
+def test_all_of_single_part_returns_part():
+    """Degenerate And/Or is meaningless noise; we return the inner node so
+    translators don't need to special-case single-part combinators."""
+    e = Eq(key="k", value="v")
+    assert all_of(e, None) is e
+    assert all_of(None, e) is e
+
+
+def test_all_of_multiple_parts_wraps_in_and():
+    a, b = Eq(key="k1", value="v"), Eq(key="k2", value="w")
+    got = all_of(a, b)
+    assert isinstance(got, And)
+    assert got.parts == (a, b)
+
+
+def test_any_of_mirrors_all_of_semantics():
+    a, b = Eq(key="k1", value="v"), Eq(key="k2", value="w")
+    assert any_of() is None
+    assert any_of(None) is None
+    assert any_of(a) is a
+    assert isinstance(any_of(a, b), Or)
+
+
+def test_combinators_nest_cleanly():
+    """Deep nesting (the realistic shape when ContextManager produces
+    combined filters) composes without surprises."""
+    combined = all_of(
+        Eq(key="chat_id", value="c42"),
+        any_of(
+            In(key="indexer", values=("vector", "vision")),
+            IsEmpty(key="indexer"),
+        ),
+    )
+    assert isinstance(combined, And)
+    assert len(combined.parts) == 2
+    inner_or = combined.parts[1]
+    assert isinstance(inner_or, Or)
+    assert len(inner_or.parts) == 2

--- a/tests/unit_test/vectorstore/test_llama_index_adapter.py
+++ b/tests/unit_test/vectorstore/test_llama_index_adapter.py
@@ -1,0 +1,86 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the LlamaIndex → VectorPoint adapter.
+
+This module is the thin boundary between "everything that speaks
+LlamaIndex" (indexers, embedders) and "everything that speaks
+VectorPoint" (backend connectors). A regression here silently drops
+metadata on the floor.
+"""
+
+from __future__ import annotations
+
+import pytest
+from llama_index.core.schema import TextNode
+
+from aperag.vectorstore.dto import VectorPoint
+from aperag.vectorstore.llama_index_adapter import (
+    node_to_vector_point,
+    nodes_to_vector_points,
+)
+
+
+def _node(text: str = "hello", metadata: dict | None = None, embedding: list | None = None) -> TextNode:
+    n = TextNode(text=text, metadata=metadata or {})
+    if embedding is not None:
+        n.embedding = embedding
+    return n
+
+
+def test_node_without_embedding_is_rejected():
+    """Writing an embedding-less node was a silent-corruption case in the
+    LlamaIndex path (``store.add`` would insert NULL-vector rows). We
+    surface it as a loud error instead."""
+    with pytest.raises(ValueError, match="no embedding"):
+        node_to_vector_point(_node())
+
+
+def test_node_to_vector_point_captures_text_and_metadata_flat():
+    node = _node(
+        text="body",
+        metadata={"source": "doc.md", "chunk_id": 3},
+        embedding=[0.1, 0.2, 0.3],
+    )
+    vp = node_to_vector_point(node)
+    assert isinstance(vp, VectorPoint)
+    assert vp.vector == [0.1, 0.2, 0.3]
+    # Flat shape: ``{text, metadata}``, NOT ``{_node_content: json_str}``.
+    # The connector is free to add its own ``_node_content`` later if it
+    # really wants to, but by default we emit the backend-neutral form.
+    assert vp.payload == {
+        "text": "body",
+        "metadata": {"source": "doc.md", "chunk_id": 3},
+    }
+
+
+def test_node_to_vector_point_stamps_tenant_when_missing():
+    """Defense-in-depth: upstream callers sometimes forget to stamp
+    ``metadata.collection_id``. The adapter fills it in from ``tenant_id``
+    so downstream multitenancy filters still work. Mirrors the old
+    ``embedding_utils`` behavior exactly."""
+    node = _node(text="t", metadata={"source": "x"}, embedding=[0.1])
+    vp = node_to_vector_point(node, tenant_id="col_xyz")
+    assert vp.payload["metadata"]["collection_id"] == "col_xyz"
+
+
+def test_node_to_vector_point_respects_existing_tenant_id():
+    node = _node(
+        text="t",
+        metadata={"source": "x", "collection_id": "col_original"},
+        embedding=[0.1],
+    )
+    vp = node_to_vector_point(node, tenant_id="col_other")
+    # Don't silently rewrite; callers that pre-set it chose their value.
+    assert vp.payload["metadata"]["collection_id"] == "col_original"
+
+
+def test_nodes_to_vector_points_preserves_order():
+    nodes = [_node(text=str(i), embedding=[float(i)]) for i in range(5)]
+    out = nodes_to_vector_points(nodes, tenant_id="col_a")
+    assert [p.payload["text"] for p in out] == ["0", "1", "2", "3", "4"]

--- a/tests/unit_test/vectorstore/test_llama_index_adapter.py
+++ b/tests/unit_test/vectorstore/test_llama_index_adapter.py
@@ -53,10 +53,70 @@ def test_node_to_vector_point_captures_text_and_metadata_flat():
     # Flat shape: ``{text, metadata}``, NOT ``{_node_content: json_str}``.
     # The connector is free to add its own ``_node_content`` later if it
     # really wants to, but by default we emit the backend-neutral form.
+    # No filterable keys are present in metadata here, so the payload
+    # stays at exactly {text, metadata}.
     assert vp.payload == {
         "text": "body",
         "metadata": {"source": "doc.md", "chunk_id": 3},
     }
+
+
+def test_node_to_vector_point_lifts_filterable_keys_to_top_level():
+    """The filter DSL addresses flat payload keys (``indexer`` / ``chat_id`` /
+    ``collection_id``). If we only stored them inside ``metadata``, every
+    ``Eq("indexer", ...)`` and ``Eq("chat_id", ...)`` filter on real writer
+    output would silently miss. Mirror those keys at the top level — and
+    only those — so the existing translator contract keeps working."""
+    node = _node(
+        text="body",
+        metadata={
+            "source": "doc.md",
+            "indexer": "vision",
+            "chat_id": "chat_abc",
+            "collection_id": "col_xyz",
+        },
+        embedding=[0.1, 0.2, 0.3],
+    )
+    vp = node_to_vector_point(node)
+    # Top-level mirror for filter translator.
+    assert vp.payload["indexer"] == "vision"
+    assert vp.payload["chat_id"] == "chat_abc"
+    assert vp.payload["collection_id"] == "col_xyz"
+    # Nested copy preserved for reader code.
+    assert vp.payload["metadata"]["indexer"] == "vision"
+    assert vp.payload["metadata"]["chat_id"] == "chat_abc"
+    assert vp.payload["metadata"]["collection_id"] == "col_xyz"
+    # Other metadata keys are NOT flattened — we only lift the ones the
+    # filter DSL actually addresses.
+    assert "source" not in vp.payload
+    assert vp.payload["metadata"]["source"] == "doc.md"
+
+
+def test_node_to_vector_point_omits_absent_filterable_keys_from_top_level():
+    """We deliberately leave the top-level key missing (instead of writing
+    ``None``) when a filterable key isn't set on the node. That way
+    ``IsEmpty(indexer)`` behaves the same on adapter-produced payloads as
+    it did on hand-written flat seeds."""
+    node = _node(
+        text="body",
+        metadata={"source": "doc.md"},
+        embedding=[0.1],
+    )
+    vp = node_to_vector_point(node)
+    assert "indexer" not in vp.payload
+    assert "chat_id" not in vp.payload
+    assert "collection_id" not in vp.payload
+
+
+def test_node_to_vector_point_lifts_collection_id_stamped_by_tenant():
+    """When the caller relies on ``tenant_id`` to stamp ``collection_id``,
+    the lifted top-level key must reflect the stamped value, not stay
+    empty. Otherwise multitenant search filters would still miss new data
+    even though the metadata is correct."""
+    node = _node(text="t", metadata={"source": "x"}, embedding=[0.1])
+    vp = node_to_vector_point(node, tenant_id="col_xyz")
+    assert vp.payload["metadata"]["collection_id"] == "col_xyz"
+    assert vp.payload["collection_id"] == "col_xyz"
 
 
 def test_node_to_vector_point_stamps_tenant_when_missing():

--- a/tests/unit_test/vectorstore/test_pgvector_end_to_end.py
+++ b/tests/unit_test/vectorstore/test_pgvector_end_to_end.py
@@ -1,0 +1,283 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""End-to-end integration test for the pgvector backend.
+
+Gated on the ``APERAG_TEST_PGVECTOR_URL`` env var. Set it to a reachable
+Postgres DSN (with pgvector installable — i.e. superuser *or* with the
+extension already created) and these tests exercise the full write →
+search → delete path.
+
+Example local run:
+
+.. code-block:: bash
+
+    export APERAG_TEST_PGVECTOR_URL="postgresql://postgres:postgres@127.0.0.1:5432/aperag_test"
+    pytest tests/unit_test/vectorstore/test_pgvector_end_to_end.py -v
+
+The tests deliberately use their own uniquely-shaped vector size
+(``size=5`` in a custom schema) so they can't interfere with production
+data in a shared database.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+pytest.importorskip("pgvector")
+pytest.importorskip("sqlalchemy")
+
+PGVECTOR_URL = os.environ.get("APERAG_TEST_PGVECTOR_URL")
+
+pytestmark = pytest.mark.skipif(
+    not PGVECTOR_URL,
+    reason="set APERAG_TEST_PGVECTOR_URL to run pgvector integration tests",
+)
+
+from sqlalchemy import text  # noqa: E402
+
+from aperag.vectorstore import pgvector_connector as pg  # noqa: E402
+from aperag.vectorstore.dto import QueryRequest, VectorPoint  # noqa: E402
+from aperag.vectorstore.filters import Eq, all_of  # noqa: E402
+from aperag.vectorstore.pgvector_connector import (  # noqa: E402
+    PgvectorVectorStoreConnector,
+)
+
+# Use 5-dim vectors so we never collide with real aperag_vectors_* tables
+# that use production vector sizes (1024, 1536, 3072, …).
+TEST_VECTOR_SIZE = 5
+VEC_A = [1.0, 0.0, 0.0, 0.0, 0.0]
+VEC_B = [0.0, 1.0, 0.0, 0.0, 0.0]
+
+
+@pytest.fixture(autouse=True)
+def _clean_slate():
+    """Drop the test table + caches before every test so we start fresh.
+
+    The module-level ``_ENSURED_TABLES`` cache only matters *within* a
+    process; wiping it along with the DB table keeps the ensure-DDL path
+    covered on every run.
+    """
+    pg._reset_engine_cache()
+    engine = pg._get_or_create_engine(PGVECTOR_URL)
+    with engine.begin() as conn:
+        conn.execute(text(f"DROP TABLE IF EXISTS aperag_vectors_{TEST_VECTOR_SIZE}_cosine CASCADE"))
+    yield
+    with engine.begin() as conn:
+        conn.execute(text(f"DROP TABLE IF EXISTS aperag_vectors_{TEST_VECTOR_SIZE}_cosine CASCADE"))
+    pg._reset_engine_cache()
+
+
+def _make_connector(tenant_id: str) -> PgvectorVectorStoreConnector:
+    return PgvectorVectorStoreConnector(
+        {
+            "collection": tenant_id,
+            "vector_size": TEST_VECTOR_SIZE,
+            "distance": "Cosine",
+            "pgvector_database_url": PGVECTOR_URL,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# ensure_collection idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_collection_creates_table_and_indexes():
+    a = _make_connector("col_a")
+    # Table was created + cached.
+    assert (a._database_url, a.table_name) in pg._ENSURED_TABLES
+    # Second call is a cache hit (no DDL).
+    a.ensure_collection()  # no exception, no DDL
+
+
+# ---------------------------------------------------------------------------
+# upsert → search round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_then_search_returns_own_point():
+    a = _make_connector("col_a")
+    pid = str(uuid.uuid4())
+    a.upsert(
+        [
+            VectorPoint(
+                id=pid,
+                vector=VEC_A,
+                payload={"text": "hello", "metadata": {"source": "unit"}},
+            )
+        ]
+    )
+    hits = a.search(QueryRequest(embedding=VEC_A, top_k=5, score_threshold=-1.0))
+    assert len(hits) == 1
+    assert hits[0].id == pid
+    # Cosine similarity of a vector with itself is ~1.
+    assert hits[0].score > 0.99
+    assert hits[0].payload.get("text") == "hello"
+    assert hits[0].payload.get("collection_id") == "col_a"
+
+
+# ---------------------------------------------------------------------------
+# tenant isolation: two connectors on same shape, different tenants
+# ---------------------------------------------------------------------------
+
+
+def test_search_is_tenant_isolated():
+    a = _make_connector("col_aa")
+    b = _make_connector("col_bb")
+    a.upsert([VectorPoint(id=str(uuid.uuid4()), vector=VEC_A, payload={"indexer": "vector"})])
+    b.upsert([VectorPoint(id=str(uuid.uuid4()), vector=VEC_A, payload={"indexer": "vector"})])
+
+    hits_a = a.search(QueryRequest(embedding=VEC_A, top_k=10, score_threshold=-1.0))
+    hits_b = b.search(QueryRequest(embedding=VEC_A, top_k=10, score_threshold=-1.0))
+
+    assert {h.payload["collection_id"] for h in hits_a} == {"col_aa"}
+    assert {h.payload["collection_id"] for h in hits_b} == {"col_bb"}
+
+
+# ---------------------------------------------------------------------------
+# retrieve: tenant guard blocks foreign-id lookups
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_drops_foreign_tenant_ids():
+    a = _make_connector("col_aa")
+    b = _make_connector("col_bb")
+    a_id = str(uuid.uuid4())
+    b_id = str(uuid.uuid4())
+    a.upsert([VectorPoint(id=a_id, vector=VEC_A, payload={})])
+    b.upsert([VectorPoint(id=b_id, vector=VEC_B, payload={})])
+
+    # A requests both ids; only its own comes back.
+    got = a.retrieve([a_id, b_id])
+    assert {p.id for p in got} == {a_id}
+
+
+# ---------------------------------------------------------------------------
+# delete by ids: tenant-guarded
+# ---------------------------------------------------------------------------
+
+
+def test_delete_by_ids_ignores_foreign_ids():
+    a = _make_connector("col_aa")
+    b = _make_connector("col_bb")
+    a_id = str(uuid.uuid4())
+    b_id = str(uuid.uuid4())
+    a.upsert([VectorPoint(id=a_id, vector=VEC_A, payload={})])
+    b.upsert([VectorPoint(id=b_id, vector=VEC_B, payload={})])
+
+    a.delete([a_id, b_id])
+
+    # A's row gone; B's row survives (the tenant guard kept B intact).
+    assert a.retrieve([a_id]) == []
+    assert len(b.retrieve([b_id])) == 1
+
+
+# ---------------------------------------------------------------------------
+# delete_by_filter: AND-merged with tenant guard
+# ---------------------------------------------------------------------------
+
+
+def test_delete_by_filter_respects_tenant_guard():
+    a = _make_connector("col_aa")
+    b = _make_connector("col_bb")
+    a.upsert([VectorPoint(id=str(uuid.uuid4()), vector=VEC_A, payload={"indexer": "vector"})])
+    b.upsert([VectorPoint(id=str(uuid.uuid4()), vector=VEC_A, payload={"indexer": "vector"})])
+
+    a.delete_by_filter(Eq(key="indexer", value="vector"))
+
+    # A's row gone.
+    assert a.search(QueryRequest(embedding=VEC_A, top_k=10, score_threshold=-1.0)) == []
+    # B's row survives.
+    assert len(b.search(QueryRequest(embedding=VEC_A, top_k=10, score_threshold=-1.0))) == 1
+
+
+def test_delete_by_filter_empty_is_rejected():
+    a = _make_connector("col_aa")
+    with pytest.raises(ValueError, match="non-empty filter"):
+        a.delete_by_filter(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# search with DSL filter
+# ---------------------------------------------------------------------------
+
+
+def test_search_applies_dsl_filter():
+    a = _make_connector("col_aa")
+    a.upsert(
+        [
+            VectorPoint(id=str(uuid.uuid4()), vector=VEC_A, payload={"indexer": "vector"}),
+            VectorPoint(id=str(uuid.uuid4()), vector=VEC_A, payload={"indexer": "vision"}),
+        ]
+    )
+    hits = a.search(
+        QueryRequest(
+            embedding=VEC_A,
+            top_k=10,
+            flt=Eq(key="indexer", value="vision"),
+            score_threshold=-1.0,
+        )
+    )
+    assert len(hits) == 1
+    assert hits[0].payload["indexer"] == "vision"
+
+
+# ---------------------------------------------------------------------------
+# drop_tenant: single shard
+# ---------------------------------------------------------------------------
+
+
+def test_drop_tenant_leaves_other_tenants_intact():
+    a = _make_connector("col_aa")
+    b = _make_connector("col_bb")
+    a.upsert([VectorPoint(id=str(uuid.uuid4()), vector=VEC_A, payload={})])
+    b.upsert([VectorPoint(id=str(uuid.uuid4()), vector=VEC_B, payload={})])
+
+    a.drop_tenant()
+
+    # A has nothing; B still has its row.
+    assert a.search(QueryRequest(embedding=VEC_A, top_k=10, score_threshold=-1.0)) == []
+    assert len(b.search(QueryRequest(embedding=VEC_B, top_k=10, score_threshold=-1.0))) == 1
+
+
+# ---------------------------------------------------------------------------
+# composed filter matches Qdrant semantics: all_of(Eq, Eq)
+# ---------------------------------------------------------------------------
+
+
+def test_composed_all_of_filter_matches_both_predicates():
+    a = _make_connector("col_aa")
+    a.upsert(
+        [
+            VectorPoint(
+                id=str(uuid.uuid4()),
+                vector=VEC_A,
+                payload={"indexer": "vector", "chat_id": "c1"},
+            ),
+            VectorPoint(
+                id=str(uuid.uuid4()),
+                vector=VEC_A,
+                payload={"indexer": "vector", "chat_id": "c2"},
+            ),
+        ]
+    )
+    hits = a.search(
+        QueryRequest(
+            embedding=VEC_A,
+            top_k=10,
+            flt=all_of(Eq(key="indexer", value="vector"), Eq(key="chat_id", value="c1")),
+            score_threshold=-1.0,
+        )
+    )
+    assert len(hits) == 1
+    assert hits[0].payload["chat_id"] == "c1"

--- a/tests/unit_test/vectorstore/test_pgvector_translator.py
+++ b/tests/unit_test/vectorstore/test_pgvector_translator.py
@@ -1,0 +1,163 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the pgvector SQL filter translator and vector-literal encoder.
+
+Zero database contact: we exercise the string-building helpers only. The
+end-to-end integration test lives in ``test_pgvector_end_to_end.py`` and
+is gated on ``APERAG_TEST_PGVECTOR_URL``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aperag.vectorstore.dto import VectorShape
+from aperag.vectorstore.filters import Eq, In, IsEmpty, Not, all_of, any_of
+from aperag.vectorstore.pgvector_connector import (
+    _table_name,
+    _translate_filter,
+    _vector_literal,
+)
+
+# ---------------------------------------------------------------------------
+# table naming
+# ---------------------------------------------------------------------------
+
+
+def test_table_name_stable_across_distance_casing():
+    """``VectorShape`` normalizes to lowercase so the physical table name
+    is deterministic regardless of whether the caller wrote ``Cosine``,
+    ``COSINE``, or ``cosine``."""
+    assert _table_name(VectorShape(size=1024, distance="Cosine")) == "aperag_vectors_1024_cosine"
+    assert _table_name(VectorShape(size=1024, distance="cosine")) == "aperag_vectors_1024_cosine"
+
+
+def test_table_name_rejects_non_positive_size():
+    with pytest.raises(ValueError):
+        VectorShape(size=0, distance="cosine")
+
+
+def test_table_name_rejects_unsupported_distance():
+    with pytest.raises(ValueError, match="distance must be one of"):
+        VectorShape(size=1024, distance="jaccard")
+
+
+# ---------------------------------------------------------------------------
+# translator: leaves
+# ---------------------------------------------------------------------------
+
+
+def test_translate_none_is_noop():
+    sql, params = _translate_filter(None)
+    assert sql == ""
+    assert params == {}
+
+
+def test_translate_eq_uses_param_binding_not_value_interpolation():
+    """Values are parameterised; only keys are interpolated (and keys are
+    hard-coded business vocabulary: ``indexer``, ``chat_id``, …). This
+    guards against SQL injection via payload values."""
+    sql, params = _translate_filter(Eq(key="chat_id", value="c42"))
+    assert sql == "payload->>'chat_id' = :f0"
+    assert params == {"f0": "c42"}
+
+
+def test_translate_eq_coerces_booleans_to_json_casing():
+    """JSON stringifies ``True`` as ``"true"``; pgvector's ``->>`` returns
+    the same. Using ``str(True)`` naively would yield ``"True"`` and never
+    match — hence the explicit coercion in ``_scalar_to_text``."""
+    sql, params = _translate_filter(Eq(key="flag", value=True))
+    assert params == {"f0": "true"}
+
+
+def test_translate_in_generates_unique_parameter_names_per_value():
+    sql, params = _translate_filter(In(key="indexer", values=("vector", "vision")))
+    assert sql == "payload->>'indexer' IN (:f0, :f1)"
+    assert params == {"f0": "vector", "f1": "vision"}
+
+
+def test_translate_in_empty_values_raises():
+    with pytest.raises(ValueError, match="empty values"):
+        _translate_filter(In(key="indexer", values=()))
+
+
+def test_translate_is_empty_matches_missing_or_json_null():
+    sql, _ = _translate_filter(IsEmpty(key="indexer"))
+    assert "NOT (payload ? 'indexer')" in sql
+    assert "'null'::jsonb" in sql
+
+
+# ---------------------------------------------------------------------------
+# translator: combinators
+# ---------------------------------------------------------------------------
+
+
+def test_translate_and_of_eq_eq_emits_and_join():
+    sql, params = _translate_filter(all_of(Eq(key="a", value="1"), Eq(key="b", value="2")))
+    # Outer parens + AND join; exact whitespace insensitive.
+    normalized = " ".join(sql.split())
+    assert normalized == "(payload->>'a' = :f0 AND payload->>'b' = :f1)"
+    assert params == {"f0": "1", "f1": "2"}
+
+
+def test_translate_or_uses_or_join():
+    sql, _ = _translate_filter(any_of(Eq(key="a", value="1"), Eq(key="b", value="2")))
+    assert " OR " in sql
+
+
+def test_translate_not_wraps_inner_sql():
+    sql, _ = _translate_filter(Not(inner=Eq(key="a", value="1")))
+    assert sql.startswith("NOT (")
+
+
+def test_translate_context_manager_shape():
+    """The production shape from ``ContextManager._create_combined_filter``:
+    ``all_of(any_of(In(indexer,...), IsEmpty(indexer)), Eq(chat_id,...))``.
+    Asserting on this structure guards against silent regressions when
+    the translator gets refactored."""
+    flt = all_of(
+        any_of(
+            In(key="indexer", values=("vector", "vision")),
+            IsEmpty(key="indexer"),
+        ),
+        Eq(key="chat_id", value="c42"),
+    )
+    sql, params = _translate_filter(flt)
+    # There are three IN values → f0/f1, one IsEmpty (no bind), one Eq → f2.
+    assert params == {"f0": "vector", "f1": "vision", "f2": "c42"}
+    # Outer AND, inner OR.
+    assert sql.count(" AND ") == 1
+    assert " OR " in sql
+
+
+def test_translate_rejects_unknown_node_loudly():
+    class Bogus:
+        pass
+
+    with pytest.raises(TypeError, match="Unsupported VectorFilter node"):
+        _translate_filter(Bogus())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# vector literal
+# ---------------------------------------------------------------------------
+
+
+def test_vector_literal_lossless_roundtrip():
+    """pgvector wants ``'[1.0, 2.0]'::vector``; the round-trip must be
+    lossless for typical floats (we use ``repr`` on purpose)."""
+    lit = _vector_literal([1.0, 0.0, -0.5])
+    assert lit == "[1.0,0.0,-0.5]"
+
+
+def test_vector_literal_handles_int_input():
+    """Callers may hand us ints when the embedding model has integer
+    output (unusual but not unheard of); we cast to float uniformly."""
+    lit = _vector_literal([1, 2, 3])
+    assert lit == "[1.0,2.0,3.0]"

--- a/tests/unit_test/vectorstore/test_qdrant_client_cache.py
+++ b/tests/unit_test/vectorstore/test_qdrant_client_cache.py
@@ -1,0 +1,110 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for the process-level QdrantClient cache.
+
+The cache is the only thing between "one HTTP/gRPC connection pool per
+connector" and "one per endpoint"; without it, a read-heavy request path
+pays a fresh TCP/TLS setup on every search.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from aperag.vectorstore import qdrant_connector as qc
+
+
+def setup_function(_fn) -> None:  # pytest-style per-test reset
+    qc._reset_client_cache()
+
+
+def teardown_function(_fn) -> None:
+    qc._reset_client_cache()
+
+
+def test_memory_url_is_never_cached():
+    """``:memory:`` is used by tests for isolated per-test stores. Caching
+    it would make the second test see state from the first, which is
+    exactly the surprise mode we want to avoid."""
+    a = qc._get_or_create_client(":memory:")
+    b = qc._get_or_create_client(":memory:")
+    assert a is not b
+
+
+def test_same_endpoint_returns_same_client(monkeypatch):
+    """Two connectors pointed at the same endpoint must share one client."""
+    built = []
+
+    def fake_ctor(*args, **kwargs):
+        inst = object()
+        built.append(inst)
+        return inst
+
+    import qdrant_client as _qc
+
+    monkeypatch.setattr(_qc, "QdrantClient", fake_ctor)
+
+    c1 = qc._get_or_create_client("http://qdrant.internal", port=6333)
+    c2 = qc._get_or_create_client("http://qdrant.internal", port=6333)
+    assert c1 is c2
+    assert len(built) == 1, f"expected 1 client build, got {len(built)}"
+
+
+def test_different_endpoints_build_different_clients(monkeypatch):
+    """Cache key must include port/grpc_port/prefer_grpc/https/api_key so a
+    staging + prod config in the same process doesn't alias."""
+    built = []
+
+    def fake_ctor(*args, **kwargs):
+        inst = object()
+        built.append(inst)
+        return inst
+
+    import qdrant_client as _qc
+
+    monkeypatch.setattr(_qc, "QdrantClient", fake_ctor)
+
+    a = qc._get_or_create_client("http://qdrant-staging", port=6333)
+    b = qc._get_or_create_client("http://qdrant-prod", port=6333)
+    c = qc._get_or_create_client("http://qdrant-staging", port=6333, prefer_grpc=True)
+    d = qc._get_or_create_client("http://qdrant-staging", port=6333, api_key="secret")
+    assert a is not b
+    assert a is not c
+    assert a is not d
+    assert len({id(a), id(b), id(c), id(d)}) == 4
+
+
+def test_concurrent_first_call_does_not_stampede(monkeypatch):
+    """Under concurrent first access to a fresh endpoint, only one client
+    should be built — the double-checked lock does its job."""
+    built = []
+
+    def fake_ctor(*args, **kwargs):
+        inst = object()
+        built.append(inst)
+        return inst
+
+    import qdrant_client as _qc
+
+    monkeypatch.setattr(_qc, "QdrantClient", fake_ctor)
+
+    clients = []
+
+    def worker():
+        clients.append(qc._get_or_create_client("http://qdrant-race", port=6333))
+
+    threads = [threading.Thread(target=worker) for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(built) == 1, f"expected 1 client under race, got {len(built)}"
+    # Every caller got the same instance.
+    assert len({id(c) for c in clients}) == 1

--- a/tests/unit_test/vectorstore/test_qdrant_filter_translation.py
+++ b/tests/unit_test/vectorstore/test_qdrant_filter_translation.py
@@ -1,0 +1,133 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the Qdrant translator of the ``VectorFilter`` DSL.
+
+Every DSL node must map to a well-formed ``qdrant_client.models.Filter``
+tree. We assert on structural equality of the produced Filter (not on its
+string representation) so translator refactors don't drift silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+from qdrant_client import models as rest
+
+from aperag.vectorstore import qdrant_connector as qc
+from aperag.vectorstore.filters import (
+    Eq,
+    In,
+    IsEmpty,
+    Not,
+    all_of,
+    any_of,
+)
+
+# ---------------------------------------------------------------------------
+# null / pass-through / unknown
+# ---------------------------------------------------------------------------
+
+
+def test_translate_none_returns_none():
+    assert qc._translate_filter(None) is None
+
+
+def test_normalize_passes_through_raw_qdrant_filter():
+    """The migration script hand-rolls ``rest.Filter``; we can't break that
+    code path, so ``_normalize_filter_input`` short-circuits and returns the
+    Filter unchanged."""
+    raw = rest.Filter(must=[rest.FieldCondition(key="k", match=rest.MatchValue(value="v"))])
+    assert qc._normalize_filter_input(raw) is raw
+
+
+def test_normalize_unknown_type_returns_none_with_warning(caplog):
+    """Any value that is neither DSL nor Qdrant Filter must be refused
+    gracefully — never silently translated into something nonsensical."""
+    with caplog.at_level("WARNING"):
+        assert qc._normalize_filter_input({"garbage": True}) is None
+    assert any("unsupported type" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# leaf nodes
+# ---------------------------------------------------------------------------
+
+
+def test_translate_eq():
+    got = qc._translate_filter(Eq(key="chat_id", value="c42"))
+    assert isinstance(got, rest.Filter)
+    assert got.must == [rest.FieldCondition(key="chat_id", match=rest.MatchValue(value="c42"))]
+
+
+def test_translate_in():
+    got = qc._translate_filter(In(key="indexer", values=("vector", "vision")))
+    assert got.must == [rest.FieldCondition(key="indexer", match=rest.MatchAny(any=["vector", "vision"]))]
+
+
+def test_translate_in_empty_values_raises():
+    """Empty ``In`` would match nothing, which is almost always a bug; we
+    refuse it loudly rather than produce a "silent zero-results" query."""
+    with pytest.raises(ValueError, match="empty values"):
+        qc._translate_filter(In(key="indexer", values=()))
+
+
+def test_translate_is_empty():
+    got = qc._translate_filter(IsEmpty(key="indexer"))
+    assert got.must == [rest.IsEmptyCondition(is_empty=rest.PayloadField(key="indexer"))]
+
+
+# ---------------------------------------------------------------------------
+# combinators
+# ---------------------------------------------------------------------------
+
+
+def test_translate_and_nests_filters_under_must():
+    """Qdrant allows Filter inside ``must`` as a sub-Filter; we rely on that
+    so each DSL child is translated to a Filter and attached directly."""
+    flt = all_of(Eq(key="k1", value="v"), Eq(key="k2", value="w"))
+    got = qc._translate_filter(flt)
+    assert isinstance(got, rest.Filter)
+    assert len(got.must) == 2
+    for sub in got.must:
+        assert isinstance(sub, rest.Filter)
+
+
+def test_translate_or_uses_should():
+    flt = any_of(Eq(key="k1", value="v"), IsEmpty(key="k1"))
+    got = qc._translate_filter(flt)
+    assert isinstance(got, rest.Filter)
+    assert len(got.should) == 2
+    assert got.must in (None, [])
+
+
+def test_translate_not_uses_must_not():
+    got = qc._translate_filter(Not(inner=Eq(key="k", value="v")))
+    assert isinstance(got, rest.Filter)
+    assert len(got.must_not) == 1
+
+
+def test_translate_real_context_manager_shape():
+    """End-to-end shape check mirroring what ``ContextManager`` produces
+    when both ``index_types`` and ``chat_id`` are set. Any regression here
+    breaks retrieval filtering, so we keep a structural snapshot."""
+    flt = all_of(
+        any_of(
+            In(key="indexer", values=("vector", "vision")),
+            IsEmpty(key="indexer"),
+        ),
+        Eq(key="chat_id", value="c42"),
+    )
+    got = qc._translate_filter(flt)
+    assert isinstance(got, rest.Filter)
+    # Two top-level AND parts: the OR-block and the chat_id Eq.
+    assert len(got.must) == 2
+    or_block, eq_block = got.must
+    assert isinstance(or_block, rest.Filter)
+    assert len(or_block.should) == 2
+    assert isinstance(eq_block, rest.Filter)
+    assert eq_block.must == [rest.FieldCondition(key="chat_id", match=rest.MatchValue(value="c42"))]

--- a/tests/unit_test/vectorstore/test_qdrant_multitenancy_integration.py
+++ b/tests/unit_test/vectorstore/test_qdrant_multitenancy_integration.py
@@ -14,9 +14,9 @@ The ``qdrant_client.QdrantClient(":memory:")`` local mode gives us a real
 point-store implementation (with scroll / upsert / filter semantics) without
 requiring a server process, so these tests execute in <1 s each.
 
-Note: payload indexes are a no-op in local mode (the client prints a warning
-to that effect). That's fine — we're exercising correctness of the
-filter-based isolation, not the segment-level defragmentation benefit.
+Note: payload indexes are a no-op in local mode (the client prints a
+warning to that effect). That's fine — we're exercising correctness of
+the filter-based isolation, not the segment-level defragmentation benefit.
 """
 
 from __future__ import annotations
@@ -31,8 +31,13 @@ pytest.importorskip("qdrant_client")
 from qdrant_client import QdrantClient  # noqa: E402
 from qdrant_client import models as rest  # noqa: E402
 
-from aperag.query.query import QueryWithEmbedding  # noqa: E402
 from aperag.vectorstore import qdrant_connector as qc  # noqa: E402
+from aperag.vectorstore.dto import (  # noqa: E402
+    QueryRequest,
+    TenantRef,
+    VectorPoint,
+    VectorShape,
+)
 from aperag.vectorstore.qdrant_connector import (  # noqa: E402
     TENANT_PAYLOAD_KEY,
     QdrantVectorStoreConnector,
@@ -62,15 +67,7 @@ def _reset_ensured_cache():
 
 @pytest.fixture
 def shared_client():
-    """One in-memory Qdrant client shared by all connectors in a test.
-
-    In production each connector instance talks to the same remote Qdrant,
-    so they see each other's writes. In tests we must mimic that by having
-    every connector reuse the same client — otherwise ``tenant A`` and
-    ``tenant B`` would each get their own isolated :memory: store and the
-    whole "are they isolated?" question becomes trivially true for the
-    wrong reason.
-    """
+    """One in-memory Qdrant client shared by all connectors in a test."""
     return QdrantClient(":memory:")
 
 
@@ -81,10 +78,10 @@ def _make_connector(
 ) -> QdrantVectorStoreConnector:
     """Spin up a connector bound to a caller-provided client.
 
-    We patch ``_ENSURED_COLLECTIONS`` via fixture (so ensure runs), and we
-    monkey-patch the client reference right after construction — because the
-    connector's ``__init__`` builds its own client from the ctx; we want all
-    connectors in a test to share one in-memory store.
+    The trick: we use ``__new__`` to bypass ``__init__`` (which would build
+    a fresh ``:memory:`` client, not share ours) and then populate the
+    fields by hand. The connector's contract from the rest of the codebase
+    is unchanged — external callers still go through ``__init__``.
     """
     ctx = {
         "url": ":memory:",
@@ -98,48 +95,38 @@ def _make_connector(
         "quantization_enabled": False,
         "hnsw_on_disk": False,
     }
-    # Strategy: pre-populate the shared client by running ensure_collection
-    # logic through ONE connector, then force subsequent connectors to reuse
-    # the same client.
+    if multitenant and not ctx.get("collection"):
+        raise ValueError("QdrantVectorStoreConnector(multitenant=True) requires ctx['collection']")
+
     conn = QdrantVectorStoreConnector.__new__(QdrantVectorStoreConnector)
     conn.ctx = ctx
     conn.multitenant = multitenant
     conn.cfg = ctx
-    if multitenant and not ctx.get("collection"):
-        raise ValueError("QdrantVectorStoreConnector(multitenant=True) requires ctx['collection']")
-    conn.tenant_id = str(tenant_id)
+    conn._tenant = TenantRef(id=str(tenant_id))
+    # VectorShape canonicalizes distance to lowercase.
+    conn._shape = VectorShape(size=VECTOR_SIZE, distance="cosine")
     conn.url = ":memory:"
     conn.port = 6333
     conn.grpc_port = 6334
     conn.prefer_grpc = False
     conn.https = False
     conn.timeout = 300
-    conn.vector_size = VECTOR_SIZE
-    conn.distance = "Cosine"
     conn.client = client
 
+    # opclass / score expr aren't used by Qdrant but the constructor
+    # leaves them absent in this path; nothing reads them.
+
     if multitenant:
-        conn.collection_name = global_collection_name(VECTOR_SIZE, "Cosine")
-        conn._ensure_collection()
+        conn.collection_name = global_collection_name(VECTOR_SIZE, "cosine")
+        conn.ensure_collection()
     else:
         conn.collection_name = tenant_id
-        # Legacy mode: caller explicitly creates the physical collection.
         if not client.collection_exists(conn.collection_name):
             client.create_collection(
                 collection_name=conn.collection_name,
                 vectors_config=rest.VectorParams(size=VECTOR_SIZE, distance=rest.Distance.COSINE),
             )
 
-    # llama_index store — not used in these tests, but the connector API
-    # expects the attribute to be set. Importing here avoids the cost when
-    # tests don't need it.
-    from llama_index.vector_stores.qdrant import QdrantVectorStore
-
-    conn.store = QdrantVectorStore(
-        client=client,
-        collection_name=conn.collection_name,
-        vectors_config=rest.VectorParams(size=VECTOR_SIZE, distance=rest.Distance.COSINE),
-    )
     return conn
 
 
@@ -148,12 +135,13 @@ def _seed_points(
     vectors: List[List[float]],
     tenant_payload: str,
 ) -> List[str]:
-    """Write raw points straight into the connector's physical collection.
+    """Write raw points into the connector's physical collection.
 
-    We deliberately bypass ``store.add()`` because llama_index serializes the
-    entire node into ``_node_content`` and adds other derived fields, which
-    muddies tests focused on tenant-payload filtering. Direct upsert with
-    ``rest.PointStruct`` mirrors what the migration script does.
+    We bypass ``upsert()`` because that method stamps ``collection_id``
+    from the connector's own ``tenant`` — which is exactly the behavior
+    under test for some scenarios. For "what if a foreign tenant's id
+    leaks in?" cases we need to plant payloads with arbitrary tenant ids,
+    which only direct ``client.upsert`` can do.
     """
     ids = [str(uuid.uuid4()) for _ in vectors]
     points = [
@@ -164,6 +152,41 @@ def _seed_points(
     return ids
 
 
+def _query(conn: QdrantVectorStoreConnector, vec: List[float], top_k: int = 10) -> list:
+    """Tiny helper to call ``search`` with just an embedding and a non-
+    restrictive threshold."""
+    return conn.search(QueryRequest(embedding=vec, top_k=top_k, score_threshold=-1.0))
+
+
+# ---------------------------------------------------------------------------
+# upsert goes native (no LlamaIndex)
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_writes_tenant_stamped_points(shared_client):
+    """Round-trip via the new ``upsert()`` API: the connector must stamp
+    ``collection_id`` on every point (matching the tenant), write
+    successfully, and make the points visible through ``search``."""
+    a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    points = [
+        VectorPoint(
+            id=str(uuid.uuid4()),
+            vector=VEC_A,
+            payload={"text": "hello", "metadata": {"source": "unit-test"}},
+        ),
+    ]
+    ids = a.upsert(points)
+    assert ids == [points[0].id]
+
+    hits = _query(a, VEC_A)
+    assert len(hits) == 1
+    # The stamped tenant id must land in the payload so downstream
+    # filter guards have something to match against.
+    assert hits[0].payload.get(TENANT_PAYLOAD_KEY) == a.tenant.id
+    # Payload round-trips.
+    assert hits[0].payload.get("text") == "hello"
+
+
 # ---------------------------------------------------------------------------
 # tenant isolation on search
 # ---------------------------------------------------------------------------
@@ -171,33 +194,25 @@ def _seed_points(
 
 def test_multitenant_search_is_isolated_between_tenants(shared_client):
     """Two tenants writing to the same physical collection must not see each
-    other's points through the connector's search path, because the connector
-    silently adds a ``collection_id`` ``must`` clause."""
+    other's points through the connector's search path."""
     a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
     b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
 
-    assert a.collection_name == b.collection_name == global_collection_name(VECTOR_SIZE, "Cosine"), (
-        "Both tenants must be routed to the same physical global collection"
-    )
+    assert a.collection_name == b.collection_name == global_collection_name(VECTOR_SIZE, "cosine")
 
-    _seed_points(a, [VEC_A, VEC_A], tenant_payload=a.tenant_id)
-    _seed_points(b, [VEC_A, VEC_B], tenant_payload=b.tenant_id)
+    _seed_points(a, [VEC_A, VEC_A], tenant_payload=a.tenant.id)
+    _seed_points(b, [VEC_A, VEC_B], tenant_payload=b.tenant.id)
 
-    # Tenant A queries with VEC_A: should hit only its own 2 points.
-    q = QueryWithEmbedding(query="", top_k=10, embedding=VEC_A)
-    res_a = a.search(q, score_threshold=0.0)
-    res_b = b.search(q, score_threshold=0.0)
+    res_a = _query(a, VEC_A)
+    res_b = _query(b, VEC_A)
 
-    tenants_seen_by_a = {r.metadata.get(TENANT_PAYLOAD_KEY) for r in res_a.results if r.metadata}
-    tenants_seen_by_b = {r.metadata.get(TENANT_PAYLOAD_KEY) for r in res_b.results if r.metadata}
+    tenants_seen_by_a = {h.payload.get(TENANT_PAYLOAD_KEY) for h in res_a}
+    tenants_seen_by_b = {h.payload.get(TENANT_PAYLOAD_KEY) for h in res_b}
 
-    assert tenants_seen_by_a == {a.tenant_id}, f"tenant A saw foreign points: {tenants_seen_by_a}"
-    assert tenants_seen_by_b == {b.tenant_id}, f"tenant B saw foreign points: {tenants_seen_by_b}"
-    assert len(res_a.results) == 2
-    # B has one VEC_A and one VEC_B; VEC_B's cosine similarity to the query VEC_A is 0 so
-    # it may be filtered out by score_threshold=0 depending on implementation, but both
-    # points belong to B regardless.
-    assert len(res_b.results) >= 1
+    assert tenants_seen_by_a == {a.tenant.id}, f"tenant A saw foreign points: {tenants_seen_by_a}"
+    assert tenants_seen_by_b == {b.tenant.id}, f"tenant B saw foreign points: {tenants_seen_by_b}"
+    assert len(res_a) == 2
+    assert len(res_b) >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -207,44 +222,43 @@ def test_multitenant_search_is_isolated_between_tenants(shared_client):
 
 def test_delete_by_ids_does_not_cross_tenants_even_if_ids_leak(shared_client):
     """If A somehow passes B's point ids into ``delete(ids=...)``, the
-    connector's defense-in-depth filter (``HasIdCondition`` +
-    ``FieldCondition(tenant)``) must refuse to delete them."""
+    connector's defense-in-depth filter must refuse to delete them."""
     a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
     b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
 
-    ids_a = _seed_points(a, [VEC_A], tenant_payload=a.tenant_id)
-    ids_b = _seed_points(b, [VEC_B], tenant_payload=b.tenant_id)
+    ids_a = _seed_points(a, [VEC_A], tenant_payload=a.tenant.id)
+    ids_b = _seed_points(b, [VEC_B], tenant_payload=b.tenant.id)
 
     # A tries to delete B's id (simulating a confused caller).
-    a.delete(ids=ids_b)
+    a.delete(ids_b)
 
     # B's point must still exist; A's own point is untouched.
     remaining_b = a.client.retrieve(collection_name=b.collection_name, ids=ids_b)
     remaining_a = a.client.retrieve(collection_name=a.collection_name, ids=ids_a)
-    assert len(remaining_b) == 1, "Cross-tenant delete must be a no-op, B's point should survive"
-    assert len(remaining_a) == 1, "A's own data should be unaffected when misusing delete"
+    assert len(remaining_b) == 1, "Cross-tenant delete must be a no-op"
+    assert len(remaining_a) == 1, "A's own data should be unaffected"
 
     # Sanity: A's own ids still delete correctly.
-    a.delete(ids=ids_a)
+    a.delete(ids_a)
     remaining_a2 = a.client.retrieve(collection_name=a.collection_name, ids=ids_a)
     assert len(remaining_a2) == 0
 
 
 # ---------------------------------------------------------------------------
-# delete_collection() = per-tenant purge, not physical drop
+# drop_tenant = per-tenant purge, not physical drop
 # ---------------------------------------------------------------------------
 
 
-def test_delete_collection_multitenant_purges_only_own_tenant(shared_client):
-    """``delete_collection`` on tenant A must wipe A's points but keep the
+def test_drop_tenant_multitenant_purges_only_own_tenant(shared_client):
+    """``drop_tenant`` on tenant A must wipe A's points but keep the
     global collection alive and B's points intact."""
     a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
     b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
 
-    _seed_points(a, [VEC_A, VEC_A, VEC_A], tenant_payload=a.tenant_id)
-    ids_b = _seed_points(b, [VEC_B, VEC_B], tenant_payload=b.tenant_id)
+    _seed_points(a, [VEC_A, VEC_A, VEC_A], tenant_payload=a.tenant.id)
+    ids_b = _seed_points(b, [VEC_B, VEC_B], tenant_payload=b.tenant.id)
 
-    a.delete_collection()
+    a.drop_tenant()
 
     # Global collection must still exist (other tenants depend on it).
     assert a.client.collection_exists(a.collection_name)
@@ -253,14 +267,14 @@ def test_delete_collection_multitenant_purges_only_own_tenant(shared_client):
     a_points, _ = a.client.scroll(
         collection_name=a.collection_name,
         scroll_filter=rest.Filter(
-            must=[rest.FieldCondition(key=TENANT_PAYLOAD_KEY, match=rest.MatchValue(value=a.tenant_id))]
+            must=[rest.FieldCondition(key=TENANT_PAYLOAD_KEY, match=rest.MatchValue(value=a.tenant.id))]
         ),
         limit=100,
     )
-    assert a_points == [], "delete_collection must remove ALL of tenant A's points"
+    assert a_points == [], "drop_tenant must remove ALL of tenant A's points"
 
     remaining_b = b.client.retrieve(collection_name=b.collection_name, ids=ids_b)
-    assert len(remaining_b) == 2, "delete_collection(A) must not touch tenant B's points"
+    assert len(remaining_b) == 2, "drop_tenant(A) must not touch tenant B's points"
 
 
 # ---------------------------------------------------------------------------
@@ -270,22 +284,63 @@ def test_delete_collection_multitenant_purges_only_own_tenant(shared_client):
 
 def test_retrieve_drops_foreign_tenant_points(shared_client):
     """``retrieve(ids=...)`` in multitenant mode must post-filter out points
-    whose ``collection_id`` payload doesn't match the connector's tenant_id,
+    whose ``collection_id`` payload doesn't match the connector's tenant id,
     even if the caller passes in an id that happens to exist under another
     tenant."""
     a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
     b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
 
-    ids_a = _seed_points(a, [VEC_A], tenant_payload=a.tenant_id)
-    ids_b = _seed_points(b, [VEC_B], tenant_payload=b.tenant_id)
+    ids_a = _seed_points(a, [VEC_A], tenant_payload=a.tenant.id)
+    ids_b = _seed_points(b, [VEC_B], tenant_payload=b.tenant.id)
 
-    # A calls retrieve with a mixture of its own and B's ids.
     mixed = ids_a + ids_b
-    points = a.retrieve(ids=mixed, with_payload=True)
+    points = a.retrieve(mixed)
 
-    # Only A's ids survive the post-filter.
-    retrieved_ids = {str(p.id) for p in points}
+    retrieved_ids = {p.id for p in points}
     assert retrieved_ids == set(ids_a), f"leaked foreign points: {retrieved_ids - set(ids_a)}"
+
+
+# ---------------------------------------------------------------------------
+# delete_by_filter
+# ---------------------------------------------------------------------------
+
+
+def test_delete_by_filter_tenant_guarded(shared_client):
+    """``delete_by_filter`` must AND-merge with the tenant guard so a
+    filter that would match B's points still leaves them alone when A
+    issues it."""
+    from aperag.vectorstore.filters import Eq
+
+    a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    b = _make_connector("col_bbbbbbbbbbbbb_b", client=shared_client)
+
+    # Both tenants seed a point with indexer=vector.
+    a_id = str(uuid.uuid4())
+    b_id = str(uuid.uuid4())
+    shared_client.upsert(
+        collection_name=a.collection_name,
+        points=[
+            rest.PointStruct(id=a_id, vector=VEC_A, payload={TENANT_PAYLOAD_KEY: a.tenant.id, "indexer": "vector"}),
+            rest.PointStruct(id=b_id, vector=VEC_A, payload={TENANT_PAYLOAD_KEY: b.tenant.id, "indexer": "vector"}),
+        ],
+        wait=True,
+    )
+
+    # A deletes every ``indexer=vector`` row — should only touch its own.
+    a.delete_by_filter(Eq(key="indexer", value="vector"))
+
+    # A's row gone, B's row survives.
+    assert a.client.retrieve(collection_name=a.collection_name, ids=[a_id]) == []
+    assert len(b.client.retrieve(collection_name=b.collection_name, ids=[b_id])) == 1
+
+
+def test_delete_by_filter_empty_filter_rejected(shared_client):
+    """An empty / None filter must never be accepted — it would DELETE
+    every point in the shared global collection. We prefer an explicit
+    raise to silent truncation."""
+    a = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    with pytest.raises(ValueError, match="non-empty filter"):
+        a.delete_by_filter(None)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -303,15 +358,11 @@ def test_legacy_mode_uses_tenant_name_as_physical_collection(shared_client):
 
     _seed_points(legacy, [VEC_A], tenant_payload="irrelevant_in_legacy")
 
-    # Legacy search does NOT add any tenant filter, so the point comes back
-    # even though its payload.collection_id is unrelated to the tenant.
-    q = QueryWithEmbedding(query="", top_k=5, embedding=VEC_A)
-    res = legacy.search(q, score_threshold=0.0)
-    assert len(res.results) == 1
-    # DocumentWithScore doesn't expose id/embedding directly; the metadata
-    # fallback path (for non-llama_index-shaped payloads) preserves the
-    # tenant-payload key so we can check it made it through the connector.
-    assert res.results[0].metadata.get(TENANT_PAYLOAD_KEY) == "irrelevant_in_legacy"
+    # Legacy search does NOT add any tenant filter, so the point comes
+    # back even though its payload.collection_id is unrelated.
+    hits = _query(legacy, VEC_A, top_k=5)
+    assert len(hits) == 1
+    assert hits[0].payload.get(TENANT_PAYLOAD_KEY) == "irrelevant_in_legacy"
 
 
 # ---------------------------------------------------------------------------
@@ -332,16 +383,11 @@ def test_multitenant_without_tenant_id_raises():
 
 
 # ---------------------------------------------------------------------------
-# purge_all_shards: the safety net when vector_size can no longer be resolved
+# purge_all_shards
 # ---------------------------------------------------------------------------
 
 
-def _make_shard(client: QdrantClient, vector_size: int, distance: str = "Cosine") -> str:
-    """Create an ``aperag_vectors_{size}_{dist}`` collection directly.
-
-    Used to simulate the "historical data in a different-dimension shard"
-    situation that makes ``purge_all_shards`` necessary.
-    """
+def _make_shard(client: QdrantClient, vector_size: int, distance: str = "cosine") -> str:
     name = global_collection_name(vector_size, distance)
     if not client.collection_exists(name):
         client.create_collection(
@@ -361,58 +407,38 @@ def _seed_into_shard(client: QdrantClient, shard: str, tenant: str, vectors: Lis
 
 
 def test_purge_all_shards_removes_tenant_from_every_global_collection(shared_client):
-    """This is the exact scenario that motivated
-    ``_purge_tenant_from_all_global_collections``: an ApeRAG collection's
-    embedding provider is removed, so ``vector_size`` can no longer be
-    resolved, so the normal ``delete_collection`` path routes to a default
-    shard and leaves orphaned points in the shard that actually holds the
-    tenant's vectors. ``purge_all_shards=True`` must clean up every shard.
-
-    We simulate by directly creating two shards with different dims, seeding
-    tenant A into both and tenant B into one; then calling
-    ``delete_collection(purge_all_shards=True)`` from a 4-dim-bound A
-    connector and asserting both shards are clean for A but B survives.
-    """
-    # Shard 1: 4-dim — what the A connector "thinks" it's bound to.
+    """The exact scenario behind ``drop_tenant(purge_all_shards=True)``:
+    an ApeRAG collection's embedding provider is removed, vector_size
+    cannot be resolved, so the normal drop routes to a default shard and
+    leaves orphans in the shard that actually holds data."""
     shard4 = _make_shard(shared_client, 4)
-    # Shard 2: 3-dim — simulates the shard where A's legacy points actually live.
     shard3 = _make_shard(shared_client, 3)
 
     ids_a4 = _seed_into_shard(shared_client, shard4, "col_a", [[1.0, 0.0, 0.0, 0.0]])
     ids_a3 = _seed_into_shard(shared_client, shard3, "col_a", [[1.0, 0.0, 0.0]])
     ids_b4 = _seed_into_shard(shared_client, shard4, "col_b", [[0.0, 1.0, 0.0, 0.0]])
 
-    # A's connector is built for 4-dim — mirroring "current config says 4-dim"
-    # even though historical data also lives in the 3-dim shard.
     a = _make_connector("col_a", client=shared_client)
+    a.drop_tenant(purge_all_shards=True)
 
-    a.delete_collection(purge_all_shards=True)
-
-    # Both shards must be free of A's points.
     for shard, ids in ((shard4, ids_a4), (shard3, ids_a3)):
         survivors = shared_client.retrieve(collection_name=shard, ids=ids)
-        assert survivors == [], f"purge_all_shards left {len(survivors)} point(s) of tenant A in {shard}"
+        assert survivors == [], f"purge_all_shards left {len(survivors)} of A in {shard}"
 
-    # B's points in shard4 are preserved — filter was scoped to A's tenant_id.
     remaining_b = shared_client.retrieve(collection_name=shard4, ids=ids_b4)
     assert len(remaining_b) == 1
 
-    # Physical shards must NOT be dropped; other tenants rely on them.
     assert shared_client.collection_exists(shard4)
     assert shared_client.collection_exists(shard3)
 
 
 def test_purge_all_shards_ignores_legacy_named_collections(shared_client):
     """``_purge_tenant_from_all_global_collections`` must scan only names
-    starting with ``aperag_vectors_``. Any legacy per-tenant collection
-    (``col<hex>``) or unrelated collection in the same Qdrant cluster must
-    be left completely alone — we'd otherwise risk deleting data belonging
-    to a deployment still on the old layout mid-migration.
-    """
+    starting with ``aperag_vectors_``. Legacy / unrelated collections in
+    the same Qdrant cluster must be left completely alone."""
     shard4 = _make_shard(shared_client, 4)
     ids_a4 = _seed_into_shard(shared_client, shard4, "col_a", [[1.0, 0.0, 0.0, 0.0]])
 
-    # An unrelated, legacy-named collection in the same cluster.
     legacy_name = "col_legacy_unrelated_x"
     shared_client.create_collection(
         collection_name=legacy_name,
@@ -421,12 +447,8 @@ def test_purge_all_shards_ignores_legacy_named_collections(shared_client):
     legacy_ids = _seed_into_shard(shared_client, legacy_name, "col_a", [[0.0, 1.0, 0.0, 0.0]])
 
     a = _make_connector("col_a", client=shared_client)
-    a.delete_collection(purge_all_shards=True)
+    a.drop_tenant(purge_all_shards=True)
 
-    # A's points gone from the global shard.
     assert shared_client.retrieve(collection_name=shard4, ids=ids_a4) == []
-
-    # Legacy-named collection untouched, even though its payload has
-    # collection_id=col_a — the prefix guard saves us.
     still_there = shared_client.retrieve(collection_name=legacy_name, ids=legacy_ids)
     assert len(still_there) == 1, "purge must not touch non-aperag_vectors_* collections"

--- a/tests/unit_test/vectorstore/test_qdrant_multitenancy_integration.py
+++ b/tests/unit_test/vectorstore/test_qdrant_multitenancy_integration.py
@@ -329,3 +329,104 @@ def test_multitenant_without_tenant_id_raises():
                 "multitenant": True,
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# purge_all_shards: the safety net when vector_size can no longer be resolved
+# ---------------------------------------------------------------------------
+
+
+def _make_shard(client: QdrantClient, vector_size: int, distance: str = "Cosine") -> str:
+    """Create an ``aperag_vectors_{size}_{dist}`` collection directly.
+
+    Used to simulate the "historical data in a different-dimension shard"
+    situation that makes ``purge_all_shards`` necessary.
+    """
+    name = global_collection_name(vector_size, distance)
+    if not client.collection_exists(name):
+        client.create_collection(
+            collection_name=name,
+            vectors_config=rest.VectorParams(size=vector_size, distance=rest.Distance.COSINE),
+        )
+    return name
+
+
+def _seed_into_shard(client: QdrantClient, shard: str, tenant: str, vectors: List[List[float]]) -> List[str]:
+    ids = [str(uuid.uuid4()) for _ in vectors]
+    points = [
+        rest.PointStruct(id=pid, vector=vec, payload={TENANT_PAYLOAD_KEY: tenant}) for pid, vec in zip(ids, vectors)
+    ]
+    client.upsert(collection_name=shard, points=points, wait=True)
+    return ids
+
+
+def test_purge_all_shards_removes_tenant_from_every_global_collection(shared_client):
+    """This is the exact scenario that motivated
+    ``_purge_tenant_from_all_global_collections``: an ApeRAG collection's
+    embedding provider is removed, so ``vector_size`` can no longer be
+    resolved, so the normal ``delete_collection`` path routes to a default
+    shard and leaves orphaned points in the shard that actually holds the
+    tenant's vectors. ``purge_all_shards=True`` must clean up every shard.
+
+    We simulate by directly creating two shards with different dims, seeding
+    tenant A into both and tenant B into one; then calling
+    ``delete_collection(purge_all_shards=True)`` from a 4-dim-bound A
+    connector and asserting both shards are clean for A but B survives.
+    """
+    # Shard 1: 4-dim — what the A connector "thinks" it's bound to.
+    shard4 = _make_shard(shared_client, 4)
+    # Shard 2: 3-dim — simulates the shard where A's legacy points actually live.
+    shard3 = _make_shard(shared_client, 3)
+
+    ids_a4 = _seed_into_shard(shared_client, shard4, "col_a", [[1.0, 0.0, 0.0, 0.0]])
+    ids_a3 = _seed_into_shard(shared_client, shard3, "col_a", [[1.0, 0.0, 0.0]])
+    ids_b4 = _seed_into_shard(shared_client, shard4, "col_b", [[0.0, 1.0, 0.0, 0.0]])
+
+    # A's connector is built for 4-dim — mirroring "current config says 4-dim"
+    # even though historical data also lives in the 3-dim shard.
+    a = _make_connector("col_a", client=shared_client)
+
+    a.delete_collection(purge_all_shards=True)
+
+    # Both shards must be free of A's points.
+    for shard, ids in ((shard4, ids_a4), (shard3, ids_a3)):
+        survivors = shared_client.retrieve(collection_name=shard, ids=ids)
+        assert survivors == [], f"purge_all_shards left {len(survivors)} point(s) of tenant A in {shard}"
+
+    # B's points in shard4 are preserved — filter was scoped to A's tenant_id.
+    remaining_b = shared_client.retrieve(collection_name=shard4, ids=ids_b4)
+    assert len(remaining_b) == 1
+
+    # Physical shards must NOT be dropped; other tenants rely on them.
+    assert shared_client.collection_exists(shard4)
+    assert shared_client.collection_exists(shard3)
+
+
+def test_purge_all_shards_ignores_legacy_named_collections(shared_client):
+    """``_purge_tenant_from_all_global_collections`` must scan only names
+    starting with ``aperag_vectors_``. Any legacy per-tenant collection
+    (``col<hex>``) or unrelated collection in the same Qdrant cluster must
+    be left completely alone — we'd otherwise risk deleting data belonging
+    to a deployment still on the old layout mid-migration.
+    """
+    shard4 = _make_shard(shared_client, 4)
+    ids_a4 = _seed_into_shard(shared_client, shard4, "col_a", [[1.0, 0.0, 0.0, 0.0]])
+
+    # An unrelated, legacy-named collection in the same cluster.
+    legacy_name = "col_legacy_unrelated_x"
+    shared_client.create_collection(
+        collection_name=legacy_name,
+        vectors_config=rest.VectorParams(size=4, distance=rest.Distance.COSINE),
+    )
+    legacy_ids = _seed_into_shard(shared_client, legacy_name, "col_a", [[0.0, 1.0, 0.0, 0.0]])
+
+    a = _make_connector("col_a", client=shared_client)
+    a.delete_collection(purge_all_shards=True)
+
+    # A's points gone from the global shard.
+    assert shared_client.retrieve(collection_name=shard4, ids=ids_a4) == []
+
+    # Legacy-named collection untouched, even though its payload has
+    # collection_id=col_a — the prefix guard saves us.
+    still_there = shared_client.retrieve(collection_name=legacy_name, ids=legacy_ids)
+    assert len(still_there) == 1, "purge must not touch non-aperag_vectors_* collections"

--- a/tests/unit_test/vectorstore/test_writer_filter_contract.py
+++ b/tests/unit_test/vectorstore/test_writer_filter_contract.py
@@ -1,0 +1,255 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Integration tests that pin the contract between the real writer path
+(``TextNode -> nodes_to_vector_points -> connector.upsert``) and the
+filter DSL used by search / delete.
+
+This exists because the prior regression coverage seeded payloads by
+hand as ``{"indexer": ...}`` flat dicts, which silently masked a
+writer/filter split: real adapter output puts filterable keys under
+``metadata.*``. If the adapter ever stops mirroring those keys at the
+top level, ``Eq("indexer", ...)`` / ``Eq("chat_id", ...)`` on new writes
+will silently return zero rows, and the only thing that will notice is
+production.
+
+We intentionally run against the Qdrant ``:memory:`` backend: it's the
+only connector that exercises real translator + real storage in-process
+with no external dependency.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+from llama_index.core.schema import TextNode
+
+pytest.importorskip("qdrant_client")
+
+from qdrant_client import QdrantClient  # noqa: E402
+from qdrant_client import models as rest  # noqa: E402
+
+from aperag.vectorstore import qdrant_connector as qc  # noqa: E402
+from aperag.vectorstore.dto import (  # noqa: E402
+    QueryRequest,
+    TenantRef,
+    VectorShape,
+)
+from aperag.vectorstore.filters import Eq, In, IsEmpty, all_of, any_of  # noqa: E402  # noqa: E402
+from aperag.vectorstore.llama_index_adapter import nodes_to_vector_points  # noqa: E402
+from aperag.vectorstore.qdrant_connector import (  # noqa: E402
+    QdrantVectorStoreConnector,
+    global_collection_name,
+)
+
+VECTOR_SIZE = 4
+VEC_A = [1.0, 0.0, 0.0, 0.0]
+VEC_B = [0.0, 1.0, 0.0, 0.0]
+VEC_C = [0.0, 0.0, 1.0, 0.0]
+
+
+@pytest.fixture(autouse=True)
+def _reset_ensured_cache():
+    qc._ENSURED_COLLECTIONS.clear()
+    yield
+    qc._ENSURED_COLLECTIONS.clear()
+
+
+@pytest.fixture
+def shared_client():
+    return QdrantClient(":memory:")
+
+
+def _make_connector(tenant_id: str, client: QdrantClient) -> QdrantVectorStoreConnector:
+    """Bind a connector to a shared in-memory client. Mirrors the helper in
+    ``test_qdrant_multitenancy_integration.py`` but intentionally duplicated
+    so a future refactor doesn't accidentally couple these test files."""
+    conn = QdrantVectorStoreConnector.__new__(QdrantVectorStoreConnector)
+    ctx = {
+        "url": ":memory:",
+        "collection": tenant_id,
+        "vector_size": VECTOR_SIZE,
+        "distance": "Cosine",
+        "multitenant": True,
+        "quantization_enabled": False,
+        "hnsw_on_disk": False,
+    }
+    conn.ctx = ctx
+    conn.cfg = ctx
+    conn.multitenant = True
+    conn._tenant = TenantRef(id=tenant_id)
+    conn._shape = VectorShape(size=VECTOR_SIZE, distance="cosine")
+    conn.url = ":memory:"
+    conn.port = 6333
+    conn.grpc_port = 6334
+    conn.prefer_grpc = False
+    conn.https = False
+    conn.timeout = 300
+    conn.client = client
+    conn.collection_name = global_collection_name(VECTOR_SIZE, "cosine")
+    conn.ensure_collection()
+    return conn
+
+
+def _node(text: str, *, embedding: List[float], metadata: dict) -> TextNode:
+    n = TextNode(text=text, metadata=metadata)
+    n.embedding = embedding
+    return n
+
+
+def _seed_via_real_writer(conn: QdrantVectorStoreConnector, nodes: List[TextNode]) -> List[str]:
+    points = nodes_to_vector_points(nodes, tenant_id=conn.tenant.id)
+    return conn.upsert(points)
+
+
+# ---------------------------------------------------------------------------
+# query filter: Eq / In / IsEmpty contract survives real writer payloads
+# ---------------------------------------------------------------------------
+
+
+def test_eq_indexer_filter_matches_real_writer_payload(shared_client):
+    """The regression that motivated this file: ``Eq("indexer", "vision")``
+    must only match points the writer actually stamped as vision. If the
+    adapter stops lifting ``indexer`` to top level, this test goes red."""
+    conn = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    _seed_via_real_writer(
+        conn,
+        [
+            _node("vec1", embedding=VEC_A, metadata={"indexer": "vector"}),
+            _node("vec2", embedding=VEC_B, metadata={"indexer": "vector"}),
+            _node("vis1", embedding=VEC_A, metadata={"indexer": "vision"}),
+            _node("sum1", embedding=VEC_A, metadata={"indexer": "summary"}),
+        ],
+    )
+
+    hits = conn.search(
+        QueryRequest(
+            embedding=VEC_A,
+            top_k=10,
+            flt=Eq(key="indexer", value="vision"),
+            score_threshold=-1.0,
+        )
+    )
+    assert len(hits) == 1
+    assert hits[0].payload.get("indexer") == "vision"
+
+
+def test_index_types_filter_does_not_leak_across_indexers(shared_client):
+    """``index_types=["vector"]`` is implemented as
+    ``In(indexer, ["vector"]) OR IsEmpty(indexer)`` — the ``IsEmpty`` half
+    exists to keep pre-migration data visible. If new writes leave the
+    top-level ``indexer`` empty (because it only lives in
+    ``metadata.indexer``), IsEmpty matches every new point, and
+    ``index_types=["vector"]`` starts bleeding summary/vision results in.
+    This test is the direct regression guard for that.
+    """
+    conn = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    _seed_via_real_writer(
+        conn,
+        [
+            _node("v1", embedding=VEC_A, metadata={"indexer": "vector"}),
+            _node("s1", embedding=VEC_A, metadata={"indexer": "summary"}),
+            _node("vi1", embedding=VEC_A, metadata={"indexer": "vision"}),
+        ],
+    )
+
+    hits = conn.search(
+        QueryRequest(
+            embedding=VEC_A,
+            top_k=10,
+            flt=any_of(
+                In(key="indexer", values=("vector",)),
+                IsEmpty(key="indexer"),
+            ),
+            score_threshold=-1.0,
+        )
+    )
+
+    indexers = {h.payload.get("indexer") for h in hits}
+    assert indexers == {"vector"}, (
+        f"index_types=['vector'] leaked across indexers: {indexers}. "
+        "Writer probably stopped lifting `indexer` to top-level payload."
+    )
+
+
+def test_chat_id_eq_filter_matches_real_writer_payload(shared_client):
+    """``chat_id`` is the other filterable key whose contract lives in
+    ``ContextManager._create_combined_filter``. Same risk: if it only sits
+    under ``metadata.chat_id``, every chat-scoped retrieval silently
+    returns nothing."""
+    conn = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+    _seed_via_real_writer(
+        conn,
+        [
+            _node(
+                "n1",
+                embedding=VEC_A,
+                metadata={"indexer": "vector", "chat_id": "chat_111"},
+            ),
+            _node(
+                "n2",
+                embedding=VEC_A,
+                metadata={"indexer": "vector", "chat_id": "chat_222"},
+            ),
+        ],
+    )
+
+    hits = conn.search(
+        QueryRequest(
+            embedding=VEC_A,
+            top_k=10,
+            flt=all_of(
+                Eq(key="indexer", value="vector"),
+                Eq(key="chat_id", value="chat_111"),
+            ),
+            score_threshold=-1.0,
+        )
+    )
+    assert len(hits) == 1
+    assert hits[0].payload.get("chat_id") == "chat_111"
+
+
+# ---------------------------------------------------------------------------
+# delete_by_filter must hit real writer payloads
+# ---------------------------------------------------------------------------
+
+
+def test_delete_by_filter_on_real_writer_payload_removes_only_matches(shared_client):
+    """The original review blocker explicitly called out that
+    ``delete_by_filter(Eq("indexer", ...))`` was only validated against
+    hand-seeded flat payloads. This is the direct regression guard:
+    write via the real adapter, then ensure the delete hits the right
+    points and leaves the rest alone."""
+    conn = _make_connector("col_aaaaaaaaaaaaa_a", client=shared_client)
+
+    _seed_via_real_writer(
+        conn,
+        [
+            _node("v1", embedding=VEC_A, metadata={"indexer": "vector"}),
+            _node("v2", embedding=VEC_B, metadata={"indexer": "vector"}),
+            _node("vi1", embedding=VEC_C, metadata={"indexer": "vision"}),
+        ],
+    )
+
+    # All three should be visible before the delete.
+    tenant_filter = rest.Filter(
+        must=[rest.FieldCondition(key="collection_id", match=rest.MatchValue(value=conn.tenant.id))]
+    )
+    before, _ = conn.client.scroll(collection_name=conn.collection_name, scroll_filter=tenant_filter, limit=100)
+    assert len(before) == 3
+
+    conn.delete_by_filter(Eq(key="indexer", value="vector"))
+
+    remaining, _ = conn.client.scroll(collection_name=conn.collection_name, scroll_filter=tenant_filter, limit=100)
+    remaining_indexers = [p.payload.get("indexer") for p in remaining]
+    assert remaining_indexers == ["vision"], (
+        f"delete_by_filter(Eq indexer=vector) did not match real writer payload: "
+        f"remaining={remaining_indexers}. Writer probably stopped lifting "
+        f"`indexer` to top-level payload."
+    )

--- a/web/src/app/workspace/collections/collection-form.tsx
+++ b/web/src/app/workspace/collections/collection-form.tsx
@@ -281,12 +281,17 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
   /**
    * Watch embeddingModelName
    * When the embedding model name is changed, synchronize changes to other model parameters.
+   * In edit mode the embedding binding is immutable (backend rejects changes), so we
+   * keep whatever values the collection already has and skip the auto-synchronisation
+   * to avoid accidentally overwriting them with a default when the current model is
+   * no longer present in the available models list.
    */
   const embeddingModelName = useWatch({
     control: form.control,
     name: 'config.embedding.model',
   });
   useEffect(() => {
+    if (action === 'edit') return;
     if (_.isEmpty(embeddingModels)) return;
 
     let defaultModel: ModelSpec | undefined;
@@ -320,7 +325,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
       'config.embedding.model',
       currentModel?.model || defaultModel?.model || '',
     );
-  }, [embeddingModelName, embeddingModels, form]);
+  }, [action, embeddingModelName, embeddingModels, form]);
 
   /**
    * load models
@@ -473,46 +478,66 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
               <FormField
                 control={form.control}
                 name="config.embedding.model"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{page_collections('embedding_model')}</FormLabel>
-                    <FormControl className="ml-auto">
-                      <Select
-                        {...field}
-                        onValueChange={field.onChange}
-                        value={field.value || ''}
-                      >
-                        <SelectTrigger className="w-full cursor-pointer md:w-6/12">
-                          <SelectValue placeholder="Select a model" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {embeddingModels
-                            ?.filter((item) => _.size(item.models))
-                            .map((item) => {
-                              return (
-                                <SelectGroup key={item.name}>
-                                  <SelectLabel>{item.label}</SelectLabel>
-                                  {item.models?.map((model) => {
-                                    return (
-                                      <SelectItem
-                                        key={model.model}
-                                        value={model.model || ''}
-                                      >
-                                        {model.model}
-                                      </SelectItem>
-                                    );
-                                  })}
-                                </SelectGroup>
-                              );
-                            })}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                    <FormDescription>
-                      {page_collections('embedding_model_description')}
-                    </FormDescription>
-                  </FormItem>
-                )}
+                render={({ field }) => {
+                  const embeddingLocked = action === 'edit';
+                  return (
+                    <FormItem>
+                      <FormLabel>
+                        {page_collections('embedding_model')}
+                        {embeddingLocked && (
+                          <Badge variant="secondary" className="ml-2">
+                            {page_collections('embedding_model_locked_badge')}
+                          </Badge>
+                        )}
+                      </FormLabel>
+                      <FormControl className="ml-auto">
+                        <Select
+                          {...field}
+                          onValueChange={field.onChange}
+                          value={field.value || ''}
+                          disabled={embeddingLocked}
+                        >
+                          <SelectTrigger
+                            className={cn(
+                              'w-full md:w-6/12',
+                              embeddingLocked
+                                ? 'cursor-not-allowed opacity-70'
+                                : 'cursor-pointer',
+                            )}
+                          >
+                            <SelectValue placeholder="Select a model" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {embeddingModels
+                              ?.filter((item) => _.size(item.models))
+                              .map((item) => {
+                                return (
+                                  <SelectGroup key={item.name}>
+                                    <SelectLabel>{item.label}</SelectLabel>
+                                    {item.models?.map((model) => {
+                                      return (
+                                        <SelectItem
+                                          key={model.model}
+                                          value={model.model || ''}
+                                        >
+                                          {model.model}
+                                        </SelectItem>
+                                      );
+                                    })}
+                                  </SelectGroup>
+                                );
+                              })}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormDescription>
+                        {embeddingLocked
+                          ? page_collections('embedding_model_locked_description')
+                          : page_collections('embedding_model_description')}
+                      </FormDescription>
+                    </FormItem>
+                  );
+                }}
               />
 
               <Separator />

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -547,6 +547,8 @@
     "model_settings_description": "Select AI models for document processing. Different index types require different model support",
     "embedding_model": "Embedding Model",
     "embedding_model_description": "An embedding model translates data into numerical vectors that capture their semantic meaning and relationships.",
+    "embedding_model_locked_badge": "Locked after creation",
+    "embedding_model_locked_description": "The embedding model cannot be changed after the collection is created, because different embedding models produce incompatible vectors. Create a new collection if you need a different model.",
     "completion_model": "Completion Model",
     "completion_model_description": "A completion model is an AI that generates new content by predicting the most likely subsequent text based on a given input.",
     "export_knowledge_base": "Export Knowledge Base",

--- a/web/src/i18n/en-US/page_collections.json
+++ b/web/src/i18n/en-US/page_collections.json
@@ -71,6 +71,8 @@
 
   "embedding_model": "Embedding Model",
   "embedding_model_description": "An embedding model translates data into numerical vectors that capture their semantic meaning and relationships.",
+  "embedding_model_locked_badge": "Locked after creation",
+  "embedding_model_locked_description": "The embedding model cannot be changed after the collection is created, because different embedding models produce incompatible vectors. Create a new collection if you need a different model.",
 
   "completion_model": "Completion Model",
   "completion_model_description": "A completion model is an AI that generates new content by predicting the most likely subsequent text based on a given input.",

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -547,6 +547,8 @@
     "model_settings_description": "选择用于文档处理的AI模型。不同索引类型需要不同的模型支持",
     "embedding_model": "嵌入模型（Embedding Model）",
     "embedding_model_description": "嵌入模型能够将数据转换为数值向量，这些向量能够捕捉数据的语义信息及其相互关系。",
+    "embedding_model_locked_badge": "创建后不可修改",
+    "embedding_model_locked_description": "嵌入模型在 Collection 创建后不可修改。不同嵌入模型产生的向量维度或语义分布不兼容，切换会导致原有向量变为孤儿数据、检索失效。如需使用其他模型，请新建 Collection 并重新导入文档。",
     "completion_model": "补全模型（Completion Model）",
     "completion_model_description": "补全模型能根据给定输入预测最可能的下文内容，从而生成新的文本。",
     "export_knowledge_base": "导出知识库",

--- a/web/src/i18n/zh-CN/page_collections.json
+++ b/web/src/i18n/zh-CN/page_collections.json
@@ -71,6 +71,8 @@
 
   "embedding_model": "嵌入模型（Embedding Model）",
   "embedding_model_description": "嵌入模型能够将数据转换为数值向量，这些向量能够捕捉数据的语义信息及其相互关系。",
+  "embedding_model_locked_badge": "创建后不可修改",
+  "embedding_model_locked_description": "嵌入模型在 Collection 创建后不可修改。不同嵌入模型产生的向量维度或语义分布不兼容，切换会导致原有向量变为孤儿数据、检索失效。如需使用其他模型，请新建 Collection 并重新导入文档。",
 
   "completion_model": "补全模型（Completion Model）",
   "completion_model_description": "补全模型能根据给定输入预测最可能的下文内容，从而生成新的文本。",


### PR DESCRIPTION
## TL;DR

Lands the vector-store abstraction layer **end-to-end**: two
production-ready backends (Qdrant + pgvector), one clean contract, zero
abstraction leaks. Switch by flipping ``VECTOR_DB_TYPE``. Also brings
in the embedding-model lock and multi-shard delete safety net from the
post-merge review of #1494.

**Merge = directly usable.** No new required env vars, no migrations,
no mandatory ops actions. If you want pgvector, flip one env and restart;
the connector builds the table on first write.

## Why all of this in one PR

This PR grew out of three converging needs:

1. **Post-merge review of #1494**: embedding model lock (product +
   backend), delete safety net for orphan cleanup, full-linkage review.
2. **M2 abstraction layer**: ``VectorFilter`` DSL, ``retrieve()`` in
   base class, ``QdrantClient`` process-level pool — so the code stops
   importing ``qdrant_client.models`` from ``ContextManager``.
3. **M3 pgvector + abstraction close-out**: the DTO suite I deliberately
   deferred last round, plus the decoupling from LlamaIndex's
   ``QdrantVectorStore.add(nodes)`` write path — both of which are
   hard blockers for pgvector.

Shipping them together means the abstraction layer is **fully realised**
in one merge: no more "nice in theory, half-implemented in practice".

## Abstraction layer (final state)

```
aperag/vectorstore/
├── base.py                    # 9 abstract methods, all DTO-typed
├── dto.py                     # TenantRef, VectorShape, VectorPoint,
│                              # QueryRequest, SearchHit, flatten_node_payload
├── filters.py                 # VectorFilter DSL: Eq/In/IsEmpty/And/Or/Not
├── connector.py               # match VECTOR_DB_TYPE → backend
├── qdrant_connector.py        # Qdrant impl + DSL translator + client pool
├── pgvector_connector.py      # pgvector impl + SQL translator + engine pool
└── llama_index_adapter.py     # BaseNode → VectorPoint (boundary)
```

**Contract**:

```python
class VectorStoreConnector(ABC):
    @property
    def tenant(self) -> TenantRef: ...
    @property
    def shape(self) -> VectorShape: ...

    def ensure_collection(self) -> None: ...
    def drop_tenant(self, *, purge_all_shards: bool = False) -> None: ...

    def upsert(self, points: Sequence[VectorPoint]) -> list[str]: ...
    def delete(self, ids: Sequence[str]) -> None: ...
    def delete_by_filter(self, flt: VectorFilter) -> None: ...

    def search(self, request: QueryRequest) -> list[SearchHit]: ...
    def retrieve(self, ids: Sequence[str], *, with_vectors: bool = False) -> list[VectorPoint]: ...
```

No LlamaIndex / no ``qdrant_client.models`` / no ``psycopg`` types in any
signature. ``dto.py`` and ``filters.py`` both explicitly ban backend SDK
imports.

## Key pgvector decisions

| Decision | Rationale |
|---|---|
| Default to ApeRAG's main Postgres (``DATABASE_URL``) | "ApeRAG-Lite / private delivery" wants one fewer component. Override via ``PGVECTOR_DATABASE_URL`` when volume outgrows the main DB |
| Dynamic ``CREATE TABLE IF NOT EXISTS aperag_vectors_<size>_<distance>`` | ``(size, distance)`` combos are a function of user-chosen embedding models, not a deploy-time constant. Mirrors Qdrant's ``ensure_collection`` semantics so runbooks translate 1:1 across backends |
| Parameterised SQL, whitelisted JSON keys | Zero SQL injection surface even though the translator interpolates table names and JSON accessors |
| HNSW + B-tree(tenant_id) + GIN(payload) | Three indexes, three jobs: vector search / per-tenant scans / DSL filter acceleration |
| "Higher score = better" for all distances | Same semantics as Qdrant; callers don't branch on distance type |
| ``CAST(:q AS vector)`` not ``:q::vector`` | Dodges a SQLAlchemy text-parser edge case under psycopg2. Details in ``pgvector_connector.py`` comments |

## Qdrant changes

The Qdrant connector was rewritten to the same contract:

- Native ``upsert`` (``client.upsert``, no more LlamaIndex ``QdrantVectorStore``).
- ``delete_by_filter`` with tenant-guarded filter merge; empty filter raises.
- ``retrieve`` returns ``list[VectorPoint]``, ids normalized to str.
- ``drop_tenant`` replaces ``delete_collection``; ``purge_all_shards``
  safety net preserved.
- All module-level helpers (``_translate_filter``, ``_merge_tenant_filter``,
  ``_ensure_tenant_payload_index``, ``_get_or_create_client``, ensured-
  collections cache) carried over verbatim.

## Embedding model lock (from the review)

- Backend: ``CollectionService._reject_embedding_change`` blocks post-
  creation changes to an existing collection's embedding model /
  provider. First-time binding is still allowed.
- Frontend: ``collection-form.tsx`` disables the embedding Select in
  edit mode, shows a "Locked after creation" badge, skips the model
  watcher (so a now-missing model doesn't get silently rewritten).
- i18n: ``embedding_model_locked_badge`` + ``embedding_model_locked_description``
  added to en-US + zh-CN.

## Delete safety net

- ``tasks/collection.py::_delete_vector_databases`` calls
  ``drop_tenant(purge_all_shards=True)`` when ``vector_size`` cannot be
  resolved. Both Qdrant and pgvector back-ends iterate every
  ``aperag_vectors_*`` shard and delete rows tagged with this tenant;
  legacy ``col<hex>`` collections / tables are strictly ignored.

## Configuration

### New env vars (all non-required)

```bash
# Backend selector; pick qdrant or pgvector.
VECTOR_DB_TYPE=qdrant

# pgvector: leave empty to reuse DATABASE_URL. Set to a dedicated DSN
# when you want a separate vector DB. The vector extension must be
# installed (apecloud/pgvector:pg16 image has it).
PGVECTOR_DATABASE_URL=

# HNSW tuning
PGVECTOR_HNSW_M=16
PGVECTOR_HNSW_EF_CONSTRUCTION=64
PGVECTOR_HNSW_EF_SEARCH=40
```

### Deploy

- ``deploy/aperag/values.yaml`` updated with ``PGVECTOR_*`` defaults.
- ``docker-compose.yml`` already uses ``apecloud/pgvector:pg16`` — no
  change.

## Backward compatibility for old Qdrant data

Data written by the pre-M3 LlamaIndex path (payload holding
``_node_content`` as a JSON string) is **read-compatible without
migration**. The read path goes through ``flatten_node_payload()``
(``dto.py``) which understands both the modern flat ``{text,
metadata}`` shape and the legacy ``_node_content`` blob, preferring
flat when both exist. ``test_dto.py`` pins the four fallback paths.

## Tests

| File | Coverage |
|---|---|
| ``test_dto.py`` (new) | VectorShape normalisation, TenantRef non-empty, VectorPoint type checks, flatten_node_payload four cases |
| ``test_llama_index_adapter.py`` (new) | BaseNode → VectorPoint conversion, tenant injection, order preservation |
| ``test_pgvector_translator.py`` (new) | Table-name safety, DSL→SQL structural snapshots, bind-param SQL-injection guard |
| ``test_pgvector_end_to_end.py`` (new, gated on ``APERAG_TEST_PGVECTOR_URL``) | 10 tests: upsert / search / retrieve / delete / delete_by_filter / drop_tenant / tenant isolation / composed filters |
| ``test_qdrant_multitenancy_integration.py`` (updated) | Fully migrated to new DTO API; added upsert + delete_by_filter + tenant-guard coverage |
| ``test_qdrant_filter_translation.py`` / ``test_qdrant_client_cache.py`` / ``test_context_manager_filter.py`` / ``test_filters.py`` / ``test_collection_service_embedding_lock.py`` / ``test_build_vector_db_context.py`` | Preserved / minor updates; all green |

**Local results** (against ``apecloud/pgvector:pg16`` in docker):
- ``pytest tests/unit_test/vectorstore tests/unit_test/service`` →
  **121/121 pass**.
- ``pytest tests/unit_test`` (excluding preexisting ``pydantic_ai`` +
  MCP docstring failures on main) → ``455+10 pass, 3 preexisting
  failures``.
- ``ruff check`` + ``ruff format --check`` → green.

## Test plan

- [x] All vectorstore + service unit tests pass locally
- [x] pgvector end-to-end tests pass against local ``pgvector:pg16``
- [x] Lint + format clean
- [ ] CI green
- [ ] Staging smoke: create collection → upload doc → search → retrieve
      chunks → delete collection, both under ``VECTOR_DB_TYPE=qdrant``
      and ``VECTOR_DB_TYPE=pgvector``

## Docs

- ``docs/zh-CN/design/vector_db_abstraction.md`` — M2 + M3 marked
  landed, gap table now all green.
- ``docs/zh-CN/design/vector_db_abstraction_m3_pr.md`` — this PR's
  narrative, design decisions, the SQLAlchemy ``::type`` cast trap, and
  "not in this PR" follow-ups (Qdrant→pgvector migration script,
  ``halfvec`` quantization, Milvus backend).
- ``docs/zh-CN/design/vector_db_abstraction_m2_pr.md`` — kept as the
  M2 narrative.
- ``docs/zh-CN/design/qdrant_memory_optimization.md`` — §7 embedding
  lock, §8 full-linkage review, §9 pointer to abstraction docs (unchanged
  from earlier in this PR).

## Related

- Builds on #1494 (Qdrant multitenancy + INT8 quantization + memory opt).
- Closes ``vector_db_abstraction.md`` §M2 and §M3.
- Next: Qdrant → pgvector data migration script, ``halfvec`` quantization,
  Milvus backend — all documented as "not in this PR" follow-ups.