### PR TITLE
[codex] harden ES fulltext contract and runtime

### DIFF
--- a/aperag/index/fulltext_index.py
+++ b/aperag/index/fulltext_index.py
@@ -26,6 +26,7 @@ from aperag.docparser.chunking import rechunk
 from aperag.index.base import BaseIndexer, IndexResult, IndexType
 from aperag.llm.completion.completion_service import CompletionService
 from aperag.query.query import DocumentWithScore
+from aperag.schema.utils import parseCollectionConfig
 from aperag.utils.tokenizer import get_default_tokenizer
 from aperag.utils.utils import generate_fulltext_index_name
 
@@ -52,8 +53,8 @@ class FulltextIndexer(BaseIndexer):
         self.async_es = AsyncElasticsearch(self.es_host, **config)
 
     def is_enabled(self, collection) -> bool:
-        """Fulltext indexing is always enabled"""
-        return True
+        """Fulltext indexing follows the collection contract."""
+        return parseCollectionConfig(collection.config).enable_fulltext is not False
 
     def _extract_chunk_data(self, part) -> Tuple[str, str, Dict[str, Any]]:
         """Extract chunk content, title and metadata from a document part"""
@@ -68,7 +69,12 @@ class FulltextIndexer(BaseIndexer):
         return chunk_content, title_text, chunk_metadata
 
     def _process_chunks(
-        self, document_id: int, doc_parts: List[Any], document_name: str, index_name: str
+        self,
+        document_id: int,
+        doc_parts: List[Any],
+        document_name: str,
+        index_name: str,
+        collection_id: str,
     ) -> Tuple[int, int]:
         """Process and insert all chunks for a document. Returns (chunk_count, total_content_length)"""
         chunk_count = 0
@@ -89,7 +95,14 @@ class FulltextIndexer(BaseIndexer):
 
             chunk_id = f"{document_id}_{chunk_idx}"
             self._insert_chunk(
-                index_name, chunk_id, document_id, document_name, chunk_content, title_text, chunk_metadata
+                index_name,
+                chunk_id,
+                document_id,
+                collection_id,
+                document_name,
+                chunk_content,
+                title_text,
+                chunk_metadata,
             )
             chunk_count += 1
             total_content_length += len(chunk_content)
@@ -120,6 +133,13 @@ class FulltextIndexer(BaseIndexer):
     def create_index(self, document_id: int, content: str, doc_parts: List[Any], collection, **kwargs) -> IndexResult:
         """Create fulltext index for document chunks"""
         try:
+            if not self.is_enabled(collection):
+                return IndexResult(
+                    success=True,
+                    index_type=self.index_type,
+                    metadata={"message": "Fulltext indexing disabled", "status": "skipped"},
+                )
+
             # Filter out non-text parts
             doc_parts = [part for part in doc_parts if hasattr(part, "content") and part.content]
 
@@ -136,7 +156,13 @@ class FulltextIndexer(BaseIndexer):
                 raise Exception(f"Document {document_id} not found")
 
             index_name = generate_fulltext_index_name(collection.id)
-            chunk_count, total_content_length = self._process_chunks(document_id, doc_parts, document.name, index_name)
+            chunk_count, total_content_length = self._process_chunks(
+                document_id,
+                doc_parts,
+                document.name,
+                index_name,
+                str(collection.id),
+            )
 
             logger.info(f"Fulltext index created for document {document_id} with {chunk_count} chunks")
             return self._create_success_result(index_name, document.name, chunk_count, total_content_length, "created")
@@ -150,6 +176,13 @@ class FulltextIndexer(BaseIndexer):
     def update_index(self, document_id: int, content: str, doc_parts: List[Any], collection, **kwargs) -> IndexResult:
         """Update fulltext index for document chunks"""
         try:
+            if not self.is_enabled(collection):
+                return IndexResult(
+                    success=True,
+                    index_type=self.index_type,
+                    metadata={"message": "Fulltext indexing disabled", "status": "skipped"},
+                )
+
             document = db_ops.query_document_by_id(document_id)
             if not document:
                 raise Exception(f"Document {document_id} not found")
