### PR TITLE
test(objectstore): cover singleton and pool info contracts

### DIFF
--- a/tests/unit_test/concurrent_control/test_redis_manager.py
+++ b/tests/unit_test/concurrent_control/test_redis_manager.py
@@ -1,0 +1,94 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from aperag.db.redis_manager import RedisConnectionManager
+
+
+class _DummyPool:
+    def __init__(
+        self,
+        *,
+        max_connections=20,
+        created_connections=4,
+        available_connections=None,
+        in_use_connections=None,
+    ):
+        self.max_connections = max_connections
+        self.created_connections = created_connections
+        if available_connections is not None:
+            self._available_connections = available_connections
+        if in_use_connections is not None:
+            self._in_use_connections = in_use_connections
+
+
+@pytest.fixture(autouse=True)
+def reset_redis_pools():
+    old_async_pool = RedisConnectionManager._async_pool
+    old_sync_pool = RedisConnectionManager._sync_pool
+    RedisConnectionManager._async_pool = None
+    RedisConnectionManager._sync_pool = None
+    try:
+        yield
+    finally:
+        RedisConnectionManager._async_pool = old_async_pool
+        RedisConnectionManager._sync_pool = old_sync_pool
+
+
+def test_get_pool_info_returns_not_initialized_when_no_pool():
+    assert RedisConnectionManager.get_pool_info() == {"status": "not_initialized"}
+
+
+def test_get_pool_info_reads_public_fields_without_private_internals():
+    RedisConnectionManager._sync_pool = _DummyPool()
+
+    assert RedisConnectionManager.get_pool_info() == {
+        "sync_pool": {
+            "max_connections": 20,
+            "created_connections": 4,
+        }
+    }
+
+
+def test_get_pool_info_counts_private_connection_lists_when_present():
+    RedisConnectionManager._async_pool = _DummyPool(
+        max_connections=10,
+        created_connections=6,
+        available_connections=["a", "b"],
+        in_use_connections=["c"],
+    )
+
+    assert RedisConnectionManager.get_pool_info() == {
+        "async_pool": {
+            "max_connections": 10,
+            "created_connections": 6,
+            "available_connections": 2,
+            "in_use_connections": 1,
+        }
+    }
+
+
+def test_get_pool_info_tolerates_non_sized_private_internals():
+    RedisConnectionManager._sync_pool = _DummyPool(
+        available_connections=object(),
+        in_use_connections=object(),
+    )
+
+    assert RedisConnectionManager.get_pool_info() == {
+        "sync_pool": {
+            "max_connections": 20,
+            "created_connections": 4,
+        }
+    }

--- a/tests/unit_test/objectstore/test_factory.py
+++ b/tests/unit_test/objectstore/test_factory.py
@@ -1,0 +1,98 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from aperag.objectstore import base as objectstore_base
+from aperag.objectstore.local import AsyncLocal, Local, LocalConfig
+from aperag.objectstore.s3 import S3, S3Config
+
+
+@pytest.fixture(autouse=True)
+def reset_objectstore_singletons():
+    old_sync = objectstore_base._SYNC_STORE
+    old_async = objectstore_base._ASYNC_STORE
+    objectstore_base._SYNC_STORE = None
+    objectstore_base._ASYNC_STORE = None
+    try:
+        yield
+    finally:
+        objectstore_base._SYNC_STORE = old_sync
+        objectstore_base._ASYNC_STORE = old_async
+
+
+def test_get_object_store_returns_local_singleton(monkeypatch, tmp_path):
+    monkeypatch.setattr(objectstore_base.settings, "object_store_type", "local")
+    monkeypatch.setattr(
+        objectstore_base.settings,
+        "object_store_local_config",
+        LocalConfig(root_dir=str(tmp_path / "sync-store")),
+    )
+    monkeypatch.setattr(objectstore_base.settings, "object_store_s3_config", None)
+
+    first = objectstore_base.get_object_store()
+    second = objectstore_base.get_object_store()
+
+    assert isinstance(first, Local)
+    assert first is second
+
+
+@pytest.mark.asyncio
+async def test_get_async_object_store_returns_local_singleton(monkeypatch, tmp_path):
+    monkeypatch.setattr(objectstore_base.settings, "object_store_type", "local")
+    monkeypatch.setattr(
+        objectstore_base.settings,
+        "object_store_local_config",
+        LocalConfig(root_dir=str(tmp_path / "async-store")),
+    )
+    monkeypatch.setattr(objectstore_base.settings, "object_store_s3_config", None)
+
+    first = objectstore_base.get_async_object_store()
+    second = objectstore_base.get_async_object_store()
+
+    assert isinstance(first, AsyncLocal)
+    assert first is second
+
+
+def test_get_object_store_returns_s3_singleton(monkeypatch):
+    monkeypatch.setattr(objectstore_base.settings, "object_store_type", "s3")
+    monkeypatch.setattr(objectstore_base.settings, "object_store_local_config", None)
+    monkeypatch.setattr(
+        objectstore_base.settings,
+        "object_store_s3_config",
+        S3Config(
+            endpoint="http://localhost:9000",
+            access_key="ak",
+            secret_key="sk",
+            bucket="bucket",
+            region="us-east-1",
+            use_path_style=True,
+        ),
+    )
+
+    first = objectstore_base.get_object_store()
+    second = objectstore_base.get_object_store()
+
+    assert isinstance(first, S3)
+    assert first is second
+
+
+@pytest.mark.asyncio
+async def test_get_async_object_store_requires_s3_config(monkeypatch):
+    monkeypatch.setattr(objectstore_base.settings, "object_store_type", "s3")
+    monkeypatch.setattr(objectstore_base.settings, "object_store_local_config", None)
+    monkeypatch.setattr(objectstore_base.settings, "object_store_s3_config", None)
+
+    with pytest.raises(RuntimeError, match="OBJECT_STORE_S3_"):
+        objectstore_base.get_async_object_store()


### PR DESCRIPTION
## Summary
- audit PRs updated in the last 20 hours and identify which ones lack focused test coverage
- add unit coverage for objectstore singleton factory behavior introduced by #1561
- add unit coverage for defensive Redis pool info inspection introduced by #1561

## Audit result
- #1554 / #1555: already test-only PRs
- #1557: docs-only, no runtime test gap
- #1556 / #1559 / #1560: implementation changes already shipped with matching unit/integration/compat coverage
- #1561: runtime behavior changed without direct tests, so this PR fills that gap

## Validation
- uvx ruff check tests/unit_test/objectstore/test_factory.py tests/unit_test/concurrent_control/test_redis_manager.py
- uvx ruff format --check tests/unit_test/objectstore/test_factory.py tests/unit_test/concurrent_control/test_redis_manager.py
- /Users/earayu/.slock/agents/78d0f075-c262-49ff-a781-ef806ae0eb0f/ApeRAG-main/.venv/bin/pytest tests/unit_test/objectstore/test_factory.py tests/unit_test/objectstore/test_local.py tests/unit_test/objectstore/test_s3.py tests/unit_test/concurrent_control/test_redis_lock.py tests/unit_test/concurrent_control/test_redis_manager.py -q

## Notes
- The existing async S3 suite still needs `moto_server` in the environment; I did not change that behavior in this PR.