### PR TITLE
[codex] harden search graph public contracts

### DIFF
--- a/aperag/schema/view_models.py
+++ b/aperag/schema/view_models.py
@@ -574,6 +574,64 @@ class VisionSearchParams(BaseModel):
     similarity: Optional[confloat(ge=0.0, le=1.0)] = Field(None, description="Similarity threshold")
 
 
+class SearchResultMetadata(BaseModel):
+    """
+    Public metadata carried by search result items.
+
+    This intentionally allow-lists fields needed by clients and excludes raw
+    index/storage metadata such as indexer, index_method, chat_id, object_path,
+    and embedded node payloads.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: Optional[str] = Field(None, description="Display source for the result")
+    title: Optional[str] = Field(None, description="Human-readable title when available")
+    collection_id: Optional[str] = Field(None, description="Collection identifier for client follow-up actions")
+    document_id: Optional[str] = Field(None, description="Document identifier for client follow-up actions")
+    asset_id: Optional[str] = Field(None, description="Asset identifier for image or binary references")
+    mimetype: Optional[str] = Field(None, description="Asset MIME type when the result references an asset")
+    page_idx: Optional[int] = Field(None, description="Zero-based page index when available")
+    url: Optional[str] = Field(None, description="External source URL when available")
+    modality: Optional[Literal["text", "image"]] = Field(None, description="Public content modality")
+
+    @classmethod
+    def from_raw(cls, metadata: Optional[dict[str, Any]]) -> Optional["SearchResultMetadata"]:
+        if not isinstance(metadata, dict) or not metadata:
+            return None
+
+        def public_str(*keys: str) -> Optional[str]:
+            for key in keys:
+                value = metadata.get(key)
+                if isinstance(value, str) and value:
+                    return value
+            return None
+
+        page_idx = metadata.get("page_idx")
+        if isinstance(page_idx, str) and page_idx.isdigit():
+            page_idx = int(page_idx)
+        if not isinstance(page_idx, int):
+            page_idx = None
+
+        modality = "image" if metadata.get("indexer") == "vision" else None
+        if modality is None and any(metadata.get(key) for key in ("asset_id", "mimetype")):
+            modality = "image"
+
+        data = {
+            "source": public_str("source", "name"),
+            "title": public_str("title"),
+            "collection_id": public_str("collection_id"),
+            "document_id": public_str("document_id"),
+            "asset_id": public_str("asset_id"),
+            "mimetype": public_str("mimetype"),
+            "page_idx": page_idx,
+            "url": public_str("url"),
+            "modality": modality,
+        }
+        public_data = {key: value for key, value in data.items() if value is not None}
+        return cls(**public_data) if public_data else None
+
+
 class SearchResultItem(BaseModel):
     rank: Optional[int] = Field(None, description="Result rank")
     score: Optional[float] = Field(None, description="Result score")
@@ -588,7 +646,16 @@ class SearchResultItem(BaseModel):
             "vision_search",
         ]
     ] = Field(None, description="Recall type")
-    metadata: Optional[dict[str, Any]] = Field(None, description="Metadata of the result")
+    metadata: Optional[SearchResultMetadata] = Field(None, description="Public metadata of the result")
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def sanitize_metadata(cls, value):
+        if value is None or isinstance(value, SearchResultMetadata):
+            return value
+        if isinstance(value, dict):
+            return SearchResultMetadata.from_raw(value)
+        return value
 
 
 class SearchResult(BaseModel):
@@ -789,28 +856,27 @@ class GraphLabelsResponse(BaseModel):
     )
 
 
-class Properties(BaseModel):
+class GraphNodeProperties(BaseModel):
     """
