### PR TITLE
[codex] add provider defaults v2 contract

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -55,6 +55,7 @@ from aperag.views.marketplace import router as marketplace_router
 from aperag.views.marketplace_collections import router as marketplace_collections_router
 from aperag.views.openai import router as openai_router
 from aperag.views.prompts import router as prompts_router
+from aperag.views.providers_v2 import router as providers_v2_router
 from aperag.views.settings import router as settings_router
 from aperag.views.web import router as web_router
 
@@ -110,6 +111,7 @@ app.include_router(openai_router, prefix="/v1")
 app.include_router(config_router, prefix="/api/v1/config")
 app.include_router(agent_runtime_router, prefix="/api/v2")
 app.include_router(evaluation_v2_router, prefix="/api/v2")
+app.include_router(providers_v2_router, prefix="/api/v2")
 
 # Only include test router in dev mode
 if os.environ.get("DEPLOYMENT_MODE") == "dev":

--- a/aperag/schema/view_models.py
+++ b/aperag/schema/view_models.py
@@ -1513,6 +1513,16 @@ class LlmProviderModelCreate(BaseModel):
     tags: Optional[list[str]] = Field([], description="Tags for model categorization")
 
 
+class LlmProviderModelCreateRequest(BaseModel):
+    api: Literal["completion", "embedding", "rerank"] = Field(..., description="API type for this model")
+    model: str = Field(..., description="Model name/identifier")
+    custom_llm_provider: str = Field(..., description="Custom LLM provider implementation")
+    context_window: Optional[int] = Field(None, description="Context window size (total tokens)", examples=[128000])
+    max_input_tokens: Optional[int] = Field(None, description="Maximum input tokens", examples=[120000])
+    max_output_tokens: Optional[int] = Field(None, description="Maximum output tokens", examples=[8000])
+    tags: Optional[list[str]] = Field([], description="Tags for model categorization")
+
+
 class LlmProviderModelUpdate(BaseModel):
     custom_llm_provider: Optional[str] = Field(None, description="Custom LLM provider implementation")
     context_window: Optional[int] = Field(None, description="Context window size (total tokens)", examples=[128000])