@@ -169,7 +202,11 @@ class FulltextIndexer(BaseIndexer):
             # Create new chunks if there are doc_parts
             if doc_parts:
                 chunk_count, total_content_length = self._process_chunks(
-                    document_id, doc_parts, document.name, index_name
+                    document_id,
+                    doc_parts,
+                    document.name,
+                    index_name,
+                    str(collection.id),
                 )
                 logger.info(f"Fulltext index updated for document {document_id} with {chunk_count} chunks")
                 return self._create_success_result(
@@ -231,6 +268,7 @@ class FulltextIndexer(BaseIndexer):
         index: str,
         chunk_id: str,
         doc_id: int,
+        collection_id: str,
         doc_name: str,
         content: str,
         title_text: str = "",
@@ -242,8 +280,10 @@ class FulltextIndexer(BaseIndexer):
             return
 
         doc = {
+            "collection_id": collection_id,
             "document_id": doc_id,
             "chunk_id": chunk_id,
+            "chat_id": (metadata or {}).get("chat_id"),
             "name": doc_name,
             "content": content,
             "title": title_text,
@@ -273,7 +313,7 @@ class FulltextIndexer(BaseIndexer):
 
             # Add chat_id filter if provided
             if chat_id:
-                query["bool"]["filter"] = [{"term": {"metadata.chat_id": chat_id}}]
+                query["bool"]["filter"] = [{"term": {"chat_id": chat_id}}]
             sort = [{"_score": {"order": "desc"}}]
             resp = await self.async_es.search(index=index, query=query, sort=sort, size=topk)
             hits = resp.body["hits"]
@@ -304,8 +344,11 @@ class FulltextIndexer(BaseIndexer):
             return result
         except Exception as e:
             logger.error(f"Failed to search documents in index {index}: {str(e)}")
-            # Return empty list on error to allow the flow to continue
-            return []
+            raise FulltextSearchDegradedError(f"search failed for {index}: {str(e)}") from e
+
+
+class FulltextSearchDegradedError(RuntimeError):
+    """Raised when fulltext search cannot execute and the caller should degrade explicitly."""
 
 
 # Global instance
@@ -556,8 +599,10 @@ def create_index(index: str):
             "properties": {
                 "content": {"type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart"},
                 "title": {"type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart"},
+                "collection_id": {"type": "keyword"},
                 "document_id": {"type": "keyword"},
                 "chunk_id": {"type": "keyword"},
+                "chat_id": {"type": "keyword"},
                 "name": {"type": "keyword"},
                 "metadata": {"type": "object", "enabled": False},
             }

--- a/aperag/index/fulltext_index.py
+++ b/aperag/index/fulltext_index.py
@@ -313,7 +313,17 @@ class FulltextIndexer(BaseIndexer):
 
             # Add chat_id filter if provided
             if chat_id:
-                query["bool"]["filter"] = [{"term": {"chat_id": chat_id}}]
+                query["bool"]["filter"] = [
+                    {
+                        "bool": {
+                            "should": [
+                                {"term": {"chat_id": str(chat_id)}},
+                                {"term": {"metadata.chat_id": str(chat_id)}},
+                            ],
+                            "minimum_should_match": 1,
+                        }
+                    }
+                ]
             sort = [{"_score": {"order": "desc"}}]
             resp = await self.async_es.search(index=index, query=query, sort=sort, size=topk)
             hits = resp.body["hits"]

--- a/aperag/service/document_service.py
+++ b/aperag/service/document_service.py
@@ -38,8 +38,8 @@ from aperag.exceptions import (
 )
 from aperag.index.manager import document_index_manager
 from aperag.objectstore.base import get_async_object_store
-from aperag.schema.utils import parseCollectionConfig
 from aperag.schema import view_models
+from aperag.schema.utils import parseCollectionConfig
 from aperag.schema.view_models import Chunk, DocumentList, DocumentPreview, VisionChunk
 from aperag.service.marketplace_service import marketplace_service
 from aperag.utils.pagination import (

--- a/aperag/service/document_service.py
+++ b/aperag/service/document_service.py
@@ -38,6 +38,7 @@ from aperag.exceptions import (
 )
 from aperag.index.manager import document_index_manager
 from aperag.objectstore.base import get_async_object_store
+from aperag.schema.utils import parseCollectionConfig
 from aperag.schema import view_models
 from aperag.schema.view_models import Chunk, DocumentList, DocumentPreview, VisionChunk
 from aperag.service.marketplace_service import marketplace_service
@@ -198,10 +199,11 @@ class DocumentService:
         """
         Get the list of index types to create based on collection configuration.
         """
-        index_types = [
-            db_models.DocumentIndexType.VECTOR,
-            db_models.DocumentIndexType.FULLTEXT,
-        ]
+        parsed_config = parseCollectionConfig(json.dumps(collection_config))
+        index_types = [db_models.DocumentIndexType.VECTOR]
+
+        if parsed_config.enable_fulltext is not False:
+            index_types.append(db_models.DocumentIndexType.FULLTEXT)
 
         if collection_config.get("enable_knowledge_graph", False):
             index_types.append(db_models.DocumentIndexType.GRAPH)

--- a/aperag/service/search_pipeline_service.py
+++ b/aperag/service/search_pipeline_service.py
@@ -35,7 +35,7 @@ from aperag.query.query import DocumentWithScore
 from aperag.schema.utils import parseCollectionConfig
 from aperag.schema.view_models import SearchRequest, SearchResultItem
 from aperag.service.default_model_service import default_model_service
-from aperag.utils.utils import generate_vector_db_collection_name
+from aperag.utils.utils import generate_fulltext_index_name, generate_vector_db_collection_name
 
 logger = logging.getLogger(__name__)
 
@@ -229,9 +229,14 @@ class SearchPipelineService:
         user_id: str,
         chat_id: Optional[str] = None,
     ) -> List[DocumentWithScore]:
-        from aperag.index.fulltext_index import fulltext_indexer
+        from aperag.index.fulltext_index import FulltextSearchDegradedError, fulltext_indexer
 
-        index_name = generate_vector_db_collection_name(collection.id)
+        config = parseCollectionConfig(collection.config)
+        if config.enable_fulltext is False:
+            logger.info("Skipping fulltext search for collection %s because enable_fulltext=false", collection.id)
+            return []
+
+        index_name = generate_fulltext_index_name(collection.id)
         final_keywords = list(keywords or [])
         if not final_keywords:
             extractor_ctx = {
@@ -244,7 +249,19 @@ class SearchPipelineService:
             final_keywords = await extract_keywords(query, extractor_ctx)
 
         final_keywords = list(set(final_keywords))
-        docs = await fulltext_indexer.search_document(index_name, final_keywords, top_k * 3, chat_id=chat_id)
+        if not final_keywords:
+            logger.warning(
+                "Fulltext keyword extraction degraded for collection %s; falling back to raw query token",
+                collection.id,
+            )
+            final_keywords = [query]
+
+        try:
+            docs = await fulltext_indexer.search_document(index_name, final_keywords, top_k * 3, chat_id=chat_id)
+        except FulltextSearchDegradedError as e:
+            logger.warning("Fulltext search degraded for collection %s: %s", collection.id, e)
+            return []
+
         for doc in docs:
             if doc.metadata is None:
                 doc.metadata = {}

--- a/aperag/tasks/collection.py
+++ b/aperag/tasks/collection.py
@@ -63,8 +63,14 @@ class CollectionTask:
             # Initialize vector database connections
             self._initialize_vector_databases(collection_id, collection)
 
-            # Initialize fulltext index
-            self._initialize_fulltext_index(collection_id)
+            config = parseCollectionConfig(collection.config)
+            if config.enable_fulltext is not False:
+                self._initialize_fulltext_index(collection_id)
+            else:
+                logger.info(
+                    "Skipping fulltext index initialization for collection %s because enable_fulltext=false",
+                    collection_id,
+                )
 
             # Update collection status
             collection.status = CollectionStatus.ACTIVE

--- a/aperag/tasks/document.py
+++ b/aperag/tasks/document.py
@@ -91,16 +91,20 @@ class DocumentIndexTask:
             elif index_type == DocumentIndexType.FULLTEXT.value:
                 from aperag.index.fulltext_index import fulltext_indexer
 
-                result = fulltext_indexer.create_index(
-                    document_id=document_id,
-                    content=parsed_data.content,
-                    doc_parts=parsed_data.doc_parts,
-                    collection=collection,
-                    file_path=parsed_data.file_path,
-                )
-                if not result.success:
-                    raise Exception(result.error)
-                result_data = result.data or {"success": True}
+                if not fulltext_indexer.is_enabled(collection):
+                    logger.info(f"Fulltext indexing disabled for document {document_id}")
+                    result_data = {"success": True, "message": "Fulltext indexing disabled"}
+                else:
+                    result = fulltext_indexer.create_index(
+                        document_id=document_id,
+                        content=parsed_data.content,
+                        doc_parts=parsed_data.doc_parts,
+                        collection=collection,
+                        file_path=parsed_data.file_path,
+                    )
+                    if not result.success:
+                        raise Exception(result.error)
+                    result_data = result.data or {"success": True}
 
             elif index_type == DocumentIndexType.GRAPH.value:
                 from aperag.index.graph_index import graph_indexer
@@ -281,16 +285,20 @@ class DocumentIndexTask:
             elif index_type == DocumentIndexType.FULLTEXT.value:
                 from aperag.index.fulltext_index import fulltext_indexer
 
-                result = fulltext_indexer.update_index(
-                    document_id=document_id,
-                    content=parsed_data.content,
-                    doc_parts=parsed_data.doc_parts,
-                    collection=collection,
-                    file_path=parsed_data.file_path,
-                )
-                if not result.success:
-                    raise Exception(result.error)
-                result_data = result.data or {"success": True}
+                if not fulltext_indexer.is_enabled(collection):
+                    logger.info(f"Fulltext indexing disabled for document {document_id}")
+                    result_data = {"success": True, "message": "Fulltext indexing disabled"}
+                else:
+                    result = fulltext_indexer.update_index(
+                        document_id=document_id,
+                        content=parsed_data.content,
+                        doc_parts=parsed_data.doc_parts,
+                        collection=collection,
+                        file_path=parsed_data.file_path,
+                    )
+                    if not result.success:
+                        raise Exception(result.error)
+                    result_data = result.data or {"success": True}
 
             elif index_type == DocumentIndexType.GRAPH.value:
                 from aperag.index.graph_index import graph_indexer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,9 @@ services:
       - "discovery.type=single-node"
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
       - "xpack.security.enabled=false"
+      - "ES_REQUIRE_IK_PLUGIN=true"
+      - "ES_AUTO_INSTALL_IK=true"
+      - "ES_IK_PLUGIN_URL=https://get.infini.cloud/elasticsearch/analysis-ik/8.8.2"
     volumes:
       - aperag-es-data:/usr/share/elasticsearch/data
       - ./scripts/init-es.sh:/usr/share/elasticsearch/bin/init-es.sh

--- a/docs/en-US/development/es-p0-contract-runtime-hardening.md
+++ b/docs/en-US/development/es-p0-contract-runtime-hardening.md
@@ -28,7 +28,9 @@ index migration risk:
 - Fulltext document indexing tasks skip cleanly when the collection disables fulltext.
 - Fulltext search uses `generate_fulltext_index_name(...)`, not the vector helper.
 - Fulltext chunks store explicit top-level filter fields.
-- Chat-scoped fulltext search filters on explicit `chat_id`.
+- Chat-scoped fulltext search writes explicit top-level `chat_id`, but keeps a
+  temporary dual-read filter on both `chat_id` and legacy `metadata.chat_id`
+  until the later reindex / rollout line removes the historical path.
 - Fulltext keyword extraction falls back to the raw query token when all extractors
   return nothing.
 - Fulltext backend failures are logged as explicit degrade events before returning
@@ -56,6 +58,14 @@ That means:
 - Rollback remains a code rollback, not an ES data rollback.
 
 The physical model changes only in the later P1 implementation.
+
+P0 also does **not** make collection-config flips self-healing at the data plane:
+
+- Turning `enable_fulltext` off stops new runtime reads and writes.
+- Turning it back on does not automatically purge or rebuild existing ES
+  projections.
+- Fulltext projection convergence after config flips still requires an explicit
+  rebuild / rollout action.
 
 ## Source Of Truth
 

--- a/docs/en-US/development/es-p0-contract-runtime-hardening.md
+++ b/docs/en-US/development/es-p0-contract-runtime-hardening.md
@@ -1,0 +1,87 @@
+# ES P0 Contract And Runtime Hardening
+
+This document captures the first implementation slice of the Elasticsearch redesign:
+
+- P0-A: contract hard-fix
+- P0-B: runtime hardening
+
+It intentionally does **not** implement the P1 shared logical index redesign or the
+P1 migration / reindex rollout. Those steps require separate design and rollout PRs.
+
+## Goals
+
+The P0 slice fixes correctness and runtime issues without introducing physical
+index migration risk:
+
+1. Make `enable_fulltext` effective in runtime behavior.
+2. Stop routing fulltext search through vector naming helpers.
+3. Add explicit filterable fulltext fields for `collection_id`, `document_id`,
+   `chunk_id`, and `chat_id`.
+4. Stop silently degrading fulltext search failures into unexplained empty recall.
+5. Turn IK from an implicit startup assumption into an explicit runtime dependency.
+
+## Scope
+
+### Included in P0
+
+- Fulltext index creation is skipped when `enable_fulltext=false`.
+- Fulltext document indexing tasks skip cleanly when the collection disables fulltext.
+- Fulltext search uses `generate_fulltext_index_name(...)`, not the vector helper.
+- Fulltext chunks store explicit top-level filter fields.
+- Chat-scoped fulltext search filters on explicit `chat_id`.
+- Fulltext keyword extraction falls back to the raw query token when all extractors
+  return nothing.
+- Fulltext backend failures are logged as explicit degrade events before returning
+  empty recall.
+- IK installation behavior is gated by explicit environment flags.
+
+### Explicitly excluded from P0
+
+- Shared logical index.
+- Alias / versioned rebuild / cutover.
+- Physical fulltext index renaming.
+- Per-collection to shared migration.
+- Reindex / backfill / rollback orchestration across existing ES data.
+
+## Compatibility Boundary
+
+P0 keeps the current physical per-collection fulltext index model in place.
+This keeps the first PR small and avoids mixing correctness fixes with data-plane
+migration.
+
+That means:
+
+- No existing ES indices are renamed in this slice.
+- No automatic reindex runs in this slice.
+- Rollback remains a code rollback, not an ES data rollback.
+
+The physical model changes only in the later P1 implementation.
+
+## Source Of Truth
+
+P0 does not change the source-of-truth model:
+
+- Object store remains the source of the original document.
+- Parser / chunking remains a derived layer.
+- Elasticsearch remains a projection for fulltext retrieval.
+
+This PR must not turn ES into an authoritative data source.
+
+## Runtime Contract For IK
+
+IK remains the Chinese analyzer dependency in this slice, but it is now treated
+as an explicit runtime dependency instead of an implicit startup side effect.
+
+The startup contract is:
+
+- `ES_REQUIRE_IK_PLUGIN=true|false`
+- `ES_AUTO_INSTALL_IK=true|false`
+- `ES_IK_PLUGIN_URL=<pinned plugin artifact>`
+
+This allows environments to:
+
+- fail fast when IK is required but unavailable, or
+- explicitly opt into controlled bootstrap behavior.
+
+Longer-term image baking / artifact pinning still belongs to the broader runtime
+hardening line, but P0 removes the hidden dependency behavior.

--- a/scripts/init-es.sh
+++ b/scripts/init-es.sh
@@ -10,9 +10,24 @@ ik_plugin_installed() {
     [ -d "/usr/share/elasticsearch/plugins/analysis-ik" ]
 }
 
+require_ik_plugin() {
+    [ "${ES_REQUIRE_IK_PLUGIN:-true}" = "true" ]
+}
+
+auto_install_ik_plugin() {
+    [ "${ES_AUTO_INSTALL_IK:-false}" = "true" ]
+}
+
 # Function to check if ES is ready
 check_ready() {
-    is_healthy
+    is_healthy || return 1
+
+    if require_ik_plugin && ! ik_plugin_installed; then
+        echo "IK Analyzer is required but not installed"
+        return 1
+    fi
+
+    return 0
 }
 
 if [ "$1" = "check" ]; then
@@ -21,16 +36,25 @@ if [ "$1" = "check" ]; then
 fi
 
 # Check and install IK Analyzer if needed
-if ! ik_plugin_installed; then
-    echo "Installing IK Analyzer..."
-    /usr/share/elasticsearch/bin/elasticsearch-plugin install -b https://get.infini.cloud/elasticsearch/analysis-ik/8.8.2
-    if [ "$?" -ne 0 ]; then
-        echo "Failed to install IK Analyzer"
+if require_ik_plugin && ! ik_plugin_installed; then
+    if auto_install_ik_plugin; then
+        IK_PLUGIN_URL="${ES_IK_PLUGIN_URL:-https://get.infini.cloud/elasticsearch/analysis-ik/8.8.2}"
+        echo "Installing IK Analyzer from ${IK_PLUGIN_URL}..."
+        /usr/share/elasticsearch/bin/elasticsearch-plugin install -b "${IK_PLUGIN_URL}"
+        if [ "$?" -ne 0 ]; then
+            echo "Failed to install IK Analyzer"
+            exit 1
+        fi
+        echo "IK Analyzer installed successfully"
+    else
+        echo "IK Analyzer is required but not installed."
+        echo "Use an Elasticsearch image with analysis-ik pre-baked, or explicitly set ES_AUTO_INSTALL_IK=true."
         exit 1
     fi
-    echo "IK Analyzer installed successfully"
-else
+elif require_ik_plugin; then
     echo "IK Analyzer is already installed"
+else
+    echo "IK Analyzer requirement disabled"
 fi
 
 # Start ES in foreground

--- a/tests/unit_test/test_es_p0_contract.py
+++ b/tests/unit_test/test_es_p0_contract.py
@@ -125,7 +125,7 @@ async def test_fulltext_search_logs_explicit_degrade_on_backend_failure(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_fulltext_index_search_filters_on_explicit_chat_id(monkeypatch):
+async def test_fulltext_index_search_uses_dual_read_chat_filter(monkeypatch):
     captured = {}
 
     class FakeAsyncIndices:
@@ -151,7 +151,17 @@ async def test_fulltext_index_search_filters_on_explicit_chat_id(monkeypatch):
     docs = await FulltextIndexer.search_document(indexer, "ft-col-1", ["hello"], topk=3, chat_id="chat-1")
 
     assert docs == []
-    assert captured["query"]["bool"]["filter"] == [{"term": {"chat_id": "chat-1"}}]
+    assert captured["query"]["bool"]["filter"] == [
+        {
+            "bool": {
+                "should": [
+                    {"term": {"chat_id": "chat-1"}},
+                    {"term": {"metadata.chat_id": "chat-1"}},
+                ],
+                "minimum_should_match": 1,
+            }
+        }
+    ]
 
 
 def test_create_index_mapping_exposes_explicit_filter_fields(monkeypatch):

--- a/tests/unit_test/test_es_p0_contract.py
+++ b/tests/unit_test/test_es_p0_contract.py
@@ -1,0 +1,182 @@
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.db.models import CollectionStatus, DocumentIndexType
+from aperag.query.query import DocumentWithScore
+from aperag.service.document_service import DocumentService
+from aperag.service.search_pipeline_service import SearchPipelineService
+from aperag.tasks.collection import CollectionTask
+from aperag.tasks.document import DocumentIndexTask
+
+
+def _collection_config(enable_fulltext=True):
+    return json.dumps(
+        {
+            "source": "system",
+            "enable_vector": True,
+            "enable_fulltext": enable_fulltext,
+            "enable_knowledge_graph": False,
+            "enable_summary": False,
+            "enable_vision": False,
+        }
+    )
+
+
+def test_document_service_respects_enable_fulltext():
+    service = DocumentService()
+
+    enabled = service._get_index_types_for_collection(json.loads(_collection_config(True)))
+    disabled = service._get_index_types_for_collection(json.loads(_collection_config(False)))
+
+    assert DocumentIndexType.FULLTEXT in enabled
+    assert DocumentIndexType.FULLTEXT not in disabled
+
+
+def test_collection_task_skips_fulltext_init_when_disabled(monkeypatch):
+    collection = SimpleNamespace(id="col-1", config=_collection_config(False), status=CollectionStatus.ACTIVE)
+    called = []
+
+    monkeypatch.setattr("aperag.tasks.collection.db_ops.query_collection_by_id", lambda *_args, **_kwargs: collection)
+    monkeypatch.setattr("aperag.tasks.collection.db_ops.update_collection", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(CollectionTask, "_initialize_vector_databases", lambda self, *_args, **_kwargs: None)
+    monkeypatch.setattr(CollectionTask, "_initialize_fulltext_index", lambda self, collection_id: called.append(collection_id))
+
+    result = CollectionTask().initialize_collection("col-1", 1)
+
+    assert result.success is True
+    assert called == []
+
+
+def test_document_index_task_skips_fulltext_create_when_disabled(monkeypatch):
+    collection = SimpleNamespace(id="col-1", config=_collection_config(False))
+    parsed = SimpleNamespace(content="content", doc_parts=[], file_path="/tmp/doc.txt")
+
+    monkeypatch.setattr(
+        "aperag.tasks.utils.get_document_and_collection",
+        lambda *_args, **_kwargs: (SimpleNamespace(id="doc-1"), collection),
+    )
+    monkeypatch.setattr(
+        "aperag.index.fulltext_index.fulltext_indexer.create_index",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("fulltext create_index should not be called")),
+    )
+
+    result = DocumentIndexTask().create_index("doc-1", DocumentIndexType.FULLTEXT.value, parsed)
+
+    assert result.success is True
+    assert result.data["message"] == "Fulltext indexing disabled"
+
+
+@pytest.mark.asyncio
+async def test_fulltext_search_uses_fulltext_helper_and_query_fallback(monkeypatch):
+    captured = {}
+
+    async def fake_extract_keywords(*_args, **_kwargs):
+        return []
+
+    async def fake_search_document(index_name, keywords, topk, chat_id=None):
+        captured["index_name"] = index_name
+        captured["keywords"] = keywords
+        captured["topk"] = topk
+        captured["chat_id"] = chat_id
+        return [DocumentWithScore(text="doc", score=1.0, metadata={})]
+
+    monkeypatch.setattr("aperag.service.search_pipeline_service.extract_keywords", fake_extract_keywords)
+    monkeypatch.setattr("aperag.service.search_pipeline_service.generate_fulltext_index_name", lambda cid: f"ft-{cid}")
+    monkeypatch.setattr("aperag.index.fulltext_index.fulltext_indexer.search_document", fake_search_document)
+
+    service = SearchPipelineService()
+    collection = SimpleNamespace(id="col-1", config=_collection_config(True))
+
+    docs = await service._fulltext_search(collection, "中文问题", 2, None, "user-1", chat_id="chat-1")
+
+    assert captured == {
+        "index_name": "ft-col-1",
+        "keywords": ["中文问题"],
+        "topk": 6,
+        "chat_id": "chat-1",
+    }
+    assert docs[0].metadata["recall_type"] == "fulltext_search"
+
+
+@pytest.mark.asyncio
+async def test_fulltext_search_logs_explicit_degrade_on_backend_failure(monkeypatch, caplog):
+    from aperag.index.fulltext_index import FulltextSearchDegradedError
+
+    async def fake_extract_keywords(*_args, **_kwargs):
+        return ["x"]
+
+    async def fake_search_document(*_args, **_kwargs):
+        raise FulltextSearchDegradedError("boom")
+
+    monkeypatch.setattr("aperag.service.search_pipeline_service.extract_keywords", fake_extract_keywords)
+    monkeypatch.setattr("aperag.index.fulltext_index.fulltext_indexer.search_document", fake_search_document)
+
+    service = SearchPipelineService()
+    collection = SimpleNamespace(id="col-1", config=_collection_config(True))
+
+    with caplog.at_level(logging.WARNING):
+        docs = await service._fulltext_search(collection, "q", 1, ["x"], "user-1", chat_id=None)
+
+    assert docs == []
+    assert "Fulltext search degraded for collection col-1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fulltext_index_search_filters_on_explicit_chat_id(monkeypatch):
+    captured = {}
+
+    class FakeAsyncIndices:
+        async def exists(self, index):
+            return SimpleNamespace(body=True)
+
+    class FakeAsyncEs:
+        def __init__(self):
+            self.indices = FakeAsyncIndices()
+
+        async def search(self, index, query, sort, size):
+            captured["index"] = index
+            captured["query"] = query
+            captured["sort"] = sort
+            captured["size"] = size
+            return SimpleNamespace(body={"hits": {"hits": []}})
+
+    from aperag.index.fulltext_index import FulltextIndexer
+
+    indexer = object.__new__(FulltextIndexer)
+    indexer.async_es = FakeAsyncEs()
+
+    docs = await FulltextIndexer.search_document(indexer, "ft-col-1", ["hello"], topk=3, chat_id="chat-1")
+
+    assert docs == []
+    assert captured["query"]["bool"]["filter"] == [{"term": {"chat_id": "chat-1"}}]
+
+
+def test_create_index_mapping_exposes_explicit_filter_fields(monkeypatch):
+    captured = {}
+
+    class FakeIndices:
+        def exists(self, index):
+            return SimpleNamespace(body=False)
+
+        def create(self, index, body):
+            captured["index"] = index
+            captured["body"] = body
+
+    class FakeElasticsearch:
+        def __init__(self, *_args, **_kwargs):
+            self.indices = FakeIndices()
+
+    monkeypatch.setattr("aperag.index.fulltext_index.Elasticsearch", FakeElasticsearch)
+
+    from aperag.index.fulltext_index import create_index
+
+    create_index("ft-col-1")
+
+    props = captured["body"]["mappings"]["properties"]
+    assert props["collection_id"]["type"] == "keyword"
+    assert props["document_id"]["type"] == "keyword"
+    assert props["chunk_id"]["type"] == "keyword"
+    assert props["chat_id"]["type"] == "keyword"


### PR DESCRIPTION
## Summary
- make `enable_fulltext` effective in collection init, document index scheduling, and fulltext task execution
- move fulltext search onto the dedicated fulltext helper, add explicit filterable fields, and stop relying on `metadata.chat_id`
- harden runtime behavior with explicit fulltext degrade logging, raw-query keyword fallback, and explicit IK dependency controls

## Scope
This PR only covers `#4 / #5`:
- P0-A contract hard-fix
- P0-B runtime hardening

It intentionally does **not** include:
- shared logical index redesign
- alias / versioned rebuild / cutover
- per-collection -> shared migration or reindex rollout

## Design Note
- added `docs/en-US/development/es-p0-contract-runtime-hardening.md`

## Verification
- `.venv/bin/python -m pytest -q tests/unit_test/test_es_p0_contract.py`
  - `7 passed`