-    Node properties containing entity metadata
+    Public node properties for graph visualization.
     """
 
     model_config = ConfigDict(
-        extra="allow",
+        extra="forbid",
     )
     entity_id: Optional[str] = Field(None, description="Entity identifier", examples=["墨香居"])
+    entity_name: Optional[str] = Field(None, description="Entity display name", examples=["墨香居"])
     entity_type: Optional[str] = Field(None, description="Type of the entity", examples=["organization"])
     description: Optional[str] = Field(
         None,
         description="Description of the entity",
         examples=["墨香居是这条老巷子里唯一的旧书店，经营着各种书籍，承载了老板李明华的情怀。"],
     )
-    source_id: Optional[str] = Field(
+    source_chunk_count: Optional[conint(ge=0)] = Field(
         None,
-        description="Source chunk ID where entity was extracted",
-        examples=["chunk-88845945407136e9498f5f594c8a00c6"],
+        description="Number of source chunks supporting this entity; raw chunk IDs are not exposed",
+        examples=[3],
     )
-    file_path: Optional[str] = Field(None, description="Source file path", examples=["story.txt"])
-    created_at: Optional[int] = Field(None, description="Creation timestamp", examples=[1751356233])
 
 
 class GraphNode(BaseModel):
@@ -824,16 +890,16 @@ class GraphNode(BaseModel):
         examples=["墨香居"],
     )
     labels: list[str] = Field(..., description="Labels associated with the node", examples=[["墨香居"]])
-    properties: Properties = Field(..., description="Node properties containing entity metadata")
+    properties: GraphNodeProperties = Field(..., description="Public node properties")
 
 
-class Properties1(BaseModel):
+class GraphEdgeProperties(BaseModel):
     """
-    Edge properties containing relationship metadata
+    Public edge properties for graph visualization.
     """
 
     model_config = ConfigDict(
-        extra="allow",
+        extra="forbid",
     )
     weight: Optional[float] = Field(None, description="Relationship weight/strength", examples=[9])
     description: Optional[str] = Field(
@@ -846,13 +912,11 @@ class Properties1(BaseModel):
         description="Keywords associated with the relationship",
         examples=["书店活力,活动"],
     )
-    source_id: Optional[str] = Field(
+    source_chunk_count: Optional[conint(ge=0)] = Field(
         None,
-        description="Source chunk ID where relationship was extracted",
-        examples=["chunk-88845945407136e9498f5f594c8a00c6"],
+        description="Number of source chunks supporting this relationship; raw chunk IDs are not exposed",
+        examples=[2],
     )
-    file_path: Optional[str] = Field(None, description="Source file path", examples=["story.txt"])
-    created_at: Optional[int] = Field(None, description="Creation timestamp", examples=[1751356233])
 
 
 class GraphEdge(BaseModel):
@@ -868,7 +932,7 @@ class GraphEdge(BaseModel):
     type: Optional[str] = Field("DIRECTED", description="Type of the relationship", examples=["DIRECTED"])
     source: str = Field(..., description="Source node ID", examples=["墨香居"])
     target: str = Field(..., description="Target node ID", examples=["深夜读书会"])
-    properties: Properties1 = Field(..., description="Edge properties containing relationship metadata")
+    properties: GraphEdgeProperties = Field(..., description="Public edge properties")
 
 
 class KnowledgeGraph(BaseModel):

--- a/aperag/service/graph_service.py
+++ b/aperag/service/graph_service.py
@@ -78,7 +78,7 @@ class GraphService:
         label: str = None,
         max_depth: int = 3,
         max_nodes: int = 1000,
-    ) -> Dict[str, Any]:
+    ) -> view_models.KnowledgeGraph:
         """Fetch a knowledge-graph subgraph for visualization.
 
         ``label`` is either a specific entity type or "*" / empty for
@@ -117,13 +117,15 @@ class GraphService:
             optimized_nodes = raw_nodes
             optimized_edges = raw_edges
 
-        result = self._to_ui_dict(optimized_nodes, optimized_edges, is_truncated)
+        result = view_models.KnowledgeGraph.model_validate(
+            self._to_ui_dict(optimized_nodes, optimized_edges, is_truncated)
+        )
         logger.info(
             "Retrieved %s graph for collection %s: %d nodes, %d edges",
             mode_description,
             collection_id,
-            len(result["nodes"]),
-            len(result["edges"]),
+            len(result.nodes),
+            len(result.edges),
         )
         return result
 
@@ -199,27 +201,32 @@ class GraphService:
         return selected_nodes, optimized_edges
 
     def _to_ui_dict(self, nodes, edges, is_truncated: bool) -> Dict[str, Any]:
-        """Convert adapted nodes/edges into the JSON the frontend expects.
+        """Convert adapted nodes/edges into the canonical public graph DTO.
 