--- a/aperag/views/providers_v2.py
+++ b/aperag/views/providers_v2.py
@@ -1,0 +1,200 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import APIRouter, Body, Depends, Path, Query, Response
+
+from aperag.db.models import Role, User
+from aperag.exceptions import PermissionDeniedError
+from aperag.schema import view_models
+from aperag.service.default_model_service import default_model_service
+from aperag.service.llm_available_model_service import llm_available_model_service
+from aperag.service.llm_provider_service import (
+    create_llm_provider,
+    create_llm_provider_model,
+    delete_llm_provider,
+    delete_llm_provider_model,
+    get_llm_configuration,
+    get_llm_provider,
+    list_llm_provider_models,
+    publish_llm_provider,
+    update_llm_provider,
+    update_llm_provider_model,
+)
+from aperag.utils.audit_decorator import audit
+from aperag.views.auth import required_user
+
+router = APIRouter(tags=["providers-v2"])
+
+
+@router.get("/providers/configuration", response_model=view_models.LlmConfigurationResponse)
+async def get_provider_configuration_view(user: User = Depends(required_user)) -> view_models.LlmConfigurationResponse:
+    """Return providers and configured models visible to the current user."""
+
+    return await get_llm_configuration(str(user.id), user.role == Role.ADMIN)
+
+
+@router.post("/providers/available-models", response_model=view_models.ModelConfigList)
+async def get_available_provider_models_view(
+    body: view_models.TagFilterRequest | None = Body(default=None),
+    user: User = Depends(required_user),
+) -> view_models.ModelConfigList:
+    """Return provider catalog models, optionally filtered by tags."""
+
+    return await llm_available_model_service.get_available_models(str(user.id), body or view_models.TagFilterRequest())
+
+
+@router.get("/default-models", response_model=view_models.DefaultModelsResponse)
+async def get_default_models_view(user: User = Depends(required_user)) -> view_models.DefaultModelsResponse:
+    """Return default model selections for each product scenario."""
+
+    return await default_model_service.get_default_models(str(user.id))
+
+
+@router.put("/default-models", response_model=view_models.DefaultModelsResponse)
+async def update_default_models_view(
+    body: view_models.DefaultModelsUpdateRequest,
+    user: User = Depends(required_user),
+) -> view_models.DefaultModelsResponse:
+    """Update default model selections for each product scenario."""
+
+    return await default_model_service.update_default_models(str(user.id), body)
+
+
+@router.post("/providers", response_model=view_models.LlmProvider)
+@audit(resource_type="llm_provider", api_name="CreateLLMProviderV2")
+async def create_provider_view(
+    body: view_models.LlmProviderCreateWithApiKey,
+    user: User = Depends(required_user),
+) -> view_models.LlmProvider:
+    """Create a provider owned by the current user."""
+
+    return await create_llm_provider(body.model_dump(), str(user.id), user.role == Role.ADMIN)
+
+
+@router.get("/providers/{provider_name}", response_model=view_models.LlmProvider)
+async def get_provider_view(
+    provider_name: str,
+    user: User = Depends(required_user),
+) -> view_models.LlmProvider:
+    """Return one provider visible to the current user."""
+
+    return await get_llm_provider(provider_name, str(user.id), user.role == Role.ADMIN)
+
+
+@router.put("/providers/{provider_name}", response_model=view_models.LlmProvider)
+@audit(resource_type="llm_provider", api_name="UpdateLLMProviderV2")
+async def update_provider_view(
+    provider_name: str,
+    body: view_models.LlmProviderUpdateWithApiKey,
+    user: User = Depends(required_user),
+) -> view_models.LlmProvider:
+    """Update a provider owned by the current user."""
+
+    return await update_llm_provider(provider_name, body.model_dump(), str(user.id), user.role == Role.ADMIN)
+
+
+@router.delete("/providers/{provider_name}", status_code=204)
+@audit(resource_type="llm_provider", api_name="DeleteLLMProviderV2")
+async def delete_provider_view(
+    provider_name: str,
+    user: User = Depends(required_user),
+) -> Response:
+    """Delete a provider owned by the current user."""
+
+    await delete_llm_provider(provider_name, str(user.id), user.role == Role.ADMIN)
+    return Response(status_code=204)
+
+
+@router.post("/providers/{provider_name}/publish", response_model=view_models.LlmProvider)
+@audit(resource_type="llm_provider", api_name="PublishLLMProviderV2")
+async def publish_provider_view(
+    provider_name: str,
+    user: User = Depends(required_user),
+) -> view_models.LlmProvider:
+    """Publish a private provider to the public catalog. Admin only."""
+
+    if user.role != Role.ADMIN:
+        raise PermissionDeniedError("Only admin can publish provider to public")
+    return await publish_llm_provider(provider_name, str(user.id))
+
+
+@router.get("/provider-models", response_model=view_models.LlmProviderModelList)
+async def list_provider_models_view(
+    provider_name: str | None = Query(default=None),
+    user: User = Depends(required_user),
+) -> view_models.LlmProviderModelList:
+    """Return models for all visible providers, optionally filtered by provider."""
+
+    return await list_llm_provider_models(
+        provider_name=provider_name, user_id=str(user.id), is_admin=user.role == Role.ADMIN
+    )
+
+
+@router.get("/providers/{provider_name}/models", response_model=view_models.LlmProviderModelList)
+async def list_provider_models_by_provider_view(
+    provider_name: str,
+    user: User = Depends(required_user),
+) -> view_models.LlmProviderModelList:
+    """Return models for one provider visible to the current user."""
+
+    return await list_llm_provider_models(
+        provider_name=provider_name, user_id=str(user.id), is_admin=user.role == Role.ADMIN
+    )
+
+
+@router.post("/providers/{provider_name}/models", response_model=view_models.LlmProviderModel)
+@audit(resource_type="llm_provider_model", api_name="CreateProviderModelV2")
+async def create_provider_model_view(
+    provider_name: str,
+    body: view_models.LlmProviderModelCreateRequest,
+    user: User = Depends(required_user),
+) -> view_models.LlmProviderModel:
+    """Create a model under a provider owned by the current user."""
+
+    return await create_llm_provider_model(provider_name, body.model_dump(), str(user.id), user.role == Role.ADMIN)
+
+
+@router.put("/providers/{provider_name}/models/{api}/{model:path}", response_model=view_models.LlmProviderModel)
+@audit(resource_type="llm_provider_model", api_name="UpdateProviderModelV2")
+async def update_provider_model_view(
+    provider_name: str,
+    api: str,
+    body: view_models.LlmProviderModelUpdate,
+    model: str = Path(..., description="Model name. Supports names with slashes."),
+    user: User = Depends(required_user),
+) -> view_models.LlmProviderModel:
+    """Update a model under a provider owned by the current user."""
+
+    return await update_llm_provider_model(
+        provider_name,
+        api,
+        model,
+        body.model_dump(exclude_unset=True),
+        str(user.id),
+        user.role == Role.ADMIN,
+    )
+
+
+@router.delete("/providers/{provider_name}/models/{api}/{model:path}", status_code=204)
+@audit(resource_type="llm_provider_model", api_name="DeleteProviderModelV2")
+async def delete_provider_model_view(
+    provider_name: str,
+    api: str,
+    model: str = Path(..., description="Model name. Supports names with slashes."),
+    user: User = Depends(required_user),
+) -> Response:
+    """Delete a model under a provider owned by the current user."""
+
+    await delete_llm_provider_model(provider_name, api, model, str(user.id), user.role == Role.ADMIN)
+    return Response(status_code=204)

