### PR TITLE
[codex] add graph curation workflow

### DIFF
--- a/aperag/api/components/schemas/graph.yaml
+++ b/aperag/api/components/schemas/graph.yaml
@@ -265,12 +265,12 @@ nodeMergeResponse:
 
 mergeSuggestionEntity:
   type: object
-  description: Entity information in merge suggestion
+  description: Snapshot of an entity captured during graph-curation analysis
   properties:
     entity_id:
       type: string
       description: Entity ID
-      example: "墨香居"
+      example: "e_moxiangju"
     entity_name:
       type: string
       description: Entity name
@@ -283,208 +283,202 @@ mergeSuggestionEntity:
       type: string
       description: Entity description
       example: "这条老巷子里唯一的旧书店"
-    degree:
+    source_chunk_count:
       type: integer
-      description: Node degree (number of connections)
-      example: 8
-      nullable: true
+      description: Number of source chunks contributing to the entity
+      example: 3
+      minimum: 0
   required:
     - entity_id
     - entity_name
     - entity_type
     - description
+    - source_chunk_count
 
-mergeSuggestionTargetEntity:
+graphCurationRunSummary:
   type: object
-  description: Suggested target entity for merge
-  properties:
-    entity_name:
-      type: string
-      description: Suggested entity name after merge
-      example: "墨香居"
-    entity_type:
-      type: string
-      description: Suggested entity type after merge
-      example: "ORGANIZATION"
-  required:
-    - entity_name
-    - entity_type
-
-mergeSuggestion:
-  type: object
-  description: Node merge suggestion
-  properties:
-    entities:
-      type: array
-      items:
-        $ref: '#/mergeSuggestionEntity'
-      description: List of entities suggested for merging
-      minItems: 2
-    confidence_score:
-      type: number
-      format: float
-      minimum: 0.0
-      maximum: 1.0
-      description: LLM confidence score for this merge suggestion
-      example: 0.85
-    merge_reason:
-      type: string
-      description: LLM-generated reason for suggesting this merge
-      example: "两个实体都描述同一个书店，'墨香居'是具体名称，'旧书店'是通用描述，应该合并为同一实体"
-    suggested_target_entity:
-      $ref: '#/mergeSuggestionTargetEntity'
-  required:
-    - entities
-    - confidence_score
-    - merge_reason
-    - suggested_target_entity
-
-mergeSuggestionsRequest:
-  type: object
-  description: Request for generating node merge suggestions
-  properties:
-    max_suggestions:
-      type: integer
-      minimum: 1
-      maximum: 100
-      default: 50
-      description: Maximum number of merge suggestions to return
-      example: 50
-    max_concurrent_llm_calls:
-      type: integer
-      minimum: 1
-      maximum: 16
-      default: 4
-      description: Maximum number of concurrent LLM calls for batch analysis
-      example: 4
-    force_refresh:
-      type: boolean
-      default: false
-      description: Force regeneration of suggestions even if valid cached suggestions exist
-      example: false
-
-mergeSuggestionItem:
-  type: object
-  description: Individual merge suggestion item
+  description: Summary of an asynchronous graph-curation run
   properties:
     id:
       type: string
-      description: Suggestion ID
-      example: "msug123"
+      description: Run ID
+      example: "gcr_abcd1234efgh5678"
     collection_id:
       type: string
       description: Collection ID
       example: "col123"
-    suggestion_batch_id:
+    status:
       type: string
-      description: Suggestion batch ID
-      example: "batch456"
+      enum: ["PENDING", "RUNNING", "COMPLETED", "FAILED"]
+      description: Run lifecycle status
+      example: "COMPLETED"
+    stats:
+      type: object
+      description: Best-effort execution stats
+      additionalProperties: true
+    error_message:
+      type: string
+      description: Failure message if the run failed
+      example: "LLM adjudication timed out"
+      nullable: true
+    created:
+      type: string
+      format: date-time
+      description: Creation timestamp
+      example: "2026-04-23T00:00:00Z"
+      nullable: true
+    updated:
+      type: string
+      format: date-time
+      description: Last update timestamp
+      example: "2026-04-23T00:02:00Z"
+      nullable: true
+    started:
+      type: string
+      format: date-time
+      description: Run start timestamp
+      example: "2026-04-23T00:00:05Z"
+      nullable: true
+    finished:
+      type: string
+      format: date-time
+      description: Run finish timestamp
+      example: "2026-04-23T00:02:00Z"
+      nullable: true
+  required:
+    - id
+    - collection_id
+    - status
+    - stats
+
+mergeSuggestionsRequest:
+  type: object
+  description: Start a new graph-curation analysis run
+  additionalProperties: false
+  example: {}
+
+mergeSuggestionItem:
+  type: object
+  description: Persisted merge suggestion produced by graph curation
+  properties:
+    id:
+      type: string
+      description: Suggestion ID
+      example: "gcs_abcd1234efgh5678"
+    run_id:
+      type: string
+      description: Run that produced this suggestion
+      example: "gcr_abcd1234efgh5678"
+    collection_id:
+      type: string
+      description: Collection ID
+      example: "col123"
     entity_ids:
       type: array
       items:
         type: string
-      description: Entity IDs suggested for merging
-      example: ["墨香居", "书店", "旧书店"]
+      description: Entity IDs in the candidate merge set
+      example: ["e_moxiangju", "e_old_bookstore"]
+    entities:
+      type: array
+      items:
+        $ref: '#/mergeSuggestionEntity'
+      description: Entity snapshots captured when the suggestion was generated
     confidence_score:
       type: number
       format: float
       minimum: 0.0
       maximum: 1.0
-      description: LLM confidence score for this merge suggestion
-      example: 0.85
-    merge_reason:
+      description: Aggregated confidence score for this suggestion
+      example: 0.91
+    target_entity_id:
       type: string
-      description: LLM-generated reason for suggesting this merge
-      example: "两个实体都描述同一个书店，'墨香居'是具体名称，'旧书店'是通用描述，应该合并为同一实体"
-    suggested_target_entity:
-      $ref: '#/mergeSuggestionTargetEntity'
+      description: Recommended surviving entity ID if accepted
+      example: "e_moxiangju"
+    reason:
+      type: string
+      description: Human-readable explanation from pairwise LLM adjudication
+      example: "两个实体都在描述同一家旧书店，名称和上下文高度重合。"
+    evidence:
+      type: object
+      description: Structured supporting evidence used during candidate generation and adjudication
+      additionalProperties: true
+      nullable: true
     status:
       type: string
-      enum: ["PENDING", "ACCEPTED", "REJECTED", "EXPIRED"]
+      enum: ["PENDING", "ACCEPTED", "REJECTED", "EXPIRED", "SUPERSEDED"]
       description: Status of the suggestion
       example: "PENDING"
+    resolution_note:
+      type: string
+      description: System note describing why the suggestion left pending state
+      example: "superseded_by:gcs_other"
+      nullable: true
     created:
       type: string
       format: date-time
       description: Creation timestamp
-      example: "2025-01-07T10:00:00Z"
+      example: "2026-04-23T00:02:00Z"
+      nullable: true
+    updated:
+      type: string
+      format: date-time
+      description: Last update timestamp
+      example: "2026-04-23T00:05:00Z"
+      nullable: true
     operated_at:
       type: string
       format: date-time
       description: User operation timestamp
-      example: "2025-01-08T15:30:00Z"
+      example: "2026-04-23T00:05:00Z"
       nullable: true
   required:
     - id
+    - run_id
     - collection_id
-    - suggestion_batch_id
     - entity_ids
+    - entities
     - confidence_score
-    - merge_reason
-    - suggested_target_entity
+    - target_entity_id
+    - reason
     - status
     - created
+    - updated
+
+mergeSuggestionsRunResponse:
+  type: object
+  description: Response returned when starting a graph-curation analysis run
+  properties:
+    run:
+      $ref: '#/graphCurationRunSummary'
+    started:
+      type: boolean
+      description: Whether a new run was actually scheduled
+      example: true
+    message:
+      type: string
+      description: Human-readable status message
+      example: "Graph curation run started"
+  required:
+    - run
+    - started
+    - message
 
 mergeSuggestionsResponse:
   type: object
-  description: Response containing node merge suggestions
+  description: Latest persisted graph-curation run and its suggestions
   properties:
+    run:
+      $ref: '#/graphCurationRunSummary'
+      nullable: true
     suggestions:
       type: array
       items:
         $ref: '#/mergeSuggestionItem'
-      description: List of merge suggestions ordered by confidence score (highest first)
-    total_analyzed_nodes:
-      type: integer
-      description: Total number of nodes analyzed
-      example: 156
-      minimum: 0
-    processing_time_seconds:
-      type: number
-      format: float
-      description: Processing time in seconds
-      example: 12.5
-      minimum: 0.0
-    from_cache:
-      type: boolean
-      description: Whether suggestions were loaded from cache
-      example: false
-      default: false
-    generated_at:
-      type: string
-      format: date-time
-      description: Generation timestamp
-      example: "2025-01-07T10:00:00Z"
-    total_suggestions:
-      type: integer
-      description: Total number of suggestions
-      example: 5
-      minimum: 0
-    pending_count:
-      type: integer
-      description: Number of pending suggestions
-      example: 3
-      minimum: 0
-    accepted_count:
-      type: integer
-      description: Number of accepted suggestions
-      example: 1
-      minimum: 0
-    rejected_count:
-      type: integer
-      description: Number of rejected suggestions
-      example: 1
-      minimum: 0
+      description: Suggestions from the latest run, ordered by confidence score
   required:
+    - run
     - suggestions
-    - total_analyzed_nodes
-    - processing_time_seconds
-    - from_cache
-    - generated_at
-    - total_suggestions
-    - pending_count
-    - accepted_count
-    - rejected_count
 
 suggestionActionRequest:
   type: object
@@ -495,14 +489,52 @@ suggestionActionRequest:
       enum: ["accept", "reject"]
       description: Action to take on the suggestion (case-insensitive, e.g., 'Accept', 'REJECT', 'accept')
       example: "accept"
-    target_entity_data:
-      $ref: '#/targetEntityDataRequest'
-      description: Optional override for target entity data (only used when action is 'accept')
   required:
     - action
   additionalProperties: false
   example:
     action: "accept"
+
+suggestionActionMergeResult:
+  type: object
+  description: Merge result returned when a suggestion is accepted
+  properties:
+    target_entity_id:
+      type: string
+      description: Surviving entity ID after merge
+      example: "e_moxiangju"
+    merged_source_ids:
+      type: array
+      items:
+        type: string
+      description: Merged-away entity IDs
+      example: ["e_old_bookstore"]
+    description:
+      type: string
+      description: Merged description of the surviving entity
+    source_chunk_ids:
+      type: array
+      items:
+        type: string
+      description: Source chunk IDs preserved on the surviving entity
+      example: ["chunk_1", "chunk_8"]
+    edges_redirected:
+      type: integer
+      description: Number of redirected edges
+      example: 5
+      minimum: 0
+    edges_collapsed:
+      type: integer
+      description: Number of duplicate edges collapsed
+      example: 2
+      minimum: 0
+  required:
+    - target_entity_id
+    - merged_source_ids
+    - description
+    - source_chunk_ids
+    - edges_redirected
+    - edges_collapsed
 
 suggestionActionResponse:
   type: object
@@ -513,10 +545,6 @@ suggestionActionResponse:
       description: Status of the action operation
       example: "success"
       enum: ["success", "error"]
-    message:
-      type: string
-      description: Detailed message about the action operation
-      example: "Suggestion msug123 has been accepted and merge completed"
     suggestion_id:
       type: string
       description: The suggestion ID that was processed
@@ -526,12 +554,17 @@ suggestionActionResponse:
       enum: ["accept", "reject"]
       description: The action that was performed (normalized to lowercase)
       example: "accept"
+    suggestion_status:
+      type: string
+      enum: ["ACCEPTED", "REJECTED"]
+      description: Suggestion status after processing the action
+      example: "ACCEPTED"
     merge_result:
-      $ref: '#/nodeMergeResponse'
+      $ref: '#/suggestionActionMergeResult'
       description: Merge operation result (only present when action is 'accept')
       nullable: true
   required:
     - status
-    - message
     - suggestion_id
     - action
+    - suggestion_status

--- a/aperag/api/paths/collections.yaml
+++ b/aperag/api/paths/collections.yaml
@@ -1036,18 +1036,109 @@ graph_nodes_merge:
               $ref: '../components/schemas/common.yaml#/failResponse'
 
 graph_merge_suggestions:
-  post:
-    summary: Generate node merge suggestions
+  get:
+    summary: Get latest graph merge suggestions
     description: |
-      Analyze knowledge graph to identify potentially mergeable nodes using LLM for semantic similarity.
-      Returns confidence-ranked merge suggestions for user review and decision.
-
-      This is a stateless endpoint that analyzes the current graph and returns suggestions
-      without persisting any state. Users can then use the suggestions with the existing
-      merge_nodes endpoint to perform actual merges.
-
-      The algorithm prioritizes high-degree nodes and uses LLM to judge semantic similarity
-      based on entity names, types, and descriptions.
+      Return the latest persisted graph-curation run for the collection together
+      with its merge suggestions. Suggestions are generated asynchronously and
+      remain pending until explicitly accepted or rejected.
+    tags:
+      - graph
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: collection_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Collection ID
+    responses:
+      '200':
+        description: Latest graph-curation run fetched successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/graph.yaml#/mergeSuggestionsResponse'
+            examples:
+              completed_run:
+                summary: Latest completed run with suggestions
+                value:
+                  run:
+                    id: "gcr_abcd1234efgh5678"
+                    collection_id: "col123"
+                    status: "COMPLETED"
+                    stats:
+                      analyzed_entities: 128
+                      candidate_pairs: 42
+                      positive_pairs: 8
+                      suggestions: 3
+                    error_message: null
+                    created: "2026-04-23T00:00:00Z"
+                    updated: "2026-04-23T00:01:18Z"
+                    started: "2026-04-23T00:00:02Z"
+                    finished: "2026-04-23T00:01:18Z"
+                  suggestions:
+                    - id: "gcs_abcd1234efgh5678"
+                      run_id: "gcr_abcd1234efgh5678"
+                      collection_id: "col123"
+                      status: "PENDING"
+                      entity_ids: ["e_moxiangju", "e_old_bookstore"]
+                      entities:
+                        - entity_id: "e_moxiangju"
+                          entity_name: "墨香居"
+                          entity_type: "ORGANIZATION"
+                          description: "这条老巷子里唯一的旧书店"
+                          source_chunk_count: 3
+                        - entity_id: "e_old_bookstore"
+                          entity_name: "旧书店"
+                          entity_type: "ORGANIZATION"
+                          description: "经营各种书籍的小店"
+                          source_chunk_count: 2
+                      target_entity_id: "e_moxiangju"
+                      confidence_score: 0.91
+                      reason: "两个实体都在描述同一家旧书店，名称和上下文高度重合。"
+                      evidence:
+                        pair_count: 1
+                      resolution_note: null
+                      created: "2026-04-23T00:01:18Z"
+                      updated: "2026-04-23T00:01:18Z"
+                      operated_at: null
+              empty:
+                summary: No run has been created yet
+                value:
+                  run: null
+                  suggestions: []
+      '400':
+        description: Bad request - collection has knowledge graph disabled
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/common.yaml#/failResponse'
+      '401':
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/common.yaml#/failResponse'
+      '404':
+        description: Collection not found
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/common.yaml#/failResponse'
+      '500':
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/common.yaml#/failResponse'
+  post:
+    summary: Start graph merge suggestion analysis
+    description: |
+      Start a new asynchronous graph-curation run for the collection.
+      The run performs cheap deterministic candidate generation, pairwise
+      LLM adjudication, and persists merge suggestions for later review.
     tags:
       - graph
     security:
@@ -1068,60 +1159,48 @@ graph_merge_suggestions:
           examples:
             default:
               summary: Default request
-              description: Generate up to 10 suggestions for all entity types
-              value:
-                max_suggestions: 10
-            specific_types:
-              summary: Specific entity types
-              description: Only analyze PERSON and ORGANIZATION entities
-              value:
-                max_suggestions: 20
-                entity_types: ["PERSON", "ORGANIZATION"]
-            minimal:
-              summary: Minimal request
-              description: Empty request body uses default values
+              description: Start a run with server-side defaults
               value: {}
     responses:
       '200':
-        description: Merge suggestions generated successfully
+        description: Graph-curation run scheduled successfully
         content:
           application/json:
             schema:
-              $ref: '../components/schemas/graph.yaml#/mergeSuggestionsResponse'
+              $ref: '../components/schemas/graph.yaml#/mergeSuggestionsRunResponse'
             examples:
-              with_suggestions:
-                summary: Response with suggestions
-                description: Successful analysis with merge suggestions
+              started:
+                summary: New run scheduled
                 value:
-                  suggestions:
-                    - entities:
-                        - entity_id: "墨香居"
-                          entity_name: "墨香居"
-                          entity_type: "ORGANIZATION"
-                          description: "这条老巷子里唯一的旧书店"
-                          degree: 8
-                        - entity_id: "旧书店"
-                          entity_name: "旧书店"
-                          entity_type: "ORGANIZATION"
-                          description: "经营各种书籍的小店"
-                          degree: 5
-                      confidence_score: 0.85
-                      merge_reason: "两个实体都描述同一个书店，'墨香居'是具体名称，'旧书店'是通用描述，应该合并为同一实体"
-                      suggested_target_entity:
-                        entity_name: "墨香居"
-                        entity_type: "ORGANIZATION"
-                        description: "墨香居是这条老巷子里唯一的旧书店，经营各种书籍"
-                  total_analyzed_nodes: 156
-                  processing_time_seconds: 12.5
-              no_suggestions:
-                summary: No suggestions found
-                description: Analysis completed but no merge candidates found
+                  run:
+                    id: "gcr_abcd1234efgh5678"
+                    collection_id: "col123"
+                    status: "PENDING"
+                    stats: {}
+                    error_message: null
+                    created: "2026-04-23T00:00:00Z"
+                    updated: "2026-04-23T00:00:00Z"
+                    started: null
+                    finished: null
+                  started: true
+                  message: "Graph curation run started"
+              already_running:
+                summary: Run already active
                 value:
-                  suggestions: []
-                  total_analyzed_nodes: 45
-                  processing_time_seconds: 3.2
+                  run:
+                    id: "gcr_existing1234567"
+                    collection_id: "col123"
+                    status: "RUNNING"
+                    stats: {}
+                    error_message: null
+                    created: "2026-04-23T00:00:00Z"
+                    updated: "2026-04-23T00:00:05Z"
+                    started: "2026-04-23T00:00:02Z"
+                    finished: null
+                  started: false
+                  message: "Graph curation run already in progress"
       '400':
-        description: Bad request - invalid parameters
+        description: Bad request - collection has knowledge graph disabled
         content:
           application/json:
             schema:
@@ -1149,22 +1228,11 @@ graph_suggestion_action:
   post:
     summary: Accept or reject a merge suggestion
     description: |
-      Take action on a specific merge suggestion.
+      Take action on a persisted graph-curation suggestion.
 
-      Actions:
-      - accept: Accept the suggestion and perform the merge operation
-      - reject: Reject the suggestion and mark it as rejected
-
-      When accepting, the system will:
-      1. Update suggestion status to ACCEPTED
-      2. Perform the actual node merge using suggested entity IDs
-      3. Mark related suggestions involving the same entities as EXPIRED
-
-      When rejecting, the system will:
-      1. Update suggestion status to REJECTED
-      2. No merge operation is performed
-
-      The target entity data can be optionally overridden when accepting a suggestion.
+      - `accept`: call the existing graph merge primitive and mark overlapping
+        pending suggestions as superseded.
+      - `reject`: mark the suggestion as rejected without mutating graph truth.
     tags:
       - graph
     security:
@@ -1199,14 +1267,6 @@ graph_suggestion_action:
               description: Reject the suggestion without merging
               value:
                 action: "reject"
-            accept_with_override:
-              summary: Accept with custom target data
-              description: Accept suggestion but override target entity data
-              value:
-                action: "accept"
-                target_entity_data:
-                  entity_name: "Custom Name"
-                  description: "Custom description for merged entity"
     responses:
       '200':
         description: Action completed successfully
@@ -1220,28 +1280,24 @@ graph_suggestion_action:
                 description: Suggestion accepted and merge completed
                 value:
                   status: "success"
-                  message: "Suggestion msug123 has been accepted and merge completed"
-                  suggestion_id: "msug123"
+                  suggestion_id: "gcs_abcd1234efgh5678"
                   action: "accept"
+                  suggestion_status: "ACCEPTED"
                   merge_result:
-                    status: "success"
-                    message: "Successfully merged 2 entities into 墨香居"
-                    entity_ids: ["墨香居", "书店"]
-                    target_entity_data:
-                      entity_name: "墨香居"
-                      entity_type: "ORGANIZATION"
-                      description: "墨香居是这条老巷子里唯一的旧书店，经营着各种书籍"
-                    source_entities: ["书店"]
+                    target_entity_id: "e_moxiangju"
+                    merged_source_ids: ["e_old_bookstore"]
+                    description: "墨香居是这条老巷子里唯一的旧书店，经营着各种书籍"
+                    source_chunk_ids: ["chunk_1", "chunk_8"]
                     redirected_edges: 5
-                    merged_description_length: 45
+                    edges_collapsed: 2
               reject_success:
                 summary: Reject action successful
                 description: Suggestion rejected successfully
                 value:
                   status: "success"
-                  message: "Suggestion msug123 has been rejected"
-                  suggestion_id: "msug123"
+                  suggestion_id: "gcs_abcd1234efgh5678"
                   action: "reject"
+                  suggestion_status: "REJECTED"
                   merge_result: null
       '400':
         description: Bad request - invalid action or suggestion already processed

--- a/aperag/db/models.py
+++ b/aperag/db/models.py
@@ -1032,6 +1032,21 @@ class ExportTaskStatus(str, Enum):
     EXPIRED = "EXPIRED"
 
 
