### PR TITLE
[codex] harden chat agent runtime contract

### DIFF
--- a/aperag/service/chat_completion_service.py
+++ b/aperag/service/chat_completion_service.py
@@ -17,7 +17,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, AsyncGenerator, Dict, List, Optional
+from typing import Any, AsyncGenerator, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -77,6 +77,42 @@ class OpenAIChatCompletionRequest(BaseModel):
     max_tokens: Optional[int] = None
     max_completion_tokens: Optional[int] = None
     timeout: Optional[int] = None
+
+
+class OpenAIChatCompletionMessage(BaseModel):
+    role: Literal["assistant"]
+    content: str
+
+
+class OpenAIChatCompletionChoice(BaseModel):
+    index: int
+    message: OpenAIChatCompletionMessage
+    finish_reason: Optional[str] = None
+
+
+class OpenAIChatCompletionUsage(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class OpenAIChatCompletionResponse(BaseModel):
+    id: str
+    object: Literal["chat.completion"]
+    created: int
+    model: str
+    choices: list[OpenAIChatCompletionChoice]
+    usage: OpenAIChatCompletionUsage
+
+
+class OpenAIErrorDetail(BaseModel):
+    message: str
+    type: str
+    code: str
+
+
+class OpenAIErrorResponse(BaseModel):
+    error: OpenAIErrorDetail
 
 
 class OpenAIFormatter:
@@ -156,7 +192,7 @@ class ChatCompletionService:
         yield f"data: {json.dumps(formatter.format_stream_end(msg_id))}\n\n"
 
     async def openai_chat_completions(self, user, body_data, query_params, headers=None):
-        """Handle OpenAI-compatible chat completions through Agent Runtime V2."""
+        """Handle OpenAI-compatible chat completions through Agent Runtime V3."""
         try:
             payload = OpenAIChatCompletionRequest.model_validate(body_data or {})
             bot_id = str(query_params.get("bot_id") or "").strip()

--- a/aperag/views/agent_runtime.py
+++ b/aperag/views/agent_runtime.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 
 from aperag.agent_runtime import (
+    AgentArtifactEnvelope,
     AgentTurnSnapshot,
     CancelTurnResponse,
     CreateTurnRequest,
@@ -80,11 +81,27 @@ async def cancel_turn_view(chat_id: str, turn_id: str, user: User = Depends(requ
 
 
 @router.get("/agent/artifacts/{artifact_id}")
-async def get_artifact_view(artifact_id: str, user: User = Depends(required_user)):
+async def get_artifact_view(artifact_id: str, user: User = Depends(required_user)) -> AgentArtifactEnvelope:
     return await runtime_manager.artifact_service.get_artifact_for_user(str(user.id), artifact_id)
 
 
-@router.get("/agent/chats/{chat_id}/turns/{turn_id}/events")
+@router.get(
+    "/agent/chats/{chat_id}/turns/{turn_id}/events",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Server-sent timeline events for one agent turn.",
+            "content": {
+                "text/event-stream": {
+                    "schema": {
+                        "type": "string",
+                        "description": "SSE frames whose data payload is AgentTimelineEventEnvelope JSON.",
+                    }
+                }
+            },
+        }
+    },
+)
 async def stream_turn_events_view(
     request: Request,
     chat_id: str,

--- a/aperag/views/openai.py
+++ b/aperag/views/openai.py
@@ -12,19 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 
 from aperag.db.models import User
-from aperag.service.chat_completion_service import OpenAIFormatter, chat_completion_service
+from aperag.service.chat_completion_service import (
+    OpenAIChatCompletionRequest,
+    OpenAIChatCompletionResponse,
+    OpenAIErrorResponse,
+    OpenAIFormatter,
+    chat_completion_service,
+)
 from aperag.views.auth import required_user
 
 router = APIRouter(tags=["openai"])
 
 
-@router.post("/chat/completions")
-async def openai_chat_completions_view(request: Request, user: User = Depends(required_user)):
-    """OpenAI-compatible chat completions endpoint backed by Agent Runtime V2."""
+@router.post(
+    "/chat/completions",
+    response_model=OpenAIChatCompletionResponse | OpenAIErrorResponse,
+    responses={
+        200: {
+            "description": "OpenAI-compatible JSON response or text/event-stream chunks when stream=true",
+            "content": {
+                "text/event-stream": {
+                    "schema": {
+                        "type": "string",
+                        "description": "Server-sent OpenAI chat.completion.chunk events.",
+                    }
+                }
+            },
+        }
+    },
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": OpenAIChatCompletionRequest.model_json_schema(ref_template="#/components/schemas/{model}")
+                }
+            },
+        }
+    },
+)
+async def openai_chat_completions_view(
+    request: Request,
+    bot_id: str | None = Query(default=None, description="Agent bot id that backs this OpenAI-compatible call"),
+    chat_id: str | None = Query(default=None, description="Existing chat id. Omit to create an ephemeral chat"),
+    language: str = Query(default="en-US", description="Response language passed through to Agent Runtime"),
+    user: User = Depends(required_user),
+):
+    """OpenAI-compatible chat completions endpoint backed by Agent Runtime V3."""
     try:
         body_data = await request.json()
     except Exception:
@@ -33,7 +71,11 @@ async def openai_chat_completions_view(request: Request, user: User = Depends(re
     stream, response = await chat_completion_service.openai_chat_completions(
         str(user.id),
         body_data,
-        request.query_params,
+        {
+            "bot_id": bot_id,
+            "chat_id": chat_id,
+            "language": language,
+        },
         request.headers,
     )
     if stream is not None:

--- a/docs/en-US/design/agent_runtime_v3.md
+++ b/docs/en-US/design/agent_runtime_v3.md
@@ -315,6 +315,28 @@ POST /api/v2/agent/chats/{chat_id}/turns/{turn_id}/cancel
 GET /api/v2/agent/artifacts/{artifact_id}
 ```
 
+### 6.2.6 OpenAI-compatible adapter
+
+```text
+POST /v1/chat/completions
+```
+
+This endpoint is a compatibility adapter for OpenAI-shaped clients. It is not
+the primary UI contract. The implementation must translate each request into an
+Agent Runtime V3 turn and then format the result as either:
+
+- `chat.completion` JSON when `stream=false`
+- `text/event-stream` `chat.completion.chunk` frames when `stream=true`
+
+The adapter contract is:
+
+- `bot_id` is required as a query parameter
+- `chat_id` is optional; if omitted, the backend creates and later deletes an
+  ephemeral chat
+- `language` is optional and defaults to `en-US`
+- `Idempotency-Key` / `X-Idempotency-Key` maps to
+  `client_idempotency_key`
+
 ## 6.3 Idempotency and reconnect
 
 ### 6.3.1 Idempotency

--- a/docs/zh-CN/design/agent_runtime_v3.md
+++ b/docs/zh-CN/design/agent_runtime_v3.md
@@ -328,6 +328,28 @@ POST /api/v2/agent/chats/{chat_id}/turns/{turn_id}/cancel
 GET /api/v2/agent/artifacts/{artifact_id}
 ```
 
+### 6.2.6 OpenAI-compatible adapter
+
+```text
+POST /v1/chat/completions
+```
+
+这个接口是给 OpenAI 形状客户端使用的兼容 adapter，不是前端主 UI
+contract。实现必须把每个请求转换成 Agent Runtime V3 turn，再按
+OpenAI 形状格式化输出：
+
+- `stream=false` 时返回 `chat.completion` JSON
+- `stream=true` 时返回 `text/event-stream` 的 `chat.completion.chunk`
+  帧
+
+adapter contract 固定为：
+
+- `bot_id` 是必填 query 参数
+- `chat_id` 可选；不传时后端创建并在请求结束后删除 ephemeral chat
+- `language` 可选，默认 `en-US`
+- `Idempotency-Key` / `X-Idempotency-Key` 映射为
+  `client_idempotency_key`
+
 ## 6.3 幂等与重连
 
 ### 6.3.1 幂等策略

--- a/tests/e2e_http/README.md
+++ b/tests/e2e_http/README.md
@@ -33,7 +33,7 @@ Current v1 scope:
   - cover document status visibility, list search by name, and collection search/history HTTP contracts
   - cover bot CRUD + agent config get/update
   - cover chat create/list/get/update/delete
-  - assert the stable unsupported `/v1/chat/completions` error contract
+  - assert the stable OpenAI-shaped `/v1/chat/completions` contract backed by Agent Runtime V3
   - cover a provider-aware business flow: collection + document + bot-bound chat turn
   - cover graph labels + graph overview + parameter validation endpoints
   - cover a scripted chat business flow that waits for vector/fulltext indexing, then asserts a non-empty answer artifact and a non-empty reference bundle

--- a/tests/e2e_http/hurl/full/README.md
+++ b/tests/e2e_http/hurl/full/README.md
@@ -10,7 +10,7 @@ Current files:
 - `12_bot.hurl`
   bot CRUD plus agent config get/update
 - `13_chat_http.hurl`
-  chat create/list/get/update/delete plus unsupported `/v1/chat/completions` contract pointing callers to Agent Runtime V3 turns
+  chat create/list/get/update/delete plus OpenAI-shaped `/v1/chat/completions` backed by Agent Runtime V3 turns
 - `14_graph_http.hurl`
   graph labels and graph overview endpoints
 - `15_agent_runtime_v3.hurl`

--- a/tests/unit_test/agent_runtime/test_agent_runtime_openapi_contract.py
+++ b/tests/unit_test/agent_runtime/test_agent_runtime_openapi_contract.py
@@ -1,0 +1,49 @@
+from aperag.app import app
+
+
+def _operation(path: str, method: str) -> dict:
+    return app.openapi()["paths"][path][method]
+
+
+def _json_schema(operation: dict, status: str = "200") -> dict:
+    return operation["responses"][status]["content"]["application/json"]["schema"]
+
+
+def test_agent_runtime_v2_openapi_contract_exposes_turn_event_and_artifact_models():
+    create_turn = _operation("/api/v2/agent/chats/{chat_id}/turns", "post")
+    assert create_turn["requestBody"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/CreateTurnRequest"
+    }
+    assert _json_schema(create_turn) == {"$ref": "#/components/schemas/CreateTurnResponse"}
+
+    snapshot = _operation("/api/v2/agent/chats/{chat_id}/turns/{turn_id}", "get")
+    assert _json_schema(snapshot) == {"$ref": "#/components/schemas/AgentTurnSnapshot"}
+
+    cancel = _operation("/api/v2/agent/chats/{chat_id}/turns/{turn_id}/cancel", "post")
+    assert _json_schema(cancel) == {"$ref": "#/components/schemas/CancelTurnResponse"}
+
+    artifact = _operation("/api/v2/agent/artifacts/{artifact_id}", "get")
+    assert _json_schema(artifact) == {"$ref": "#/components/schemas/AgentArtifactEnvelope"}
+
+    events = _operation("/api/v2/agent/chats/{chat_id}/turns/{turn_id}/events", "get")
+    event_stream = events["responses"]["200"]["content"]["text/event-stream"]["schema"]
+    assert event_stream["type"] == "string"
+    assert "AgentTimelineEventEnvelope" in event_stream["description"]
+
+
+def test_openai_compatible_chat_completions_openapi_contract_is_explicit():
+    operation = _operation("/v1/chat/completions", "post")
+    parameter_names = {parameter["name"] for parameter in operation["parameters"]}
+    assert {"bot_id", "chat_id", "language"}.issubset(parameter_names)
+
+    request_schema = operation["requestBody"]["content"]["application/json"]["schema"]
+    assert request_schema["title"] == "OpenAIChatCompletionRequest"
+    assert {"messages", "stream", "model"}.issubset(request_schema["properties"])
+
+    json_any_of = _json_schema(operation)["anyOf"]
+    assert {"$ref": "#/components/schemas/OpenAIChatCompletionResponse"} in json_any_of
+    assert {"$ref": "#/components/schemas/OpenAIErrorResponse"} in json_any_of
+
+    stream_schema = operation["responses"]["200"]["content"]["text/event-stream"]["schema"]
+    assert stream_schema["type"] == "string"
+    assert "chat.completion.chunk" in stream_schema["description"]


### PR DESCRIPTION
## Summary

- Expose Agent Runtime V3 artifact and SSE routes as explicit code-first FastAPI contracts.
- Expose `/v1/chat/completions` query parameters, OpenAI-shaped JSON response schema, error schema, and streaming response media type without changing the service execution path.
- Add focused OpenAPI contract tests for agent-runtime and OpenAI-compatible chat completion surfaces.
- Update Agent Runtime V3 docs and HTTP E2E README wording to reflect that `/v1/chat/completions` is now backed by Agent Runtime V3.

## Scope

This is a backend-only #13 slice. It does not touch:

- `aperag/api/**` static YAML, because #8 owns the code-first export migration.
- frontend typed client, feature adapter, or chat UI files, because #9 owns that boundary.

After #8 lands the canonical exporter, this PR should be rebased and validated against `scripts/export_openapi.py -> openapi.full.json / openapi.public.json`.

## Validation

- `uv run ruff format --check aperag/service/chat_completion_service.py aperag/views/openai.py aperag/views/agent_runtime.py tests/unit_test/agent_runtime/test_agent_runtime_openapi_contract.py`
- `uv run ruff check aperag/service/chat_completion_service.py aperag/views/openai.py aperag/views/agent_runtime.py tests/unit_test/agent_runtime/test_agent_runtime_openapi_contract.py`
- `uv run pytest tests/unit_test/agent_runtime/test_agent_runtime_openapi_contract.py tests/unit_test/agent_runtime/test_agent_runtime_v3.py tests/unit_test/chat/test_chat_completion_service.py tests/unit_test/chat/test_turn_feedback_service.py -q`