--- a/tests/unit_test/test_provider_v2_openapi_contract.py
+++ b/tests/unit_test/test_provider_v2_openapi_contract.py
@@ -1,0 +1,49 @@
+from fastapi import FastAPI
+
+from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
+from aperag.views.providers_v2 import router
+
+
+def _provider_v2_spec():
+    app = FastAPI(generate_unique_id_function=custom_generate_unique_id)
+    app.include_router(router, prefix="/api/v2")
+    return filter_public_openapi(build_full_openapi_spec(app))
+
+
+def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
+    return spec["paths"][path][method]["responses"][status]["content"]["application/json"]["schema"]["$ref"]
+
+
+def test_provider_v2_routes_are_public_and_typed():
+    spec = _provider_v2_spec()
+    paths = spec["paths"]
+
+    assert "/api/v2/providers/configuration" in paths
+    assert "/api/v2/providers/available-models" in paths
+    assert "/api/v2/default-models" in paths
+    assert "/api/v2/providers" in paths
+    assert "/api/v2/providers/{provider_name}" in paths
+    assert "/api/v2/providers/{provider_name}/models" in paths
+    assert "/api/v2/providers/{provider_name}/models/{api}/{model}" in paths
+
+    assert _json_ref(spec, "/api/v2/providers/configuration", "get") == "#/components/schemas/LlmConfigurationResponse"
+    assert _json_ref(spec, "/api/v2/providers/available-models", "post") == "#/components/schemas/ModelConfigList"
+    assert _json_ref(spec, "/api/v2/default-models", "get") == "#/components/schemas/DefaultModelsResponse"
+    assert _json_ref(spec, "/api/v2/default-models", "put") == "#/components/schemas/DefaultModelsResponse"
+    assert _json_ref(spec, "/api/v2/providers", "post") == "#/components/schemas/LlmProvider"
+    assert (
+        _json_ref(spec, "/api/v2/providers/{provider_name}/models", "post") == "#/components/schemas/LlmProviderModel"
+    )
+
+
+def test_provider_v2_model_create_request_uses_path_provider():
+    spec = _provider_v2_spec()
+
+    request_ref = spec["paths"]["/api/v2/providers/{provider_name}/models"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    request_schema_name = request_ref.removeprefix("#/components/schemas/")
+    request_schema = spec["components"]["schemas"][request_schema_name]
+
+    assert request_schema_name == "LlmProviderModelCreateRequest"
+    assert "provider_name" not in request_schema["properties"]


### PR DESCRIPTION
## Summary
- add code-first /api/v2 provider/default-models routes with explicit request/response models
- add a v2 provider model create request that takes provider identity from the path instead of duplicating provider_name in the body
- add focused OpenAPI contract tests for provider/default-models v2 public spec visibility and schema shape

## Validation
- make openapi-check
- make lint
- uv run --extra test pytest tests/unit_test/test_provider_v2_openapi_contract.py tests/unit_test/test_openapi_spec.py -q
- git diff --check

## Scope boundary
- backend contract only for #10
- no frontend files changed; #9 remains owner of typed client / provider page adapter
- no collection/document/indexing changes; #11 remains separate