+class GraphCurationRunStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+
+
+class GraphCurationSuggestionStatus(str, Enum):
+    PENDING = "PENDING"
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+    EXPIRED = "EXPIRED"
+    SUPERSEDED = "SUPERSEDED"
+
+
 class ExportTask(Base):
     __tablename__ = "export_task"
     __table_args__ = (
@@ -1055,6 +1070,60 @@ class ExportTask(Base):
     gmt_updated = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     gmt_completed = Column(DateTime(timezone=True), nullable=True)
     gmt_expires = Column(DateTime(timezone=True), nullable=True)
+
+
+class GraphCurationRun(Base):
+    __tablename__ = "graph_curation_runs"
+    __table_args__ = (
+        Index("idx_graph_curation_runs_collection_status", "collection_id", "status"),
+        Index("idx_graph_curation_runs_user_created", "user_id", "gmt_created"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "gcr_" + random_id()[:16])
+    user_id = Column(String(256), nullable=False)
+    collection_id = Column(String(24), nullable=False)
+    status = Column(
+        EnumColumn(GraphCurationRunStatus),
+        nullable=False,
+        default=GraphCurationRunStatus.PENDING,
+    )
+    config_json = Column(JSON, nullable=True)
+    stats = Column(JSON, nullable=True)
+    error_message = Column(Text, nullable=True)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    gmt_started = Column(DateTime(timezone=True), nullable=True)
+    gmt_finished = Column(DateTime(timezone=True), nullable=True)
+
+
+class GraphCurationSuggestion(Base):
+    __tablename__ = "graph_curation_suggestions"
+    __table_args__ = (
+        Index("idx_graph_curation_suggestions_run", "run_id"),
+        Index("idx_graph_curation_suggestions_collection_status", "collection_id", "status"),
+        Index("idx_graph_curation_suggestions_collection_created", "collection_id", "gmt_created"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "gcs_" + random_id()[:16])
+    run_id = Column(String(32), nullable=False)
+    user_id = Column(String(256), nullable=False)
+    collection_id = Column(String(24), nullable=False)
+    status = Column(
+        EnumColumn(GraphCurationSuggestionStatus),
+        nullable=False,
+        default=GraphCurationSuggestionStatus.PENDING,
+    )
+    entity_ids = Column(JSON, nullable=False)
+    entity_snapshots = Column(JSON, nullable=False)
+    target_entity_id = Column(String(255), nullable=False)
+    confidence_score = Column(Numeric(6, 3), nullable=False)
+    reason = Column(Text, nullable=False)
+    evidence = Column(JSON, nullable=True)
+    resolution_note = Column(Text, nullable=True)
+    operated_by = Column(String(256), nullable=True)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    gmt_operated = Column(DateTime(timezone=True), nullable=True)
 
 
 class PromptTemplate(Base):

--- a/aperag/graph_curation/__init__.py
+++ b/aperag/graph_curation/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Graph curation workflow.
+
+This module is deliberately separate from ``aperag.graphindex``:
+
+- ``graphindex`` owns graph truth and the merge primitive
+- ``graph_curation`` owns suggestion discovery and review state
+"""
+
+from __future__ import annotations
+
+__all__ = ["GraphCurationService", "graph_curation_service"]
+
+
+def __getattr__(name: str):
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from aperag.graph_curation.service import GraphCurationService, graph_curation_service
+
+    exports = {
+        "GraphCurationService": GraphCurationService,
+        "graph_curation_service": graph_curation_service,
+    }
+    return exports[name]

--- a/aperag/graph_curation/candidate_generation.py
+++ b/aperag/graph_curation/candidate_generation.py
@@ -1,0 +1,205 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cheap deterministic candidate generation for graph curation."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Sequence
+
+from aperag.graphindex.dto import Entity
+
+_WORD_RE = re.compile(r"[a-z0-9]+", re.IGNORECASE)
+_NON_ALNUM_RE = re.compile(r"[^0-9a-zA-Z]+")
+
+
+@dataclass(frozen=True)
+class CandidatePair:
+    left_id: str
+    right_id: str
+    score: float
+    signals: dict[str, Any]
+
+
+def entity_snapshot(entity: Entity) -> dict[str, Any]:
+    return {
+        "entity_id": entity.entity_id,
+        "entity_name": entity.name,
+        "entity_type": entity.type,
+        "description": entity.description,
+        "source_chunk_count": len(entity.source_chunk_ids or ()),
+    }
+
+
+def build_candidate_pairs(
+    entities: Sequence[Entity],
+    vector_neighbors: dict[str, list[tuple[str, float]]] | None = None,
+    *,
+    max_pairs_per_entity: int,
+    max_total_pairs: int,
+) -> list[CandidatePair]:
+    if not entities:
+        return []
+
+    vector_neighbors = vector_neighbors or {}
+    entities_by_id = {entity.entity_id: entity for entity in entities}
+    same_type_groups: dict[str, list[Entity]] = defaultdict(list)
+    for entity in entities:
+        same_type_groups[(entity.type or "").strip().lower()].append(entity)
+
+    pair_signals: dict[tuple[str, str], dict[str, Any]] = {}
+
+    def _upsert_signal(entity_a: Entity, entity_b: Entity, signal_updates: dict[str, Any]) -> None:
+        key = _pair_key(entity_a.entity_id, entity_b.entity_id)
+        current = pair_signals.setdefault(key, {})
+        for name, value in signal_updates.items():
+            if isinstance(value, (int, float)) and isinstance(current.get(name), (int, float)):
+                current[name] = max(float(current[name]), float(value))
+            else:
+                current[name] = value
+
+    for group in same_type_groups.values():
+        group_size = len(group)
+        for idx in range(group_size):
+            left = group[idx]
+            for jdx in range(idx + 1, group_size):
+                right = group[jdx]
+                lexical = _lexical_signals(left, right)
+                if lexical:
+                    _upsert_signal(left, right, lexical)
+
+    for entity_id, neighbors in vector_neighbors.items():
+        left = entities_by_id.get(entity_id)
+        if left is None:
+            continue
+        for neighbor_id, score in neighbors:
+            right = entities_by_id.get(neighbor_id)
+            if right is None or right.entity_id == left.entity_id or right.type != left.type:
+                continue
+            _upsert_signal(
+                left,
+                right,
+                {
+                    "vector_score": float(score),
+                    "vector_neighbor": True,
+                },
+            )
+
+    ranked: list[CandidatePair] = []
+    for left_id, right_id in sorted(pair_signals.keys()):
+        left = entities_by_id[left_id]
+        right = entities_by_id[right_id]
+        signals = dict(pair_signals[(left_id, right_id)])
+        shared_chunks = len(set(left.source_chunk_ids or ()) & set(right.source_chunk_ids or ()))
+        if shared_chunks:
+            signals["shared_chunk_count"] = shared_chunks
+
+        score = _pair_score(signals)
+        if score <= 0:
+            continue
+        ranked.append(CandidatePair(left_id=left_id, right_id=right_id, score=score, signals=signals))
+
+    ranked.sort(key=lambda item: (-item.score, item.left_id, item.right_id))
+    per_entity_counts: dict[str, int] = defaultdict(int)
+    selected: list[CandidatePair] = []
+    for pair in ranked:
+        if per_entity_counts[pair.left_id] >= max_pairs_per_entity:
+            continue
+        if per_entity_counts[pair.right_id] >= max_pairs_per_entity:
+            continue
+        selected.append(pair)
+        per_entity_counts[pair.left_id] += 1
+        per_entity_counts[pair.right_id] += 1
+        if len(selected) >= max_total_pairs:
+            break
+    return selected
+
+
+def _pair_key(left_id: str, right_id: str) -> tuple[str, str]:
+    return (left_id, right_id) if left_id < right_id else (right_id, left_id)
+
+
+def _normalize_name(value: str) -> str:
+    compact = _NON_ALNUM_RE.sub(" ", value or "").strip().lower()
+    return " ".join(compact.split())
+
+
+def _tokens(value: str) -> set[str]:
+    return {token for token in _WORD_RE.findall((value or "").lower()) if token}
+
+
+def _acronym(value: str) -> str:
+    tokens = [token for token in re.split(r"[\s\-_./]+", (value or "").strip()) if token]
+    return "".join(token[0].lower() for token in tokens if token)
+
+
+def _jaccard(left: Iterable[str], right: Iterable[str]) -> float:
+    left_set = set(left)
+    right_set = set(right)
+    if not left_set or not right_set:
+        return 0.0
+    return len(left_set & right_set) / len(left_set | right_set)
+
+
+def _lexical_signals(left: Entity, right: Entity) -> dict[str, Any]:
+    left_norm = _normalize_name(left.name)
+    right_norm = _normalize_name(right.name)
+    if not left_norm or not right_norm:
+        return {}
+
+    signals: dict[str, Any] = {}
+    if left_norm == right_norm:
+        signals["normalized_name_exact"] = True
+    elif left_norm in right_norm or right_norm in left_norm:
+        signals["normalized_name_contains"] = True
+
+    left_acronym = _acronym(left.name)
+    right_acronym = _acronym(right.name)
+    if left_acronym and left_acronym == right_acronym and len(left_acronym) >= 2:
+        signals["acronym_match"] = True
+
+    name_token_overlap = _jaccard(_tokens(left.name), _tokens(right.name))
+    if name_token_overlap >= 0.5:
+        signals["name_token_overlap"] = round(name_token_overlap, 3)
+
+    description_overlap = _jaccard(_tokens(left.description), _tokens(right.description))
+    if description_overlap >= 0.2:
+        signals["description_token_overlap"] = round(description_overlap, 3)
+
+    return signals
+
+
+def _pair_score(signals: Dict[str, Any]) -> float:
+    score = 0.0
+    if signals.get("normalized_name_exact"):
+        score += 0.65
+    if signals.get("normalized_name_contains"):
+        score += 0.35
+    if signals.get("acronym_match"):
+        score += 0.30
+    if signals.get("name_token_overlap"):
+        score += min(float(signals["name_token_overlap"]) * 0.35, 0.30)
+    if signals.get("description_token_overlap"):
+        score += min(float(signals["description_token_overlap"]) * 0.20, 0.15)
+    if signals.get("shared_chunk_count"):
+        score += min(int(signals["shared_chunk_count"]) * 0.20, 0.50)
+    if signals.get("vector_score") is not None:
+        score += min(max(float(signals["vector_score"]), 0.0) * 0.35, 0.35)
+    return round(score, 3)
+
+
+__all__ = ["CandidatePair", "build_candidate_pairs", "entity_snapshot"]

--- a/aperag/graph_curation/integration.py
+++ b/aperag/graph_curation/integration.py
@@ -1,0 +1,82 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable
+
+from aperag.db.ops import db_ops
+from aperag.graph_curation.service import graph_curation_service
+from aperag.graphindex.integration import (
+    build_collection_llm_callable,
+    make_service_for_collection,
+)
+
+
+def run_graph_curation_run_sync(run_id: str, collection_id: str) -> None:
+    collection = db_ops.query_collection_by_id(collection_id, ignore_deleted=False)
+    if collection is None:
+        raise ValueError(f"Collection {collection_id!r} not found")
+
+    async def _run() -> None:
+        graph_service = make_service_for_collection(collection)
+        await graph_curation_service.generate_run(
+            run_id=run_id,
+            collection=collection,
+            graph_service=graph_service,
+            llm=build_collection_llm_callable(collection),
+        )
+
+    _run_in_new_loop(_run())
+
+
+def run_expire_graph_curation_collection_sync(collection_id: str, reason: str) -> None:
+    async def _run() -> None:
+        await graph_curation_service.expire_pending_for_collection(collection_id, reason=reason)
+
+    _run_in_new_loop(_run())
+
+
+def run_purge_graph_curation_collection_sync(collection_id: str) -> None:
+    async def _run() -> None:
+        await graph_curation_service.purge_collection(collection_id)
+
+    _run_in_new_loop(_run())
+
+
+def _run_in_new_loop(coro: Awaitable[Any]) -> Any:
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(coro)
+    finally:
+        try:
+            pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(asyncio.wait(pending, timeout=1.0))
+        except Exception:
+            pass
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+
+__all__ = [
+    "run_graph_curation_run_sync",
+    "run_expire_graph_curation_collection_sync",
+    "run_purge_graph_curation_collection_sync",
+]

--- a/aperag/graph_curation/prompts.py
+++ b/aperag/graph_curation/prompts.py
@@ -1,0 +1,70 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM prompts for graph curation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+MERGE_ADJUDICATION = """\
+You are reviewing two knowledge-graph entities from the same collection.
+
+Decide whether they refer to the same real-world entity.
+
+Rules:
+
+1. Output JSON only.
+2. Be conservative. If the evidence is weak, answer `same_entity=false`.
+3. `recommended_target_entity_id` must be one of the two provided ids
+   when `same_entity=true`; otherwise return `null`.
+4. Do not invent a new entity id or a new canonical node.
+5. Use the deterministic signals as hints, not as truth.
+
+JSON schema:
+{{
+  "same_entity": <true|false>,
+  "confidence": <number between 0 and 1>,
+  "reason": "<short explanation>",
+  "recommended_target_entity_id": "<left id | right id | null>"
+}}
+
+Entity A:
+{left_json}
+
+Entity B:
+{right_json}
+
+Deterministic signals:
+{signals_json}
+
+Output JSON only:
+"""
+
+
+def render_merge_adjudication_prompt(
+    *,
+    left: dict[str, Any],
+    right: dict[str, Any],
+    signals: dict[str, Any],
+) -> str:
+    return MERGE_ADJUDICATION.format(
+        left_json=json.dumps(left, ensure_ascii=False, indent=2, sort_keys=True),
+        right_json=json.dumps(right, ensure_ascii=False, indent=2, sort_keys=True),
+        signals_json=json.dumps(signals, ensure_ascii=False, indent=2, sort_keys=True),
+    )
+
+
+__all__ = ["render_merge_adjudication_prompt"]

--- a/aperag/graph_curation/service.py
+++ b/aperag/graph_curation/service.py
@@ -1,0 +1,691 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import Counter, defaultdict
+from typing import Any, Optional, Sequence
+
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aperag.db.models import (
+    Collection,
+    GraphCurationRun,
+    GraphCurationRunStatus,
+    GraphCurationSuggestion,
+    GraphCurationSuggestionStatus,
+)
+from aperag.db.ops import AsyncDatabaseOps, async_db_ops
+from aperag.db.repositories.base import AsyncBaseRepository
+from aperag.exceptions import CollectionNotFoundException
+from aperag.graph_curation.candidate_generation import (
+    CandidatePair,
+    build_candidate_pairs,
+    entity_snapshot,
+)
+from aperag.graph_curation.prompts import render_merge_adjudication_prompt
+from aperag.graphindex.dto import Entity
+from aperag.graphindex.service import GraphIndexService, LLMCall
+from aperag.utils.utils import utc_now
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_ENTITIES = 400
+DEFAULT_MAX_PAIRS_PER_ENTITY = 6
+DEFAULT_MAX_CANDIDATE_PAIRS = 240
+DEFAULT_MAX_SUGGESTIONS = 32
+DEFAULT_VECTOR_TOP_K = 4
+DEFAULT_VECTOR_SCORE_THRESHOLD = 0.72
+DEFAULT_LLM_CONCURRENCY = 4
+
+
+class MergeJudgement(BaseModel):
+    same_entity: bool
+    confidence: float = Field(ge=0.0, le=1.0)
+    reason: str
+    recommended_target_entity_id: Optional[str] = None
+
+
+class GraphCurationService(AsyncBaseRepository):
+    def __init__(self, session: AsyncSession = None):
+        super().__init__(session)
+        from aperag.service.collection_service import collection_service
+
+        self.collection_service = collection_service
+        self.db_ops = async_db_ops if session is None else AsyncDatabaseOps(session)
+
+    async def start_run(self, user_id: str, collection_id: str) -> dict[str, Any]:
+        await self._get_and_validate_collection(user_id, collection_id)
+
+        async def _op(session: AsyncSession):
+            active_stmt = (
+                select(GraphCurationRun)
+                .where(
+                    GraphCurationRun.collection_id == collection_id,
+                    GraphCurationRun.status.in_(
+                        [GraphCurationRunStatus.PENDING, GraphCurationRunStatus.RUNNING]
+                    ),
+                )
+                .order_by(GraphCurationRun.gmt_created.desc())
+                .limit(1)
+            )
+            active = (await session.execute(active_stmt)).scalars().first()
+            if active is not None:
+                return active, False
+
+            run = GraphCurationRun(
+                user_id=user_id,
+                collection_id=collection_id,
+                status=GraphCurationRunStatus.PENDING,
+                config_json=self._default_run_config(),
+            )
+            session.add(run)
+            await session.flush()
+            await session.refresh(run)
+            return run, True
+
+        run, created = await self.execute_with_transaction(_op)
+
+        if created:
+            from config.celery_tasks import generate_graph_curation_run_task
+
+            generate_graph_curation_run_task.delay(run.id, collection_id)
+
+        return {
+            "run": self._run_to_dict(run),
+            "started": created,
+            "message": "Graph curation run started" if created else "Graph curation run already in progress",
+        }
+
+    async def get_latest(self, user_id: str, collection_id: str) -> dict[str, Any]:
+        await self._get_and_validate_collection(user_id, collection_id)
+
+        async def _query(session: AsyncSession):
+            run_stmt = (
+                select(GraphCurationRun)
+                .where(GraphCurationRun.collection_id == collection_id)
+                .order_by(GraphCurationRun.gmt_created.desc())
+                .limit(1)
+            )
+            run = (await session.execute(run_stmt)).scalars().first()
+            if run is None:
+                return None, []
+
+            suggestion_stmt = (
+                select(GraphCurationSuggestion)
+                .where(GraphCurationSuggestion.run_id == run.id)
+                .order_by(
+                    GraphCurationSuggestion.confidence_score.desc(),
+                    GraphCurationSuggestion.gmt_created.asc(),
+                )
+            )
+            suggestions = (await session.execute(suggestion_stmt)).scalars().all()
+            return run, suggestions
+
+        run, suggestions = await self._execute_query(_query)
+        return {
+            "run": self._run_to_dict(run) if run is not None else None,
+            "suggestions": [self._suggestion_to_dict(item) for item in suggestions],
+        }
+
+    async def handle_action(
+        self,
+        user_id: str,
+        collection_id: str,
+        suggestion_id: str,
+        *,
+        action: str,
+    ) -> dict[str, Any]:
+        collection = await self._get_and_validate_collection(user_id, collection_id)
+        action_normalized = (action or "").strip().lower()
+        if action_normalized not in {"accept", "reject"}:
+            raise ValueError("action must be one of: accept, reject")
+
+        async def _load(session: AsyncSession):
+            stmt = select(GraphCurationSuggestion).where(
+                GraphCurationSuggestion.id == suggestion_id,
+                GraphCurationSuggestion.collection_id == collection_id,
+            )
+            return (await session.execute(stmt)).scalars().first()
+
+        suggestion = await self._execute_query(_load)
+        if suggestion is None:
+            raise KeyError(f"Suggestion {suggestion_id!r} not found")
+        if suggestion.status != GraphCurationSuggestionStatus.PENDING:
+            raise ValueError(f"Suggestion {suggestion_id!r} is already {suggestion.status}")
+
+        if action_normalized == "reject":
+            await self._mark_suggestion_status(
+                suggestion_id=suggestion_id,
+                status=GraphCurationSuggestionStatus.REJECTED,
+                operated_by=user_id,
+                resolution_note="rejected_by_user",
+            )
+            return {
+                "status": "success",
+                "suggestion_id": suggestion_id,
+                "action": "reject",
+                "suggestion_status": GraphCurationSuggestionStatus.REJECTED.value,
+                "merge_result": None,
+            }
+
+        from aperag.graphindex.integration import make_service_for_collection
+
+        graph_service = make_service_for_collection(collection)
+        entity_ids = list(suggestion.entity_ids or [])
+        target_entity_id = suggestion.target_entity_id
+        source_entity_ids = [entity_id for entity_id in entity_ids if entity_id != target_entity_id]
+        merge_result = await graph_service.merge_entities(
+            collection_id=collection_id,
+            target_entity_id=target_entity_id,
+            source_entity_ids=source_entity_ids,
+        )
+
+        await self._accept_and_supersede(
+            collection_id=collection_id,
+            suggestion_id=suggestion_id,
+            entity_ids=entity_ids,
+            operated_by=user_id,
+        )
+
+        return {
+            "status": "success",
+            "suggestion_id": suggestion_id,
+            "action": "accept",
+            "suggestion_status": GraphCurationSuggestionStatus.ACCEPTED.value,
+            "merge_result": {
+                "target_entity_id": merge_result.target_entity_id,
+                "merged_source_ids": list(merge_result.merged_source_ids),
+                "description": merge_result.description,
+                "source_chunk_ids": list(merge_result.source_chunk_ids),
+                "edges_redirected": merge_result.edges_redirected,
+                "edges_collapsed": merge_result.edges_collapsed,
+            },
+        }
+
+    async def generate_run(
+        self,
+        *,
+        run_id: str,
+        collection: Collection,
+        graph_service: GraphIndexService,
+        llm: LLMCall,
+    ) -> None:
+        collection_id = str(collection.id)
+        await self._mark_run_running(run_id)
+
+        try:
+            entities = await graph_service.list_entities_for_curation(
+                collection_id=collection_id,
+                limit=DEFAULT_MAX_ENTITIES,
+            )
+            entities_by_id = {entity.entity_id: entity for entity in entities}
+            vector_neighbors = await graph_service.find_entity_shadow_neighbors(
+                collection_id=collection_id,
+                entity_ids=list(entities_by_id.keys()),
+                top_k_per_entity=DEFAULT_VECTOR_TOP_K,
+                score_threshold=DEFAULT_VECTOR_SCORE_THRESHOLD,
+            )
+
+            candidate_pairs = build_candidate_pairs(
+                entities=entities,
+                vector_neighbors=vector_neighbors,
+                max_pairs_per_entity=DEFAULT_MAX_PAIRS_PER_ENTITY,
+                max_total_pairs=DEFAULT_MAX_CANDIDATE_PAIRS,
+            )
+            judgements = await self._adjudicate_pairs(candidate_pairs, entities_by_id, llm)
+            suggestions = self._aggregate_positive_judgements(
+                entities_by_id=entities_by_id,
+                adjudications=judgements,
+            )[:DEFAULT_MAX_SUGGESTIONS]
+
+            stats = {
+                "analyzed_entities": len(entities),
+                "candidate_pairs": len(candidate_pairs),
+                "positive_pairs": len(judgements),
+                "suggestions": len(suggestions),
+            }
+            await self._finish_run(
+                run_id=run_id,
+                user_id=str(collection.user),
+                collection_id=collection_id,
+                suggestions=suggestions,
+                stats=stats,
+            )
+        except Exception as exc:
+            logger.exception("graph curation run %s failed", run_id)
+            await self._mark_run_failed(run_id, str(exc))
+            raise
+
+    async def expire_pending_for_collection(self, collection_id: str, *, reason: str) -> None:
+        now = utc_now()
+
+        async def _op(session: AsyncSession):
+            await session.execute(
+                update(GraphCurationSuggestion)
+                .where(
+                    GraphCurationSuggestion.collection_id == collection_id,
+                    GraphCurationSuggestion.status == GraphCurationSuggestionStatus.PENDING,
+                )
+                .values(
+                    status=GraphCurationSuggestionStatus.EXPIRED,
+                    resolution_note=reason,
+                    gmt_updated=now,
+                    gmt_operated=now,
+                )
+            )
+
+        await self.execute_with_transaction(_op)
+
+    async def expire_pending_for_entities(
+        self,
+        collection_id: str,
+        entity_ids: Sequence[str],
+        *,
+        reason: str,
+    ) -> None:
+        if not entity_ids:
+            return
+        entity_id_set = set(entity_ids)
+        now = utc_now()
+
+        async def _op(session: AsyncSession):
+            stmt = select(GraphCurationSuggestion).where(
+                GraphCurationSuggestion.collection_id == collection_id,
+                GraphCurationSuggestion.status == GraphCurationSuggestionStatus.PENDING,
+            )
+            suggestions = (await session.execute(stmt)).scalars().all()
+            for suggestion in suggestions:
+                if entity_id_set & set(suggestion.entity_ids or []):
+                    suggestion.status = GraphCurationSuggestionStatus.EXPIRED
+                    suggestion.resolution_note = reason
+                    suggestion.gmt_updated = now
+                    suggestion.gmt_operated = now
+
+        await self.execute_with_transaction(_op)
+
+    async def purge_collection(self, collection_id: str) -> None:
+        async def _op(session: AsyncSession):
+            await session.execute(delete(GraphCurationSuggestion).where(GraphCurationSuggestion.collection_id == collection_id))
+            await session.execute(delete(GraphCurationRun).where(GraphCurationRun.collection_id == collection_id))
+
+        await self.execute_with_transaction(_op)
+
+    async def _get_and_validate_collection(self, user_id: str, collection_id: str) -> Collection:
+        try:
+            view_collection = await self.collection_service.get_collection(user_id, collection_id)
+        except Exception:
+            raise CollectionNotFoundException(collection_id)
+
+        if not view_collection.config or not view_collection.config.enable_knowledge_graph:
+            raise ValueError(f"Knowledge graph is not enabled for collection {collection_id}")
+
+        db_collection = await self.collection_service.db_ops.query_collection(user_id, collection_id)
+        if not db_collection:
+            raise CollectionNotFoundException(collection_id)
+
+        return db_collection
+
+    @staticmethod
+    def _default_run_config() -> dict[str, Any]:
+        return {
+            "max_entities": DEFAULT_MAX_ENTITIES,
+            "max_pairs_per_entity": DEFAULT_MAX_PAIRS_PER_ENTITY,
+            "max_candidate_pairs": DEFAULT_MAX_CANDIDATE_PAIRS,
+            "max_suggestions": DEFAULT_MAX_SUGGESTIONS,
+            "vector_top_k": DEFAULT_VECTOR_TOP_K,
+            "vector_score_threshold": DEFAULT_VECTOR_SCORE_THRESHOLD,
+            "llm_concurrency": DEFAULT_LLM_CONCURRENCY,
+        }
+
+    @staticmethod
+    def _run_to_dict(run: GraphCurationRun) -> dict[str, Any]:
+        return {
+            "id": run.id,
+            "collection_id": run.collection_id,
+            "status": run.status,
+            "stats": run.stats or {},
+            "error_message": run.error_message,
+            "created": run.gmt_created.isoformat() if run.gmt_created else None,
+            "updated": run.gmt_updated.isoformat() if run.gmt_updated else None,
+            "started": run.gmt_started.isoformat() if run.gmt_started else None,
+            "finished": run.gmt_finished.isoformat() if run.gmt_finished else None,
+        }
+
+    @staticmethod
+    def _suggestion_to_dict(suggestion: GraphCurationSuggestion) -> dict[str, Any]:
+        return {
+            "id": suggestion.id,
+            "run_id": suggestion.run_id,
+            "collection_id": suggestion.collection_id,
+            "status": suggestion.status,
+            "entity_ids": list(suggestion.entity_ids or []),
+            "entities": list(suggestion.entity_snapshots or []),
+            "target_entity_id": suggestion.target_entity_id,
+            "confidence_score": float(suggestion.confidence_score),
+            "reason": suggestion.reason,
+            "evidence": suggestion.evidence or {},
+            "resolution_note": suggestion.resolution_note,
+            "created": suggestion.gmt_created.isoformat() if suggestion.gmt_created else None,
+            "updated": suggestion.gmt_updated.isoformat() if suggestion.gmt_updated else None,
+            "operated_at": suggestion.gmt_operated.isoformat() if suggestion.gmt_operated else None,
+        }
+
+    async def _mark_run_running(self, run_id: str) -> None:
+        now = utc_now()
+
+        async def _op(session: AsyncSession):
+            await session.execute(
+                update(GraphCurationRun)
+                .where(GraphCurationRun.id == run_id)
+                .values(
+                    status=GraphCurationRunStatus.RUNNING,
+                    gmt_updated=now,
+                    gmt_started=now,
+                    error_message=None,
+                )
+            )
+
+        await self.execute_with_transaction(_op)
+
+    async def _mark_run_failed(self, run_id: str, error_message: str) -> None:
+        now = utc_now()
+
+        async def _op(session: AsyncSession):
+            await session.execute(
+                update(GraphCurationRun)
+                .where(GraphCurationRun.id == run_id)
+                .values(
+                    status=GraphCurationRunStatus.FAILED,
+                    error_message=error_message[:2000],
+                    gmt_updated=now,
+                    gmt_finished=now,
+                )
+            )
+
+        await self.execute_with_transaction(_op)
+
+    async def _mark_suggestion_status(
+        self,
+        *,
+        suggestion_id: str,
+        status: GraphCurationSuggestionStatus,
+        operated_by: str,
+        resolution_note: str,
+    ) -> None:
+        now = utc_now()
+
+        async def _op(session: AsyncSession):
+            await session.execute(
+                update(GraphCurationSuggestion)
+                .where(GraphCurationSuggestion.id == suggestion_id)
+                .values(
+                    status=status,
+                    operated_by=operated_by,
+                    resolution_note=resolution_note,
+                    gmt_updated=now,
+                    gmt_operated=now,
+                )
+            )
+
+        await self.execute_with_transaction(_op)
+
+    async def _accept_and_supersede(
+        self,
+        *,
+        collection_id: str,
+        suggestion_id: str,
+        entity_ids: Sequence[str],
+        operated_by: str,
+    ) -> None:
+        now = utc_now()
+        entity_id_set = set(entity_ids)
+
+        async def _op(session: AsyncSession):
+            stmt = select(GraphCurationSuggestion).where(
+                GraphCurationSuggestion.collection_id == collection_id,
+                GraphCurationSuggestion.status == GraphCurationSuggestionStatus.PENDING,
+            )
+            pending = (await session.execute(stmt)).scalars().all()
+            for suggestion in pending:
+                if suggestion.id == suggestion_id:
+                    suggestion.status = GraphCurationSuggestionStatus.ACCEPTED
+                    suggestion.operated_by = operated_by
+                    suggestion.resolution_note = "accepted_by_user"
+                    suggestion.gmt_updated = now
+                    suggestion.gmt_operated = now
+                    continue
+                if entity_id_set & set(suggestion.entity_ids or []):
+                    suggestion.status = GraphCurationSuggestionStatus.SUPERSEDED
+                    suggestion.operated_by = operated_by
+                    suggestion.resolution_note = f"superseded_by:{suggestion_id}"
+                    suggestion.gmt_updated = now
+                    suggestion.gmt_operated = now
+
+        await self.execute_with_transaction(_op)
+
+    async def _finish_run(
+        self,
+        *,
+        run_id: str,
+        user_id: str,
+        collection_id: str,
+        suggestions: list[dict[str, Any]],
+        stats: dict[str, Any],
+    ) -> None:
+        now = utc_now()
+
+        async def _op(session: AsyncSession):
+            await session.execute(
+                update(GraphCurationSuggestion)
+                .where(
+                    GraphCurationSuggestion.collection_id == collection_id,
+                    GraphCurationSuggestion.status == GraphCurationSuggestionStatus.PENDING,
+                    GraphCurationSuggestion.run_id != run_id,
+                )
+                .values(
+                    status=GraphCurationSuggestionStatus.SUPERSEDED,
+                    resolution_note=f"superseded_by_run:{run_id}",
+                    gmt_updated=now,
+                    gmt_operated=now,
+                )
+            )
+            await session.execute(delete(GraphCurationSuggestion).where(GraphCurationSuggestion.run_id == run_id))
+            for suggestion in suggestions:
+                session.add(
+                    GraphCurationSuggestion(
+                        run_id=run_id,
+                        user_id=user_id,
+                        collection_id=collection_id,
+                        status=GraphCurationSuggestionStatus.PENDING,
+                        entity_ids=suggestion["entity_ids"],
+                        entity_snapshots=suggestion["entity_snapshots"],
+                        target_entity_id=suggestion["target_entity_id"],
+                        confidence_score=suggestion["confidence_score"],
+                        reason=suggestion["reason"],
+                        evidence=suggestion["evidence"],
+                    )
+                )
+            await session.execute(
+                update(GraphCurationRun)
+                .where(GraphCurationRun.id == run_id)
+                .values(
+                    status=GraphCurationRunStatus.COMPLETED,
+                    stats=stats,
+                    gmt_updated=now,
+                    gmt_finished=now,
+                    error_message=None,
+                )
+            )
+
+        await self.execute_with_transaction(_op)
+
+    async def _adjudicate_pairs(
+        self,
+        pairs: Sequence[CandidatePair],
+        entities_by_id: dict[str, Entity],
+        llm: LLMCall,
+    ) -> list[tuple[CandidatePair, MergeJudgement]]:
+        if not pairs:
+            return []
+
+        semaphore = asyncio.Semaphore(DEFAULT_LLM_CONCURRENCY)
+
+        async def _one(pair: CandidatePair):
+            left = entities_by_id[pair.left_id]
+            right = entities_by_id[pair.right_id]
+            prompt = render_merge_adjudication_prompt(
+                left=entity_snapshot(left),
+                right=entity_snapshot(right),
+                signals=pair.signals,
+            )
+            try:
+                async with semaphore:
+                    raw = await llm(prompt)
+                judgement = MergeJudgement.model_validate(self._extract_json_object(raw))
+                if judgement.same_entity and judgement.recommended_target_entity_id not in {
+                    pair.left_id,
+                    pair.right_id,
+                }:
+                    judgement.recommended_target_entity_id = None
+                return pair, judgement
+            except Exception:
+                logger.exception("graph curation: pair adjudication failed for %s/%s", pair.left_id, pair.right_id)
+                return None
+
+        results = await asyncio.gather(*(_one(pair) for pair in pairs))
+        return [result for result in results if result and result[1].same_entity]
+
+    def _aggregate_positive_judgements(
+        self,
+        *,
+        entities_by_id: dict[str, Entity],
+        adjudications: Sequence[tuple[CandidatePair, MergeJudgement]],
+    ) -> list[dict[str, Any]]:
+        if not adjudications:
+            return []
+
+        parent = {entity_id: entity_id for entity_id in entities_by_id}
+
+        def _find(entity_id: str) -> str:
+            while parent[entity_id] != entity_id:
+                parent[entity_id] = parent[parent[entity_id]]
+                entity_id = parent[entity_id]
+            return entity_id
+
+        def _union(left_id: str, right_id: str) -> None:
+            root_left = _find(left_id)
+            root_right = _find(right_id)
+            if root_left != root_right:
+                parent[root_right] = root_left
+
+        for pair, _judgement in adjudications:
+            _union(pair.left_id, pair.right_id)
+
+        components: dict[str, set[str]] = defaultdict(set)
+        for entity_id in entities_by_id:
+            components[_find(entity_id)].add(entity_id)
+
+        by_component: dict[frozenset[str], list[tuple[CandidatePair, MergeJudgement]]] = defaultdict(list)
+        for pair, judgement in adjudications:
+            component_key = frozenset(components[_find(pair.left_id)])
+            if len(component_key) >= 2:
+                by_component[component_key].append((pair, judgement))
+
+        suggestions: list[dict[str, Any]] = []
+        for component_ids, component_pairs in by_component.items():
+            ordered_ids = sorted(component_ids)
+            target_entity_id = self._choose_target_entity(ordered_ids, component_pairs, entities_by_id)
+            snapshots = [entity_snapshot(entities_by_id[entity_id]) for entity_id in ordered_ids]
+            confidence = round(
+                sum(judgement.confidence for _pair, judgement in component_pairs) / len(component_pairs),
+                3,
+            )
+            reasons = []
+            for _pair, judgement in component_pairs:
+                reason = (judgement.reason or "").strip()
+                if reason and reason not in reasons:
+                    reasons.append(reason)
+            suggestions.append(
+                {
+                    "entity_ids": ordered_ids,
+                    "entity_snapshots": snapshots,
+                    "target_entity_id": target_entity_id,
+                    "confidence_score": confidence,
+                    "reason": " ; ".join(reasons[:3]) or "LLM judged these entities to be the same entity.",
+                    "evidence": {
+                        "pair_count": len(component_pairs),
+                        "pairs": [
+                            {
+                                "left_id": pair.left_id,
+                                "right_id": pair.right_id,
+                                "pair_score": pair.score,
+                                "signals": pair.signals,
+                                "confidence": judgement.confidence,
+                                "recommended_target_entity_id": judgement.recommended_target_entity_id,
+                                "reason": judgement.reason,
+                            }
+                            for pair, judgement in component_pairs
+                        ],
+                    },
+                }
+            )
+
+        suggestions.sort(
+            key=lambda item: (
+                -float(item["confidence_score"]),
+                len(item["entity_ids"]),
+                item["target_entity_id"],
+            )
+        )
+        return suggestions
+
+    @staticmethod
+    def _choose_target_entity(
+        entity_ids: Sequence[str],
+        component_pairs: Sequence[tuple[CandidatePair, MergeJudgement]],
+        entities_by_id: dict[str, Entity],
+    ) -> str:
+        vote_counter: Counter[str] = Counter(
+            judgement.recommended_target_entity_id
+            for _pair, judgement in component_pairs
+            if judgement.recommended_target_entity_id in set(entity_ids)
+        )
+        ranked = sorted(
+            entity_ids,
+            key=lambda entity_id: (
+                -vote_counter.get(entity_id, 0),
+                -len(entities_by_id[entity_id].source_chunk_ids or ()),
+                entity_id,
+            ),
+        )
+        return ranked[0]
+
+    @staticmethod
+    def _extract_json_object(raw_text: str) -> dict[str, Any]:
+        start = raw_text.find("{")
+        end = raw_text.rfind("}")
+        if start < 0 or end <= start:
+            raise ValueError("LLM did not return a JSON object")
+        return json.loads(raw_text[start : end + 1])
+
+
+graph_curation_service = GraphCurationService()
+
+__all__ = ["GraphCurationService", "graph_curation_service"]

--- a/aperag/graph_curation/service.py
+++ b/aperag/graph_curation/service.py
@@ -78,9 +78,7 @@ class GraphCurationService(AsyncBaseRepository):
                 select(GraphCurationRun)
                 .where(
                     GraphCurationRun.collection_id == collection_id,
-                    GraphCurationRun.status.in_(
-                        [GraphCurationRunStatus.PENDING, GraphCurationRunStatus.RUNNING]
-                    ),
+                    GraphCurationRun.status.in_([GraphCurationRunStatus.PENDING, GraphCurationRunStatus.RUNNING]),
                 )
                 .order_by(GraphCurationRun.gmt_created.desc())
                 .limit(1)
@@ -331,7 +329,9 @@ class GraphCurationService(AsyncBaseRepository):
 
     async def purge_collection(self, collection_id: str) -> None:
         async def _op(session: AsyncSession):
-            await session.execute(delete(GraphCurationSuggestion).where(GraphCurationSuggestion.collection_id == collection_id))
+            await session.execute(
+                delete(GraphCurationSuggestion).where(GraphCurationSuggestion.collection_id == collection_id)
+            )
             await session.execute(delete(GraphCurationRun).where(GraphCurationRun.collection_id == collection_id))
 
         await self.execute_with_transaction(_op)

--- a/aperag/graph_curation/service.py
+++ b/aperag/graph_curation/service.py
@@ -105,7 +105,16 @@ class GraphCurationService(AsyncBaseRepository):
         if created:
             from config.celery_tasks import generate_graph_curation_run_task
 
-            generate_graph_curation_run_task.delay(run.id, collection_id)
+            try:
+                generate_graph_curation_run_task.delay(run.id, collection_id)
+            except Exception as exc:
+                logger.exception(
+                    "graph curation: failed to enqueue run %s for collection %s",
+                    run.id,
+                    collection_id,
+                )
+                await self._mark_run_failed(run.id, f"enqueue_failed: {exc}")
+                raise RuntimeError("Failed to schedule graph curation run") from exc
 
         return {
             "run": self._run_to_dict(run),

--- a/aperag/graphindex/integration.py
+++ b/aperag/graphindex/integration.py
@@ -91,7 +91,7 @@ _DEFAULT_STORE = _build_store()
 # ---------------------------------------------------------------------------
 
 
-def _build_llm_callable(collection: Collection):
+def build_collection_llm_callable(collection: Collection):
     """Construct the ``LLMCall`` for a specific collection.
 
     Reads the collection's completion config (provider, model, base_url,
@@ -134,7 +134,7 @@ def _build_llm_callable(collection: Collection):
     return _llm
 
 
-def _build_embed_callables(collection: Collection):
+def build_collection_embed_callables(collection: Collection):
     """Build the ``embed_query`` and ``embed_texts`` callables for
     vector-based entity/relation recall.
 
@@ -163,7 +163,7 @@ def _build_embed_callables(collection: Collection):
     return _embed_query, _embed_texts
 
 
-def _build_vector_connector_or_none(collection: Collection):
+def build_collection_vector_connector_or_none(collection: Collection):
     """Return a ``VectorStoreConnector`` for writing/reading entity and
     relation embeddings, or ``None`` if configuration is incomplete.
 
@@ -201,11 +201,11 @@ def make_service_for_collection(
     Only the LLM closure is built fresh per call, and it doesn't open
     any connections until the first ``llm(prompt)`` call.
     """
-    embed_query, embed_texts = _build_embed_callables(collection)
-    vector_connector = _build_vector_connector_or_none(collection)
+    embed_query, embed_texts = build_collection_embed_callables(collection)
+    vector_connector = build_collection_vector_connector_or_none(collection)
     return GraphIndexService(
         store=_DEFAULT_STORE,
-        llm=_build_llm_callable(collection),
+        llm=build_collection_llm_callable(collection),
         embed_query=embed_query,
         embed_texts=embed_texts,
         vector_connector=vector_connector,
@@ -299,6 +299,9 @@ def _run_in_new_loop(coro: Awaitable[Any]) -> Any:
 
 
 __all__ = [
+    "build_collection_llm_callable",
+    "build_collection_embed_callables",
+    "build_collection_vector_connector_or_none",
     "make_service_for_collection",
     "run_index_document_sync",
     "run_delete_document_sync",

--- a/aperag/graphindex/service.py
+++ b/aperag/graphindex/service.py
@@ -289,6 +289,79 @@ class GraphIndexService:
 
         return result
 
+    async def list_entities_for_curation(
+        self,
+        *,
+        collection_id: str,
+        limit: int,
+    ) -> List[Entity]:
+        """Return up to ``limit`` entities for offline curation analysis.
+
+        This stays a bounded read on graph truth rather than introducing a
+        second enumeration path just for curation. Passing ``0`` thresholds
+        intentionally disables the "oversized" predicate and lets the store
+        act as a simple collection-scoped entity listing primitive.
+        """
+        return await self._store.find_oversized_entities(
+            collection_id=collection_id,
+            min_chars=0,
+            min_fragments=0,
+            limit=limit,
+        )
+
+    async def find_entity_shadow_neighbors(
+        self,
+        *,
+        collection_id: str,
+        entity_ids: List[str],
+        top_k_per_entity: int,
+        score_threshold: float,
+    ) -> dict[str, list[tuple[str, float]]]:
+        """Return nearest ``graph_entity`` shadow-vector neighbors.
+
+        Used by the graph-curation workflow to enrich deterministic name
+        blocking with semantic recall while staying inside the existing
+        vectorstore abstraction. The search is restricted to the
+        caller-provided ``entity_ids`` set so offline curation stays
+        bounded to one analysis run.
+        """
+        del collection_id  # Tenant scoping is already enforced by the connector.
+        if self._vector_connector is None or not entity_ids or top_k_per_entity <= 0:
+            return {}
+
+        from aperag.vectorstore.dto import QueryRequest
+        from aperag.vectorstore.filters import Eq, _in, all_of
+
+        connector = self._vector_connector
+        points = connector.retrieve([f"ge_{entity_id}" for entity_id in entity_ids], with_vectors=True)
+        if not points:
+            return {}
+
+        allowed_ids = list(dict.fromkeys(entity_ids))
+        flt = all_of(Eq("indexer", "graph_entity"), _in("entity_id", allowed_ids))
+        neighbors: dict[str, list[tuple[str, float]]] = {}
+        for point in points:
+            source_id = (point.payload or {}).get("entity_id")
+            if not source_id or not point.vector:
+                continue
+            hits = connector.search(
+                QueryRequest(
+                    embedding=point.vector,
+                    top_k=top_k_per_entity + 1,
+                    flt=flt,
+                    score_threshold=score_threshold,
+                )
+            )
+            neighbor_list: list[tuple[str, float]] = []
+            for hit in hits:
+                target_id = (hit.payload or {}).get("entity_id")
+                if not target_id or target_id == source_id:
+                    continue
+                neighbor_list.append((target_id, float(hit.score)))
+            if neighbor_list:
+                neighbors[source_id] = neighbor_list
+        return neighbors
+
     # ============================================================= read
     async def query_context(
         self,

--- a/aperag/migration/versions/20260423103000-a7b8c9d0e1f2.py
+++ b/aperag/migration/versions/20260423103000-a7b8c9d0e1f2.py
@@ -1,0 +1,109 @@
+"""create graph curation run and suggestion tables
+
+Revision ID: a7b8c9d0e1f2
+Revises: f1e2d3c4b5a6
+Create Date: 2026-04-23 10:30:00.000000
+
+Graph merge suggestion discovery is reintroduced in graphindex v2 as a
+dedicated ``graph_curation`` workflow instead of reviving the old
+LightRAG-era pipeline. The new workflow persists:
+
+* async analysis runs
+* persisted suggestions for review / accept / reject
+
+The graph truth path remains unchanged: accepting a suggestion reuses
+the existing ``GraphIndexService.merge_entities`` primitive.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, Sequence[str], None] = "f1e2d3c4b5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "graph_curation_runs",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("user_id", sa.String(length=256), nullable=False),
+        sa.Column("collection_id", sa.String(length=24), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("config_json", sa.JSON(), nullable=True),
+        sa.Column("stats", sa.JSON(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_started", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("gmt_finished", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_graph_curation_runs_collection_status",
+        "graph_curation_runs",
+        ["collection_id", "status"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_graph_curation_runs_user_created",
+        "graph_curation_runs",
+        ["user_id", "gmt_created"],
+        unique=False,
+    )
+    op.create_table(
+        "graph_curation_suggestions",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("run_id", sa.String(length=32), nullable=False),
+        sa.Column("user_id", sa.String(length=256), nullable=False),
+        sa.Column("collection_id", sa.String(length=24), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("entity_ids", sa.JSON(), nullable=False),
+        sa.Column("entity_snapshots", sa.JSON(), nullable=False),
+        sa.Column("target_entity_id", sa.String(length=255), nullable=False),
+        sa.Column("confidence_score", sa.Numeric(precision=6, scale=3), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("evidence", sa.JSON(), nullable=True),
+        sa.Column("resolution_note", sa.Text(), nullable=True),
+        sa.Column("operated_by", sa.String(length=256), nullable=True),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_operated", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_graph_curation_suggestions_run",
+        "graph_curation_suggestions",
+        ["run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_graph_curation_suggestions_collection_status",
+        "graph_curation_suggestions",
+        ["collection_id", "status"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_graph_curation_suggestions_collection_created",
+        "graph_curation_suggestions",
+        ["collection_id", "gmt_created"],
+        unique=False,
+    )
+def downgrade() -> None:
+    op.drop_index(
+        "idx_graph_curation_suggestions_collection_created",
+        table_name="graph_curation_suggestions",
+    )
+    op.drop_index(
+        "idx_graph_curation_suggestions_collection_status",
+        table_name="graph_curation_suggestions",
+    )
+    op.drop_index("idx_graph_curation_suggestions_run", table_name="graph_curation_suggestions")
+    op.drop_table("graph_curation_suggestions")
+
+    op.drop_index("idx_graph_curation_runs_user_created", table_name="graph_curation_runs")
+    op.drop_index("idx_graph_curation_runs_collection_status", table_name="graph_curation_runs")
+    op.drop_table("graph_curation_runs")

--- a/aperag/schema/view_models.py
+++ b/aperag/schema/view_models.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal, Optional, Union
 
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field, RootModel, confloat, conint
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, RootModel, confloat, conint, field_validator
 
 
 class ModelSpec(BaseModel):
@@ -1124,6 +1124,13 @@ class SuggestionActionRequest(BaseModel):
         description="Action to take on the suggestion (case-insensitive, e.g., 'Accept', 'REJECT', 'accept')",
         examples=["accept"],
     )
+
+    @field_validator("action", mode="before")
+    @classmethod
+    def normalize_action(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
 
 
 class SuggestionActionMergeResult(BaseModel):

--- a/aperag/schema/view_models.py
+++ b/aperag/schema/view_models.py
@@ -27,42 +27,38 @@ from pydantic import AnyUrl, BaseModel, ConfigDict, Field, RootModel, confloat, 
 class ModelSpec(BaseModel):
     model: Optional[str] = Field(
         None,
-        description='The name of the language model to use',
-        examples=['gpt-4o-mini'],
+        description="The name of the language model to use",
+        examples=["gpt-4o-mini"],
     )
     model_service_provider: Optional[str] = Field(
         None,
-        description='Used for querying auth information (api_key/api_base/...) for a model service provider.',
-        examples=['openai'],
+        description="Used for querying auth information (api_key/api_base/...) for a model service provider.",
+        examples=["openai"],
     )
     custom_llm_provider: Optional[str] = Field(
         None,
         description="Used for Non-OpenAI LLMs (e.g. 'bedrock' for amazon.titan-tg1-large)",
-        examples=['openai'],
+        examples=["openai"],
     )
     temperature: Optional[confloat(ge=0.0, le=2.0)] = Field(
         0.1,
-        description='Controls randomness in the output. Values between 0 and 2. Lower values make output more focused and deterministic',
+        description="Controls randomness in the output. Values between 0 and 2. Lower values make output more focused and deterministic",
         examples=[0.1],
     )
     max_tokens: Optional[conint(ge=1)] = Field(
-        None, description='Maximum number of tokens to generate', examples=[4096]
+        None, description="Maximum number of tokens to generate", examples=[4096]
     )
     max_completion_tokens: Optional[conint(ge=1)] = Field(
         None,
-        description='Upper bound for generated completion tokens, including visible and reasoning tokens',
+        description="Upper bound for generated completion tokens, including visible and reasoning tokens",
         examples=[4096],
     )
-    timeout: Optional[conint(ge=1)] = Field(
-        None, description='Maximum execution time in seconds for the API request'
-    )
-    top_n: Optional[conint(ge=1)] = Field(
-        None, description='Number of top results to return when reranking documents'
-    )
+    timeout: Optional[conint(ge=1)] = Field(None, description="Maximum execution time in seconds for the API request")
+    top_n: Optional[conint(ge=1)] = Field(None, description="Number of top results to return when reranking documents")
     tags: Optional[list[str]] = Field(
         [],
-        description='Tags for model categorization',
-        examples=[['free', 'recommend']],
+        description="Tags for model categorization",
+        examples=[["free", "recommend"]],
     )
 
 
@@ -73,17 +69,17 @@ class KnowledgeGraphConfig(BaseModel):
 
     entity_types: Optional[list[str]] = Field(
         [
-            'organization',
-            'person',
-            'geo',
-            'event',
-            'product',
-            'technology',
-            'date',
-            'category',
+            "organization",
+            "person",
+            "geo",
+            "event",
+            "product",
+            "technology",
+            "date",
+            "category",
         ],
-        description='List of entity types to extract during graph indexing',
-        examples=[['organization', 'person', 'geo', 'event']],
+        description="List of entity types to extract during graph indexing",
+        examples=[["organization", "person", "geo", "event"]],
     )
 
 
@@ -92,57 +88,43 @@ class IndexPrompts(BaseModel):
     Custom prompts for various index types
     """
 
-    graph: Optional[str] = Field(
-        None, description='Custom prompt for graph/entity extraction'
-    )
-    summary: Optional[str] = Field(
-        None, description='Custom prompt for document summarization'
-    )
-    vision: Optional[str] = Field(None, description='Custom prompt for image analysis')
+    graph: Optional[str] = Field(None, description="Custom prompt for graph/entity extraction")
+    summary: Optional[str] = Field(None, description="Custom prompt for document summarization")
+    vision: Optional[str] = Field(None, description="Custom prompt for image analysis")
 
 
 class CollectionConfig(BaseModel):
     source: Optional[str] = Field(
-        'system',
-        description='Source system identifier. Only `system` is supported.',
-        examples=['system'],
+        "system",
+        description="Source system identifier. Only `system` is supported.",
+        examples=["system"],
     )
-    enable_vector: Optional[bool] = Field(
-        True, description='Whether to enable vector index'
-    )
-    enable_fulltext: Optional[bool] = Field(
-        True, description='Whether to enable fulltext index'
-    )
-    enable_knowledge_graph: Optional[bool] = Field(
-        True, description='Whether to enable knowledge graph index'
-    )
-    enable_summary: Optional[bool] = Field(
-        False, description='Whether to enable summary index'
-    )
-    enable_vision: Optional[bool] = Field(
-        False, description='Whether to enable vision index'
-    )
+    enable_vector: Optional[bool] = Field(True, description="Whether to enable vector index")
+    enable_fulltext: Optional[bool] = Field(True, description="Whether to enable fulltext index")
+    enable_knowledge_graph: Optional[bool] = Field(True, description="Whether to enable knowledge graph index")
+    enable_summary: Optional[bool] = Field(False, description="Whether to enable summary index")
+    enable_vision: Optional[bool] = Field(False, description="Whether to enable vision index")
     knowledge_graph_config: Optional[KnowledgeGraphConfig] = Field(
         default_factory=lambda: KnowledgeGraphConfig.model_validate(
             {
-                'entity_types': [
-                    'organization',
-                    'person',
-                    'geo',
-                    'event',
-                    'product',
-                    'technology',
-                    'date',
-                    'category',
+                "entity_types": [
+                    "organization",
+                    "person",
+                    "geo",
+                    "event",
+                    "product",
+                    "technology",
+                    "date",
+                    "category",
                 ]
             }
         )
     )
     index_prompts: Optional[IndexPrompts] = None
-    language: Optional[Literal['zh-CN', 'en-US', 'ja-JP', 'ko-KR']] = Field(
-        'zh-CN',
-        description='Language for the collection content and processing',
-        examples=['zh-CN'],
+    language: Optional[Literal["zh-CN", "en-US", "ja-JP", "ko-KR"]] = Field(
+        "zh-CN",
+        description="Language for the collection content and processing",
+        examples=["zh-CN"],
     )
     embedding: Optional[ModelSpec] = None
     completion: Optional[ModelSpec] = None
@@ -158,15 +140,11 @@ class Collection(BaseModel):
     type: Optional[str] = None
     description: Optional[str] = None
     config: Optional[CollectionConfig] = None
-    status: Optional[Literal['ACTIVE', 'INACTIVE', 'DELETED']] = None
+    status: Optional[Literal["ACTIVE", "INACTIVE", "DELETED"]] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
-    is_published: Optional[bool] = Field(
-        False, description='Whether the collection is published to marketplace'
-    )
-    published_at: Optional[datetime] = Field(
-        None, description='Publication time, null when not published'
-    )
+    is_published: Optional[bool] = Field(False, description="Whether the collection is published to marketplace")
+    published_at: Optional[datetime] = Field(None, description="Publication time, null when not published")
 
 
 class Agent(BaseModel):
@@ -184,8 +162,8 @@ class Bot(BaseModel):
     id: Optional[str] = None
     title: Optional[str] = None
     description: Optional[str] = None
-    type: Optional[Literal['knowledge', 'common', 'agent']] = Field(
-        None, description='The type of bot', examples=['agent']
+    type: Optional[Literal["knowledge", "common", "agent"]] = Field(
+        None, description="The type of bot", examples=["agent"]
     )
     config: Optional[BotConfig] = None
     created: Optional[datetime] = None
@@ -197,9 +175,9 @@ class PageResult(BaseModel):
     PageResult info (deprecated, use paginatedResponse instead)
     """
 
-    page_number: Optional[int] = Field(None, description='The page number')
-    page_size: Optional[int] = Field(None, description='The page size')
-    count: Optional[int] = Field(None, description='The total count of items')
+    page_number: Optional[int] = Field(None, description="The page number")
+    page_size: Optional[int] = Field(None, description="The page size")
+    count: Optional[int] = Field(None, description="The total count of items")
 
 
 class BotList(BaseModel):
@@ -212,18 +190,14 @@ class BotList(BaseModel):
 
 
 class FailResponse(BaseModel):
-    code: Optional[str] = Field(None, description='Error code', examples=['400'])
-    message: Optional[str] = Field(
-        None, description='Error message', examples=['Invalid request']
-    )
+    code: Optional[str] = Field(None, description="Error code", examples=["400"])
+    message: Optional[str] = Field(None, description="Error message", examples=["Invalid request"])
 
 
 class BotCreate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
-    type: Optional[Literal['agent']] = Field(
-        None, description='The supported bot type', examples=['agent']
-    )
+    type: Optional[Literal["agent"]] = Field(None, description="The supported bot type", examples=["agent"])
     config: Optional[BotConfig] = None
 
 
@@ -239,33 +213,19 @@ class Chat(BaseModel):
     title: Optional[str] = None
     bot_id: Optional[str] = None
     peer_id: Optional[str] = None
-    peer_type: Optional[
-        Literal['system', 'feishu', 'weixin', 'weixin_official', 'web', 'dingtalk']
-    ] = None
-    status: Optional[Literal['active', 'archived']] = None
+    peer_type: Optional[Literal["system", "feishu", "weixin", "weixin_official", "web", "dingtalk"]] = None
+    status: Optional[Literal["active", "archived"]] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
 
 
 class PaginatedResponse(BaseModel):
-    total: Optional[conint(ge=0)] = Field(
-        None, description='Total number of items', examples=[100]
-    )
-    page: Optional[conint(ge=1)] = Field(
-        None, description='Current page number', examples=[1]
-    )
-    page_size: Optional[conint(ge=1)] = Field(
-        None, description='Number of items per page', examples=[10]
-    )
-    total_pages: Optional[conint(ge=1)] = Field(
-        None, description='Total number of pages', examples=[10]
-    )
-    has_next: Optional[bool] = Field(
-        None, description='Whether there is a next page', examples=[True]
-    )
-    has_prev: Optional[bool] = Field(
-        None, description='Whether there is a previous page', examples=[False]
-    )
+    total: Optional[conint(ge=0)] = Field(None, description="Total number of items", examples=[100])
+    page: Optional[conint(ge=1)] = Field(None, description="Current page number", examples=[1])
+    page_size: Optional[conint(ge=1)] = Field(None, description="Number of items per page", examples=[10])
+    total_pages: Optional[conint(ge=1)] = Field(None, description="Total number of pages", examples=[10])
+    has_next: Optional[bool] = Field(None, description="Whether there is a next page", examples=[True])
+    has_prev: Optional[bool] = Field(None, description="Whether there is a previous page", examples=[False])
 
 
 class ChatList(PaginatedResponse):
@@ -297,18 +257,18 @@ class ChatMessage(BaseModel):
     part_id: Optional[str] = None
     type: Optional[
         Literal[
-            'welcome',
-            'message',
-            'start',
-            'stop',
-            'error',
-            'tool_call_result',
-            'thinking',
-            'references',
+            "welcome",
+            "message",
+            "start",
+            "stop",
+            "error",
+            "tool_call_result",
+            "thinking",
+            "references",
         ]
     ] = None
     timestamp: Optional[float] = None
-    role: Optional[Literal['human', 'ai']] = None
+    role: Optional[Literal["human", "ai"]] = None
     data: Optional[str] = None
     references: Optional[list[Reference]] = None
     urls: Optional[list[str]] = None
@@ -320,14 +280,12 @@ class ChatDetails(BaseModel):
     title: Optional[str] = None
     bot_id: Optional[str] = None
     peer_id: Optional[str] = None
-    peer_type: Optional[
-        Literal['system', 'feishu', 'weixin', 'weixin_official', 'web', 'dingtalk']
-    ] = None
+    peer_type: Optional[Literal["system", "feishu", "weixin", "weixin_official", "web", "dingtalk"]] = None
     history: Optional[list[list[ChatMessage]]] = Field(
         None,
-        description='Array of conversation turns, where each turn is an array of message parts',
+        description="Array of conversation turns, where each turn is an array of message parts",
     )
-    status: Optional[Literal['active', 'archived']] = None
+    status: Optional[Literal["active", "archived"]] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
 
@@ -337,25 +295,21 @@ class ChatUpdate(BaseModel):
 
 
 class TitleGenerateRequest(BaseModel):
-    max_length: Optional[conint(ge=6, le=50)] = Field(
-        20, description='Maximum length of the generated title'
+    max_length: Optional[conint(ge=6, le=50)] = Field(20, description="Maximum length of the generated title")
+    language: Optional[Literal["zh-CN", "en-US", "ja-JP", "ko-KR"]] = Field(
+        "zh-CN", description="Language for the title generation (IETF BCP 47 tag)"
     )
-    language: Optional[Literal['zh-CN', 'en-US', 'ja-JP', 'ko-KR']] = Field(
-        'zh-CN', description='Language for the title generation (IETF BCP 47 tag)'
-    )
-    turns: Optional[conint(ge=1)] = Field(
-        1, description='Number of most recent conversation turns to consider'
-    )
+    turns: Optional[conint(ge=1)] = Field(1, description="Number of most recent conversation turns to consider")
 
 
 class TitleGenerateResponse(BaseModel):
-    title: str = Field(..., description='Generated title string')
+    title: str = Field(..., description="Generated title string")
 
 
 class TurnFeedback(BaseModel):
     turn_id: str
-    type: Literal['good', 'bad']
-    tag: Optional[Literal['Harmful', 'Unsafe', 'Fake', 'Unhelpful', 'Other']] = None
+    type: Literal["good", "bad"]
+    tag: Optional[Literal["Harmful", "Unsafe", "Fake", "Unhelpful", "Other"]] = None
     message: Optional[str] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
@@ -366,8 +320,8 @@ class TurnFeedbackList(BaseModel):
 
 
 class Feedback(BaseModel):
-    type: Optional[Literal['good', 'bad']] = None
-    tag: Optional[Literal['Harmful', 'Unsafe', 'Fake', 'Unhelpful', 'Other']] = None
+    type: Optional[Literal["good", "bad"]] = None
+    tag: Optional[Literal["Harmful", "Unsafe", "Fake", "Unhelpful", "Other"]] = None
     message: Optional[str] = None
 
 
@@ -379,87 +333,77 @@ class Document(BaseModel):
     name: Optional[str] = None
     status: Optional[
         Literal[
-            'UPLOADED',
-            'EXPIRED',
-            'PENDING',
-            'RUNNING',
-            'COMPLETE',
-            'FAILED',
-            'DELETING',
-            'DELETED',
+            "UPLOADED",
+            "EXPIRED",
+            "PENDING",
+            "RUNNING",
+            "COMPLETE",
+            "FAILED",
+            "DELETING",
+            "DELETED",
         ]
     ] = None
     vector_index_status: Optional[
         Literal[
-            'PENDING',
-            'CREATING',
-            'ACTIVE',
-            'DELETING',
-            'DELETION_IN_PROGRESS',
-            'FAILED',
-            'SKIPPED',
+            "PENDING",
+            "CREATING",
+            "ACTIVE",
+            "DELETING",
+            "DELETION_IN_PROGRESS",
+            "FAILED",
+            "SKIPPED",
         ]
     ] = None
     fulltext_index_status: Optional[
         Literal[
-            'PENDING',
-            'CREATING',
-            'ACTIVE',
-            'DELETING',
-            'DELETION_IN_PROGRESS',
-            'FAILED',
-            'SKIPPED',
+            "PENDING",
+            "CREATING",
+            "ACTIVE",
+            "DELETING",
+            "DELETION_IN_PROGRESS",
+            "FAILED",
+            "SKIPPED",
         ]
     ] = None
     graph_index_status: Optional[
         Literal[
-            'PENDING',
-            'CREATING',
-            'ACTIVE',
-            'DELETING',
-            'DELETION_IN_PROGRESS',
-            'FAILED',
-            'SKIPPED',
+            "PENDING",
+            "CREATING",
+            "ACTIVE",
+            "DELETING",
+            "DELETION_IN_PROGRESS",
+            "FAILED",
+            "SKIPPED",
         ]
     ] = None
     summary_index_status: Optional[
         Literal[
-            'PENDING',
-            'CREATING',
-            'ACTIVE',
-            'DELETING',
-            'DELETION_IN_PROGRESS',
-            'FAILED',
-            'SKIPPED',
+            "PENDING",
+            "CREATING",
+            "ACTIVE",
+            "DELETING",
+            "DELETION_IN_PROGRESS",
+            "FAILED",
+            "SKIPPED",
         ]
     ] = None
     vision_index_status: Optional[
         Literal[
-            'PENDING',
-            'CREATING',
-            'ACTIVE',
-            'DELETING',
-            'DELETION_IN_PROGRESS',
-            'FAILED',
-            'SKIPPED',
+            "PENDING",
+            "CREATING",
+            "ACTIVE",
+            "DELETING",
+            "DELETION_IN_PROGRESS",
+            "FAILED",
+            "SKIPPED",
         ]
     ] = None
-    vector_index_updated: Optional[datetime] = Field(
-        None, description='Vector index last updated time'
-    )
-    fulltext_index_updated: Optional[datetime] = Field(
-        None, description='Fulltext index last updated time'
-    )
-    graph_index_updated: Optional[datetime] = Field(
-        None, description='Graph index last updated time'
-    )
-    summary_index_updated: Optional[datetime] = Field(
-        None, description='Summary index last updated time'
-    )
-    vision_index_updated: Optional[datetime] = Field(
-        None, description='Vision index last updated time'
-    )
-    summary: Optional[str] = Field(None, description='Summary of the document')
+    vector_index_updated: Optional[datetime] = Field(None, description="Vector index last updated time")
+    fulltext_index_updated: Optional[datetime] = Field(None, description="Fulltext index last updated time")
+    graph_index_updated: Optional[datetime] = Field(None, description="Graph index last updated time")
+    summary_index_updated: Optional[datetime] = Field(None, description="Summary index last updated time")
+    vision_index_updated: Optional[datetime] = Field(None, description="Vision index last updated time")
+    summary: Optional[str] = Field(None, description="Summary of the document")
     size: Optional[float] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
@@ -474,22 +418,18 @@ class CollectionView(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     type: Optional[str] = None
-    status: Optional[Literal['ACTIVE', 'INACTIVE', 'DELETED']] = None
+    status: Optional[Literal["ACTIVE", "INACTIVE", "DELETED"]] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
     is_published: Optional[bool] = False
-    published_at: Optional[datetime] = Field(
-        None, description='Publication time, null when not published'
-    )
-    owner_user_id: Optional[str] = Field(None, description='Collection owner user ID')
-    owner_username: Optional[str] = Field(None, description='Collection owner username')
+    published_at: Optional[datetime] = Field(None, description="Publication time, null when not published")
+    owner_user_id: Optional[str] = Field(None, description="Collection owner user ID")
+    owner_username: Optional[str] = Field(None, description="Collection owner username")
     subscription_id: Optional[str] = Field(
         None,
-        description='Subscription ID if this is a subscribed collection, null for owned collections',
+        description="Subscription ID if this is a subscribed collection, null for owned collections",
     )
-    subscribed_at: Optional[datetime] = Field(
-        None, description='Subscription time, null for owned collections'
-    )
+    subscribed_at: Optional[datetime] = Field(None, description="Subscription time, null for owned collections")
 
 
 class CollectionViewList(BaseModel):
@@ -523,8 +463,8 @@ class DocumentList(PaginatedResponse):
 
 
 class RebuildIndexesRequest(BaseModel):
-    index_types: list[Literal['VECTOR', 'FULLTEXT', 'GRAPH', 'SUMMARY', 'VISION']] = (
-        Field(..., description='Types of indexes to rebuild', min_length=1)
+    index_types: list[Literal["VECTOR", "FULLTEXT", "GRAPH", "SUMMARY", "VISION"]] = Field(
+        ..., description="Types of indexes to rebuild", min_length=1
     )
 
 
@@ -542,154 +482,118 @@ class Chunk(BaseModel):
 
 
 class DocumentPreview(BaseModel):
-    doc_object_path: Optional[str] = Field(
-        None, description='The path to the document object.'
-    )
-    doc_filename: Optional[str] = Field(None, description='The name of the document.')
-    converted_pdf_object_path: Optional[str] = Field(
-        None, description='The path to the converted PDF object.'
-    )
-    markdown_content: Optional[str] = Field(
-        None, description='The markdown content of the document.'
-    )
+    doc_object_path: Optional[str] = Field(None, description="The path to the document object.")
+    doc_filename: Optional[str] = Field(None, description="The name of the document.")
+    converted_pdf_object_path: Optional[str] = Field(None, description="The path to the converted PDF object.")
+    markdown_content: Optional[str] = Field(None, description="The markdown content of the document.")
     chunks: Optional[list[Chunk]] = None
     vision_chunks: Optional[list[VisionChunk]] = None
 
 
 class UploadDocumentResponse(BaseModel):
-    document_id: str = Field(..., description='ID of the uploaded document')
-    filename: str = Field(..., description='Name of the uploaded file')
-    size: int = Field(..., description='Size of the uploaded file in bytes')
-    status: Literal[
-        'UPLOADED', 'PENDING', 'RUNNING', 'COMPLETE', 'FAILED', 'DELETED', 'EXPIRED'
-    ] = Field(
+    document_id: str = Field(..., description="ID of the uploaded document")
+    filename: str = Field(..., description="Name of the uploaded file")
+    size: int = Field(..., description="Size of the uploaded file in bytes")
+    status: Literal["UPLOADED", "PENDING", "RUNNING", "COMPLETE", "FAILED", "DELETED", "EXPIRED"] = Field(
         ...,
-        description='Status of the document (UPLOADED for new uploads, or existing status for duplicate files)',
+        description="Status of the document (UPLOADED for new uploads, or existing status for duplicate files)",
     )
 
 
 class ConfirmDocumentsRequest(BaseModel):
-    document_ids: list[str] = Field(
-        ..., description='List of document IDs to confirm', min_length=1
-    )
+    document_ids: list[str] = Field(..., description="List of document IDs to confirm", min_length=1)
 
 
 class FailedDocument(BaseModel):
     document_id: Optional[str] = None
-    name: Optional[str] = Field(None, description='Name of the document')
+    name: Optional[str] = Field(None, description="Name of the document")
     error: Optional[str] = None
 
 
 class ConfirmDocumentsResponse(BaseModel):
-    confirmed_count: int = Field(
-        ..., description='Number of documents successfully confirmed'
-    )
-    failed_count: int = Field(
-        ..., description='Number of documents that failed to confirm'
-    )
-    failed_documents: Optional[list[FailedDocument]] = Field(
-        None, description='Details of failed confirmations'
-    )
+    confirmed_count: int = Field(..., description="Number of documents successfully confirmed")
+    failed_count: int = Field(..., description="Number of documents that failed to confirm")
+    failed_documents: Optional[list[FailedDocument]] = Field(None, description="Details of failed confirmations")
 
 
 class FetchUrlRequest(BaseModel):
     urls: list[AnyUrl] = Field(
         ...,
-        description='List of URLs to fetch and import (max 10)',
-        examples=[['https://example.com/article1', 'https://example.com/article2']],
+        description="List of URLs to fetch and import (max 10)",
+        examples=[["https://example.com/article1", "https://example.com/article2"]],
     )
 
 
 class FetchUrlResultItem(BaseModel):
-    url: str = Field(..., description='The source URL')
-    fetch_status: Literal['success', 'error'] = Field(
-        ..., description='Whether the URL was fetched successfully'
-    )
-    document_id: Optional[str] = Field(
-        None, description='ID of the created document (only present on success)'
-    )
-    filename: Optional[str] = Field(
-        None, description='Filename of the created document (only present on success)'
-    )
+    url: str = Field(..., description="The source URL")
+    fetch_status: Literal["success", "error"] = Field(..., description="Whether the URL was fetched successfully")
+    document_id: Optional[str] = Field(None, description="ID of the created document (only present on success)")
+    filename: Optional[str] = Field(None, description="Filename of the created document (only present on success)")
     size: Optional[int] = Field(
         None,
-        description='Size of the created document in bytes (only present on success)',
+        description="Size of the created document in bytes (only present on success)",
     )
-    status: Optional[str] = Field(
-        None, description='Document status (only present on success)'
-    )
-    error: Optional[str] = Field(
-        None, description='Error message (only present on failure)'
-    )
+    status: Optional[str] = Field(None, description="Document status (only present on success)")
+    error: Optional[str] = Field(None, description="Error message (only present on failure)")
 
 
 class FetchUrlResponse(BaseModel):
-    results: list[FetchUrlResultItem] = Field(..., description='Results for each URL')
-    total: int = Field(..., description='Total number of URLs processed')
-    succeeded: int = Field(..., description='Number of URLs successfully fetched')
-    failed: int = Field(..., description='Number of URLs that failed')
+    results: list[FetchUrlResultItem] = Field(..., description="Results for each URL")
+    total: int = Field(..., description="Total number of URLs processed")
+    succeeded: int = Field(..., description="Number of URLs successfully fetched")
+    failed: int = Field(..., description="Number of URLs that failed")
 
 
 class StagedDocumentsResponse(BaseModel):
     documents: list[UploadDocumentResponse] = Field(
-        ..., description='List of staged (UPLOADED) documents awaiting confirmation'
+        ..., description="List of staged (UPLOADED) documents awaiting confirmation"
     )
-    total: int = Field(..., description='Total number of staged documents')
+    total: int = Field(..., description="Total number of staged documents")
 
 
 class VectorSearchParams(BaseModel):
-    topk: Optional[int] = Field(None, description='Top K results')
-    similarity: Optional[confloat(ge=0.0, le=1.0)] = Field(
-        None, description='Similarity threshold'
-    )
+    topk: Optional[int] = Field(None, description="Top K results")
+    similarity: Optional[confloat(ge=0.0, le=1.0)] = Field(None, description="Similarity threshold")
 
 
 class FulltextSearchParams(BaseModel):
-    topk: Optional[int] = Field(None, description='Top K results')
-    keywords: Optional[list[str]] = Field(
-        None, description='Custom keywords to use for fulltext search'
-    )
+    topk: Optional[int] = Field(None, description="Top K results")
+    keywords: Optional[list[str]] = Field(None, description="Custom keywords to use for fulltext search")
 
 
 class GraphSearchParams(BaseModel):
-    topk: Optional[int] = Field(None, description='Top K results')
+    topk: Optional[int] = Field(None, description="Top K results")
 
 
 class SummarySearchParams(BaseModel):
-    topk: Optional[int] = Field(None, description='Top K results')
-    similarity: Optional[confloat(ge=0.0, le=1.0)] = Field(
-        None, description='Similarity threshold'
-    )
+    topk: Optional[int] = Field(None, description="Top K results")
+    similarity: Optional[confloat(ge=0.0, le=1.0)] = Field(None, description="Similarity threshold")
 
 
 class VisionSearchParams(BaseModel):
-    topk: Optional[int] = Field(None, description='Top K results')
-    similarity: Optional[confloat(ge=0.0, le=1.0)] = Field(
-        None, description='Similarity threshold'
-    )
+    topk: Optional[int] = Field(None, description="Top K results")
+    similarity: Optional[confloat(ge=0.0, le=1.0)] = Field(None, description="Similarity threshold")
 
 
 class SearchResultItem(BaseModel):
-    rank: Optional[int] = Field(None, description='Result rank')
-    score: Optional[float] = Field(None, description='Result score')
-    content: Optional[str] = Field(None, description='Result content')
-    source: Optional[str] = Field(None, description='Source document or metadata')
+    rank: Optional[int] = Field(None, description="Result rank")
+    score: Optional[float] = Field(None, description="Result score")
+    content: Optional[str] = Field(None, description="Result content")
+    source: Optional[str] = Field(None, description="Source document or metadata")
     recall_type: Optional[
         Literal[
-            'vector_search',
-            'graph_search',
-            'fulltext_search',
-            'summary_search',
-            'vision_search',
+            "vector_search",
+            "graph_search",
+            "fulltext_search",
+            "summary_search",
+            "vision_search",
         ]
-    ] = Field(None, description='Recall type')
-    metadata: Optional[dict[str, Any]] = Field(
-        None, description='Metadata of the result'
-    )
+    ] = Field(None, description="Recall type")
+    metadata: Optional[dict[str, Any]] = Field(None, description="Metadata of the result")
 
 
 class SearchResult(BaseModel):
-    id: Optional[str] = Field(None, description='The id of the search result')
+    id: Optional[str] = Field(None, description="The id of the search result")
     query: Optional[str] = None
     vector_search: Optional[VectorSearchParams] = None
     fulltext_search: Optional[FulltextSearchParams] = None
@@ -697,9 +601,7 @@ class SearchResult(BaseModel):
     summary_search: Optional[SummarySearchParams] = None
     vision_search: Optional[VisionSearchParams] = None
     items: Optional[list[SearchResultItem]] = None
-    created: Optional[datetime] = Field(
-        None, description='The creation time of the search result'
-    )
+    created: Optional[datetime] = Field(None, description="The creation time of the search result")
 
 
 class SearchResultList(BaseModel):
@@ -723,38 +625,36 @@ class SearchRequest(BaseModel):
     vision_search: Optional[VisionSearchParams] = None
     save_to_history: Optional[bool] = Field(
         False,
-        description='Whether to save search result to database history',
+        description="Whether to save search result to database history",
         examples=[True],
     )
     rerank: Optional[bool] = Field(
         False,
-        description='Whether to enable rerank for search results',
+        description="Whether to enable rerank for search results",
         examples=[True],
     )
 
 
 class Settings(BaseModel):
-    use_mineru: Optional[bool] = Field(None, description='Whether to use MinerU')
-    mineru_api_token: Optional[str] = Field(None, description='API token for MinerU')
-    use_markitdown: Optional[bool] = Field(
-        None, description='Whether to use MarkItDown'
-    )
+    use_mineru: Optional[bool] = Field(None, description="Whether to use MinerU")
+    mineru_api_token: Optional[str] = Field(None, description="API token for MinerU")
+    use_markitdown: Optional[bool] = Field(None, description="Whether to use MarkItDown")
 
 
 class ParserHealthItem(BaseModel):
     key: str
     label: str
-    status: Literal['ok', 'warning', 'error', 'disabled']
+    status: Literal["ok", "warning", "error", "disabled"]
     detail: str
 
 
 class ParserSupportTier(BaseModel):
     key: str
     label: str
-    category: Literal['official', 'conditional', 'enhanced', 'optional']
+    category: Literal["official", "conditional", "enhanced", "optional"]
     parser: str
     formats: list[str]
-    status: Literal['available', 'limited', 'unavailable', 'disabled']
+    status: Literal["available", "limited", "unavailable", "disabled"]
     detail: str
     requirements: list[str]
 
@@ -775,16 +675,10 @@ class PromptDetail(BaseModel):
     Detailed prompt information with source and customization status
     """
 
-    content: Optional[str] = Field(
-        None, description='Actual prompt content (resolved with priority)'
-    )
-    source: Optional[Literal['user', 'system', 'hardcoded']] = Field(
-        None, description='Source of the prompt'
-    )
-    customized: Optional[bool] = Field(
-        None, description='Whether user has customized this prompt'
-    )
-    description: Optional[str] = Field(None, description='Optional description')
+    content: Optional[str] = Field(None, description="Actual prompt content (resolved with priority)")
+    source: Optional[Literal["user", "system", "hardcoded"]] = Field(None, description="Source of the prompt")
+    customized: Optional[bool] = Field(None, description="Whether user has customized this prompt")
+    description: Optional[str] = Field(None, description="Optional description")
 
 
 class UserPromptsResponse(BaseModel):
@@ -804,29 +698,21 @@ class Prompts(BaseModel):
     Prompts to update (all fields are optional, only provided fields will be updated)
     """
 
-    agent_system: Optional[str] = Field(
-        None, description='Agent system prompt (persona definition)'
-    )
-    agent_query: Optional[str] = Field(None, description='Agent query prompt template')
-    index_graph: Optional[str] = Field(
-        None, description='Graph index prompt for entity/relation extraction'
-    )
-    index_summary: Optional[str] = Field(
-        None, description='Summary index prompt for document summarization'
-    )
-    index_vision: Optional[str] = Field(
-        None, description='Vision index prompt for image content extraction'
-    )
+    agent_system: Optional[str] = Field(None, description="Agent system prompt (persona definition)")
+    agent_query: Optional[str] = Field(None, description="Agent query prompt template")
+    index_graph: Optional[str] = Field(None, description="Graph index prompt for entity/relation extraction")
+    index_summary: Optional[str] = Field(None, description="Summary index prompt for document summarization")
+    index_vision: Optional[str] = Field(None, description="Vision index prompt for image content extraction")
 
 
 class UpdateUserPromptsRequest(BaseModel):
     prompts: Prompts = Field(
         ...,
-        description='Prompts to update (all fields are optional, only provided fields will be updated)',
+        description="Prompts to update (all fields are optional, only provided fields will be updated)",
         examples=[
             {
-                'agent_system': 'You are a professional technical support assistant...',
-                'index_graph': 'Extract entities from medical text...',
+                "agent_system": "You are a professional technical support assistant...",
+                "index_graph": "Extract entities from medical text...",
             }
         ],
     )
@@ -841,13 +727,11 @@ class DeleteUserPromptResponse(BaseModel):
     message: Optional[str] = None
     type: Optional[str] = None
     new_content: Optional[str] = None
-    source: Optional[Literal['system', 'hardcoded']] = None
+    source: Optional[Literal["system", "hardcoded"]] = None
 
 
 class ResetPromptsRequest(BaseModel):
-    types: Optional[list[str]] = Field(
-        None, description='Prompt types to reset, omit to reset all'
-    )
+    types: Optional[list[str]] = Field(None, description="Prompt types to reset, omit to reset all")
 
 
 class ResetPromptsResponse(BaseModel):
@@ -884,9 +768,7 @@ class PreviewResponse(BaseModel):
 
 
 class ValidateRequest(BaseModel):
-    type: Literal[
-        'agent_system', 'agent_query', 'index_graph', 'index_summary', 'index_vision'
-    ]
+    type: Literal["agent_system", "agent_query", "index_graph", "index_summary", "index_vision"]
     template: str
 
 
@@ -903,8 +785,8 @@ class GraphLabelsResponse(BaseModel):
 
     labels: list[str] = Field(
         ...,
-        description='List of available node labels in the knowledge graph',
-        examples=[['墨香居', '李明华', '林晓雯', '深夜读书会']],
+        description="List of available node labels in the knowledge graph",
+        examples=[["墨香居", "李明华", "林晓雯", "深夜读书会"]],
     )
 
 
@@ -914,32 +796,22 @@ class Properties(BaseModel):
     """
 
     model_config = ConfigDict(
-        extra='allow',
+        extra="allow",
     )
-    entity_id: Optional[str] = Field(
-        None, description='Entity identifier', examples=['墨香居']
-    )
-    entity_type: Optional[str] = Field(
-        None, description='Type of the entity', examples=['organization']
-    )
+    entity_id: Optional[str] = Field(None, description="Entity identifier", examples=["墨香居"])
+    entity_type: Optional[str] = Field(None, description="Type of the entity", examples=["organization"])
     description: Optional[str] = Field(
         None,
-        description='Description of the entity',
-        examples=[
-            '墨香居是这条老巷子里唯一的旧书店，经营着各种书籍，承载了老板李明华的情怀。'
-        ],
+        description="Description of the entity",
+        examples=["墨香居是这条老巷子里唯一的旧书店，经营着各种书籍，承载了老板李明华的情怀。"],
     )
     source_id: Optional[str] = Field(
         None,
-        description='Source chunk ID where entity was extracted',
-        examples=['chunk-88845945407136e9498f5f594c8a00c6'],
+        description="Source chunk ID where entity was extracted",
+        examples=["chunk-88845945407136e9498f5f594c8a00c6"],
     )
-    file_path: Optional[str] = Field(
-        None, description='Source file path', examples=['story.txt']
-    )
-    created_at: Optional[int] = Field(
-        None, description='Creation timestamp', examples=[1751356233]
-    )
+    file_path: Optional[str] = Field(None, description="Source file path", examples=["story.txt"])
+    created_at: Optional[int] = Field(None, description="Creation timestamp", examples=[1751356233])
 
 
 class GraphNode(BaseModel):
@@ -949,15 +821,11 @@ class GraphNode(BaseModel):
 
     id: str = Field(
         ...,
-        description='Unique identifier for the node (entity name)',
-        examples=['墨香居'],
+        description="Unique identifier for the node (entity name)",
+        examples=["墨香居"],
     )
-    labels: list[str] = Field(
-        ..., description='Labels associated with the node', examples=[['墨香居']]
-    )
-    properties: Properties = Field(
-        ..., description='Node properties containing entity metadata'
-    )
+    labels: list[str] = Field(..., description="Labels associated with the node", examples=[["墨香居"]])
+    properties: Properties = Field(..., description="Node properties containing entity metadata")
 
 
 class Properties1(BaseModel):
@@ -966,32 +834,26 @@ class Properties1(BaseModel):
     """
 
     model_config = ConfigDict(
-        extra='allow',
+        extra="allow",
     )
-    weight: Optional[float] = Field(
-        None, description='Relationship weight/strength', examples=[9]
-    )
+    weight: Optional[float] = Field(None, description="Relationship weight/strength", examples=[9])
     description: Optional[str] = Field(
         None,
-        description='Description of the relationship',
-        examples=['深夜读书会是墨香居的新活动，旨在提升书店的活力和吸引顾客。'],
+        description="Description of the relationship",
+        examples=["深夜读书会是墨香居的新活动，旨在提升书店的活力和吸引顾客。"],
     )
     keywords: Optional[str] = Field(
         None,
-        description='Keywords associated with the relationship',
-        examples=['书店活力,活动'],
+        description="Keywords associated with the relationship",
+        examples=["书店活力,活动"],
     )
     source_id: Optional[str] = Field(
         None,
-        description='Source chunk ID where relationship was extracted',
-        examples=['chunk-88845945407136e9498f5f594c8a00c6'],
+        description="Source chunk ID where relationship was extracted",
+        examples=["chunk-88845945407136e9498f5f594c8a00c6"],
     )
-    file_path: Optional[str] = Field(
-        None, description='Source file path', examples=['story.txt']
-    )
-    created_at: Optional[int] = Field(
-        None, description='Creation timestamp', examples=[1751356233]
-    )
+    file_path: Optional[str] = Field(None, description="Source file path", examples=["story.txt"])
+    created_at: Optional[int] = Field(None, description="Creation timestamp", examples=[1751356233])
 
 
 class GraphEdge(BaseModel):
@@ -1001,17 +863,13 @@ class GraphEdge(BaseModel):
 
     id: str = Field(
         ...,
-        description='Unique identifier for the edge',
-        examples=['墨香居-深夜读书会'],
+        description="Unique identifier for the edge",
+        examples=["墨香居-深夜读书会"],
     )
-    type: Optional[str] = Field(
-        'DIRECTED', description='Type of the relationship', examples=['DIRECTED']
-    )
-    source: str = Field(..., description='Source node ID', examples=['墨香居'])
-    target: str = Field(..., description='Target node ID', examples=['深夜读书会'])
-    properties: Properties1 = Field(
-        ..., description='Edge properties containing relationship metadata'
-    )
+    type: Optional[str] = Field("DIRECTED", description="Type of the relationship", examples=["DIRECTED"])
+    source: str = Field(..., description="Source node ID", examples=["墨香居"])
+    target: str = Field(..., description="Target node ID", examples=["深夜读书会"])
+    properties: Properties1 = Field(..., description="Edge properties containing relationship metadata")
 
 
 class KnowledgeGraph(BaseModel):
@@ -1019,15 +877,11 @@ class KnowledgeGraph(BaseModel):
     Knowledge graph containing nodes and edges
     """
 
-    nodes: list[GraphNode] = Field(
-        ..., description='List of nodes in the knowledge graph'
-    )
-    edges: list[GraphEdge] = Field(
-        ..., description='List of edges in the knowledge graph'
-    )
+    nodes: list[GraphNode] = Field(..., description="List of nodes in the knowledge graph")
+    edges: list[GraphEdge] = Field(..., description="List of edges in the knowledge graph")
     is_truncated: bool = Field(
         ...,
-        description='Whether the graph was truncated due to size limits',
+        description="Whether the graph was truncated due to size limits",
         examples=[False],
     )
 
@@ -1039,20 +893,12 @@ class TargetEntityDataRequest(BaseModel):
 
     entity_name: Optional[str] = Field(
         None,
-        description='Target entity name. If not specified, auto-select entity with highest degree',
+        description="Target entity name. If not specified, auto-select entity with highest degree",
     )
-    entity_type: Optional[str] = Field(
-        None, description='Entity type for the target entity'
-    )
-    description: Optional[str] = Field(
-        None, description='Description for the target entity'
-    )
-    source_id: Optional[str] = Field(
-        None, description='Source ID for the target entity'
-    )
-    file_path: Optional[str] = Field(
-        None, description='File path for the target entity'
-    )
+    entity_type: Optional[str] = Field(None, description="Entity type for the target entity")
+    description: Optional[str] = Field(None, description="Description for the target entity")
+    source_id: Optional[str] = Field(None, description="Source ID for the target entity")
+    file_path: Optional[str] = Field(None, description="File path for the target entity")
 
 
 class NodeMergeRequest(BaseModel):
@@ -1062,12 +908,12 @@ class NodeMergeRequest(BaseModel):
     """
 
     model_config = ConfigDict(
-        extra='forbid',
+        extra="forbid",
     )
     entity_ids: list[str] = Field(
         ...,
-        description='List of entity IDs to merge directly',
-        examples=[['墨香居', '书店', '旧书店']],
+        description="List of entity IDs to merge directly",
+        examples=[["墨香居", "书店", "旧书店"]],
         min_length=1,
     )
     target_entity_data: Optional[TargetEntityDataRequest] = None
@@ -1080,25 +926,17 @@ class TargetEntityDataResponse(BaseModel):
 
     entity_name: str = Field(
         ...,
-        description='The entity name that was kept (merge target)',
-        examples=['墨香居'],
+        description="The entity name that was kept (merge target)",
+        examples=["墨香居"],
     )
-    entity_type: str = Field(
-        ..., description='Entity type of the target entity', examples=['ORGANIZATION']
-    )
+    entity_type: str = Field(..., description="Entity type of the target entity", examples=["ORGANIZATION"])
     description: str = Field(
         ...,
-        description='Merged description of the target entity',
-        examples=[
-            '墨香居是这条老巷子里唯一的旧书店，经营着各种书籍，承载了老板李明华的情怀。'
-        ],
+        description="Merged description of the target entity",
+        examples=["墨香居是这条老巷子里唯一的旧书店，经营着各种书籍，承载了老板李明华的情怀。"],
     )
-    source_id: Optional[str] = Field(
-        None, description='Source ID information', examples=['chunk-001,chunk-002']
-    )
-    file_path: Optional[str] = Field(
-        None, description='File path information', examples=['story.txt,book.txt']
-    )
+    source_id: Optional[str] = Field(None, description="Source ID information", examples=["chunk-001,chunk-002"])
+    file_path: Optional[str] = Field(None, description="File path information", examples=["story.txt,book.txt"])
 
 
 class NodeMergeResponse(BaseModel):
@@ -1106,144 +944,170 @@ class NodeMergeResponse(BaseModel):
     Response containing node merge results
     """
 
-    status: Literal['success', 'error'] = Field(
-        ..., description='Status of the merge operation', examples=['success']
-    )
+    status: Literal["success", "error"] = Field(..., description="Status of the merge operation", examples=["success"])
     message: str = Field(
         ...,
-        description='Detailed message about the merge operation',
-        examples=['Successfully merged 2 entities into 墨香居'],
+        description="Detailed message about the merge operation",
+        examples=["Successfully merged 2 entities into 墨香居"],
     )
     entity_ids: list[str] = Field(
         ...,
-        description='Entity IDs that were merged',
-        examples=[['墨香居', '书店', '旧书店']],
+        description="Entity IDs that were merged",
+        examples=[["墨香居", "书店", "旧书店"]],
     )
     target_entity_data: TargetEntityDataResponse
     source_entities: list[str] = Field(
         ...,
-        description='List of entities that were merged into the target',
-        examples=[['书店', '旧书店']],
+        description="List of entities that were merged into the target",
+        examples=[["书店", "旧书店"]],
     )
     redirected_edges: conint(ge=0) = Field(
         ...,
-        description='Number of edges that were redirected during merge',
+        description="Number of edges that were redirected during merge",
         examples=[12],
     )
-    merged_description_length: conint(ge=0) = Field(
-        ..., description='Length of the merged description', examples=[512]
-    )
+    merged_description_length: conint(ge=0) = Field(..., description="Length of the merged description", examples=[512])
     suggestion_id: Optional[str] = Field(
         None,
-        description='Suggestion ID if this merge was based on a suggestion',
-        examples=['msug123'],
+        description="Suggestion ID if this merge was based on a suggestion",
+        examples=["msug123"],
     )
 
 
 class MergeSuggestionsRequest(BaseModel):
     """
-    Request for generating node merge suggestions
+    Start a new graph-curation analysis run.
     """
 
-    max_suggestions: Optional[conint(ge=1, le=100)] = Field(
-        50, description='Maximum number of merge suggestions to return', examples=[50]
-    )
-    max_concurrent_llm_calls: Optional[conint(ge=1, le=16)] = Field(
-        4,
-        description='Maximum number of concurrent LLM calls for batch analysis',
-        examples=[4],
-    )
-    force_refresh: Optional[bool] = Field(
-        False,
-        description='Force regeneration of suggestions even if valid cached suggestions exist',
-        examples=[False],
+    model_config = ConfigDict(
+        extra="forbid",
     )
 
 
-class MergeSuggestionTargetEntity(BaseModel):
+class GraphCurationRunSummary(BaseModel):
     """
-    Suggested target entity for merge
+    Summary of an asynchronous graph-curation run.
     """
 
-    entity_name: str = Field(
-        ..., description='Suggested entity name after merge', examples=['墨香居']
+    id: str = Field(..., description="Run ID", examples=["gcr_abcd1234efgh5678"])
+    collection_id: str = Field(..., description="Collection ID", examples=["col123"])
+    status: Literal["PENDING", "RUNNING", "COMPLETED", "FAILED"] = Field(
+        ..., description="Run lifecycle status", examples=["COMPLETED"]
     )
-    entity_type: str = Field(
-        ..., description='Suggested entity type after merge', examples=['ORGANIZATION']
+    stats: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Best-effort execution stats for the latest run",
+    )
+    error_message: Optional[str] = Field(
+        None,
+        description="Failure message if the run failed",
+        examples=["LLM adjudication timed out"],
+    )
+    created: Optional[datetime] = Field(None, description="Creation timestamp", examples=["2026-04-23T00:00:00Z"])
+    updated: Optional[datetime] = Field(None, description="Last update timestamp", examples=["2026-04-23T00:02:00Z"])
+    started: Optional[datetime] = Field(None, description="Run start timestamp", examples=["2026-04-23T00:00:05Z"])
+    finished: Optional[datetime] = Field(
+        None,
+        description="Run finish timestamp",
+        examples=["2026-04-23T00:02:00Z"],
     )
 
 
-class MergeSuggestionItem(BaseModel):
+class GraphMergeSuggestionEntity(BaseModel):
     """
-    Individual merge suggestion item
+    Snapshot of an entity at suggestion-generation time.
     """
 
-    id: str = Field(..., description='Suggestion ID', examples=['msug123'])
-    collection_id: str = Field(..., description='Collection ID', examples=['col123'])
-    suggestion_batch_id: str = Field(
-        ..., description='Suggestion batch ID', examples=['batch456']
+    entity_id: str = Field(..., description="Entity ID", examples=["e_moxiangju"])
+    entity_name: str = Field(..., description="Entity name", examples=["墨香居"])
+    entity_type: str = Field(..., description="Entity type", examples=["ORGANIZATION"])
+    description: str = Field(..., description="Entity description", examples=["这条老巷子里唯一的旧书店"])
+    source_chunk_count: conint(ge=0) = Field(
+        ...,
+        description="Number of source chunks referenced by this entity",
+        examples=[3],
+    )
+
+
+class GraphMergeSuggestionItem(BaseModel):
+    """
+    Persisted merge suggestion produced by graph curation.
+    """
+
+    id: str = Field(..., description="Suggestion ID", examples=["gcs_abcd1234efgh5678"])
+    run_id: str = Field(..., description="Run that produced this suggestion", examples=["gcr_abcd1234efgh5678"])
+    collection_id: str = Field(..., description="Collection ID", examples=["col123"])
+    status: Literal["PENDING", "ACCEPTED", "REJECTED", "EXPIRED", "SUPERSEDED"] = Field(
+        ..., description="Suggestion lifecycle status", examples=["PENDING"]
     )
     entity_ids: list[str] = Field(
         ...,
-        description='Entity IDs suggested for merging',
-        examples=[['墨香居', '书店', '旧书店']],
+        description="Entity IDs in the candidate merge set",
+        examples=[["e_moxiangju", "e_old_bookstore"]],
+    )
+    entities: list[GraphMergeSuggestionEntity] = Field(
+        ...,
+        description="Entity snapshots captured when the suggestion was generated",
+    )
+    target_entity_id: str = Field(
+        ...,
+        description="Recommended surviving entity ID if the suggestion is accepted",
+        examples=["e_moxiangju"],
     )
     confidence_score: confloat(ge=0.0, le=1.0) = Field(
         ...,
-        description='LLM confidence score for this merge suggestion',
-        examples=[0.85],
+        description="Aggregated confidence score for this suggestion",
+        examples=[0.91],
     )
-    merge_reason: str = Field(
+    reason: str = Field(
         ...,
-        description='LLM-generated reason for suggesting this merge',
-        examples=[
-            "两个实体都描述同一个书店，'墨香居'是具体名称，'旧书店'是通用描述，应该合并为同一实体"
-        ],
+        description="Human-readable explanation from pairwise LLM adjudication",
+        examples=["两个实体都在描述同一家旧书店，名称和上下文高度重合。"],
     )
-    suggested_target_entity: MergeSuggestionTargetEntity
-    status: Literal['PENDING', 'ACCEPTED', 'REJECTED', 'EXPIRED'] = Field(
-        ..., description='Status of the suggestion', examples=['PENDING']
+    evidence: Optional[dict[str, Any]] = Field(
+        None,
+        description="Structured supporting evidence used to generate the suggestion",
     )
-    created: datetime = Field(
-        ..., description='Creation timestamp', examples=['2025-01-07T10:00:00Z']
+    resolution_note: Optional[str] = Field(
+        None,
+        description="System note explaining why the suggestion left pending state",
+        examples=["superseded_by:gcs_other"],
     )
+    created: Optional[datetime] = Field(None, description="Creation timestamp", examples=["2026-04-23T00:02:00Z"])
+    updated: Optional[datetime] = Field(None, description="Last update timestamp", examples=["2026-04-23T00:05:00Z"])
     operated_at: Optional[datetime] = Field(
-        None, description='User operation timestamp', examples=['2025-01-08T15:30:00Z']
+        None,
+        description="User-operation timestamp for accepted/rejected suggestions",
+        examples=["2026-04-23T00:05:00Z"],
+    )
+
+
+class MergeSuggestionsRunResponse(BaseModel):
+    """
+    Response returned when starting a graph-curation run.
+    """
+
+    run: GraphCurationRunSummary
+    started: bool = Field(..., description="Whether a new run was actually scheduled", examples=[True])
+    message: str = Field(
+        ...,
+        description="Human-readable status message",
+        examples=["Graph curation run started"],
     )
 
 
 class MergeSuggestionsResponse(BaseModel):
     """
-    Response containing node merge suggestions
+    Latest persisted graph-curation run and its suggestions.
     """
 
-    suggestions: list[MergeSuggestionItem] = Field(
+    run: Optional[GraphCurationRunSummary] = Field(
+        None,
+        description="Latest graph-curation run for this collection, if any",
+    )
+    suggestions: list[GraphMergeSuggestionItem] = Field(
         ...,
-        description='List of merge suggestions ordered by confidence score (highest first)',
-    )
-    total_analyzed_nodes: conint(ge=0) = Field(
-        ..., description='Total number of nodes analyzed', examples=[156]
-    )
-    processing_time_seconds: confloat(ge=0.0) = Field(
-        ..., description='Processing time in seconds', examples=[12.5]
-    )
-    from_cache: bool = Field(
-        ..., description='Whether suggestions were loaded from cache', examples=[False]
-    )
-    generated_at: datetime = Field(
-        ..., description='Generation timestamp', examples=['2025-01-07T10:00:00Z']
-    )
-    total_suggestions: conint(ge=0) = Field(
-        ..., description='Total number of suggestions', examples=[5]
-    )
-    pending_count: conint(ge=0) = Field(
-        ..., description='Number of pending suggestions', examples=[3]
-    )
-    accepted_count: conint(ge=0) = Field(
-        ..., description='Number of accepted suggestions', examples=[1]
-    )
-    rejected_count: conint(ge=0) = Field(
-        ..., description='Number of rejected suggestions', examples=[1]
+        description="Suggestions from the latest run, ordered by confidence score",
     )
 
 
@@ -1253,17 +1117,30 @@ class SuggestionActionRequest(BaseModel):
     """
 
     model_config = ConfigDict(
-        extra='forbid',
+        extra="forbid",
     )
-    action: Literal['accept', 'reject'] = Field(
+    action: Literal["accept", "reject"] = Field(
         ...,
         description="Action to take on the suggestion (case-insensitive, e.g., 'Accept', 'REJECT', 'accept')",
-        examples=['accept'],
+        examples=["accept"],
     )
-    target_entity_data: Optional[TargetEntityDataRequest] = Field(
-        None,
-        description="Optional override for target entity data (only used when action is 'accept')",
+
+
+class SuggestionActionMergeResult(BaseModel):
+    """
+    Merge result returned when accepting a graph-curation suggestion.
+    """
+
+    target_entity_id: str = Field(..., description="Surviving entity ID after merge", examples=["e_moxiangju"])
+    merged_source_ids: list[str] = Field(..., description="Merged-away entity IDs", examples=[["e_old_bookstore"]])
+    description: str = Field(..., description="Merged description of the surviving entity")
+    source_chunk_ids: list[str] = Field(
+        ...,
+        description="Source chunk IDs preserved on the surviving entity",
+        examples=[["chunk_1", "chunk_8"]],
     )
+    edges_redirected: conint(ge=0) = Field(..., description="Number of redirected edges", examples=[5])
+    edges_collapsed: conint(ge=0) = Field(..., description="Number of duplicate edges collapsed", examples=[2])
 
 
 class SuggestionActionResponse(BaseModel):
@@ -1271,23 +1148,24 @@ class SuggestionActionResponse(BaseModel):
     Response containing suggestion action results
     """
 
-    status: Literal['success', 'error'] = Field(
-        ..., description='Status of the action operation', examples=['success']
-    )
+    status: Literal["success", "error"] = Field(..., description="Status of the action operation", examples=["success"])
     message: str = Field(
         ...,
-        description='Detailed message about the action operation',
-        examples=['Suggestion msug123 has been accepted and merge completed'],
+        description="Detailed message about the action operation",
+        examples=["Suggestion msug123 has been accepted and merge completed"],
     )
-    suggestion_id: str = Field(
-        ..., description='The suggestion ID that was processed', examples=['msug123']
-    )
-    action: Literal['accept', 'reject'] = Field(
+    suggestion_id: str = Field(..., description="The suggestion ID that was processed", examples=["msug123"])
+    action: Literal["accept", "reject"] = Field(
         ...,
-        description='The action that was performed (normalized to lowercase)',
-        examples=['accept'],
+        description="The action that was performed (normalized to lowercase)",
+        examples=["accept"],
     )
-    merge_result: Optional[NodeMergeResponse] = Field(
+    suggestion_status: Literal["ACCEPTED", "REJECTED"] = Field(
+        ...,
+        description="Suggestion status after action processing",
+        examples=["ACCEPTED"],
+    )
+    merge_result: Optional[SuggestionActionMergeResult] = Field(
         None,
         description="Merge operation result (only present when action is 'accept')",
     )
@@ -1298,10 +1176,8 @@ class SharingStatusResponse(BaseModel):
     Simple sharing status response
     """
 
-    is_published: bool = Field(..., description='Whether published to marketplace')
-    published_at: Optional[datetime] = Field(
-        None, description='Publication time, null when not published'
-    )
+    is_published: bool = Field(..., description="Whether published to marketplace")
+    published_at: Optional[datetime] = Field(None, description="Publication time, null when not published")
 
 
 class SharedCollectionConfig(BaseModel):
@@ -1309,15 +1185,11 @@ class SharedCollectionConfig(BaseModel):
     Configuration settings for shared collection features
     """
 
-    enable_vector: bool = Field(..., description='Whether vector search is enabled')
-    enable_fulltext: bool = Field(..., description='Whether fulltext search is enabled')
-    enable_knowledge_graph: bool = Field(
-        ..., description='Whether knowledge graph is enabled'
-    )
-    enable_summary: bool = Field(
-        ..., description='Whether summary generation is enabled'
-    )
-    enable_vision: bool = Field(..., description='Whether vision processing is enabled')
+    enable_vector: bool = Field(..., description="Whether vector search is enabled")
+    enable_fulltext: bool = Field(..., description="Whether fulltext search is enabled")
+    enable_knowledge_graph: bool = Field(..., description="Whether knowledge graph is enabled")
+    enable_summary: bool = Field(..., description="Whether summary generation is enabled")
+    enable_vision: bool = Field(..., description="Whether vision processing is enabled")
 
 
 class SharedCollection(BaseModel):
@@ -1325,22 +1197,18 @@ class SharedCollection(BaseModel):
     Shared Collection information for marketplace users
     """
 
-    id: str = Field(..., description='Collection ID')
-    title: str = Field(..., description='Collection title')
-    description: Optional[str] = Field(None, description='Collection description')
-    owner_user_id: str = Field(..., description='Original owner user ID')
-    owner_username: Optional[str] = Field(None, description='Original owner username')
+    id: str = Field(..., description="Collection ID")
+    title: str = Field(..., description="Collection title")
+    description: Optional[str] = Field(None, description="Collection description")
+    owner_user_id: str = Field(..., description="Original owner user ID")
+    owner_username: Optional[str] = Field(None, description="Original owner username")
     subscription_id: Optional[str] = Field(
         None,
-        description='Subscription record ID (has value if subscribed, null if not subscribed)',
+        description="Subscription record ID (has value if subscribed, null if not subscribed)",
     )
-    gmt_subscribed: Optional[datetime] = Field(
-        None, description='Subscription time (only has value when subscribed)'
-    )
-    subscription_count: int = Field(..., description='Total number of subscriptions')
-    config: SharedCollectionConfig = Field(
-        ..., description='Collection configuration settings'
-    )
+    gmt_subscribed: Optional[datetime] = Field(None, description="Subscription time (only has value when subscribed)")
+    subscription_count: int = Field(..., description="Total number of subscriptions")
+    config: SharedCollectionConfig = Field(..., description="Collection configuration settings")
 
 
 class SharedCollectionList(BaseModel):
@@ -1348,10 +1216,10 @@ class SharedCollectionList(BaseModel):
     Shared Collection list response
     """
 
-    items: list[SharedCollection] = Field(..., description='List of shared Collections')
-    total: int = Field(..., description='Total count (for pagination)')
-    page: int = Field(..., description='Current page number')
-    page_size: int = Field(..., description='Page size')
+    items: list[SharedCollection] = Field(..., description="List of shared Collections")
+    total: int = Field(..., description="Total count (for pagination)")
+    page: int = Field(..., description="Current page number")
+    page_size: int = Field(..., description="Page size")
 
 
 class ApiKey(BaseModel):
@@ -1381,15 +1249,15 @@ class ApiKeyUpdate(BaseModel):
 
 
 class TagFilterCondition(BaseModel):
-    operation: Literal['AND', 'OR'] = Field(
+    operation: Literal["AND", "OR"] = Field(
         ...,
-        description='Logical operation for tags in this condition',
-        examples=['AND'],
+        description="Logical operation for tags in this condition",
+        examples=["AND"],
     )
     tags: list[str] = Field(
         ...,
-        description='List of tags for this condition',
-        examples=[['free', 'recommend']],
+        description="List of tags for this condition",
+        examples=[["free", "recommend"]],
     )
 
 
@@ -1403,8 +1271,8 @@ class TagFilterRequest(BaseModel):
         description='List of tag filter conditions (OR relationship between conditions). If not provided or empty, returns models with "recommend" tag by default.',
         examples=[
             [
-                {'operation': 'AND', 'tags': ['free', 'recommend']},
-                {'operation': 'OR', 'tags': ['openai', 'gpt']},
+                {"operation": "AND", "tags": ["free", "recommend"]},
+                {"operation": "OR", "tags": ["openai", "gpt"]},
             ]
         ],
     )
@@ -1430,46 +1298,42 @@ class ModelConfigList(BaseModel):
 
 class DefaultModelConfig(BaseModel):
     scenario: Literal[
-        'default_for_collection_completion',
-        'default_for_agent_completion',
-        'default_for_embedding',
-        'default_for_rerank',
-        'default_for_background_task',
+        "default_for_collection_completion",
+        "default_for_agent_completion",
+        "default_for_embedding",
+        "default_for_rerank",
+        "default_for_background_task",
     ] = Field(
         ...,
-        description='The scenario for which this default model is configured',
-        examples=['default_for_embedding'],
+        description="The scenario for which this default model is configured",
+        examples=["default_for_embedding"],
     )
     custom_llm_provider: Optional[str] = None
-    provider_name: Optional[str] = Field(
-        None, description='The name of the model provider', examples=['openai']
-    )
-    model: Optional[str] = Field(
-        None, description='The name of the model', examples=['text-embedding-3-small']
-    )
+    provider_name: Optional[str] = Field(None, description="The name of the model provider", examples=["openai"])
+    model: Optional[str] = Field(None, description="The name of the model", examples=["text-embedding-3-small"])
 
 
 class DefaultModelsResponse(BaseModel):
     items: list[DefaultModelConfig] = Field(
-        ..., description='List of default model configurations for different scenarios'
+        ..., description="List of default model configurations for different scenarios"
     )
 
 
 class DefaultModelsUpdateRequest(BaseModel):
     defaults: list[DefaultModelConfig] = Field(
         ...,
-        description='List of default model configurations to update',
+        description="List of default model configurations to update",
         examples=[
             [
                 {
-                    'scenario': 'default_for_embedding',
-                    'provider_name': 'openai',
-                    'model': 'text-embedding-3-small',
+                    "scenario": "default_for_embedding",
+                    "provider_name": "openai",
+                    "model": "text-embedding-3-small",
                 },
                 {
-                    'scenario': 'default_for_collection_completion',
-                    'provider_name': 'openai',
-                    'model': 'gpt-4o-mini',
+                    "scenario": "default_for_collection_completion",
+                    "provider_name": "openai",
+                    "model": "gpt-4o-mini",
                 },
             ]
         ],
@@ -1477,143 +1341,89 @@ class DefaultModelsUpdateRequest(BaseModel):
 
 
 class LlmProvider(BaseModel):
-    name: str = Field(
-        ..., description='Unique provider name identifier', examples=['openai']
-    )
+    name: str = Field(..., description="Unique provider name identifier", examples=["openai"])
     user_id: str = Field(
         ...,
         description='User ID of the provider owner, "public" for system providers',
-        examples=['public'],
+        examples=["public"],
     )
-    label: str = Field(
-        ..., description='Human-readable provider display name', examples=['OpenAI']
-    )
+    label: str = Field(..., description="Human-readable provider display name", examples=["OpenAI"])
     completion_dialect: Optional[str] = Field(
-        'openai',
-        description='API dialect for completion/chat APIs',
-        examples=['openai'],
+        "openai",
+        description="API dialect for completion/chat APIs",
+        examples=["openai"],
     )
     embedding_dialect: Optional[str] = Field(
-        'openai', description='API dialect for embedding APIs', examples=['openai']
+        "openai", description="API dialect for embedding APIs", examples=["openai"]
     )
-    rerank_dialect: Optional[str] = Field(
-        'jina_ai', description='API dialect for rerank APIs', examples=['jina_ai']
-    )
-    allow_custom_base_url: Optional[bool] = Field(
-        False, description='Whether custom base URLs are allowed'
-    )
+    rerank_dialect: Optional[str] = Field("jina_ai", description="API dialect for rerank APIs", examples=["jina_ai"])
+    allow_custom_base_url: Optional[bool] = Field(False, description="Whether custom base URLs are allowed")
     base_url: str = Field(
         ...,
-        description='Default API base URL for this provider',
-        examples=['https://api.openai.com/v1'],
+        description="Default API base URL for this provider",
+        examples=["https://api.openai.com/v1"],
     )
-    extra: Optional[str] = Field(
-        None, description='Additional configuration data in JSON format'
-    )
-    api_key: Optional[str] = Field(
-        None, description='API key for this provider (if configured by user)'
-    )
-    created: Optional[datetime] = Field(None, description='Creation timestamp')
-    updated: Optional[datetime] = Field(None, description='Last update timestamp')
+    extra: Optional[str] = Field(None, description="Additional configuration data in JSON format")
+    api_key: Optional[str] = Field(None, description="API key for this provider (if configured by user)")
+    created: Optional[datetime] = Field(None, description="Creation timestamp")
+    updated: Optional[datetime] = Field(None, description="Last update timestamp")
 
 
 class LlmProviderModel(BaseModel):
-    provider_name: str = Field(
-        ..., description='Reference to LLMProvider.name', examples=['openai']
+    provider_name: str = Field(..., description="Reference to LLMProvider.name", examples=["openai"])
+    api: Literal["completion", "embedding", "rerank"] = Field(
+        ..., description="API type for this model", examples=["completion"]
     )
-    api: Literal['completion', 'embedding', 'rerank'] = Field(
-        ..., description='API type for this model', examples=['completion']
-    )
-    model: str = Field(
-        ..., description='Model name/identifier', examples=['gpt-4o-mini']
-    )
-    custom_llm_provider: str = Field(
-        ..., description='Custom LLM provider implementation', examples=['openai']
-    )
-    context_window: Optional[int] = Field(
-        None, description='Context window size (total tokens)', examples=[128000]
-    )
-    max_input_tokens: Optional[int] = Field(
-        None, description='Maximum input tokens', examples=[120000]
-    )
-    max_output_tokens: Optional[int] = Field(
-        None, description='Maximum output tokens', examples=[8000]
-    )
+    model: str = Field(..., description="Model name/identifier", examples=["gpt-4o-mini"])
+    custom_llm_provider: str = Field(..., description="Custom LLM provider implementation", examples=["openai"])
+    context_window: Optional[int] = Field(None, description="Context window size (total tokens)", examples=[128000])
+    max_input_tokens: Optional[int] = Field(None, description="Maximum input tokens", examples=[120000])
+    max_output_tokens: Optional[int] = Field(None, description="Maximum output tokens", examples=[8000])
     tags: Optional[list[str]] = Field(
         [],
-        description='Tags for model categorization',
-        examples=[['free', 'recommend']],
+        description="Tags for model categorization",
+        examples=[["free", "recommend"]],
     )
-    created: Optional[datetime] = Field(None, description='Creation timestamp')
-    updated: Optional[datetime] = Field(None, description='Last update timestamp')
+    created: Optional[datetime] = Field(None, description="Creation timestamp")
+    updated: Optional[datetime] = Field(None, description="Last update timestamp")
 
 
 class LlmConfigurationResponse(BaseModel):
-    providers: list[LlmProvider] = Field(..., description='List of LLM providers')
-    models: list[LlmProviderModel] = Field(
-        ..., description='List of LLM provider models'
-    )
+    providers: list[LlmProvider] = Field(..., description="List of LLM providers")
+    models: list[LlmProviderModel] = Field(..., description="List of LLM provider models")
 
 
 class LlmProviderCreateWithApiKey(BaseModel):
     name: Optional[str] = Field(
         None,
-        description='Unique provider name identifier (auto-generated if not provided)',
+        description="Unique provider name identifier (auto-generated if not provided)",
     )
-    label: str = Field(..., description='Human-readable provider display name')
-    completion_dialect: Optional[str] = Field(
-        'openai', description='API dialect for completion/chat APIs'
-    )
-    embedding_dialect: Optional[str] = Field(
-        'openai', description='API dialect for embedding APIs'
-    )
-    rerank_dialect: Optional[str] = Field(
-        'jina_ai', description='API dialect for rerank APIs'
-    )
-    allow_custom_base_url: Optional[bool] = Field(
-        False, description='Whether custom base URLs are allowed'
-    )
-    base_url: str = Field(..., description='Default API base URL for this provider')
-    extra: Optional[str] = Field(
-        None, description='Additional configuration data in JSON format'
-    )
-    api_key: Optional[str] = Field(
-        None, description='Optional API key for this provider'
-    )
-    status: Optional[Literal['enable', 'disable']] = Field(
+    label: str = Field(..., description="Human-readable provider display name")
+    completion_dialect: Optional[str] = Field("openai", description="API dialect for completion/chat APIs")
+    embedding_dialect: Optional[str] = Field("openai", description="API dialect for embedding APIs")
+    rerank_dialect: Optional[str] = Field("jina_ai", description="API dialect for rerank APIs")
+    allow_custom_base_url: Optional[bool] = Field(False, description="Whether custom base URLs are allowed")
+    base_url: str = Field(..., description="Default API base URL for this provider")
+    extra: Optional[str] = Field(None, description="Additional configuration data in JSON format")
+    api_key: Optional[str] = Field(None, description="Optional API key for this provider")
+    status: Optional[Literal["enable", "disable"]] = Field(
         None,
-        description='Provider status - enable to create/update API key, disable to remove API key',
+        description="Provider status - enable to create/update API key, disable to remove API key",
     )
 
 
 class LlmProviderUpdateWithApiKey(BaseModel):
-    label: Optional[str] = Field(
-        None, description='Human-readable provider display name'
-    )
-    completion_dialect: Optional[str] = Field(
-        None, description='API dialect for completion/chat APIs'
-    )
-    embedding_dialect: Optional[str] = Field(
-        None, description='API dialect for embedding APIs'
-    )
-    rerank_dialect: Optional[str] = Field(
-        None, description='API dialect for rerank APIs'
-    )
-    allow_custom_base_url: Optional[bool] = Field(
-        None, description='Whether custom base URLs are allowed'
-    )
-    base_url: Optional[str] = Field(
-        None, description='Default API base URL for this provider'
-    )
-    extra: Optional[str] = Field(
-        None, description='Additional configuration data in JSON format'
-    )
-    api_key: Optional[str] = Field(
-        None, description='Optional API key for this provider'
-    )
-    status: Optional[Literal['enable', 'disable']] = Field(
+    label: Optional[str] = Field(None, description="Human-readable provider display name")
+    completion_dialect: Optional[str] = Field(None, description="API dialect for completion/chat APIs")
+    embedding_dialect: Optional[str] = Field(None, description="API dialect for embedding APIs")
+    rerank_dialect: Optional[str] = Field(None, description="API dialect for rerank APIs")
+    allow_custom_base_url: Optional[bool] = Field(None, description="Whether custom base URLs are allowed")
+    base_url: Optional[str] = Field(None, description="Default API base URL for this provider")
+    extra: Optional[str] = Field(None, description="Additional configuration data in JSON format")
+    api_key: Optional[str] = Field(None, description="Optional API key for this provider")
+    status: Optional[Literal["enable", "disable"]] = Field(
         None,
-        description='Provider status - enable to create/update API key, disable to remove API key',
+        description="Provider status - enable to create/update API key, disable to remove API key",
     )
 
 
@@ -1623,40 +1433,22 @@ class LlmProviderModelList(BaseModel):
 
 
 class LlmProviderModelCreate(BaseModel):
-    provider_name: str = Field(..., description='Reference to LLMProvider.name')
-    api: Literal['completion', 'embedding', 'rerank'] = Field(
-        ..., description='API type for this model'
-    )
-    model: str = Field(..., description='Model name/identifier')
-    custom_llm_provider: str = Field(
-        ..., description='Custom LLM provider implementation'
-    )
-    context_window: Optional[int] = Field(
-        None, description='Context window size (total tokens)', examples=[128000]
-    )
-    max_input_tokens: Optional[int] = Field(
-        None, description='Maximum input tokens', examples=[120000]
-    )
-    max_output_tokens: Optional[int] = Field(
-        None, description='Maximum output tokens', examples=[8000]
-    )
-    tags: Optional[list[str]] = Field([], description='Tags for model categorization')
+    provider_name: str = Field(..., description="Reference to LLMProvider.name")
+    api: Literal["completion", "embedding", "rerank"] = Field(..., description="API type for this model")
+    model: str = Field(..., description="Model name/identifier")
+    custom_llm_provider: str = Field(..., description="Custom LLM provider implementation")
+    context_window: Optional[int] = Field(None, description="Context window size (total tokens)", examples=[128000])
+    max_input_tokens: Optional[int] = Field(None, description="Maximum input tokens", examples=[120000])
+    max_output_tokens: Optional[int] = Field(None, description="Maximum output tokens", examples=[8000])
+    tags: Optional[list[str]] = Field([], description="Tags for model categorization")
 
 
 class LlmProviderModelUpdate(BaseModel):
-    custom_llm_provider: Optional[str] = Field(
-        None, description='Custom LLM provider implementation'
-    )
-    context_window: Optional[int] = Field(
-        None, description='Context window size (total tokens)', examples=[128000]
-    )
-    max_input_tokens: Optional[int] = Field(
-        None, description='Maximum input tokens', examples=[120000]
-    )
-    max_output_tokens: Optional[int] = Field(
-        None, description='Maximum output tokens', examples=[8000]
-    )
-    tags: Optional[list[str]] = Field(None, description='Tags for model categorization')
+    custom_llm_provider: Optional[str] = Field(None, description="Custom LLM provider implementation")
+    context_window: Optional[int] = Field(None, description="Context window size (total tokens)", examples=[128000])
+    max_input_tokens: Optional[int] = Field(None, description="Maximum input tokens", examples=[120000])
+    max_output_tokens: Optional[int] = Field(None, description="Maximum output tokens", examples=[8000])
+    tags: Optional[list[str]] = Field(None, description="Tags for model categorization")
 
 
 class EmbeddingRequest(BaseModel):
@@ -1666,13 +1458,13 @@ class EmbeddingRequest(BaseModel):
 
     provider: str = Field(
         ...,
-        description='LLM provider name (e.g., openai, anthropic)',
-        examples=['openai'],
+        description="LLM provider name (e.g., openai, anthropic)",
+        examples=["openai"],
     )
     model: str = Field(
         ...,
-        description='Model name for embedding generation',
-        examples=['text-embedding-3-small'],
+        description="Model name for embedding generation",
+        examples=["text-embedding-3-small"],
     )
     input: Union[str, list[str]]
 
@@ -1682,17 +1474,15 @@ class EmbeddingData(BaseModel):
     Individual embedding result
     """
 
-    object: str = Field(
-        ..., description='Object type identifier', examples=['embedding']
-    )
+    object: str = Field(..., description="Object type identifier", examples=["embedding"])
     embedding: list[float] = Field(
         ...,
-        description='The embedding vector as a list of floats',
+        description="The embedding vector as a list of floats",
         examples=[[0.0023064255, -0.009327292, 0.015797421, 0.0012345678]],
     )
     index: int = Field(
         ...,
-        description='Index of the input text corresponding to this embedding',
+        description="Index of the input text corresponding to this embedding",
         examples=[0],
     )
 
@@ -1702,12 +1492,10 @@ class EmbeddingUsage(BaseModel):
     Token usage information for the embedding request
     """
 
-    prompt_tokens: int = Field(
-        ..., description='Number of tokens in the input text(s)', examples=[16]
-    )
+    prompt_tokens: int = Field(..., description="Number of tokens in the input text(s)", examples=[16])
     total_tokens: int = Field(
         ...,
-        description='Total number of tokens used (same as prompt_tokens for embeddings)',
+        description="Total number of tokens used (same as prompt_tokens for embeddings)",
         examples=[16],
     )
 
@@ -1717,12 +1505,12 @@ class EmbeddingResponse(BaseModel):
     Response containing generated embeddings in OpenAI-compatible format
     """
 
-    object: str = Field(..., description='Object type identifier', examples=['list'])
-    data: list[EmbeddingData] = Field(..., description='List of embedding results')
+    object: str = Field(..., description="Object type identifier", examples=["list"])
+    data: list[EmbeddingData] = Field(..., description="List of embedding results")
     model: str = Field(
         ...,
-        description='Model used for embedding generation',
-        examples=['text-embedding-3-small'],
+        description="Model used for embedding generation",
+        examples=["text-embedding-3-small"],
     )
     usage: EmbeddingUsage
 
@@ -1730,13 +1518,13 @@ class EmbeddingResponse(BaseModel):
 class Document1(BaseModel):
     text: str = Field(
         ...,
-        description='Document text content',
-        examples=['Paris is the capital of France.'],
+        description="Document text content",
+        examples=["Paris is the capital of France."],
     )
     metadata: Optional[dict[str, Any]] = Field(
         None,
-        description='Optional document metadata',
-        examples=[{'id': 'doc_123', 'source': 'wikipedia'}],
+        description="Optional document metadata",
+        examples=[{"id": "doc_123", "source": "wikipedia"}],
     )
 
 
@@ -1747,24 +1535,22 @@ class RerankRequest(BaseModel):
 
     provider: str = Field(
         ...,
-        description='LLM provider name (e.g., cohere, jina_ai)',
-        examples=['cohere'],
+        description="LLM provider name (e.g., cohere, jina_ai)",
+        examples=["cohere"],
     )
-    model: str = Field(
-        ..., description='Model name for reranking', examples=['rerank-english-v3.0']
-    )
+    model: str = Field(..., description="Model name for reranking", examples=["rerank-english-v3.0"])
     query: str = Field(
         ...,
-        description='Search query to rank documents against',
-        examples=['What is the capital of France?'],
+        description="Search query to rank documents against",
+        examples=["What is the capital of France?"],
     )
     documents: Union[list[str], list[Document1]]
     top_k: Optional[conint(ge=1, le=1000)] = Field(
-        10, description='Maximum number of top-ranked documents to return', examples=[3]
+        10, description="Maximum number of top-ranked documents to return", examples=[3]
     )
     return_documents: Optional[bool] = Field(
         True,
-        description='Whether to return document content in response',
+        description="Whether to return document content in response",
         examples=[True],
     )
 
@@ -1776,13 +1562,13 @@ class Document2(BaseModel):
 
     text: str = Field(
         ...,
-        description='Document text content',
-        examples=['Paris is the capital of France.'],
+        description="Document text content",
+        examples=["Paris is the capital of France."],
     )
     metadata: Optional[dict[str, Any]] = Field(
         None,
-        description='Document metadata if provided in the request',
-        examples=[{'id': 'doc_123', 'source': 'wikipedia'}],
+        description="Document metadata if provided in the request",
+        examples=[{"id": "doc_123", "source": "wikipedia"}],
     )
 
 
@@ -1793,17 +1579,17 @@ class RerankDocument(BaseModel):
 
     index: int = Field(
         ...,
-        description='Original index of the document in the input array',
+        description="Original index of the document in the input array",
         examples=[0],
     )
     relevance_score: confloat(ge=0.0, le=1.0) = Field(
         ...,
-        description='Relevance score between 0 and 1 (higher is more relevant)',
+        description="Relevance score between 0 and 1 (higher is more relevant)",
         examples=[0.95],
     )
     document: Optional[Document2] = Field(
         None,
-        description='Document content and metadata (only present if return_documents=true)',
+        description="Document content and metadata (only present if return_documents=true)",
     )
 
 
@@ -1814,7 +1600,7 @@ class RerankUsage(BaseModel):
 
     total_tokens: int = Field(
         ...,
-        description='Total number of tokens processed (query + all documents)',
+        description="Total number of tokens processed (query + all documents)",
         examples=[156],
     )
 
@@ -1824,14 +1610,12 @@ class RerankResponse(BaseModel):
     Response containing reranked documents in industry-standard format
     """
 
-    object: str = Field(..., description='Object type identifier', examples=['list'])
+    object: str = Field(..., description="Object type identifier", examples=["list"])
     data: list[RerankDocument] = Field(
         ...,
-        description='List of reranked documents ordered by relevance (highest first)',
+        description="List of reranked documents ordered by relevance (highest first)",
     )
-    model: str = Field(
-        ..., description='Model used for reranking', examples=['rerank-english-v3.0']
-    )
+    model: str = Field(..., description="Model used for reranking", examples=["rerank-english-v3.0"])
     usage: RerankUsage
 
 
@@ -1851,21 +1635,19 @@ class Logto(BaseModel):
 
 
 class Auth(BaseModel):
-    type: Optional[Literal['none', 'auth0', 'authing', 'logto', 'cookie']] = None
+    type: Optional[Literal["none", "auth0", "authing", "logto", "cookie"]] = None
     auth0: Optional[Auth0] = None
     authing: Optional[Authing] = None
     logto: Optional[Logto] = None
 
 
 class Config(BaseModel):
-    admin_user_exists: Optional[bool] = Field(
-        None, description='Whether the admin user exists'
-    )
+    admin_user_exists: Optional[bool] = Field(None, description="Whether the admin user exists")
     auth: Optional[Auth] = None
     login_methods: Optional[list[str]] = Field(
         None,
-        description='Available login methods',
-        examples=[['local', 'google', 'github']],
+        description="Available login methods",
+        examples=[["local", "google", "github"]],
     )
 
 
@@ -1874,54 +1656,42 @@ class AuditLog(BaseModel):
     Audit log entry
     """
 
-    id: Optional[str] = Field(None, description='Audit log ID')
-    user_id: Optional[str] = Field(None, description='User ID who performed the action')
-    username: Optional[str] = Field(None, description='Username for display')
+    id: Optional[str] = Field(None, description="Audit log ID")
+    user_id: Optional[str] = Field(None, description="User ID who performed the action")
+    username: Optional[str] = Field(None, description="Username for display")
     resource_type: Optional[
         Literal[
-            'collection',
-            'document',
-            'bot',
-            'chat',
-            'message',
-            'api_key',
-            'llm',
-            'llm_provider',
-            'llm_provider_model',
-            'model_service_provider',
-            'user',
-            'flow',
-            'search',
-            'index',
+            "collection",
+            "document",
+            "bot",
+            "chat",
+            "message",
+            "api_key",
+            "llm",
+            "llm_provider",
+            "llm_provider_model",
+            "model_service_provider",
+            "user",
+            "flow",
+            "search",
+            "index",
         ]
-    ] = Field(None, description='Type of resource')
-    resource_id: Optional[str] = Field(
-        None, description='ID of the resource (extracted at query time)'
-    )
-    api_name: Optional[str] = Field(None, description='API operation name')
-    http_method: Optional[str] = Field(
-        None, description='HTTP method (POST, PUT, DELETE)'
-    )
-    path: Optional[str] = Field(None, description='API path')
-    status_code: Optional[int] = Field(None, description='HTTP status code')
-    start_time: Optional[int] = Field(
-        None, description='Request start time (milliseconds since epoch)'
-    )
-    end_time: Optional[int] = Field(
-        None, description='Request end time (milliseconds since epoch)'
-    )
-    duration_ms: Optional[int] = Field(
-        None, description='Request duration in milliseconds (calculated)'
-    )
-    request_data: Optional[str] = Field(None, description='Request data (JSON string)')
-    response_data: Optional[str] = Field(
-        None, description='Response data (JSON string)'
-    )
-    error_message: Optional[str] = Field(None, description='Error message if failed')
-    ip_address: Optional[str] = Field(None, description='Client IP address')
-    user_agent: Optional[str] = Field(None, description='User agent string')
-    request_id: Optional[str] = Field(None, description='Request ID for tracking')
-    created: Optional[datetime] = Field(None, description='Created timestamp')
+    ] = Field(None, description="Type of resource")
+    resource_id: Optional[str] = Field(None, description="ID of the resource (extracted at query time)")
+    api_name: Optional[str] = Field(None, description="API operation name")
+    http_method: Optional[str] = Field(None, description="HTTP method (POST, PUT, DELETE)")
+    path: Optional[str] = Field(None, description="API path")
+    status_code: Optional[int] = Field(None, description="HTTP status code")
+    start_time: Optional[int] = Field(None, description="Request start time (milliseconds since epoch)")
+    end_time: Optional[int] = Field(None, description="Request end time (milliseconds since epoch)")
+    duration_ms: Optional[int] = Field(None, description="Request duration in milliseconds (calculated)")
+    request_data: Optional[str] = Field(None, description="Request data (JSON string)")
+    response_data: Optional[str] = Field(None, description="Response data (JSON string)")
+    error_message: Optional[str] = Field(None, description="Error message if failed")
+    ip_address: Optional[str] = Field(None, description="Client IP address")
+    user_agent: Optional[str] = Field(None, description="User agent string")
+    request_id: Optional[str] = Field(None, description="Request ID for tracking")
+    created: Optional[datetime] = Field(None, description="Created timestamp")
 
 
 class AuditLogList(PaginatedResponse):
@@ -1929,38 +1699,24 @@ class AuditLogList(PaginatedResponse):
     List of audit logs with pagination
     """
 
-    items: Optional[list[AuditLog]] = Field(None, description='Audit log entries')
+    items: Optional[list[AuditLog]] = Field(None, description="Audit log entries")
 
 
 class InvitationCreate(BaseModel):
-    username: Optional[str] = Field(None, description='The username of the user')
-    email: Optional[str] = Field(None, description='The email of the user')
-    role: Optional[Literal['admin', 'rw', 'ro']] = Field(
-        None, description='The role of the user (admin, rw, ro)'
-    )
+    username: Optional[str] = Field(None, description="The username of the user")
+    email: Optional[str] = Field(None, description="The email of the user")
+    role: Optional[Literal["admin", "rw", "ro"]] = Field(None, description="The role of the user (admin, rw, ro)")
 
 
 class Invitation(BaseModel):
-    email: Optional[str] = Field(None, description='The email of the user')
-    token: Optional[str] = Field(None, description='The token of the invitation')
-    created_by: Optional[str] = Field(
-        None, description='The ID of the user who created the invitation'
-    )
-    created_at: Optional[str] = Field(
-        None, description='The date and time the invitation was created'
-    )
-    is_valid: Optional[bool] = Field(
-        None, description='Whether the invitation is valid'
-    )
-    used_at: Optional[str] = Field(
-        None, description='The date and time the invitation was used'
-    )
-    role: Optional[Literal['admin', 'rw', 'ro']] = Field(
-        None, description='The role of the user (admin, rw, ro)'
-    )
-    expires_at: Optional[str] = Field(
-        None, description='The date and time the invitation will expire'
-    )
+    email: Optional[str] = Field(None, description="The email of the user")
+    token: Optional[str] = Field(None, description="The token of the invitation")
+    created_by: Optional[str] = Field(None, description="The ID of the user who created the invitation")
+    created_at: Optional[str] = Field(None, description="The date and time the invitation was created")
+    is_valid: Optional[bool] = Field(None, description="Whether the invitation is valid")
+    used_at: Optional[str] = Field(None, description="The date and time the invitation was used")
+    role: Optional[Literal["admin", "rw", "ro"]] = Field(None, description="The role of the user (admin, rw, ro)")
+    expires_at: Optional[str] = Field(None, description="The date and time the invitation will expire")
 
 
 class InvitationList(BaseModel):
@@ -1977,30 +1733,28 @@ class Register(BaseModel):
     The email of the user
     """
 
-    token: Optional[str] = Field(None, description='The invitation token')
-    email: Optional[str] = Field(None, description='The email of the user')
-    username: Optional[str] = Field(None, description='The username of the user')
-    password: Optional[str] = Field(None, description='The password of the user')
+    token: Optional[str] = Field(None, description="The invitation token")
+    email: Optional[str] = Field(None, description="The email of the user")
+    username: Optional[str] = Field(None, description="The username of the user")
+    password: Optional[str] = Field(None, description="The password of the user")
 
 
 class User(BaseModel):
-    id: Optional[str] = Field(None, description='The ID of the user')
-    username: Optional[str] = Field(None, description='The username of the user')
-    email: Optional[str] = Field(None, description='The email of the user')
-    role: Optional[str] = Field(None, description='The role of the user')
-    is_active: Optional[bool] = Field(None, description='Whether the user is active')
-    date_joined: Optional[str] = Field(
-        None, description='The date and time the user joined the system'
-    )
+    id: Optional[str] = Field(None, description="The ID of the user")
+    username: Optional[str] = Field(None, description="The username of the user")
+    email: Optional[str] = Field(None, description="The email of the user")
+    role: Optional[str] = Field(None, description="The role of the user")
+    is_active: Optional[bool] = Field(None, description="Whether the user is active")
+    date_joined: Optional[str] = Field(None, description="The date and time the user joined the system")
     registration_source: Optional[str] = Field(
         None,
-        description='The registration source of the user (local, google, github, etc.)',
+        description="The registration source of the user (local, google, github, etc.)",
     )
 
 
 class Login(BaseModel):
-    username: Optional[str] = Field(None, description='The username of the user')
-    password: Optional[str] = Field(None, description='The password of the user')
+    username: Optional[str] = Field(None, description="The username of the user")
+    password: Optional[str] = Field(None, description="The password of the user")
 
 
 class UserList(BaseModel):
@@ -2013,13 +1767,9 @@ class UserList(BaseModel):
 
 
 class ChangePassword(BaseModel):
-    username: Optional[str] = Field(None, description='The username of the user')
-    old_password: Optional[str] = Field(
-        None, description='The old password of the user'
-    )
-    new_password: Optional[str] = Field(
-        None, description='The new password of the user'
-    )
+    username: Optional[str] = Field(None, description="The username of the user")
+    old_password: Optional[str] = Field(None, description="The old password of the user")
+    new_password: Optional[str] = Field(None, description="The new password of the user")
 
 
 class QuotaInfo(BaseModel):
@@ -2027,12 +1777,10 @@ class QuotaInfo(BaseModel):
     Quota information for a specific quota type
     """
 
-    quota_type: str = Field(
-        ..., description='Type of quota', examples=['max_collection_count']
-    )
-    quota_limit: int = Field(..., description='Maximum allowed usage', examples=[10])
-    current_usage: int = Field(..., description='Current usage count', examples=[3])
-    remaining: int = Field(..., description='Remaining quota available', examples=[7])
+    quota_type: str = Field(..., description="Type of quota", examples=["max_collection_count"])
+    quota_limit: int = Field(..., description="Maximum allowed usage", examples=[10])
+    current_usage: int = Field(..., description="Current usage count", examples=[3])
+    remaining: int = Field(..., description="Remaining quota available", examples=[7])
 
 
 class UserQuotaInfo(BaseModel):
@@ -2040,13 +1788,11 @@ class UserQuotaInfo(BaseModel):
     Complete quota information for a user
     """
 
-    user_id: str = Field(..., description='User ID', examples=['user123'])
-    username: Optional[str] = Field(None, description='Username', examples=['john_doe'])
-    email: Optional[str] = Field(
-        None, description='User email', examples=['john@example.com']
-    )
-    role: str = Field(..., description='User role', examples=['rw'])
-    quotas: list[QuotaInfo] = Field(..., description='List of quota information')
+    user_id: str = Field(..., description="User ID", examples=["user123"])
+    username: Optional[str] = Field(None, description="Username", examples=["john_doe"])
+    email: Optional[str] = Field(None, description="User email", examples=["john@example.com"])
+    role: str = Field(..., description="User role", examples=["rw"])
+    quotas: list[QuotaInfo] = Field(..., description="List of quota information")
 
 
 class UserQuotaList(BaseModel):
@@ -2054,9 +1800,7 @@ class UserQuotaList(BaseModel):
     List of user quota information (admin view)
     """
 
-    items: list[UserQuotaInfo] = Field(
-        ..., description='List of user quota information'
-    )
+    items: list[UserQuotaInfo] = Field(..., description="List of user quota information")
 
 
 class QuotaUpdateRequest(BaseModel):
@@ -2064,28 +1808,22 @@ class QuotaUpdateRequest(BaseModel):
     Request to update user quotas (supports both single and batch updates)
     """
 
-    max_collection_count: Optional[conint(ge=0)] = Field(
-        None, description='New limit for collection count'
-    )
-    max_document_count: Optional[conint(ge=0)] = Field(
-        None, description='New limit for document count'
-    )
+    max_collection_count: Optional[conint(ge=0)] = Field(None, description="New limit for collection count")
+    max_document_count: Optional[conint(ge=0)] = Field(None, description="New limit for document count")
     max_document_count_per_collection: Optional[conint(ge=0)] = Field(
-        None, description='New limit for documents per collection'
+        None, description="New limit for documents per collection"
     )
-    max_bot_count: Optional[conint(ge=0)] = Field(
-        None, description='New limit for bot count'
-    )
+    max_bot_count: Optional[conint(ge=0)] = Field(None, description="New limit for bot count")
 
 
 class UpdatedQuota(BaseModel):
     quota_type: str = Field(
         ...,
-        description='Type of quota that was updated',
-        examples=['max_collection_count'],
+        description="Type of quota that was updated",
+        examples=["max_collection_count"],
     )
-    old_limit: int = Field(..., description='Previous quota limit', examples=[10])
-    new_limit: int = Field(..., description='New quota limit', examples=[20])
+    old_limit: int = Field(..., description="Previous quota limit", examples=[10])
+    new_limit: int = Field(..., description="New quota limit", examples=[20])
 
 
 class QuotaUpdateResponse(BaseModel):
@@ -2093,18 +1831,10 @@ class QuotaUpdateResponse(BaseModel):
     Response after updating user quotas (supports both single and batch updates)
     """
 
-    success: bool = Field(
-        ..., description='Whether the update was successful', examples=[True]
-    )
-    message: str = Field(
-        ..., description='Status message', examples=['Quotas updated successfully']
-    )
-    user_id: str = Field(
-        ..., description='User ID that was updated', examples=['user123']
-    )
-    updated_quotas: list[UpdatedQuota] = Field(
-        ..., description='List of updated quotas'
-    )
+    success: bool = Field(..., description="Whether the update was successful", examples=[True])
+    message: str = Field(..., description="Status message", examples=["Quotas updated successfully"])
+    user_id: str = Field(..., description="User ID that was updated", examples=["user123"])
+    updated_quotas: list[UpdatedQuota] = Field(..., description="List of updated quotas")
 
 
 class SystemDefaultQuotas(BaseModel):
@@ -2112,18 +1842,12 @@ class SystemDefaultQuotas(BaseModel):
     System default quota configuration
     """
 
-    max_collection_count: conint(ge=0) = Field(
-        ..., description='Default maximum collection count', examples=[10]
-    )
-    max_document_count: conint(ge=0) = Field(
-        ..., description='Default maximum document count', examples=[1000]
-    )
+    max_collection_count: conint(ge=0) = Field(..., description="Default maximum collection count", examples=[10])
+    max_document_count: conint(ge=0) = Field(..., description="Default maximum document count", examples=[1000])
     max_document_count_per_collection: conint(ge=0) = Field(
-        ..., description='Default maximum documents per collection', examples=[100]
+        ..., description="Default maximum documents per collection", examples=[100]
     )
-    max_bot_count: conint(ge=0) = Field(
-        ..., description='Default maximum bot count', examples=[5]
-    )
+    max_bot_count: conint(ge=0) = Field(..., description="Default maximum bot count", examples=[5])
 
 
 class SystemDefaultQuotasResponse(BaseModel):
@@ -2147,13 +1871,11 @@ class SystemDefaultQuotasUpdateResponse(BaseModel):
     Response after updating system default quotas
     """
 
-    success: bool = Field(
-        ..., description='Whether the update was successful', examples=[True]
-    )
+    success: bool = Field(..., description="Whether the update was successful", examples=[True])
     message: str = Field(
         ...,
-        description='Status message',
-        examples=['System default quotas updated successfully'],
+        description="Status message",
+        examples=["System default quotas updated successfully"],
     )
     quotas: SystemDefaultQuotas
 
@@ -2165,22 +1887,16 @@ class WebSearchRequest(BaseModel):
 
     query: Optional[str] = Field(
         None,
-        description='Search query for web search. Optional when using source-only site browsing.',
-        examples=['ApeRAG 2025年最新发展'],
+        description="Search query for web search. Optional when using source-only site browsing.",
+        examples=["ApeRAG 2025年最新发展"],
     )
-    max_results: Optional[int] = Field(
-        5, description='Maximum number of results to return', examples=[5]
-    )
-    timeout: Optional[int] = Field(
-        30, description='Request timeout in seconds', examples=[30]
-    )
-    locale: Optional[str] = Field(
-        'en-US', description='Browser locale', examples=['en-US']
-    )
+    max_results: Optional[int] = Field(5, description="Maximum number of results to return", examples=[5])
+    timeout: Optional[int] = Field(30, description="Request timeout in seconds", examples=[30])
+    locale: Optional[str] = Field("en-US", description="Browser locale", examples=["en-US"])
     source: Optional[str] = Field(
         None,
         description="Domain or URL for site-specific filtering. When provided with query, limits search results to this domain (e.g., 'site:vercel.com query').",
-        examples=['vercel.com'],
+        examples=["vercel.com"],
     )
 
 
@@ -2189,22 +1905,16 @@ class WebSearchResultItem(BaseModel):
     Individual web search result
     """
 
-    rank: int = Field(..., description='Result rank', examples=[1])
-    title: str = Field(
-        ..., description='Page title', examples=['ApeRAG 2025年技术路线图']
-    )
+    rank: int = Field(..., description="Result rank", examples=[1])
+    title: str = Field(..., description="Page title", examples=["ApeRAG 2025年技术路线图"])
     url: str = Field(
         ...,
-        description='Page URL',
-        examples=['https://example.com/aperag-2025-roadmap'],
+        description="Page URL",
+        examples=["https://example.com/aperag-2025-roadmap"],
     )
-    snippet: str = Field(
-        ..., description='Page snippet', examples=['ApeRAG在2025年将重点发展...']
-    )
-    domain: str = Field(..., description='Domain name', examples=['example.com'])
-    timestamp: Optional[datetime] = Field(
-        None, description='Result timestamp', examples=['2025-01-01T00:00:00Z']
-    )
+    snippet: str = Field(..., description="Page snippet", examples=["ApeRAG在2025年将重点发展..."])
+    domain: str = Field(..., description="Domain name", examples=["example.com"])
+    timestamp: Optional[datetime] = Field(None, description="Result timestamp", examples=["2025-01-01T00:00:00Z"])
 
 
 class WebSearchMeta(BaseModel):
@@ -2212,30 +1922,30 @@ class WebSearchMeta(BaseModel):
     Lightweight execution diagnostics for web search.
     """
 
-    search_status: Literal['ok', 'empty', 'unavailable', 'disabled'] = Field(
+    search_status: Literal["ok", "empty", "unavailable", "disabled"] = Field(
         ...,
-        description='Overall search outcome: successful, empty, unavailable, or disabled.',
-        examples=['ok'],
+        description="Overall search outcome: successful, empty, unavailable, or disabled.",
+        examples=["ok"],
     )
     provider_used: list[str] = Field(
         default_factory=list,
-        description='Search providers attempted during this request.',
-        examples=[['jina', 'duckduckgo']],
+        description="Search providers attempted during this request.",
+        examples=[["jina", "duckduckgo"]],
     )
     backend_used: list[str] = Field(
         default_factory=list,
-        description='Concrete backend path used for this request when known.',
-        examples=[['duckduckgo:auto']],
+        description="Concrete backend path used for this request when known.",
+        examples=[["duckduckgo:auto"]],
     )
     fallback_used: bool = Field(
         False,
-        description='Whether the request had to fall back from its preferred path.',
+        description="Whether the request had to fall back from its preferred path.",
         examples=[True],
     )
     error_code: Optional[str] = Field(
         None,
-        description='Machine-readable error code when the search path is unavailable.',
-        examples=['search_provider_unavailable'],
+        description="Machine-readable error code when the search path is unavailable.",
+        examples=["search_provider_unavailable"],
     )
 
 
@@ -2244,17 +1954,13 @@ class WebSearchResponse(BaseModel):
     Web search response
     """
 
-    query: str = Field(..., description='Original search query')
-    results: list[WebSearchResultItem] = Field(
-        ..., description='List of search results'
-    )
-    total_results: Optional[int] = Field(
-        None, description='Total number of results found'
-    )
-    search_time: Optional[float] = Field(None, description='Search time in seconds')
+    query: str = Field(..., description="Original search query")
+    results: list[WebSearchResultItem] = Field(..., description="List of search results")
+    total_results: Optional[int] = Field(None, description="Total number of results found")
+    search_time: Optional[float] = Field(None, description="Search time in seconds")
     meta: Optional[WebSearchMeta] = Field(
         None,
-        description='Lightweight execution diagnostics for status, provider selection, and fallback behavior.',
+        description="Lightweight execution diagnostics for status, provider selection, and fallback behavior.",
     )
 
 
@@ -2265,18 +1971,12 @@ class WebReadRequest(BaseModel):
 
     url_list: list[str] = Field(
         ...,
-        description='List of URLs to read (for single URL, use array with one element)',
-        examples=[['https://example.com/article']],
+        description="List of URLs to read (for single URL, use array with one element)",
+        examples=[["https://example.com/article"]],
     )
-    timeout: Optional[int] = Field(
-        30, description='Request timeout in seconds', examples=[30]
-    )
-    locale: Optional[str] = Field(
-        'en-US', description='Browser locale', examples=['en-US']
-    )
-    max_concurrent: Optional[int] = Field(
-        3, description='Maximum concurrent requests for multiple URLs', examples=[3]
-    )
+    timeout: Optional[int] = Field(30, description="Request timeout in seconds", examples=[30])
+    locale: Optional[str] = Field("en-US", description="Browser locale", examples=["en-US"])
+    max_concurrent: Optional[int] = Field(3, description="Maximum concurrent requests for multiple URLs", examples=[3])
 
 
 class WebReadResultItem(BaseModel):
@@ -2284,19 +1984,15 @@ class WebReadResultItem(BaseModel):
     Individual web content reading result
     """
 
-    url: str = Field(..., description='Requested URL')
-    status: Literal['success', 'error'] = Field(..., description='Processing status')
-    title: Optional[str] = Field(None, description='Page title')
-    content: Optional[str] = Field(
-        None, description='Extracted content in Markdown format'
-    )
-    extracted_at: Optional[datetime] = Field(
-        None, description='Content extraction timestamp'
-    )
-    word_count: Optional[int] = Field(None, description='Word count of content')
-    token_count: Optional[int] = Field(None, description='Estimated token count')
-    error: Optional[str] = Field(None, description='Error message if failed')
-    error_code: Optional[str] = Field(None, description='Error code if failed')
+    url: str = Field(..., description="Requested URL")
+    status: Literal["success", "error"] = Field(..., description="Processing status")
+    title: Optional[str] = Field(None, description="Page title")
+    content: Optional[str] = Field(None, description="Extracted content in Markdown format")
+    extracted_at: Optional[datetime] = Field(None, description="Content extraction timestamp")
+    word_count: Optional[int] = Field(None, description="Word count of content")
+    token_count: Optional[int] = Field(None, description="Estimated token count")
+    error: Optional[str] = Field(None, description="Error message if failed")
+    error_code: Optional[str] = Field(None, description="Error code if failed")
 
 
 class WebReadResponse(BaseModel):
@@ -2304,13 +2000,11 @@ class WebReadResponse(BaseModel):
     Web content reading response
     """
 
-    results: list[WebReadResultItem] = Field(..., description='List of reading results')
-    total_urls: int = Field(..., description='Total number of URLs processed')
-    successful: int = Field(..., description='Number of successful extractions')
-    failed: int = Field(..., description='Number of failed extractions')
-    processing_time: Optional[float] = Field(
-        None, description='Total processing time in seconds'
-    )
+    results: list[WebReadResultItem] = Field(..., description="List of reading results")
+    total_urls: int = Field(..., description="Total number of URLs processed")
+    successful: int = Field(..., description="Number of successful extractions")
+    failed: int = Field(..., description="Number of failed extractions")
+    processing_time: Optional[float] = Field(None, description="Total processing time in seconds")
 
 
 class QuestionSet(BaseModel):
@@ -2330,10 +2024,8 @@ class QuestionSetList(BaseModel):
     page_size: Optional[int] = None
 
 
-class QuestionType(RootModel[Literal['FACTUAL', 'INFERENTIAL', 'USER_DEFINED']]):
-    root: Literal['FACTUAL', 'INFERENTIAL', 'USER_DEFINED'] = Field(
-        ..., description='Question type enumeration'
-    )
+class QuestionType(RootModel[Literal["FACTUAL", "INFERENTIAL", "USER_DEFINED"]]):
+    root: Literal["FACTUAL", "INFERENTIAL", "USER_DEFINED"] = Field(..., description="Question type enumeration")
 
 
 class Question(BaseModel):
@@ -2351,7 +2043,7 @@ class QuestionSetCreate(BaseModel):
     description: Optional[str] = None
     collection_id: Optional[str] = None
     questions: Optional[list[Question]] = Field(
-        None, description='A list of questions. Maximum 1000 questions are allowed.'
+        None, description="A list of questions. Maximum 1000 questions are allowed."
     )
 
 
@@ -2400,11 +2092,9 @@ class QuestionUpdate(BaseModel):
     question_type: Optional[QuestionType] = None
 
 
-class EvaluationStatus(
-    RootModel[Literal['PENDING', 'RUNNING', 'PAUSED', 'COMPLETED', 'FAILED']]
-):
-    root: Literal['PENDING', 'RUNNING', 'PAUSED', 'COMPLETED', 'FAILED'] = Field(
-        ..., description='Evaluation task lifecycle status'
+class EvaluationStatus(RootModel[Literal["PENDING", "RUNNING", "PAUSED", "COMPLETED", "FAILED"]]):
+    root: Literal["PENDING", "RUNNING", "PAUSED", "COMPLETED", "FAILED"] = Field(
+        ..., description="Evaluation task lifecycle status"
     )
 
 
@@ -2440,11 +2130,9 @@ class EvaluationCreate(BaseModel):
     judge_llm_config: LLMConfig
 
 
-class EvaluationItemStatus(
-    RootModel[Literal['PENDING', 'RUNNING', 'COMPLETED', 'FAILED']]
-):
-    root: Literal['PENDING', 'RUNNING', 'COMPLETED', 'FAILED'] = Field(
-        ..., description='Evaluation item lifecycle status'
+class EvaluationItemStatus(RootModel[Literal["PENDING", "RUNNING", "COMPLETED", "FAILED"]]):
+    root: Literal["PENDING", "RUNNING", "COMPLETED", "FAILED"] = Field(
+        ..., description="Evaluation item lifecycle status"
     )
 
 
@@ -2494,17 +2182,13 @@ class ChatSuccessResponse(BaseModel):
 
 
 class AgentErrorResponse(BaseModel):
-    type: Optional[Literal['error']] = Field(
-        None, description="The type of the response, must be 'error'."
-    )
+    type: Optional[Literal["error"]] = Field(None, description="The type of the response, must be 'error'.")
     id: Optional[str] = None
-    data: Optional[str] = Field(None, description='Error message')
+    data: Optional[str] = Field(None, description="Error message")
     timestamp: Optional[int] = None
 
 
-class EvaluationChatWithAgentResponse(
-    RootModel[Union[ChatSuccessResponse, AgentErrorResponse]]
-):
+class EvaluationChatWithAgentResponse(RootModel[Union[ChatSuccessResponse, AgentErrorResponse]]):
     root: Union[ChatSuccessResponse, AgentErrorResponse]
 
 
@@ -2513,66 +2197,56 @@ class AgentMessage(BaseModel):
     Message format for agent-type bots with additional capabilities
     """
 
-    query: str = Field(
-        ..., description='User query', examples=['Tell me about ApeRAG features']
-    )
+    query: str = Field(..., description="User query", examples=["Tell me about ApeRAG features"])
     collections: list[Collection] = Field(
         ...,
-        description='List of collection objects to search in',
+        description="List of collection objects to search in",
         examples=[
             [
-                {'id': 'col_123', 'title': 'Example Collection'},
-                {'id': 'col_456', 'title': 'Another Collection'},
+                {"id": "col_123", "title": "Example Collection"},
+                {"id": "col_456", "title": "Another Collection"},
             ]
         ],
     )
     completion: Optional[ModelSpec] = Field(
         None,
-        description='Model specification for completion including provider and model details',
+        description="Model specification for completion including provider and model details",
     )
-    web_search_enabled: Optional[bool] = Field(
-        False, description='Whether to enable web search', examples=[True]
-    )
+    web_search_enabled: Optional[bool] = Field(False, description="Whether to enable web search", examples=[True])
     language: Optional[
         Literal[
-            'en-US',
-            'zh-CN',
-            'zh-TW',
-            'ja-JP',
-            'ko-KR',
-            'fr-FR',
-            'de-DE',
-            'es-ES',
-            'it-IT',
-            'pt-BR',
-            'ru-RU',
+            "en-US",
+            "zh-CN",
+            "zh-TW",
+            "ja-JP",
+            "ko-KR",
+            "fr-FR",
+            "de-DE",
+            "es-ES",
+            "it-IT",
+            "pt-BR",
+            "ru-RU",
         ]
-    ] = Field(
-        'en-US', description='Language preference for the response', examples=['en-US']
-    )
+    ] = Field("en-US", description="Language preference for the response", examples=["en-US"])
     files: Optional[list[File]] = None
 
 
 class ExportTaskResponse(BaseModel):
-    export_task_id: str = Field(..., description='Unique ID of the export task')
-    status: Literal['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED', 'EXPIRED'] = Field(
-        ..., description='Current status of the export task'
+    export_task_id: str = Field(..., description="Unique ID of the export task")
+    status: Literal["PENDING", "PROCESSING", "COMPLETED", "FAILED", "EXPIRED"] = Field(
+        ..., description="Current status of the export task"
     )
-    progress: Optional[conint(ge=0, le=100)] = Field(
-        None, description='Progress percentage (0-100)'
-    )
-    message: Optional[str] = Field(None, description='Human-readable status message')
-    error_message: Optional[str] = Field(
-        None, description='Error detail when status is FAILED'
-    )
+    progress: Optional[conint(ge=0, le=100)] = Field(None, description="Progress percentage (0-100)")
+    message: Optional[str] = Field(None, description="Human-readable status message")
+    error_message: Optional[str] = Field(None, description="Error detail when status is FAILED")
     download_url: Optional[str] = Field(
         None,
-        description='URL to download the ZIP file (only set when status is COMPLETED)',
+        description="URL to download the ZIP file (only set when status is COMPLETED)",
     )
-    file_size: Optional[int] = Field(None, description='Size of the ZIP file in bytes')
+    file_size: Optional[int] = Field(None, description="Size of the ZIP file in bytes")
     gmt_created: Optional[datetime] = None
     gmt_completed: Optional[datetime] = None
     gmt_expires: Optional[datetime] = Field(
         None,
-        description='Time when the export file will be automatically deleted (7 days after creation)',
+        description="Time when the export file will be automatically deleted (7 days after creation)",
     )

--- a/aperag/service/graph_service.py
+++ b/aperag/service/graph_service.py
@@ -26,19 +26,9 @@ Three endpoints route through here:
 * ``merge_entities`` — consolidate multiple entities into one, with an
   LLM-generated summary description.
 
-Two LightRAG-era curation features are not re-exposed in v2:
-
-* ``generate_merge_suggestions`` / ``handle_suggestion_action`` — the
-  "discover clusters to merge" pipeline. It was a 500-line LLM
-  orchestration over LightRAG internals; its v2 replacement (if the
-  product needs one) should be a dedicated module, not part of
-  graphindex.
-* ``export_for_kg_eval`` — snapshot export for the KG eval harness.
-  Can be rebuilt as a thin SQL dump whenever we want it back.
-
-The REST routes for those two actions still exist under
-``aperag/views/graph.py`` and return HTTP 410 until the frontend is
-updated. See ``docs/zh-CN/design/graphindex_rewrite.md``.
+Merge-suggestion discovery itself now lives in the dedicated
+``aperag.graph_curation`` module. This service remains the thin wrapper
+around the one merge truth path.
 """
 
 from __future__ import annotations
@@ -164,6 +154,16 @@ class GraphService:
             target_entity_id=target_entity_id,
             source_entity_ids=source_entity_ids,
         )
+        try:
+            from aperag.graph_curation import graph_curation_service
+
+            await graph_curation_service.expire_pending_for_entities(
+                collection_id=collection_id,
+                entity_ids=[target_entity_id, *source_entity_ids],
+                reason="manual_merge",
+            )
+        except Exception:
+            logger.exception("Failed to expire stale graph-curation suggestions after manual merge")
         return {
             "target_entity_id": result.target_entity_id,
             "merged_source_ids": list(result.merged_source_ids),

--- a/aperag/tasks/collection.py
+++ b/aperag/tasks/collection.py
@@ -179,15 +179,19 @@ class CollectionTask:
         if not enable_knowledge_graph:
             return deletion_stats
 
+        from aperag.graph_curation.integration import run_purge_graph_curation_collection_sync
         from aperag.graphindex.integration import run_drop_collection_sync
 
         try:
             run_drop_collection_sync(str(collection.id))
+            run_purge_graph_curation_collection_sync(str(collection.id))
             deletion_stats["graphindex_dropped"] = True
+            deletion_stats["graph_curation_purged"] = True
             logger.info(f"graphindex: dropped all rows for collection {collection.id}")
         except Exception as e:
             deletion_stats["graphindex_dropped"] = False
             deletion_stats["graphindex_error"] = str(e)
+            deletion_stats["graph_curation_purged"] = False
             logger.warning(f"graphindex: failed to drop collection {collection.id}: {e}")
 
         return deletion_stats

--- a/aperag/tasks/document.py
+++ b/aperag/tasks/document.py
@@ -56,7 +56,6 @@ class DocumentIndexTask:
 
     def _upsert_graph_index(self, document_id: str, collection, parsed_data: ParsedDocumentData) -> dict:
         """Index a document into the graphindex v2 graph store."""
-        from aperag.graph_curation.integration import run_expire_graph_curation_collection_sync
         from aperag.graphindex.integration import run_index_document_sync
 
         res = run_index_document_sync(
@@ -65,7 +64,7 @@ class DocumentIndexTask:
             content=parsed_data.content,
             file_path=parsed_data.file_path,
         )
-        run_expire_graph_curation_collection_sync(str(collection.id), "document_reindex")
+        self._expire_graph_curation_collection_best_effort(str(collection.id), "document_reindex")
         return {
             "status": "success",
             "doc_id": res.doc_id,
@@ -76,11 +75,24 @@ class DocumentIndexTask:
 
     def _delete_graph_index(self, document_id: str, collection) -> None:
         """Delete a document's graph rows from graphindex v2."""
-        from aperag.graph_curation.integration import run_expire_graph_curation_collection_sync
         from aperag.graphindex.integration import run_delete_document_sync
 
         run_delete_document_sync(collection=collection, doc_id=document_id)
-        run_expire_graph_curation_collection_sync(str(collection.id), "document_delete")
+        self._expire_graph_curation_collection_best_effort(str(collection.id), "document_delete")
+
+    def _expire_graph_curation_collection_best_effort(self, collection_id: str, reason: str) -> None:
+        """Expire stale graph-curation suggestions without blocking graph truth writes."""
+        from aperag.graph_curation.integration import run_expire_graph_curation_collection_sync
+
+        try:
+            run_expire_graph_curation_collection_sync(collection_id, reason)
+        except Exception:
+            logger.warning(
+                "Graph curation invalidation failed for collection %s (%s); graph truth write already succeeded",
+                collection_id,
+                reason,
+                exc_info=True,
+            )
 
     def create_index(self, document_id: str, index_type: str, parsed_data: ParsedDocumentData) -> IndexTaskResult:
         """

--- a/aperag/tasks/document.py
+++ b/aperag/tasks/document.py
@@ -56,6 +56,7 @@ class DocumentIndexTask:
 
     def _upsert_graph_index(self, document_id: str, collection, parsed_data: ParsedDocumentData) -> dict:
         """Index a document into the graphindex v2 graph store."""
+        from aperag.graph_curation.integration import run_expire_graph_curation_collection_sync
         from aperag.graphindex.integration import run_index_document_sync
 
         res = run_index_document_sync(
@@ -64,6 +65,7 @@ class DocumentIndexTask:
             content=parsed_data.content,
             file_path=parsed_data.file_path,
         )
+        run_expire_graph_curation_collection_sync(str(collection.id), "document_reindex")
         return {
             "status": "success",
             "doc_id": res.doc_id,
@@ -74,9 +76,11 @@ class DocumentIndexTask:
 
     def _delete_graph_index(self, document_id: str, collection) -> None:
         """Delete a document's graph rows from graphindex v2."""
+        from aperag.graph_curation.integration import run_expire_graph_curation_collection_sync
         from aperag.graphindex.integration import run_delete_document_sync
 
         run_delete_document_sync(collection=collection, doc_id=document_id)
+        run_expire_graph_curation_collection_sync(str(collection.id), "document_delete")
 
     def create_index(self, document_id: str, index_type: str, parsed_data: ParsedDocumentData) -> IndexTaskResult:
         """

--- a/aperag/views/graph.py
+++ b/aperag/views/graph.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Graph-index HTTP routes.
+"""Graph HTTP routes.
 
-Merge endpoint is live against graphindex v2 + its LLM-based description
-summarization. Merge-suggestion discovery and the KG-eval export are not
-re-implemented in v2 and remain HTTP 410 until a dedicated curation
-module is introduced (see ``docs/zh-CN/design/graphindex_rewrite.md``).
+``graphindex`` owns graph truth and merge primitives.
+``graph_curation`` owns merge-suggestion discovery and review state.
+
+The only removed route left in this file is the historical KG-eval
+export endpoint.
 """
 
 from __future__ import annotations
@@ -28,6 +29,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Request
 
 from aperag.db.models import User
 from aperag.exceptions import CollectionNotFoundException
+from aperag.graph_curation import graph_curation_service
+from aperag.schema import view_models
 from aperag.service.graph_service import graph_service
 from aperag.views.auth import required_user
 
@@ -35,16 +38,15 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-_REMOVAL_DETAIL = (
-    "This graph-curation endpoint was removed together with the "
-    "LightRAG-based graph index in graphindex v2. See "
-    "docs/zh-CN/design/graphindex_rewrite.md."
+_KG_EVAL_REMOVAL_DETAIL = (
+    "This legacy KG-eval export endpoint was removed together with the "
+    "LightRAG-era graph workflow. See docs/zh-CN/design/graphindex_rewrite.md."
 )
 
 
 def _gone() -> HTTPException:
-    """Uniform 410 response for every removed curation route."""
-    return HTTPException(status_code=410, detail=_REMOVAL_DETAIL)
+    """Uniform 410 response for the removed KG-eval route."""
+    return HTTPException(status_code=410, detail=_KG_EVAL_REMOVAL_DETAIL)
 
 
 @router.post("/collections/{collection_id}/graphs/nodes/merge", tags=["graph"])
@@ -93,13 +95,59 @@ async def merge_nodes_view(
     "/collections/{collection_id}/graphs/merge-suggestions/{suggestion_id}/action",
     tags=["graph"],
 )
-async def handle_suggestion_action_view(request: Request, collection_id: str, suggestion_id: str) -> dict:
-    raise _gone()
+async def handle_suggestion_action_view(
+    request: Request,
+    collection_id: str,
+    suggestion_id: str,
+    payload: view_models.SuggestionActionRequest = Body(...),
+    user: User = Depends(required_user),
+) -> dict:
+    try:
+        return await graph_curation_service.handle_action(
+            str(user.id),
+            collection_id,
+            suggestion_id,
+            action=payload.action,
+        )
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=exc.args[0] if exc.args else "Suggestion not found",
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 @router.post("/collections/{collection_id}/graphs/merge-suggestions", tags=["graph"])
-async def merge_suggestions_view(request: Request, collection_id: str) -> dict:
-    raise _gone()
+async def merge_suggestions_view(
+    request: Request,
+    collection_id: str,
+    payload: view_models.MergeSuggestionsRequest = Body(default_factory=view_models.MergeSuggestionsRequest),
+    user: User = Depends(required_user),
+) -> dict:
+    del payload
+    try:
+        return await graph_curation_service.start_run(str(user.id), collection_id)
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get("/collections/{collection_id}/graphs/merge-suggestions", tags=["graph"])
+async def get_merge_suggestions_view(
+    request: Request,
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> dict:
+    try:
+        return await graph_curation_service.get_latest(str(user.id), collection_id)
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 @router.get("/collections/{collection_id}/graphs/export/kg-eval", tags=["graph"])

--- a/config/celery_tasks.py
+++ b/config/celery_tasks.py
@@ -1389,6 +1389,19 @@ def cleanup_expired_documents_task():
     return result
 
 
+@app.task(bind=True)
+def generate_graph_curation_run_task(self, run_id: str, collection_id: str) -> Any:
+    """Execute one graph-curation scan run."""
+    try:
+        from aperag.graph_curation.integration import run_graph_curation_run_sync
+
+        run_graph_curation_run_sync(run_id, collection_id)
+        return {"success": True, "run_id": run_id, "collection_id": collection_id}
+    except Exception as e:
+        logger.error(f"Graph curation run failed for {collection_id}/{run_id}: {e}", exc_info=True)
+        raise
+
+
 # ========== Evaluation Tasks ==========
 
 

--- a/docs/zh-CN/design/graph_curation.md
+++ b/docs/zh-CN/design/graph_curation.md
@@ -1,0 +1,373 @@
+# Graph Curation Module
+
+## 1. Decision
+
+### 1.1 Do we need merge-suggestion discovery?
+
+Yes.
+
+Current graphindex v2 already keeps the **manual merge primitive**
+(`GraphIndexService.merge_entities()`), which means the product still
+accepts graph curation as a valid user workflow. What v2 removed was the
+**discovery layer** that finds likely duplicate entities and turns them
+into reviewable suggestions.
+
+From first principles:
+
+- If graph data is only a transient retrieval scaffold, manual merge
+  should not exist at all.
+- If manual merge exists, users need a reliable way to find candidates.
+- Therefore, merge-suggestion discovery is a missing product layer, not
+  an optional old feature to half-revive.
+
+### 1.2 What should be rebuilt?
+
+Rebuild a **new** `graph_curation` module.
+
+Do **not** revive the LightRAG-era pipeline shape:
+
+- not `top-degree -> LLM grouping -> action`
+- not stateless request-time analysis
+- not prompt/state/review logic mixed into `graphindex`
+
+## 2. Goals And Non-Goals
+
+### 2.1 Goals
+
+- Provide a simple async workflow that scans one collection and produces
+  persisted merge suggestions.
+- Keep graph truth on a single write path: accept uses the existing
+  `GraphIndexService.merge_entities()` only.
+- Stay viable across PostgreSQL / Neo4j / Nebula graph backends.
+- Keep API and interaction surface minimal.
+- Keep performance and token cost bounded by deterministic blocking and
+  explicit caps.
+
+### 2.2 Non-Goals
+
+- No full-graph LLM clustering.
+- No synchronous analysis in index/query/UI hot paths.
+- No second merge implementation in the curation module.
+- No backend-specific fuzzy search logic that only works on one graph DB.
+
+## 3. Module Boundary
+
+### 3.1 `graphindex`
+
+Responsibilities remain:
+
+- graph truth writes
+- graph query context
+- label/subgraph reads
+- structural merge primitive
+- graph shadow vector maintenance
+
+It may expose **read-only helper methods** for curation, but it does not
+own:
+
+- suggestion state
+- review workflow
+- run orchestration
+- invalidation policy
+
+### 3.2 `graph_curation`
+
+New module responsibilities:
+
+- create async analysis runs
+- enumerate candidate entities from graph truth
+- build cheap candidate pairs
+- ask LLM for pairwise adjudication
+- aggregate positive pairs into suggestions
+- persist suggestion state
+- accept/reject/expire/supersede suggestions
+
+## 4. First-Principles Architecture
+
+```mermaid
+flowchart TD
+  A[POST merge-suggestions] --> B[create run row]
+  B --> C[Celery task]
+  C --> D[list entities from graphindex]
+  D --> E[deterministic candidate generation]
+  E --> F[pairwise LLM adjudication]
+  F --> G[connected-component aggregation]
+  G --> H[persist suggestions]
+  H --> I[GET merge-suggestions]
+  I --> J[human accept/reject]
+  J --> K[GraphIndexService.merge_entities]
+  K --> L[supersede overlapping suggestions]
+```
+
+Key design choice:
+
+- candidate discovery uses **graph truth + graph shadow vectors**
+- not graph-backend-native fuzzy/text search
+
+This keeps the module portable across PG / Neo4j / Nebula.
+
+## 5. Data Model
+
+### 5.1 `graph_curation_runs`
+
+One row per async scan.
+
+Fields:
+
+- `id`
+- `user_id`
+- `collection_id`
+- `status`: `PENDING | RUNNING | COMPLETED | FAILED`
+- `config_json`: immutable run config snapshot
+- `stats`: counts for analyzed entities, candidate pairs, positive pairs,
+  final suggestions
+- `error_message`
+- `gmt_created / gmt_updated / gmt_started / gmt_finished`
+
+### 5.2 `graph_curation_suggestions`
+
+One row per reviewable suggestion.
+
+Fields:
+
+- `id`
+- `run_id`
+- `user_id`
+- `collection_id`
+- `status`: `PENDING | ACCEPTED | REJECTED | EXPIRED | SUPERSEDED`
+- `entity_ids`: all entities in the suggestion
+- `entity_snapshots`: display payload captured at generation time
+- `target_entity_id`: deterministic target chosen from existing nodes
+- `confidence_score`
+- `reason`
+- `evidence`: structured trace of pairwise signals / adjudications
+- `resolution_note`
+- `operated_by`
+- `gmt_created / gmt_updated / gmt_operated`
+
+No separate suggestion-items table is required in v1 of this module:
+
+- entity membership is already naturally represented as JSON array
+- the workflow is simple and collection-scoped
+- write/read paths stay cheaper and easier to reason about
+
+If later UI/product needs per-item moderation or cross-suggestion joins,
+that is a future schema migration, not a reason to over-model now.
+
+## 6. Candidate Generation
+
+### 6.1 Input Set
+
+The module scans up to a bounded number of entities per collection
+(`max_entities`).
+
+Enumeration comes from `GraphIndexService.list_entities_for_curation()`,
+which is implemented as a bounded read over the existing graph truth.
+
+### 6.2 Candidate Signals
+
+Generate pair candidates only within the same `entity_type`, then score
+them with cheap deterministic signals:
+
+- normalized-name exact match
+- normalized-name containment
+- acronym match
+- token overlap
+- description token overlap
+- shared source chunk overlap
+- optional graph shadow vector nearest neighbors
+
+This gives three important properties:
+
+- bounded compute
+- explainable candidate provenance
+- backend independence
+
+### 6.3 Why use graph shadow vectors?
+
+Entity vectors are already written to the existing vector store as
+`indexer=graph_entity`.
+
+Using those shadows means:
+
+- no duplicate vector infrastructure
+- no graph-backend-specific text indexing
+- same candidate discovery logic works across PG / Neo4j / Nebula
+
+## 7. LLM Adjudication
+
+### 7.1 Unit Of Judgement
+
+Use **pairwise** adjudication.
+
+Input:
+
+- entity A snapshot
+- entity B snapshot
+- deterministic candidate signals
+
+Output JSON only:
+
+- `same_entity: bool`
+- `confidence: float`
+- `reason: str`
+- `recommended_target_entity_id: str | null`
+
+Constraint:
+
+- `recommended_target_entity_id` must be one of the two existing ids
+- the model cannot invent a new canonical node
+
+### 7.2 Why pairwise instead of cluster-level?
+
+Because pairwise is:
+
+- easier to prompt
+- easier to test
+- easier to bound in cost
+- easier to aggregate deterministically
+
+Multi-entity suggestions are formed **after** pairwise positives are
+known.
+
+## 8. Suggestion Aggregation
+
+Positive pair edges form a graph over entity ids.
+
+The module builds connected components:
+
+- size `< 2` -> ignored
+- size `>= 2` -> one suggestion
+
+Target selection is deterministic:
+
+1. pairwise recommendation votes
+2. larger supporting chunk count
+3. lexical tie-break on entity id
+
+This preserves a single graph identity rule without delegating target
+creation to the LLM.
+
+## 9. API Contract
+
+Keep the public API narrow.
+
+### 9.1 Start Run
+
+`POST /collections/{collection_id}/graphs/merge-suggestions`
+
+Behavior:
+
+- if a run is already `PENDING/RUNNING`, return that run
+- otherwise create a new run and enqueue Celery work
+
+### 9.2 Read Latest Suggestions
+
+`GET /collections/{collection_id}/graphs/merge-suggestions`
+
+Behavior:
+
+- return the latest run summary
+- return suggestions from that run
+
+### 9.3 Act On A Suggestion
+
+`POST /collections/{collection_id}/graphs/merge-suggestions/{suggestion_id}/action`
+
+Body:
+
+- `{"action": "accept"}` or `{"action": "reject"}`
+
+Accept:
+
+- call existing `GraphIndexService.merge_entities()`
+- mark accepted suggestion as `ACCEPTED`
+- mark overlapping pending suggestions as `SUPERSEDED`
+
+Reject:
+
+- mark suggestion as `REJECTED`
+
+No target override API is exposed. The point of this module is simple,
+low-support review, not a second complex merge editor.
+
+## 10. Invalidation Rules
+
+Freshness is conservative by design.
+
+### 10.1 Expire Pending Suggestions On
+
+- document re-index
+- document delete
+- manual merge
+
+### 10.2 Purge Everything On
+
+- collection delete
+
+### 10.3 Supersede Pending Suggestions On
+
+- successful completion of a newer run
+- accepting one suggestion that overlaps their entity set
+
+The module prefers **expire + rerun** over trying to incrementally patch
+old suggestions in place.
+
+## 11. Performance And Cost
+
+Hard caps are server-side, not UI-driven:
+
+- max entities analyzed per run
+- max candidate pairs kept after blocking
+- max vector neighbors per entity
+- max concurrent LLM adjudications
+- max final suggestions persisted
+
+This keeps the feature predictable in three dimensions:
+
+- DB cost
+- vector search cost
+- LLM token cost
+
+## 12. Backend Viability
+
+### 12.1 PostgreSQL
+
+Works through existing graphindex tables and vector shadows.
+
+### 12.2 Neo4j
+
+Works because the curation module does not rely on Neo4j-specific text
+or full-text behavior. It reads entities through graphindex and uses the
+same vector shadow path.
+
+### 12.3 Nebula
+
+Works for the same reason: graph truth comes from graphindex storage
+calls, not Nebula-specific fuzzy search. This avoids Nebula's async
+schema/index readiness problems from becoming curation-specific product
+bugs.
+
+## 13. Historical Cleanup
+
+The implementation removes stale v1/v2 residuals:
+
+- old `410` merge-suggestion routes
+- old stateless request/response schemas
+- stale OpenAPI contract that still described high-degree LightRAG scan
+
+Historical code and analysis docs remain only as archaeology input, not
+as active runtime contract.
+
+## 14. Implementation Notes
+
+This rollout intentionally keeps one truth path:
+
+- discover in `graph_curation`
+- merge in `graphindex`
+
+That gives us a simple rule for future maintenance:
+
+> if code changes graph truth directly, it belongs in `graphindex`;
+> if code proposes or reviews graph edits, it belongs in
+> `graph_curation`.

--- a/docs/zh-CN/design/graphindex_rewrite.md
+++ b/docs/zh-CN/design/graphindex_rewrite.md
@@ -1,6 +1,7 @@
 # Graph Index 模块重写（v2）
 
-> Status: **v2 已落地 + 归一化/合并能力已回填**。
+> Status: **v2 已落地 + 归一化/合并能力已回填 + merge suggestion 已迁入独立
+> `graph_curation` 模块**。
 >
 > 历史记录：
 >
@@ -41,7 +42,7 @@
 | `get_knowledge_graph`（拉一张子图）             | ✅ **原生实现**       | UI 图浏览器依赖                              |
 | **description 归一化（LLM 摘要）**               | ✅ **原生实现（v2.2）** | 累积多片段 → LLM 总结，详见 §4                   |
 | **`merge_entities`（多个 entity 合并成 1 个）**   | ✅ **原生实现（v2.2）** | 走 SQL 结构合并 + LLM 总结 description，详见 §4  |
-| `generate_merge_suggestions`（LLM 挖合并候选）  | ❌ **删除**         | UX 层发现算法，不属于 Graph Index 职责；日后单独做模块    |
+| `generate_merge_suggestions`（LLM 挖合并候选）  | ✅ **迁出 Graph Index** | 现在归属独立 `graph_curation` workflow，详见 `graph_curation.md` |
 | `export_for_kg_eval`（导出评测数据）             | ❌ **删除**         | 管理工具；需要时可以基于 graphindex 表直接 dump        |
 
 
@@ -50,11 +51,10 @@
 单纯在字符上限处截断又会丢信息。v2.2 的实现用 LLM 总结在写后和合并
 后各做一次压缩，保证语义不丢。详细设计见 §4。
 
-**`generate_merge_suggestions` 和 `export_for_kg_eval` 仍然不回。**
-前者是发现候选的 UX 管线（LightRAG 用 500 行 LLM orchestration 实现），
-不是 Graph Index 的职责；未来要做应当放在独立 curation 模块。后者是
-一个薄 SQL dump，需要时再写。这两个的 REST 路由继续保留 **HTTP 410
-Gone** 作为运行时信号。
+**边界保持不变：Graph Index 仍然不负责 merge suggestion discovery。**
+变化只在于：这条能力已经按第一性原理迁到了独立的
+`graph_curation` 模块，而不是继续停留在 `410 Gone`。`export_for_kg_eval`
+仍然不回；它是单独的管理工具，不属于 Graph Index 主链。
 
 ---
 
@@ -461,8 +461,8 @@ DSL 过滤。
 
 ## 8. 业务层切换点
 
-所有 5 处调用全部改指 `aperag/graphindex`；curation 的 3 个 REST 路由
-保留返回 410 直到前端 UI 清理完成。
+所有 5 处 graph truth 调用都改指 `aperag/graphindex`；merge suggestion
+改由独立的 `graph_curation` 模块接管；只剩 `kg-eval` 导出路由保留 `410`。
 
 
 | 位置                                                         | 本 PR 改动                                                                 |
@@ -474,7 +474,8 @@ DSL 过滤。
 | `aperag/tasks/document.py`（3 处 celery 调用）                   | → `run_index_document_sync` / `run_delete_document_sync`                 |
 | `aperag/service/prompt_template_service.py::hardcoded[graph]` | → `graphindex.prompts.ENTITY_RELATION_EXTRACTION`                        |
 | `aperag/views/graph.py::merge_nodes_view`                    | **200**，委托 `graph_service.merge_entities` → `GraphIndexService.merge_entities` |
-| `aperag/views/graph.py`（merge_suggestions / kg-eval）         | **410 Gone**（属于 UX 层能力，本次范围外）                                           |
+| `aperag/views/graph.py::merge_suggestions*`                 | → `graph_curation_service.start_run / get_latest / handle_action`                    |
+| `aperag/views/graph.py::export_kg_eval_view`               | **410 Gone**（管理工具，本次范围外）                                                  |
 
 
 ---
@@ -506,4 +507,3 @@ DSL 过滤。
 - 不做 KV storage / doc status storage —— 这些是 LightRAG 内部实现细节，
   v2 的流程不需要它们；
 - 不做 v1 ↔ v2 数据迁移工具 —— 切换是硬切换，用户按需 re-index。
-

--- a/tests/unit_test/graph_curation/test_candidate_generation.py
+++ b/tests/unit_test/graph_curation/test_candidate_generation.py
@@ -1,0 +1,83 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from aperag.graph_curation.candidate_generation import build_candidate_pairs
+from aperag.graphindex.dto import Entity
+
+
+def _entity(
+    entity_id: str,
+    name: str,
+    *,
+    entity_type: str = "organization",
+    description: str = "",
+    chunk_ids: tuple[str, ...] = (),
+) -> Entity:
+    return Entity(
+        entity_id=entity_id,
+        collection_id="c1",
+        name=name,
+        type=entity_type,
+        description=description,
+        source_chunk_ids=chunk_ids,
+    )
+
+
+def test_build_candidate_pairs_prefers_same_type_pairs_with_real_signals():
+    bookstore = _entity(
+        "e1",
+        "墨香居",
+        description="这条老巷子里唯一的旧书店",
+        chunk_ids=("chunk-a", "chunk-b"),
+    )
+    old_bookstore = _entity(
+        "e2",
+        "旧书店",
+        description="经营各种书籍的小店",
+        chunk_ids=("chunk-b",),
+    )
+    person = _entity(
+        "e3",
+        "李明华",
+        entity_type="person",
+        description="书店老板",
+    )
+
+    pairs = build_candidate_pairs(
+        entities=[bookstore, old_bookstore, person],
+        vector_neighbors={"e1": [("e2", 0.88)], "e3": [("e1", 0.99)]},
+        max_pairs_per_entity=4,
+        max_total_pairs=10,
+    )
+
+    assert len(pairs) == 1
+    pair = pairs[0]
+    assert (pair.left_id, pair.right_id) == ("e1", "e2")
+    assert pair.signals["vector_neighbor"] is True
+    assert pair.signals["vector_score"] == 0.88
+    assert pair.signals["shared_chunk_count"] == 1
+    assert pair.score > 0.0
+
+
+def test_build_candidate_pairs_caps_pairs_per_entity():
+    entities = [
+        _entity("e1", "Acme"),
+        _entity("e2", "Acme Inc"),
+        _entity("e3", "Acme Labs"),
+    ]
+
+    pairs = build_candidate_pairs(
+        entities=entities,
+        vector_neighbors={},
+        max_pairs_per_entity=1,
+        max_total_pairs=10,
+    )
+
+    assert len(pairs) == 1
+    pair = pairs[0]
+    assert {pair.left_id, pair.right_id}.issubset({"e1", "e2", "e3"})

--- a/tests/unit_test/graph_curation/test_service.py
+++ b/tests/unit_test/graph_curation/test_service.py
@@ -1,0 +1,89 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from aperag.graph_curation.candidate_generation import CandidatePair
+from aperag.graph_curation.service import GraphCurationService, MergeJudgement
+from aperag.graphindex.dto import Entity
+
+
+def _entity(entity_id: str, name: str, *, chunk_ids: tuple[str, ...] = ()) -> Entity:
+    return Entity(
+        entity_id=entity_id,
+        collection_id="c1",
+        name=name,
+        type="organization",
+        description=f"description for {name}",
+        source_chunk_ids=chunk_ids,
+    )
+
+
+def test_aggregate_positive_judgements_groups_pairs_and_picks_voted_target():
+    service = GraphCurationService.__new__(GraphCurationService)
+    entities_by_id = {
+        "e1": _entity("e1", "墨香居", chunk_ids=("c1", "c2")),
+        "e2": _entity("e2", "旧书店", chunk_ids=("c3",)),
+        "e3": _entity("e3", "墨香旧书店", chunk_ids=("c4",)),
+    }
+    adjudications = [
+        (
+            CandidatePair(
+                left_id="e1",
+                right_id="e2",
+                score=0.92,
+                signals={"normalized_name_contains": True},
+            ),
+            MergeJudgement(
+                same_entity=True,
+                confidence=0.93,
+                reason="名称和描述高度重合",
+                recommended_target_entity_id="e1",
+            ),
+        ),
+        (
+            CandidatePair(
+                left_id="e2",
+                right_id="e3",
+                score=0.87,
+                signals={"vector_neighbor": True},
+            ),
+            MergeJudgement(
+                same_entity=True,
+                confidence=0.89,
+                reason="上下文表明是同一家店",
+                recommended_target_entity_id="e1",
+            ),
+        ),
+    ]
+
+    suggestions = service._aggregate_positive_judgements(
+        entities_by_id=entities_by_id,
+        adjudications=adjudications,
+    )
+
+    assert len(suggestions) == 1
+    suggestion = suggestions[0]
+    assert suggestion["entity_ids"] == ["e1", "e2", "e3"]
+    assert suggestion["target_entity_id"] == "e1"
+    assert suggestion["confidence_score"] == 0.91
+    assert suggestion["evidence"]["pair_count"] == 2
+    assert {item["entity_id"] for item in suggestion["entity_snapshots"]} == {
+        "e1",
+        "e2",
+        "e3",
+    }
+
+
+def test_extract_json_object_ignores_non_json_prefix_suffix():
+    raw = 'analysis...\n```json\n{"same_entity": true, "confidence": 0.88, "reason": "match"}\n```\n'
+    result = GraphCurationService._extract_json_object(raw)
+
+    assert result == {
+        "same_entity": True,
+        "confidence": 0.88,
+        "reason": "match",
+    }

--- a/tests/unit_test/graph_curation/test_service.py
+++ b/tests/unit_test/graph_curation/test_service.py
@@ -6,9 +6,15 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
 from aperag.graph_curation.candidate_generation import CandidatePair
 from aperag.graph_curation.service import GraphCurationService, MergeJudgement
 from aperag.graphindex.dto import Entity
+from aperag.schema.view_models import SuggestionActionRequest
 
 
 def _entity(entity_id: str, name: str, *, chunk_ids: tuple[str, ...] = ()) -> Entity:
@@ -87,3 +93,47 @@ def test_extract_json_object_ignores_non_json_prefix_suffix():
         "confidence": 0.88,
         "reason": "match",
     }
+
+
+@pytest.mark.asyncio
+async def test_start_run_marks_failed_when_enqueue_raises(monkeypatch):
+    service = GraphCurationService.__new__(GraphCurationService)
+    service._get_and_validate_collection = AsyncMock(return_value=object())
+
+    run = SimpleNamespace(
+        id="gcr_run1",
+        collection_id="col1",
+        status="PENDING",
+        stats={},
+        error_message=None,
+        gmt_created=None,
+        gmt_updated=None,
+        gmt_started=None,
+        gmt_finished=None,
+    )
+
+    async def fake_execute_with_transaction(_operation):
+        return run, True
+
+    service.execute_with_transaction = fake_execute_with_transaction
+    service._mark_run_failed = AsyncMock()
+
+    class _FakeTask:
+        @staticmethod
+        def delay(_run_id, _collection_id):
+            raise RuntimeError("broker unavailable")
+
+    monkeypatch.setattr("config.celery_tasks.generate_graph_curation_run_task", _FakeTask)
+
+    with pytest.raises(RuntimeError, match="Failed to schedule graph curation run"):
+        await service.start_run("user1", "col1")
+
+    service._mark_run_failed.assert_awaited_once()
+    assert service._mark_run_failed.await_args.args[0] == "gcr_run1"
+    assert "enqueue_failed:" in service._mark_run_failed.await_args.args[1]
+
+
+def test_suggestion_action_request_normalizes_case_insensitively():
+    request = SuggestionActionRequest(action=" REJECT ")
+
+    assert request.action == "reject"

--- a/tests/unit_test/tasks/test_document_graph_curation_contract.py
+++ b/tests/unit_test/tasks/test_document_graph_curation_contract.py
@@ -1,0 +1,65 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import logging
+from types import SimpleNamespace
+
+from aperag.tasks.document import DocumentIndexTask
+
+
+def test_upsert_graph_index_tolerates_graph_curation_invalidation_failure(monkeypatch, caplog):
+    task = DocumentIndexTask()
+    collection = SimpleNamespace(id="col-1")
+    parsed = SimpleNamespace(content="doc content", file_path="/tmp/doc.txt")
+
+    monkeypatch.setattr(
+        "aperag.graphindex.integration.run_index_document_sync",
+        lambda **_kwargs: SimpleNamespace(
+            doc_id="doc-1",
+            chunks_created=2,
+            entities_extracted=3,
+            relations_extracted=4,
+        ),
+    )
+    monkeypatch.setattr(
+        "aperag.graph_curation.integration.run_expire_graph_curation_collection_sync",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("curation tables missing")),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = task._upsert_graph_index("doc-1", collection, parsed)
+
+    assert result == {
+        "status": "success",
+        "doc_id": "doc-1",
+        "chunks_created": 2,
+        "entities_extracted": 3,
+        "relations_extracted": 4,
+    }
+    assert "Graph curation invalidation failed for collection col-1 (document_reindex)" in caplog.text
+
+
+def test_delete_graph_index_tolerates_graph_curation_invalidation_failure(monkeypatch, caplog):
+    task = DocumentIndexTask()
+    collection = SimpleNamespace(id="col-1")
+    calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        "aperag.graphindex.integration.run_delete_document_sync",
+        lambda **_kwargs: calls.append(("delete", _kwargs["doc_id"])),
+    )
+    monkeypatch.setattr(
+        "aperag.graph_curation.integration.run_expire_graph_curation_collection_sync",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("curation db unavailable")),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        task._delete_graph_index("doc-2", collection)
+
+    assert calls == [("delete", "doc-2")]
+    assert "Graph curation invalidation failed for collection col-1 (document_delete)" in caplog.text


### PR DESCRIPTION
## What changed

This PR introduces a dedicated `graph_curation` workflow for merge-suggestion discovery instead of reviving the old LightRAG-era pipeline inside `graphindex`.

Key changes:
- add a new `aperag.graph_curation` module for candidate generation, LLM adjudication, suggestion persistence, and accept/reject actions
- add relational persistence for curation runs and suggestions plus an Alembic migration
- switch `/graphs/merge-suggestions` from retired placeholder behavior to the new persisted async workflow
- keep merge truth on the existing path by routing accept to `GraphIndexService.merge_entities()` only
- add graph truth invalidation hooks for document reindex/delete, collection drop, and manual merge
- update design docs so merge suggestions are owned by `graph_curation`, while `graphindex` stays focused on graph truth/query

## Why

The current codebase still supports manual entity merge, but it no longer has a valid discovery workflow for finding merge candidates. From first principles, that leaves graph curation incomplete.

This PR restores that missing capability without reintroducing the old coupling:
- `graphindex` stays responsible for graph truth and primitives
- `graph_curation` owns offline discovery, review state, and suggestion lifecycle
- no second merge write path is introduced

## Impact

User-facing:
- merge-suggestion routes now create and return async graph-curation runs/suggestions instead of staying retired
- accept/reject works on persisted suggestions

System-facing:
- new DB tables: `graph_curation_runs`, `graph_curation_suggestions`
- new Celery task for async curation runs
- suggestion invalidation is wired to graph lifecycle events

## Validation

Local validation completed:
- `uv run ruff check aperag/graph_curation aperag/graphindex/integration.py aperag/graphindex/service.py aperag/service/graph_service.py aperag/tasks/document.py aperag/tasks/collection.py aperag/views/graph.py config/celery_tasks.py aperag/db/models.py tests/unit_test/graph_curation tests/unit_test/graphindex/test_service.py tests/unit_test/graphindex/test_connector.py`
- `uv run pytest tests/unit_test/graph_curation tests/unit_test/graphindex/test_service.py tests/unit_test/graphindex/test_connector.py -q`

Not yet covered locally:
- DB-backed migration/application run
- end-to-end HTTP flow
- integration checks across all graph backends
