### PR TITLE
[codex] roll ES fulltext into shared logical index

### DIFF
--- a/aperag/config.py
+++ b/aperag/config.py
@@ -178,6 +178,8 @@ class Config(BaseSettings):
     es_host: Optional[str] = Field(None, alias="ES_HOST")
     es_timeout: int = Field(30, alias="ES_TIMEOUT")  # ES request timeout in seconds
     es_max_retries: int = Field(3, alias="ES_MAX_RETRIES")  # Max retries for ES requests
+    es_fulltext_number_of_shards: int = Field(1, alias="ES_FULLTEXT_NUMBER_OF_SHARDS")
+    es_fulltext_number_of_replicas: int = Field(0, alias="ES_FULLTEXT_NUMBER_OF_REPLICAS")
 
     # LLM keyword extraction
     llm_keyword_extraction_provider: str = Field("", alias="LLM_KEYWORD_EXTRACTION_PROVIDER")

--- a/aperag/index/fulltext_index.py
+++ b/aperag/index/fulltext_index.py
@@ -99,7 +99,9 @@ def ensure_physical_index_exists(
 
     created_physical = False
     if not es.indices.exists(index=physical_index).body:
-        es.indices.create(index=physical_index, body={"settings": _fulltext_settings(), "mappings": _fulltext_mapping()})
+        es.indices.create(
+            index=physical_index, body={"settings": _fulltext_settings(), "mappings": _fulltext_mapping()}
+        )
         created_physical = True
 
     return {"physical_index": physical_index, "created_physical": created_physical}
@@ -117,7 +119,12 @@ def ensure_shared_index(
     if current_target is not None:
         if physical_index is not None:
             ensure_physical_index_exists(physical_index=physical_index, es=es)
-        return {"alias": alias, "physical_index": current_target, "created_physical": False, "targets": [current_target]}
+        return {
+            "alias": alias,
+            "physical_index": current_target,
+            "created_physical": False,
+            "targets": [current_target],
+        }
 
     ensured = ensure_physical_index_exists(physical_index=physical_index, es=es)
     es.indices.put_alias(index=ensured["physical_index"], name=alias)
@@ -185,7 +192,9 @@ def delete_collection_documents(
     return int(response.get("deleted", 0))
 
 
-def build_legacy_reindex_body(source_index: str, collection_id: str, dest_index: Optional[str] = None) -> Dict[str, Any]:
+def build_legacy_reindex_body(
+    source_index: str, collection_id: str, dest_index: Optional[str] = None
+) -> Dict[str, Any]:
     return {
         "source": {"index": source_index},
         "dest": {"index": dest_index or generate_fulltext_physical_index_name()},

--- a/aperag/index/fulltext_index.py
+++ b/aperag/index/fulltext_index.py
@@ -28,7 +28,11 @@ from aperag.llm.completion.completion_service import CompletionService
 from aperag.query.query import DocumentWithScore
 from aperag.schema.utils import parseCollectionConfig
 from aperag.utils.tokenizer import get_default_tokenizer
-from aperag.utils.utils import generate_fulltext_index_name
+from aperag.utils.utils import (
+    generate_fulltext_index_alias,
+    generate_fulltext_index_name,
+    generate_fulltext_physical_index_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +44,186 @@ def _create_es_client_config() -> Dict[str, Any]:
         "max_retries": settings.es_max_retries,
         "retry_on_timeout": True,
     }
+
+
+def _fulltext_mapping() -> Dict[str, Any]:
+    return {
+        "properties": {
+            "content": {"type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart"},
+            "title": {"type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart"},
+            "collection_id": {"type": "keyword"},
+            "document_id": {"type": "keyword"},
+            "chunk_id": {"type": "keyword"},
+            "chat_id": {"type": "keyword"},
+            "name": {"type": "keyword"},
+            "metadata": {"type": "object", "enabled": False},
+        }
+    }
+
+
+def _fulltext_settings() -> Dict[str, Any]:
+    return {
+        "number_of_shards": settings.es_fulltext_number_of_shards,
+        "number_of_replicas": settings.es_fulltext_number_of_replicas,
+    }
+
+
+def _get_sync_es() -> Elasticsearch:
+    return Elasticsearch(settings.es_host, **_create_es_client_config())
+
+
+def list_alias_targets(alias: Optional[str] = None, es: Optional[Elasticsearch] = None) -> List[str]:
+    alias = alias or generate_fulltext_index_alias()
+    es = es or _get_sync_es()
+    if not es.indices.exists_alias(name=alias).body:
+        return []
+    return list(es.indices.get_alias(name=alias).body.keys())
+
+
+def resolve_alias_target(alias: Optional[str] = None, es: Optional[Elasticsearch] = None) -> Optional[str]:
+    alias = alias or generate_fulltext_index_alias()
+    targets = list_alias_targets(alias, es=es)
+    if not targets:
+        return None
+    if len(targets) > 1:
+        raise ValueError(f"fulltext alias {alias} unexpectedly points to multiple indices: {targets}")
+    return targets[0]
+
+
+def ensure_physical_index_exists(
+    physical_index: Optional[str] = None,
+    es: Optional[Elasticsearch] = None,
+) -> Dict[str, Any]:
+    physical_index = physical_index or generate_fulltext_physical_index_name()
+    es = es or _get_sync_es()
+
+    created_physical = False
+    if not es.indices.exists(index=physical_index).body:
+        es.indices.create(index=physical_index, body={"settings": _fulltext_settings(), "mappings": _fulltext_mapping()})
+        created_physical = True
+
+    return {"physical_index": physical_index, "created_physical": created_physical}
+
+
+def ensure_shared_index(
+    alias: Optional[str] = None,
+    physical_index: Optional[str] = None,
+    es: Optional[Elasticsearch] = None,
+) -> Dict[str, Any]:
+    alias = alias or generate_fulltext_index_alias()
+    es = es or _get_sync_es()
+
+    current_target = resolve_alias_target(alias, es=es)
+    if current_target is not None:
+        if physical_index is not None:
+            ensure_physical_index_exists(physical_index=physical_index, es=es)
+        return {"alias": alias, "physical_index": current_target, "created_physical": False, "targets": [current_target]}
+
+    ensured = ensure_physical_index_exists(physical_index=physical_index, es=es)
+    es.indices.put_alias(index=ensured["physical_index"], name=alias)
+    return {
+        "alias": alias,
+        "physical_index": ensured["physical_index"],
+        "created_physical": ensured["created_physical"],
+        "targets": [ensured["physical_index"]],
+    }
+
+
+def switch_shared_index_alias(
+    target_index: str,
+    alias: Optional[str] = None,
+    es: Optional[Elasticsearch] = None,
+) -> Dict[str, Any]:
+    alias = alias or generate_fulltext_index_alias()
+    es = es or _get_sync_es()
+    ensure_physical_index_exists(physical_index=target_index, es=es)
+
+    current_targets = list_alias_targets(alias, es=es)
+    if current_targets == [target_index]:
+        return {"alias": alias, "target_index": target_index, "previous_targets": current_targets}
+
+    if current_targets:
+        actions = [{"remove": {"index": current, "alias": alias}} for current in current_targets]
+        actions.append({"add": {"index": target_index, "alias": alias}})
+        es.indices.update_aliases(body={"actions": actions})
+    else:
+        es.indices.put_alias(index=target_index, name=alias)
+    return {"alias": alias, "target_index": target_index, "previous_targets": current_targets}
+
+
+def count_documents(index: str, collection_id: Optional[str] = None, es: Optional[Elasticsearch] = None) -> int:
+    es = es or _get_sync_es()
+    if not es.indices.exists(index=index).body:
+        return 0
+    if collection_id is None:
+        return int(es.count(index=index).body["count"])
+    return int(
+        es.count(
+            index=index,
+            query={"term": {"collection_id": str(collection_id)}},
+            routing=str(collection_id),
+        ).body["count"]
+    )
+
+
+def delete_collection_documents(
+    collection_id: str,
+    index: Optional[str] = None,
+    es: Optional[Elasticsearch] = None,
+) -> int:
+    es = es or _get_sync_es()
+    index = index or generate_fulltext_index_name()
+    if not es.indices.exists(index=index).body:
+        return 0
+    response = es.delete_by_query(
+        index=index,
+        body={"query": {"term": {"collection_id": str(collection_id)}}},
+        conflicts="proceed",
+        refresh=True,
+        routing=str(collection_id),
+    )
+    return int(response.get("deleted", 0))
+
+
+def build_legacy_reindex_body(source_index: str, collection_id: str, dest_index: Optional[str] = None) -> Dict[str, Any]:
+    return {
+        "source": {"index": source_index},
+        "dest": {"index": dest_index or generate_fulltext_physical_index_name()},
+        "script": {
+            "lang": "painless",
+            "source": """
+ctx._source.collection_id = params.collection_id;
+ctx._routing = params.collection_id;
+if (ctx._source.document_id != null) {
+  ctx._source.document_id = ctx._source.document_id.toString();
+}
+if (ctx._source.chunk_id == null) {
+  ctx._source.chunk_id = ctx._id;
+} else {
+  ctx._source.chunk_id = ctx._source.chunk_id.toString();
+}
+if (ctx._source.chat_id == null && ctx._source.metadata != null && ctx._source.metadata.chat_id != null) {
+  ctx._source.chat_id = ctx._source.metadata.chat_id.toString();
+} else if (ctx._source.chat_id != null) {
+  ctx._source.chat_id = ctx._source.chat_id.toString();
+}
+""",
+            "params": {"collection_id": str(collection_id)},
+        },
+    }
+
+
+def migrate_legacy_index(
+    source_index: str,
+    collection_id: str,
+    dest_index: Optional[str] = None,
+    es: Optional[Elasticsearch] = None,
+) -> Dict[str, Any]:
+    es = es or _get_sync_es()
+    target_index = dest_index or generate_fulltext_physical_index_name()
+    ensure_physical_index_exists(physical_index=target_index, es=es)
+    body = build_legacy_reindex_body(source_index, collection_id, dest_index=dest_index)
+    return es.reindex(body=body, wait_for_completion=True, refresh=True, conflicts="proceed")
 
 
 class FulltextIndexer(BaseIndexer):
@@ -155,7 +339,8 @@ class FulltextIndexer(BaseIndexer):
             if not document:
                 raise Exception(f"Document {document_id} not found")
 
-            index_name = generate_fulltext_index_name(collection.id)
+            index_name = generate_fulltext_index_name()
+            create_index(index_name)
             chunk_count, total_content_length = self._process_chunks(
                 document_id,
                 doc_parts,
@@ -187,11 +372,12 @@ class FulltextIndexer(BaseIndexer):
             if not document:
                 raise Exception(f"Document {document_id} not found")
 
-            index_name = generate_fulltext_index_name(collection.id)
+            index_name = generate_fulltext_index_name()
+            create_index(index_name)
 
             # Remove old chunks for this document
             try:
-                self._remove_document_chunks(index_name, document_id)
+                self._remove_document_chunks(index_name, document_id, collection_id=str(collection.id))
                 logger.debug(f"Removed old fulltext chunks for document {document_id}")
             except Exception as e:
                 logger.warning(f"Failed to remove old fulltext chunks for document {document_id}: {str(e)}")
@@ -228,8 +414,8 @@ class FulltextIndexer(BaseIndexer):
     def delete_index(self, document_id: int, collection, **kwargs) -> IndexResult:
         """Delete fulltext index for document chunks"""
         try:
-            index_name = generate_fulltext_index_name(collection.id)
-            deleted_count = self._remove_document_chunks(index_name, document_id)
+            index_name = generate_fulltext_index_name()
+            deleted_count = self._remove_document_chunks(index_name, document_id, collection_id=str(collection.id))
 
             logger.info(f"Fulltext index deleted for document {document_id}, removed {deleted_count} chunks")
 
@@ -246,15 +432,21 @@ class FulltextIndexer(BaseIndexer):
                 success=False, index_type=self.index_type, error=f"Fulltext index deletion failed: {str(e)}"
             )
 
-    def _remove_document_chunks(self, index: str, doc_id: int) -> int:
+    def _remove_document_chunks(self, index: str, doc_id: int, collection_id: Optional[str] = None) -> int:
         """Remove all chunks for a specific document"""
         if not self.es.indices.exists(index=index).body:
             logger.warning("index %s not exists", index)
             return 0
 
         try:
-            query = {"query": {"term": {"document_id": doc_id}}}
-            response = self.es.delete_by_query(index=index, body=query)
+            filters = [{"term": {"document_id": str(doc_id)}}]
+            if collection_id is not None:
+                filters.append({"term": {"collection_id": str(collection_id)}})
+            query = {"query": {"bool": {"filter": filters}}}
+            request_kwargs = {"index": index, "body": query}
+            if collection_id is not None:
+                request_kwargs["routing"] = str(collection_id)
+            response = self.es.delete_by_query(**request_kwargs)
             deleted_count = response.get("deleted", 0)
             logger.info(f"Deleted {deleted_count} chunks for document {doc_id} from index {index}")
             return deleted_count
@@ -289,10 +481,10 @@ class FulltextIndexer(BaseIndexer):
             "title": title_text,
             "metadata": metadata or {},
         }
-        self.es.index(index=index, id=chunk_id, document=doc)
+        self.es.index(index=index, id=chunk_id, document=doc, routing=str(collection_id))
 
     async def search_document(
-        self, index: str, keywords: List[str], topk=3, chat_id: str = None
+        self, index: str, collection_id: str, keywords: List[str], topk=3, chat_id: str = None
     ) -> List[DocumentWithScore]:
         try:
             resp = await self.async_es.indices.exists(index=index)
@@ -308,12 +500,13 @@ class FulltextIndexer(BaseIndexer):
                     "should": [{"match": {"content": keyword}} for keyword in keywords]
                     + [{"match": {"title": keyword}} for keyword in keywords],
                     "minimum_should_match": "80%",
+                    "filter": [{"term": {"collection_id": str(collection_id)}}],
                 },
             }
 
             # Add chat_id filter if provided
             if chat_id:
-                query["bool"]["filter"] = [
+                query["bool"]["filter"].append(
                     {
                         "bool": {
                             "should": [
@@ -323,9 +516,15 @@ class FulltextIndexer(BaseIndexer):
                             "minimum_should_match": 1,
                         }
                     }
-                ]
+                )
             sort = [{"_score": {"order": "desc"}}]
-            resp = await self.async_es.search(index=index, query=query, sort=sort, size=topk)
+            resp = await self.async_es.search(
+                index=index,
+                query=query,
+                sort=sort,
+                size=topk,
+                routing=str(collection_id),
+            )
             hits = resp.body["hits"]
             result = []
             for hit in hits["hits"]:
@@ -599,33 +798,21 @@ async def extract_keywords(text: str, ctx: Dict[str, Any]) -> List[str]:
     return []
 
 
-def create_index(index: str):
-    """Create ES index with proper mapping for chunks"""
-    config = _create_es_client_config()
-    es = Elasticsearch(settings.es_host, **config)
-
-    if not es.indices.exists(index=index).body:
-        mapping = {
-            "properties": {
-                "content": {"type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart"},
-                "title": {"type": "text", "analyzer": "ik_max_word", "search_analyzer": "ik_smart"},
-                "collection_id": {"type": "keyword"},
-                "document_id": {"type": "keyword"},
-                "chunk_id": {"type": "keyword"},
-                "chat_id": {"type": "keyword"},
-                "name": {"type": "keyword"},
-                "metadata": {"type": "object", "enabled": False},
-            }
-        }
-        es.indices.create(index=index, body={"mappings": mapping})
-    else:
-        logger.warning("index %s already exists", index)
+def create_index(index: Optional[str] = None, physical_index: Optional[str] = None):
+    """Ensure the shared logical fulltext index exists and is aliased."""
+    return ensure_shared_index(alias=index or generate_fulltext_index_name(), physical_index=physical_index)
 
 
 def delete_index(index: str):
-    """Delete ES index"""
-    config = _create_es_client_config()
-    es = Elasticsearch(settings.es_host, **config)
+    """Delete a legacy physical ES index.
 
+    The shared logical index alias is intentionally protected from deletion here.
+    Collection-level cleanup in the shared-index model must use delete-by-query.
+    """
+    if index == generate_fulltext_index_alias():
+        logger.warning("Refusing to delete shared fulltext alias %s; use delete_collection_documents instead", index)
+        return
+
+    es = _get_sync_es()
     if es.indices.exists(index=index).body:
         es.indices.delete(index=index)

--- a/aperag/service/search_pipeline_service.py
+++ b/aperag/service/search_pipeline_service.py
@@ -257,7 +257,13 @@ class SearchPipelineService:
             final_keywords = [query]
 
         try:
-            docs = await fulltext_indexer.search_document(index_name, final_keywords, top_k * 3, chat_id=chat_id)
+            docs = await fulltext_indexer.search_document(
+                index_name,
+                str(collection.id),
+                final_keywords,
+                top_k * 3,
+                chat_id=chat_id,
+            )
         except FulltextSearchDegradedError as e:
             logger.warning("Fulltext search degraded for collection %s: %s", collection.id, e)
             return []

--- a/aperag/tasks/collection.py
+++ b/aperag/tasks/collection.py
@@ -24,13 +24,15 @@ from aperag.config import get_vector_db_connector
 from aperag.db import models as db_models
 from aperag.db.models import CollectionStatus
 from aperag.db.ops import db_ops
-from aperag.index.fulltext_index import create_index, delete_index
+from aperag.graph import lightrag_manager
+from aperag.index.fulltext_index import create_index, delete_collection_documents, delete_index
 from aperag.llm.embed.base_embedding import get_collection_embedding_service_sync
 from aperag.objectstore.base import get_object_store
 from aperag.schema.utils import parseCollectionConfig
 from aperag.tasks.models import TaskResult
 from aperag.utils.utils import (
     generate_fulltext_index_name,
+    generate_legacy_fulltext_index_name,
     generate_vector_db_collection_name,
     utc_now,
 )
@@ -156,7 +158,7 @@ class CollectionTask:
         logger.debug(f"Initialized vector databases for collection {collection_id}")
 
     def _initialize_fulltext_index(self, collection_id: str) -> None:
-        """Initialize fulltext search index"""
+        """Initialize the shared fulltext logical index."""
         index_name = generate_fulltext_index_name(collection_id)
         create_index(index_name)
         logger.debug(f"Initialized fulltext index {index_name}")
@@ -240,10 +242,13 @@ class CollectionTask:
         logger.debug(f"Deleted vector database data for collection {collection_id}")
 
     def _delete_fulltext_index(self, collection_id: str) -> None:
-        """Delete fulltext search index"""
-        index_name = generate_fulltext_index_name(collection_id)
-        delete_index(index_name)
-        logger.debug(f"Deleted fulltext index {index_name}")
+        """Delete a collection's documents from the shared fulltext index and prune legacy index."""
+        deleted_shared = delete_collection_documents(collection_id, index=generate_fulltext_index_name(collection_id))
+        logger.debug("Deleted %s shared fulltext docs for collection %s", deleted_shared, collection_id)
+
+        legacy_index = generate_legacy_fulltext_index_name(collection_id)
+        delete_index(legacy_index)
+        logger.debug(f"Deleted legacy fulltext index {legacy_index}")
 
     def cleanup_expired_documents(self, collection_id: str):
         """

--- a/aperag/tasks/collection.py
+++ b/aperag/tasks/collection.py
@@ -24,7 +24,6 @@ from aperag.config import get_vector_db_connector
 from aperag.db import models as db_models
 from aperag.db.models import CollectionStatus
 from aperag.db.ops import db_ops
-from aperag.graph import lightrag_manager
 from aperag.index.fulltext_index import create_index, delete_collection_documents, delete_index
 from aperag.llm.embed.base_embedding import get_collection_embedding_service_sync
 from aperag.objectstore.base import get_object_store

--- a/aperag/utils/utils.py
+++ b/aperag/utils/utils.py
@@ -19,14 +19,35 @@ from datetime import datetime, timezone
 from Crypto.Cipher import AES
 
 AVAILABLE_SOURCE = ["system"]
+FULLTEXT_SHARED_INDEX_ALIAS = "aperag-fulltext"
+FULLTEXT_DEFAULT_INDEX_VERSION = "v1"
 
 
 def now_unix_milliseconds():
     return int(utc_now().timestamp() * 1e3)
 
 
-def generate_fulltext_index_name(collection_id) -> str:
+def generate_fulltext_index_alias() -> str:
+    return FULLTEXT_SHARED_INDEX_ALIAS
+
+
+def normalize_fulltext_index_version(version=None) -> str:
+    if version is None:
+        return FULLTEXT_DEFAULT_INDEX_VERSION
+    version = str(version)
+    return version if version.startswith("v") else f"v{version}"
+
+
+def generate_fulltext_physical_index_name(version=None) -> str:
+    return f"{generate_fulltext_index_alias()}-{normalize_fulltext_index_version(version)}"
+
+
+def generate_legacy_fulltext_index_name(collection_id) -> str:
     return str(collection_id)
+
+
+def generate_fulltext_index_name(collection_id=None) -> str:
+    return generate_fulltext_index_alias()
 
 
 def generate_vector_db_collection_name(collection_id) -> str:

--- a/docs/en-US/development/es-shared-logical-index-rollout.md
+++ b/docs/en-US/development/es-shared-logical-index-rollout.md
@@ -1,0 +1,194 @@
+# ES Shared Logical Index Rollout
+
+This document captures the P1 implementation slice of the Elasticsearch redesign:
+
+- P1-A: shared logical fulltext index
+- P1-B: migration / reindex / rollout
+
+It is the follow-up to `es-p0-contract-runtime-hardening.md`. P0 fixed runtime
+correctness and explicit contracts; P1 changes the physical fulltext layout.
+
+## Goals
+
+1. Replace the per-collection physical fulltext index model with a shared
+   logical index.
+2. Make alias / versioned rebuild / cutover / rollback first-class rollout
+   primitives instead of one-off manual steps.
+3. Preserve per-collection correctness by keeping `collection_id` and `chat_id`
+   as explicit fulltext filter fields.
+4. Provide a real migration path for existing data instead of leaving rollout as
+   a docs-only follow-up.
+
+## Target Runtime Model
+
+### Logical view
+
+- Runtime fulltext reads and writes use the shared alias: `aperag-fulltext`
+- The alias points to a concrete versioned physical index:
+  - `aperag-fulltext-v1`
+  - `aperag-fulltext-v2`
+  - ...
+
+### Document contract inside the shared index
+
+Each chunk document stores explicit top-level fields:
+
+- `collection_id`
+- `document_id`
+- `chunk_id`
+- `chat_id`
+- `name`
+- `content`
+- `title`
+
+`metadata` remains a stored payload blob, not the authoritative filter path.
+
+### Query model
+
+- Fulltext recall is now always collection-scoped in ES itself.
+- Collection filters run on top-level `collection_id`.
+- Chat-scoped recall keeps the P0 dual-read guard:
+  - `chat_id`
+  - `metadata.chat_id`
+
+This means P1 does not regress existing-data compatibility while the rollout is
+still in flight.
+
+## Shared Index Settings
+
+The shared physical index no longer relies on cluster-default topology.
+
+The creation contract is now explicit:
+
+- `ES_FULLTEXT_NUMBER_OF_SHARDS`
+- `ES_FULLTEXT_NUMBER_OF_REPLICAS`
+
+Default values:
+
+- `number_of_shards = 1`
+- `number_of_replicas = 0`
+
+These defaults are intentionally single-node friendly. Production deployments
+can override them explicitly instead of inheriting incompatible cluster
+defaults across many tiny indices.
+
+## Routing Strategy
+
+The shared index uses `collection_id` as the routing key for:
+
+- chunk writes
+- collection-scoped deletes
+- collection-scoped search
+- collection-scoped count verification
+- legacy reindex migration
+
+This keeps shared-index writes and reads collection-local inside ES without
+bringing back per-collection physical index fragmentation.
+
+## Source Of Truth And Rebuild Authority
+
+The source-of-truth model remains unchanged:
+
+- Object store is the source of original documents.
+- Parser / chunking output is derived data.
+- PostgreSQL remains the authority for ApeRAG collection/document identity.
+- Elasticsearch remains a projection for BM25/fulltext retrieval.
+
+Therefore:
+
+- ES loss must be recoverable from the authoritative source path.
+- ES migration does not redefine ownership of document data.
+- Rollback means alias rollback and, if necessary, rebuild from the true source
+  path, not treating ES as authoritative state.
+
+## Rollout Script
+
+The rollout entrypoint is:
+
+```bash
+python scripts/migrate_es_fulltext_shared_index.py
+```
+
+### Legacy -> shared migration
+
+Dry-run the plan first:
+
+```bash
+python scripts/migrate_es_fulltext_shared_index.py --dry-run
+```
+
+Copy legacy per-collection indices into the shared physical target:
+
+```bash
+python scripts/migrate_es_fulltext_shared_index.py --target-version v1
+```
+
+Cut the shared alias after verification:
+
+```bash
+python scripts/migrate_es_fulltext_shared_index.py --target-version v1 --cutover
+```
+
+Delete old legacy indices after the new path is verified:
+
+```bash
+python scripts/migrate_es_fulltext_shared_index.py --only-delete --delete-old
+```
+
+### Versioned rebuild
+
+Rebuild the current shared target into a new physical version:
+
+```bash
+python scripts/migrate_es_fulltext_shared_index.py --mode shared --target-version v2
+```
+
+Cut the alias to the rebuilt target:
+
+```bash
+python scripts/migrate_es_fulltext_shared_index.py --mode shared --target-version v2 --cutover
+```
+
+Rollback the alias if the cutover needs to be reverted:
+
+```bash
+python scripts/migrate_es_fulltext_shared_index.py --rollback-to aperag-fulltext-v1
+```
+
+## Verification Contract
+
+The rollout script verifies:
+
+- legacy source document counts
+- migrated document counts inside the shared target, scoped by `collection_id`
+- shared rebuild total counts for versioned alias rebuilds
+
+Legacy migration is intentionally rerunnable:
+
+- before reindexing a collection, the script deletes that collection's docs from
+  the target physical index
+- then reindexes the source collection again
+
+This assumes a controlled rollout window where writers are paused.
+
+## Explicit Boundaries
+
+### Included in P1
+
+- shared logical index alias
+- versioned physical fulltext indices
+- explicit shard / replica settings
+- collection-based routing
+- legacy per-collection -> shared migration
+- alias cutover / rollback
+- legacy index cleanup
+
+### Explicitly excluded from P1
+
+- replacing Elasticsearch with another engine
+- bucketed physical index as the default layout
+- automatic config-flip-driven rebuild orchestration for `enable_fulltext`
+
+If future scale or isolation requirements prove shared is no longer economical,
+bucketed physical indices remain a later conditional follow-up, not the default
+P1 outcome.

--- a/scripts/migrate_es_fulltext_shared_index.py
+++ b/scripts/migrate_es_fulltext_shared_index.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Roll Elasticsearch fulltext storage from per-collection indices to a shared logical index.
+
+This script covers two operational paths:
+
+1. Initial migration:
+   - Copy legacy per-collection indices into a shared physical index.
+   - Verify counts per collection.
+   - Cut the shared alias over once the target is ready.
+   - Optionally delete old per-collection indices after verification.
+
+2. Versioned rebuild:
+   - Reindex the current shared physical target into a new versioned physical index.
+   - Cut the shared alias to the new target.
+   - Roll back by switching the alias back to a previous physical index if needed.
+
+The script is deliberately idempotent for the legacy migration path: before each
+collection reindex it deletes that collection's docs from the target physical
+index. This assumes a controlled rollout window where writers are paused.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import List, Optional, Set
+
+from sqlalchemy import select
+
+# Make sure the repo root is importable regardless of how this script is invoked.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from aperag.config import get_sync_session  # noqa: E402
+from aperag.db import models as db_models  # noqa: E402
+from aperag.index.fulltext_index import (  # noqa: E402
+    _get_sync_es,
+    count_documents,
+    delete_collection_documents,
+    delete_index,
+    ensure_physical_index_exists,
+    migrate_legacy_index,
+    resolve_alias_target,
+    switch_shared_index_alias,
+)
+from aperag.utils.utils import (  # noqa: E402
+    generate_fulltext_index_alias,
+    generate_fulltext_physical_index_name,
+    generate_legacy_fulltext_index_name,
+)
+
+logger = logging.getLogger("migrate_es_fulltext_shared_index")
+
+
+@dataclass
+class LegacySourceInfo:
+    index_name: str
+    collection_id: str
+    documents: int
+
+
+def _load_aperag_collection_ids() -> Set[str]:
+    ids: Set[str] = set()
+    for session in get_sync_session():
+        rows = session.execute(select(db_models.Collection.id)).all()
+        ids.update(str(row[0]) for row in rows)
+    return ids
+
+
+def _list_physical_indices(es) -> Set[str]:
+    indices = es.cat.indices(format="json")
+    return {item["index"] for item in indices}
+
+
+def _discover_legacy_sources(es, limit: int = 0, only_name: Optional[str] = None) -> List[LegacySourceInfo]:
+    aperag_ids = _load_aperag_collection_ids()
+    existing = _list_physical_indices(es)
+    shared_alias = generate_fulltext_index_alias()
+    existing.discard(shared_alias)
+    current_shared_target = resolve_alias_target(shared_alias, es=es)
+    if current_shared_target is not None:
+        existing.discard(current_shared_target)
+
+    source_names = sorted(existing & aperag_ids)
+    if only_name is not None:
+        if only_name not in source_names:
+            raise ValueError(f"--only-name {only_name} is not a known legacy fulltext index")
+        source_names = [only_name]
+    if limit > 0:
+        source_names = source_names[:limit]
+
+    sources: List[LegacySourceInfo] = []
+    for name in source_names:
+        collection_id = generate_legacy_fulltext_index_name(name)
+        sources.append(
+            LegacySourceInfo(
+                index_name=name,
+                collection_id=collection_id,
+                documents=count_documents(name, es=es),
+            )
+        )
+    return sources
+
+
+def _build_shared_reindex_body(source_index: str, dest_index: str) -> dict:
+    return {"source": {"index": source_index}, "dest": {"index": dest_index}}
+
+
+def _migrate_legacy_sources(es, sources: List[LegacySourceInfo], target_index: str, dry_run: bool) -> None:
+    if not sources:
+        logger.info("no legacy per-collection fulltext indices found")
+        return
+
+    ensure_physical_index_exists(physical_index=target_index, es=es)
+    for idx, source in enumerate(sources, start=1):
+        logger.info(
+            "[%d/%d] legacy index %s -> %s (%d docs)",
+            idx,
+            len(sources),
+            source.index_name,
+            target_index,
+            source.documents,
+        )
+        if dry_run:
+            continue
+
+        # Make reruns deterministic inside the rollout window.
+        delete_collection_documents(source.collection_id, index=target_index, es=es)
+        migrate_legacy_index(source.index_name, source.collection_id, dest_index=target_index, es=es)
+
+        target_docs = count_documents(target_index, collection_id=source.collection_id, es=es)
+        if target_docs != source.documents:
+            raise RuntimeError(
+                f"verification failed for {source.index_name}: source={source.documents}, "
+                f"target(collection_id={source.collection_id})={target_docs}"
+            )
+
+
+def _rebuild_from_shared_alias(es, target_index: str, dry_run: bool) -> None:
+    source_index = resolve_alias_target(generate_fulltext_index_alias(), es=es)
+    if source_index is None:
+        raise RuntimeError("shared alias does not exist yet; nothing to rebuild from")
+
+    logger.info("rebuilding shared fulltext target %s -> %s", source_index, target_index)
+    if source_index == target_index:
+        logger.info("target %s already matches current shared alias target; skipping rebuild", target_index)
+        return
+    if dry_run:
+        return
+
+    ensure_physical_index_exists(physical_index=target_index, es=es)
+    es.reindex(
+        body=_build_shared_reindex_body(source_index, target_index),
+        wait_for_completion=True,
+        refresh=True,
+        conflicts="proceed",
+    )
+
+    source_docs = count_documents(source_index, es=es)
+    target_docs = count_documents(target_index, es=es)
+    if target_docs != source_docs:
+        raise RuntimeError(
+            f"verification failed for shared rebuild: source={source_docs}, target={target_docs}, "
+            f"source_index={source_index}, target_index={target_index}"
+        )
+
+
+def _delete_legacy_sources(sources: List[LegacySourceInfo], dry_run: bool) -> None:
+    if not sources:
+        logger.info("no legacy per-collection fulltext indices to delete")
+        return
+
+    for idx, source in enumerate(sources, start=1):
+        logger.info("[%d/%d] deleting legacy fulltext index %s", idx, len(sources), source.index_name)
+        if dry_run:
+            continue
+        delete_index(source.index_name)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--mode",
+        choices=("legacy", "shared"),
+        default="legacy",
+        help="legacy: migrate per-collection indices; shared: rebuild current shared target into a new version",
+    )
+    parser.add_argument("--target-version", default="v1", help="shared physical index version, e.g. v1 / v2")
+    parser.add_argument("--dry-run", action="store_true", help="print the plan without writing")
+    parser.add_argument("--limit", type=int, default=0, help="only process the first N legacy indices (0 = all)")
+    parser.add_argument("--only-name", type=str, default=None, help="restrict legacy migration to one collection id")
+    parser.add_argument("--cutover", action="store_true", help="switch the shared alias to the target index")
+    parser.add_argument(
+        "--delete-old",
+        action="store_true",
+        help="delete legacy per-collection indices after successful migration verification",
+    )
+    parser.add_argument(
+        "--only-delete",
+        action="store_true",
+        help="skip migration and only delete legacy per-collection indices after a prior successful rollout",
+    )
+    parser.add_argument(
+        "--rollback-to",
+        type=str,
+        default=None,
+        help="switch the shared alias back to a specific physical index and exit",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="enable DEBUG logging")
+    args = parser.parse_args(argv)
+
+    if args.mode != "legacy" and (args.only_name is not None or args.limit > 0 or args.delete_old or args.only_delete):
+        parser.error("--limit/--only-name/--delete-old/--only-delete only apply to --mode legacy")
+    if args.rollback_to and args.cutover:
+        parser.error("--rollback-to and --cutover are mutually exclusive")
+    if args.only_delete and args.mode != "legacy":
+        parser.error("--only-delete only applies to --mode legacy")
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    es = _get_sync_es()
+    shared_alias = generate_fulltext_index_alias()
+    current_target = resolve_alias_target(shared_alias, es=es)
+    target_index = generate_fulltext_physical_index_name(args.target_version)
+
+    logger.info("shared alias: %s", shared_alias)
+    logger.info("current alias target: %s", current_target or "<none>")
+    logger.info("requested target index: %s", target_index)
+
+    if args.rollback_to:
+        logger.info("rolling back alias %s -> %s", shared_alias, args.rollback_to)
+        if not args.dry_run:
+            switch_shared_index_alias(args.rollback_to, alias=shared_alias, es=es)
+        logger.info("rollback done")
+        return 0
+
+    started_at = time.time()
+    sources: List[LegacySourceInfo] = []
+    if args.mode == "legacy":
+        sources = _discover_legacy_sources(es, limit=args.limit, only_name=args.only_name)
+        logger.info("legacy migration sources: %d", len(sources))
+        for source in sources:
+            logger.info("  %s (%d docs)", source.index_name, source.documents)
+
+        if not args.only_delete:
+            _migrate_legacy_sources(es, sources, target_index=target_index, dry_run=args.dry_run)
+    else:
+        _rebuild_from_shared_alias(es, target_index=target_index, dry_run=args.dry_run)
+
+    if args.cutover:
+        logger.info("cutting alias %s -> %s", shared_alias, target_index)
+        if not args.dry_run:
+            switch_shared_index_alias(target_index, alias=shared_alias, es=es)
+
+    if args.delete_old or args.only_delete:
+        _delete_legacy_sources(sources, dry_run=args.dry_run)
+
+    logger.info("done in %.1fs", time.time() - started_at)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_test/test_es_p0_contract.py
+++ b/tests/unit_test/test_es_p0_contract.py
@@ -76,8 +76,9 @@ async def test_fulltext_search_uses_fulltext_helper_and_query_fallback(monkeypat
     async def fake_extract_keywords(*_args, **_kwargs):
         return []
 
-    async def fake_search_document(index_name, keywords, topk, chat_id=None):
+    async def fake_search_document(index_name, collection_id, keywords, topk, chat_id=None):
         captured["index_name"] = index_name
+        captured["collection_id"] = collection_id
         captured["keywords"] = keywords
         captured["topk"] = topk
         captured["chat_id"] = chat_id
@@ -94,6 +95,7 @@ async def test_fulltext_search_uses_fulltext_helper_and_query_fallback(monkeypat
 
     assert captured == {
         "index_name": "ft-col-1",
+        "collection_id": "col-1",
         "keywords": ["中文问题"],
         "topk": 6,
         "chat_id": "chat-1",
@@ -136,11 +138,12 @@ async def test_fulltext_index_search_uses_dual_read_chat_filter(monkeypatch):
         def __init__(self):
             self.indices = FakeAsyncIndices()
 
-        async def search(self, index, query, sort, size):
+        async def search(self, index, query, sort, size, routing):
             captured["index"] = index
             captured["query"] = query
             captured["sort"] = sort
             captured["size"] = size
+            captured["routing"] = routing
             return SimpleNamespace(body={"hits": {"hits": []}})
 
     from aperag.index.fulltext_index import FulltextIndexer
@@ -148,10 +151,11 @@ async def test_fulltext_index_search_uses_dual_read_chat_filter(monkeypatch):
     indexer = object.__new__(FulltextIndexer)
     indexer.async_es = FakeAsyncEs()
 
-    docs = await FulltextIndexer.search_document(indexer, "ft-col-1", ["hello"], topk=3, chat_id="chat-1")
+    docs = await FulltextIndexer.search_document(indexer, "ft-col-1", "col-1", ["hello"], topk=3, chat_id="chat-1")
 
     assert docs == []
     assert captured["query"]["bool"]["filter"] == [
+        {"term": {"collection_id": "col-1"}},
         {
             "bool": {
                 "should": [
@@ -162,6 +166,7 @@ async def test_fulltext_index_search_uses_dual_read_chat_filter(monkeypatch):
             }
         }
     ]
+    assert captured["routing"] == "col-1"
 
 
 def test_create_index_mapping_exposes_explicit_filter_fields(monkeypatch):
@@ -170,6 +175,15 @@ def test_create_index_mapping_exposes_explicit_filter_fields(monkeypatch):
     class FakeIndices:
         def exists(self, index):
             return SimpleNamespace(body=False)
+
+        def exists_alias(self, name):
+            return SimpleNamespace(body=False)
+
+        def get_alias(self, name):
+            return SimpleNamespace(body={})
+
+        def put_alias(self, index, name):
+            captured["alias"] = (index, name)
 
         def create(self, index, body):
             captured["index"] = index
@@ -186,6 +200,7 @@ def test_create_index_mapping_exposes_explicit_filter_fields(monkeypatch):
     create_index("ft-col-1")
 
     props = captured["body"]["mappings"]["properties"]
+    assert captured["alias"] == ("aperag-fulltext-v1", "ft-col-1")
     assert props["collection_id"]["type"] == "keyword"
     assert props["document_id"]["type"] == "keyword"
     assert props["chunk_id"]["type"] == "keyword"

--- a/tests/unit_test/test_es_shared_index_rollout.py
+++ b/tests/unit_test/test_es_shared_index_rollout.py
@@ -1,0 +1,199 @@
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.tasks.collection import CollectionTask
+from aperag.utils.utils import (
+    generate_fulltext_index_alias,
+    generate_fulltext_index_name,
+    generate_fulltext_physical_index_name,
+    generate_legacy_fulltext_index_name,
+)
+
+
+def test_fulltext_name_helpers_use_shared_alias_and_legacy_names():
+    assert generate_fulltext_index_alias() == "aperag-fulltext"
+    assert generate_fulltext_index_name("col-1") == "aperag-fulltext"
+    assert generate_fulltext_physical_index_name() == "aperag-fulltext-v1"
+    assert generate_fulltext_physical_index_name("v2") == "aperag-fulltext-v2"
+    assert generate_fulltext_physical_index_name(3) == "aperag-fulltext-v3"
+    assert generate_legacy_fulltext_index_name("col-1") == "col-1"
+
+
+def test_create_index_ensures_alias_for_shared_index(monkeypatch):
+    captured = {"created": [], "aliases": []}
+
+    class FakeIndices:
+        def exists(self, index):
+            return SimpleNamespace(body=index == "aperag-fulltext-v1")
+
+        def exists_alias(self, name):
+            return SimpleNamespace(body=False)
+
+        def get_alias(self, name):
+            return SimpleNamespace(body={})
+
+        def put_alias(self, index, name):
+            captured["aliases"].append((index, name))
+
+        def create(self, index, body):
+            captured["created"].append((index, body))
+
+    class FakeElasticsearch:
+        def __init__(self, *_args, **_kwargs):
+            self.indices = FakeIndices()
+
+    monkeypatch.setattr("aperag.index.fulltext_index.Elasticsearch", FakeElasticsearch)
+
+    from aperag.index.fulltext_index import create_index
+
+    create_index("aperag-fulltext")
+
+    assert captured["created"] == []
+    assert captured["aliases"] == [("aperag-fulltext-v1", "aperag-fulltext")]
+
+
+def test_create_index_materializes_explicit_shard_and_replica_settings(monkeypatch):
+    captured = {}
+
+    class FakeIndices:
+        def exists(self, index):
+            return SimpleNamespace(body=False)
+
+        def exists_alias(self, name):
+            return SimpleNamespace(body=False)
+
+        def get_alias(self, name):
+            return SimpleNamespace(body={})
+
+        def put_alias(self, index, name):
+            captured["alias"] = (index, name)
+
+        def create(self, index, body):
+            captured["index"] = index
+            captured["body"] = body
+
+    class FakeElasticsearch:
+        def __init__(self, *_args, **_kwargs):
+            self.indices = FakeIndices()
+
+    monkeypatch.setattr("aperag.index.fulltext_index.Elasticsearch", FakeElasticsearch)
+    monkeypatch.setattr("aperag.index.fulltext_index.settings.es_fulltext_number_of_shards", 3)
+    monkeypatch.setattr("aperag.index.fulltext_index.settings.es_fulltext_number_of_replicas", 1)
+
+    from aperag.index.fulltext_index import create_index
+
+    create_index("aperag-fulltext")
+
+    assert captured["index"] == "aperag-fulltext-v1"
+    assert captured["alias"] == ("aperag-fulltext-v1", "aperag-fulltext")
+    assert captured["body"]["settings"] == {"number_of_shards": 3, "number_of_replicas": 1}
+
+
+def test_create_index_preserves_existing_alias_target(monkeypatch):
+    captured = {"created": [], "aliases": [], "updated": []}
+
+    class FakeIndices:
+        def exists(self, index):
+            return SimpleNamespace(body=index == "aperag-fulltext-v2")
+
+        def exists_alias(self, name):
+            return SimpleNamespace(body=True)
+
+        def get_alias(self, name):
+            return SimpleNamespace(body={"aperag-fulltext-v2": {}})
+
+        def put_alias(self, index, name):
+            captured["aliases"].append((index, name))
+
+        def create(self, index, body):
+            captured["created"].append((index, body))
+
+        def update_aliases(self, body):
+            captured["updated"].append(body)
+
+    class FakeElasticsearch:
+        def __init__(self, *_args, **_kwargs):
+            self.indices = FakeIndices()
+
+    monkeypatch.setattr("aperag.index.fulltext_index.Elasticsearch", FakeElasticsearch)
+
+    from aperag.index.fulltext_index import create_index
+
+    result = create_index("aperag-fulltext")
+
+    assert result["physical_index"] == "aperag-fulltext-v2"
+    assert captured["created"] == []
+    assert captured["aliases"] == []
+    assert captured["updated"] == []
+
+
+@pytest.mark.asyncio
+async def test_fulltext_search_filters_on_collection_and_chat_id():
+    captured = {}
+
+    class FakeAsyncIndices:
+        async def exists(self, index):
+            return SimpleNamespace(body=True)
+
+    class FakeAsyncEs:
+        def __init__(self):
+            self.indices = FakeAsyncIndices()
+
+        async def search(self, index, query, sort, size, routing):
+            captured["index"] = index
+            captured["query"] = query
+            captured["sort"] = sort
+            captured["size"] = size
+            captured["routing"] = routing
+            return SimpleNamespace(body={"hits": {"hits": []}})
+
+    from aperag.index.fulltext_index import FulltextIndexer
+
+    indexer = object.__new__(FulltextIndexer)
+    indexer.async_es = FakeAsyncEs()
+
+    docs = await FulltextIndexer.search_document(indexer, "aperag-fulltext", "col-1", ["hello"], topk=3, chat_id="chat-1")
+
+    assert docs == []
+    assert captured["routing"] == "col-1"
+    assert captured["query"]["bool"]["filter"] == [
+        {"term": {"collection_id": "col-1"}},
+        {
+            "bool": {
+                "should": [
+                    {"term": {"chat_id": "chat-1"}},
+                    {"term": {"metadata.chat_id": "chat-1"}},
+                ],
+                "minimum_should_match": 1,
+            }
+        },
+    ]
+
+
+def test_collection_task_deletes_shared_docs_and_legacy_index(monkeypatch):
+    calls = {"shared": [], "legacy": []}
+
+    monkeypatch.setattr(
+        "aperag.tasks.collection.delete_collection_documents",
+        lambda collection_id, index=None: calls["shared"].append((collection_id, index)) or 3,
+    )
+    monkeypatch.setattr("aperag.tasks.collection.delete_index", lambda index: calls["legacy"].append(index))
+
+    CollectionTask()._delete_fulltext_index("col-1")
+
+    assert calls["shared"] == [("col-1", "aperag-fulltext")]
+    assert calls["legacy"] == ["col-1"]
+
+
+def test_build_legacy_reindex_body_promotes_contract_fields():
+    from aperag.index.fulltext_index import build_legacy_reindex_body
+
+    body = build_legacy_reindex_body("col-1", "col-1")
+
+    assert body["source"]["index"] == "col-1"
+    assert body["dest"]["index"] == "aperag-fulltext-v1"
+    assert body["script"]["params"]["collection_id"] == "col-1"
+    assert "ctx._source.collection_id" in body["script"]["source"]
+    assert "ctx._routing = params.collection_id" in body["script"]["source"]
+    assert "ctx._source.chat_id" in body["script"]["source"]


### PR DESCRIPTION
## Summary
- move Elasticsearch fulltext from per-collection physical indices to a shared logical alias with versioned physical targets
- add collection-scoped routing plus legacy-to-shared migration / cutover / rollback tooling and rollout docs
- refresh focused ES tests on current main and cover the new shared-index helpers

## Testing
- ruff check aperag/config.py aperag/index/fulltext_index.py aperag/service/search_pipeline_service.py aperag/tasks/collection.py aperag/utils/utils.py scripts/migrate_es_fulltext_shared_index.py tests/unit_test/test_es_p0_contract.py tests/unit_test/test_es_shared_index_rollout.py
- /Users/earayu/.slock/agents/2ed69b4f-4e0e-4308-9c6a-239da070fc34/repos/ApeRAG/.venv/bin/python -m pytest -q tests/unit_test/test_es_p0_contract.py tests/unit_test/test_es_shared_index_rollout.py
- /Users/earayu/.slock/agents/2ed69b4f-4e0e-4308-9c6a-239da070fc34/repos/ApeRAG/.venv/bin/python scripts/migrate_es_fulltext_shared_index.py --help >/dev/null