### PR TITLE
test: harden ES shared fulltext contracts

### DIFF
--- a/tests/unit_test/test_es_shared_index_rollout.py
+++ b/tests/unit_test/test_es_shared_index_rollout.py
@@ -153,7 +153,9 @@ async def test_fulltext_search_filters_on_collection_and_chat_id():
     indexer = object.__new__(FulltextIndexer)
     indexer.async_es = FakeAsyncEs()
 
-    docs = await FulltextIndexer.search_document(indexer, "aperag-fulltext", "col-1", ["hello"], topk=3, chat_id="chat-1")
+    docs = await FulltextIndexer.search_document(
+        indexer, "aperag-fulltext", "col-1", ["hello"], topk=3, chat_id="chat-1"
+    )
 
     assert docs == []
     assert captured["routing"] == "col-1"
@@ -197,3 +199,196 @@ def test_build_legacy_reindex_body_promotes_contract_fields():
     assert "ctx._source.collection_id" in body["script"]["source"]
     assert "ctx._routing = params.collection_id" in body["script"]["source"]
     assert "ctx._source.chat_id" in body["script"]["source"]
+
+
+def test_switch_shared_index_alias_repoints_atomically():
+    captured = {}
+
+    class FakeIndices:
+        def exists(self, index):
+            return SimpleNamespace(body=index in {"aperag-fulltext-v1", "aperag-fulltext-v2"})
+
+        def exists_alias(self, name):
+            return SimpleNamespace(body=True)
+
+        def get_alias(self, name):
+            return SimpleNamespace(body={"aperag-fulltext-v1": {}})
+
+        def update_aliases(self, body):
+            captured["body"] = body
+
+        def put_alias(self, index, name):
+            raise AssertionError("existing aliases should be updated atomically")
+
+        def create(self, index, body):
+            raise AssertionError("target physical index should already exist")
+
+    class FakeEs:
+        indices = FakeIndices()
+
+    from aperag.index.fulltext_index import switch_shared_index_alias
+
+    result = switch_shared_index_alias("aperag-fulltext-v2", es=FakeEs())
+
+    assert result == {
+        "alias": "aperag-fulltext",
+        "target_index": "aperag-fulltext-v2",
+        "previous_targets": ["aperag-fulltext-v1"],
+    }
+    assert captured["body"] == {
+        "actions": [
+            {"remove": {"index": "aperag-fulltext-v1", "alias": "aperag-fulltext"}},
+            {"add": {"index": "aperag-fulltext-v2", "alias": "aperag-fulltext"}},
+        ]
+    }
+
+
+def test_delete_collection_documents_filters_and_routes_by_collection():
+    captured = {}
+
+    class FakeIndices:
+        def exists(self, index):
+            return SimpleNamespace(body=True)
+
+    class FakeEs:
+        indices = FakeIndices()
+
+        def delete_by_query(self, **kwargs):
+            captured.update(kwargs)
+            return {"deleted": 7}
+
+    from aperag.index.fulltext_index import delete_collection_documents
+
+    deleted = delete_collection_documents("col-1", index="aperag-fulltext", es=FakeEs())
+
+    assert deleted == 7
+    assert captured == {
+        "index": "aperag-fulltext",
+        "body": {"query": {"term": {"collection_id": "col-1"}}},
+        "conflicts": "proceed",
+        "refresh": True,
+        "routing": "col-1",
+    }
+
+
+def test_remove_document_chunks_filters_by_document_and_collection():
+    captured = {}
+
+    class FakeIndices:
+        def exists(self, index):
+            return SimpleNamespace(body=True)
+
+    class FakeEs:
+        indices = FakeIndices()
+
+        def delete_by_query(self, **kwargs):
+            captured.update(kwargs)
+            return {"deleted": 2}
+
+    from aperag.index.fulltext_index import FulltextIndexer
+
+    indexer = object.__new__(FulltextIndexer)
+    indexer.es = FakeEs()
+
+    deleted = FulltextIndexer._remove_document_chunks(
+        indexer,
+        "aperag-fulltext",
+        42,
+        collection_id="col-1",
+    )
+
+    assert deleted == 2
+    assert captured == {
+        "index": "aperag-fulltext",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"term": {"document_id": "42"}},
+                        {"term": {"collection_id": "col-1"}},
+                    ]
+                }
+            }
+        },
+        "routing": "col-1",
+    }
+
+
+def test_insert_chunk_writes_collection_and_chat_fields_with_routing():
+    captured = {}
+
+    class FakeIndices:
+        def exists(self, index):
+            return SimpleNamespace(body=True)
+
+    class FakeEs:
+        indices = FakeIndices()
+
+        def index(self, **kwargs):
+            captured.update(kwargs)
+
+    from aperag.index.fulltext_index import FulltextIndexer
+
+    indexer = object.__new__(FulltextIndexer)
+    indexer.es = FakeEs()
+
+    FulltextIndexer._insert_chunk(
+        indexer,
+        "aperag-fulltext",
+        "doc-42_0",
+        42,
+        "col-1",
+        "handbook.md",
+        "chunk text",
+        title_text="Title",
+        metadata={"chat_id": "chat-1", "page": 3},
+    )
+
+    assert captured == {
+        "index": "aperag-fulltext",
+        "id": "doc-42_0",
+        "routing": "col-1",
+        "document": {
+            "collection_id": "col-1",
+            "document_id": 42,
+            "chunk_id": "doc-42_0",
+            "chat_id": "chat-1",
+            "name": "handbook.md",
+            "content": "chunk text",
+            "title": "Title",
+            "metadata": {"chat_id": "chat-1", "page": 3},
+        },
+    }
+
+
+def test_migrate_legacy_index_ensures_target_and_reindexes_with_verification_flags(monkeypatch):
+    captured = {"ensured": [], "reindex": []}
+
+    class FakeEs:
+        def reindex(self, **kwargs):
+            captured["reindex"].append(kwargs)
+            return {"created": 3}
+
+    monkeypatch.setattr(
+        "aperag.index.fulltext_index.ensure_physical_index_exists",
+        lambda physical_index, es: captured["ensured"].append((physical_index, es)),
+    )
+
+    from aperag.index.fulltext_index import migrate_legacy_index
+
+    es = FakeEs()
+    result = migrate_legacy_index("legacy-col-1", "col-1", dest_index="aperag-fulltext-v2", es=es)
+
+    assert result == {"created": 3}
+    assert captured["ensured"] == [("aperag-fulltext-v2", es)]
+    assert len(captured["reindex"]) == 1
+    reindex_call = captured["reindex"][0]
+    assert reindex_call["body"]["source"] == {"index": "legacy-col-1"}
+    assert reindex_call["body"]["dest"] == {"index": "aperag-fulltext-v2"}
+    assert reindex_call["body"]["script"]["lang"] == "painless"
+    assert reindex_call["body"]["script"]["params"] == {"collection_id": "col-1"}
+    assert "ctx._source.collection_id = params.collection_id" in reindex_call["body"]["script"]["source"]
+    assert "ctx._routing = params.collection_id" in reindex_call["body"]["script"]["source"]
+    assert reindex_call["wait_for_completion"] is True
+    assert reindex_call["refresh"] is True
+    assert reindex_call["conflicts"] == "proceed"


### PR DESCRIPTION
## What
- Add direct backend contract tests for the shared Full Index rollout path.
- Cover alias cutover, collection/document delete filtering, chunk write routing/fields, and legacy reindex safety flags.

## Why
- The database-layer audit identified Full Index as the thinnest default-gate area after the shared logical index migration.
- These tests lock the runtime authority shape around shared alias, routing, delete, and reindex behavior without requiring a live ES service.

## Validation
- uv run ruff format --check tests/unit_test/test_es_shared_index_rollout.py
- uv run ruff check tests/unit_test/test_es_shared_index_rollout.py
- uv run pytest tests/unit_test/test_es_shared_index_rollout.py tests/unit_test/test_es_p0_contract.py -q