-        The schema is preserved exactly as it was under LightRAG so the
-        web UI doesn't need to change: each node carries ``id``,
-        ``labels``, and a flat ``properties`` dict; each edge has
-        ``source``, ``target``, ``type``, and ``properties``.
+        Keep the visualizer shape (id/labels/properties and source/target),
+        but strip storage internals such as source chunk IDs, file paths, and
+        timestamps before the data crosses the API boundary.
         """
         default_node_fields = [
             "entity_id",
             "entity_name",
             "entity_type",
             "description",
-            "source_id",
-            "file_path",
+            "source_chunk_count",
         ]
-        default_edge_fields = ["weight", "description", "keywords", "source_id", "file_path"]
+        default_edge_fields = ["weight", "description", "keywords", "source_chunk_count"]
 
         def extract_properties(obj, fields):
+            raw = {}
             if hasattr(obj, "properties") and obj.properties:
-                return obj.properties
-            return {f: getattr(obj, f, None) for f in fields if hasattr(obj, f)}
+                raw = obj.properties
+                if hasattr(raw, "model_dump"):
+                    raw = raw.model_dump(exclude_none=True)
+                elif not isinstance(raw, dict):
+                    raw = dict(raw)
+            else:
+                raw = {f: getattr(obj, f, None) for f in fields if hasattr(obj, f)}
+            return {f: raw.get(f) for f in fields if raw.get(f) is not None}
 
         def node_to_item(node):
             props = extract_properties(node, default_node_fields)
@@ -289,8 +296,7 @@ def _adapt_nodes(nodes: List[GraphIndexEntity]) -> List[SimpleNamespace]:
             "entity_name": n.name,
             "entity_type": n.type,
             "description": n.description,
-            "source_id": ",".join(n.source_chunk_ids) if n.source_chunk_ids else "",
-            "file_path": "",
+            "source_chunk_count": len(n.source_chunk_ids),
         }
         out.append(
             SimpleNamespace(
@@ -301,8 +307,7 @@ def _adapt_nodes(nodes: List[GraphIndexEntity]) -> List[SimpleNamespace]:
                 entity_name=n.name,
                 entity_type=n.type,
                 description=n.description,
-                source_id=props["source_id"],
-                file_path="",
+                source_chunk_count=props["source_chunk_count"],
             )
         )
     return out
@@ -319,8 +324,7 @@ def _adapt_edges(edges: List[GraphIndexRelation]) -> List[SimpleNamespace]:
             "weight": float(e.weight),
             "description": e.description,
             "keywords": "",
-            "source_id": ",".join(e.source_chunk_ids) if e.source_chunk_ids else "",
-            "file_path": "",
+            "source_chunk_count": len(e.source_chunk_ids),
         }
         out.append(
             SimpleNamespace(
@@ -332,8 +336,7 @@ def _adapt_edges(edges: List[GraphIndexRelation]) -> List[SimpleNamespace]:
                 weight=props["weight"],
                 description=e.description,
                 keywords="",
-                source_id=props["source_id"],
-                file_path="",
+                source_chunk_count=props["source_chunk_count"],
             )
         )
     return out

--- a/aperag/service/search_pipeline_service.py
+++ b/aperag/service/search_pipeline_service.py
@@ -33,7 +33,7 @@ from aperag.llm.llm_error_types import (
 from aperag.llm.rerank.rerank_service import RerankService
 from aperag.query.query import DocumentWithScore
 from aperag.schema.utils import parseCollectionConfig
-from aperag.schema.view_models import SearchRequest, SearchResultItem
+from aperag.schema.view_models import SearchRequest, SearchResultItem, SearchResultMetadata
 from aperag.service.default_model_service import default_model_service
 from aperag.utils.utils import generate_fulltext_index_name, generate_vector_db_collection_name
 
@@ -167,14 +167,16 @@ class SearchPipelineService:
         items = []
         for idx, doc in enumerate(reranked_docs):
             metadata = doc.metadata or {}
+            public_metadata = SearchResultMetadata.from_raw(metadata)
+            source = public_metadata.source if public_metadata and public_metadata.source else ""
             items.append(
                 SearchResultItem(
                     rank=idx + 1,
                     score=doc.score,
                     content=doc.text,
-                    source=metadata.get("source", ""),
+                    source=source,
                     recall_type=metadata.get("recall_type", ""),
-                    metadata=metadata,
+                    metadata=public_metadata,
                 )
             )
 

--- a/aperag/views/collections.py
+++ b/aperag/views/collections.py
@@ -434,7 +434,7 @@ async def fetch_url_document_view(
     return await document_service.fetch_url_documents(str(user.id), collection_id, fetch_request.urls)
 
 
-@router.get("/collections/{collection_id}/graphs", tags=["graph"])
+@router.get("/collections/{collection_id}/graphs", tags=["graph"], response_model=view_models.KnowledgeGraph)
 async def get_knowledge_graph_view(
     request: Request,
     collection_id: str,
@@ -442,7 +442,7 @@ async def get_knowledge_graph_view(
     max_nodes: int = 1000,
     max_depth: int = 3,
     user: User = Depends(required_user),
-):
+) -> view_models.KnowledgeGraph:
     """Get knowledge graph - overview mode or subgraph mode"""
     from aperag.service.graph_service import graph_service
 

--- a/aperag/views/marketplace_collections.py
+++ b/aperag/views/marketplace_collections.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
@@ -155,7 +154,7 @@ async def get_marketplace_collection_document_object(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/marketplace/collections/{collection_id}/graph", tags=["graph"])
+@router.get("/marketplace/collections/{collection_id}/graph", tags=["graph"], response_model=view_models.KnowledgeGraph)
 async def get_marketplace_collection_graph(
     request: Request,
     collection_id: str,
@@ -163,7 +162,7 @@ async def get_marketplace_collection_graph(
     max_nodes: int = Query(1000, ge=1, le=10000),
     max_depth: int = Query(3, ge=1, le=10),
     user: User = Depends(optional_user),
-) -> Dict[str, Any]:
+) -> view_models.KnowledgeGraph:
     """Get knowledge graph for MarketplaceCollection (read-only)"""
     from aperag.service.graph_service import graph_service
 

--- a/tests/unit_test/service/test_search_graph_contract.py
+++ b/tests/unit_test/service/test_search_graph_contract.py
@@ -1,0 +1,133 @@
+from types import SimpleNamespace
+
+from aperag.graphindex.dto import Entity, Relation
+from aperag.schema.view_models import KnowledgeGraph, SearchResultItem
+from aperag.service.graph_service import GraphService, _adapt_edges, _adapt_nodes
+
+
+def test_search_result_metadata_is_public_allowlist():
+    item = SearchResultItem(
+        rank=1,
+        score=0.9,
+        content="result",
+        source="doc.pdf",
+        recall_type="vision_search",
+        metadata={
+            "source": "doc.pdf",
+            "name": "ignored-fallback.pdf",
+            "title": "Document title",
+            "collection_id": "col-1",
+            "document_id": "doc-1",
+            "asset_id": "asset-1",
+            "mimetype": "image/png",
+            "page_idx": "2",
+            "url": "https://example.com/doc.pdf",
+            "indexer": "vision",
+            "index_method": "vision_to_text",
+            "chat_id": "chat-1",
+            "object_path": "internal/object/path",
+            "_node_content": {"private": True},
+        },
+    )
+
+    dumped = item.model_dump(exclude_none=True)
+
+    assert dumped["metadata"] == {
+        "source": "doc.pdf",
+        "title": "Document title",
+        "collection_id": "col-1",
+        "document_id": "doc-1",
+        "asset_id": "asset-1",
+        "mimetype": "image/png",
+        "page_idx": 2,
+        "url": "https://example.com/doc.pdf",
+        "modality": "image",
+    }
+
+
+def test_graphindex_adapter_exposes_public_graph_properties_only():
+    node = Entity(
+        entity_id="entity-1",
+        collection_id="col-1",
+        name="ApeRAG",
+        type="product",
+        description="Graph RAG product",
+        source_chunk_ids=("chunk-1", "chunk-2"),
+    )
+    edge = Relation(
+        collection_id="col-1",
+        source_id="entity-1",
+        target_id="entity-2",
+        description="relates to",
+        weight=8,
+        source_chunk_ids=("chunk-3",),
+    )
+
+    service = GraphService.__new__(GraphService)
+    graph = KnowledgeGraph.model_validate(
+        service._to_ui_dict(_adapt_nodes([node]), _adapt_edges([edge]), is_truncated=False)
+    )
+    dumped = graph.model_dump(exclude_none=True)
+
+    node_props = dumped["nodes"][0]["properties"]
+    assert node_props == {
+        "entity_id": "entity-1",
+        "entity_name": "ApeRAG",
+        "entity_type": "product",
+        "description": "Graph RAG product",
+        "source_chunk_count": 2,
+    }
+
+    edge_props = dumped["edges"][0]["properties"]
+    assert edge_props == {
+        "weight": 8.0,
+        "description": "relates to",
+        "keywords": "",
+        "source_chunk_count": 1,
+    }
+
+
+def test_legacy_graph_properties_are_sanitized_before_public_response():
+    legacy_node = SimpleNamespace(
+        id="entity-1",
+        labels=["entity-1"],
+        properties={
+            "entity_id": "entity-1",
+            "entity_name": "ApeRAG",
+            "entity_type": "product",
+            "description": "Graph RAG product",
+            "source_id": "chunk-1,chunk-2",
+            "file_path": "/private/doc.pdf",
+            "created_at": 123,
+        },
+    )
+    legacy_edge = SimpleNamespace(
+        id="entity-1->entity-2",
+        type="DIRECTED",
+        source="entity-1",
+        target="entity-2",
+        properties={
+            "weight": 3.0,
+            "description": "relates to",
+            "keywords": "graph",
+            "source_id": "chunk-3",
+            "file_path": "/private/doc.pdf",
+            "created_at": 456,
+        },
+    )
+
+    service = GraphService.__new__(GraphService)
+    graph = KnowledgeGraph.model_validate(service._to_ui_dict([legacy_node], [legacy_edge], is_truncated=False))
+    dumped = graph.model_dump(exclude_none=True)
+
+    assert dumped["nodes"][0]["properties"] == {
+        "entity_id": "entity-1",
+        "entity_name": "ApeRAG",
+        "entity_type": "product",
+        "description": "Graph RAG product",
+    }
+    assert dumped["edges"][0]["properties"] == {
+        "weight": 3.0,
+        "description": "relates to",
+        "keywords": "graph",
+    }


### PR DESCRIPTION
## Scope

Backend-only slice for `#12` Search/graph v2 contract hard-cut.

This PR tightens the public search/graph DTO boundary without touching frontend generated-client work or the `#9` feature adapter skeleton.

## Changes

- Adds a strict `SearchResultMetadata` model and sanitizes raw search metadata before it crosses the API boundary.
- Keeps client-needed public metadata (`source`, `document_id`, `collection_id`, asset fields, page index, URL, modality) while dropping raw index/storage internals such as `indexer`, `index_method`, `chat_id`, `object_path`, and `_node_content`.
- Replaces LightRAG-era graph `properties` passthrough with explicit public node/edge property models.
- Removes graph response leakage of raw `source_id`, `file_path`, and `created_at`; exposes `source_chunk_count` instead of raw source chunk IDs.
- Adds explicit `KnowledgeGraph` response models on collection and marketplace graph routes.
- Adds focused contract tests for search metadata allow-listing and graph property sanitization.

## Not Included

- No frontend page migration in this PR.
- No `web/src/features/**`, `web/package.json`, or typed-client generation changes.
- No changes to `aperag/api/**`; `#8 / PR #1569` owns the code-first OpenAPI export mechanism and YAML-first exit.

## Validation

- `uv run --extra test pytest tests/unit_test/service/test_search_graph_contract.py -q` -> `3 passed`
- `uv run --extra test pytest tests/unit_test/test_es_p0_contract.py -q` -> `7 passed`
- `uvx ruff check --no-fix aperag/schema/view_models.py aperag/service/search_pipeline_service.py aperag/service/graph_service.py aperag/views/collections.py aperag/views/marketplace_collections.py tests/unit_test/service/test_search_graph_contract.py`
- `uvx ruff format --check aperag/schema/view_models.py aperag/service/search_pipeline_service.py aperag/service/graph_service.py aperag/views/collections.py aperag/views/marketplace_collections.py tests/unit_test/service/test_search_graph_contract.py`
- `git diff --check`
