### PR TITLE
feat(api): Collection/Sharing v2 contract (#11a / task #16)

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -44,6 +44,7 @@ from aperag.views.auth import router as auth_router
 from aperag.views.bot import router as bot_router
 from aperag.views.chat import router as chat_router
 from aperag.views.collections import router as collections_router
+from aperag.views.collections_v2 import router as collections_v2_router
 from aperag.views.config import router as config_router
 from aperag.views.evaluation import router as evaluation_router
 from aperag.views.evaluation_v2 import router as evaluation_v2_router
@@ -112,6 +113,7 @@ app.include_router(config_router, prefix="/api/v1/config")
 app.include_router(agent_runtime_router, prefix="/api/v2")
 app.include_router(evaluation_v2_router, prefix="/api/v2")
 app.include_router(providers_v2_router, prefix="/api/v2")
+app.include_router(collections_v2_router, prefix="/api/v2")
 
 # Only include test router in dev mode
 if os.environ.get("DEPLOYMENT_MODE") == "dev":

--- a/aperag/schema/view_models.py
+++ b/aperag/schema/view_models.py
@@ -1250,6 +1250,38 @@ class SharingStatusResponse(BaseModel):
     published_at: Optional[datetime] = Field(None, description="Publication time, null when not published")
 
 
+class CollectionSummaryTriggerResponse(BaseModel):
+    """Trigger-response envelope for POST /collections/{collection_id}/summary/generate."""
+
+    collection_id: str = Field(..., description="Collection id whose summary generation was triggered")
+    success: bool = Field(..., description="Whether the background job was scheduled")
+    message: str = Field(..., description="Human-readable status message")
+    summary_status: Literal["PENDING", "GENERATING"] = Field(
+        ...,
+        description="Server-side summary state after the trigger call",
+    )
+
+
+class MineruTokenTestRequest(BaseModel):
+    """Request body for POST /collections/test-mineru-token."""
+
+    token: str = Field(..., description="MinerU API token to validate")
+
+
+class MineruTokenTestResponse(BaseModel):
+    """Response envelope for POST /collections/test-mineru-token.
+
+    `status_code` is the HTTP status returned by MinerU's upstream test endpoint;
+    `data` is the passthrough body echoed to the caller.
+    """
+
+    status_code: int = Field(..., description="HTTP status code returned by MinerU upstream")
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Passthrough body from MinerU upstream",
+    )
+
+
 class SharedCollectionConfig(BaseModel):
     """
     Configuration settings for shared collection features

--- a/aperag/views/collections_v2.py
+++ b/aperag/views/collections_v2.py
@@ -1,0 +1,192 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+
+from aperag.db.models import User
+from aperag.exceptions import CollectionNotFoundException, PermissionDeniedError
+from aperag.schema import view_models
+from aperag.service.collection_service import collection_service
+from aperag.service.collection_summary_service import collection_summary_service
+from aperag.service.marketplace_service import marketplace_service
+from aperag.utils.audit_decorator import audit
+from aperag.views.auth import required_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["collections-v2"])
+
+
+# Static-path routes must be declared before `/collections/{collection_id}` so FastAPI
+# matches them first and provider/collection names cannot shadow them.
+
+
+@router.post(
+    "/collections/test-mineru-token",
+    response_model=view_models.MineruTokenTestResponse,
+)
+async def test_mineru_token_view(
+    body: view_models.MineruTokenTestRequest,
+    user: User = Depends(required_user),
+) -> view_models.MineruTokenTestResponse:
+    """Probe an upstream MinerU API token and echo the status envelope."""
+
+    result = await collection_service.test_mineru_token(body.token)
+    return view_models.MineruTokenTestResponse(
+        status_code=int(result.get("status_code", 500)),
+        data=result.get("data") or {},
+    )
+
+
+@router.post("/collections", response_model=view_models.Collection)
+@audit(resource_type="collection", api_name="CreateCollectionV2")
+async def create_collection_view(
+    collection: view_models.CollectionCreate,
+    user: User = Depends(required_user),
+) -> view_models.Collection:
+    """Create a collection owned by the current user."""
+
+    return await collection_service.create_collection(str(user.id), collection)
+
+
+@router.get("/collections", response_model=view_models.CollectionViewList)
+async def list_collections_view(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    include_subscribed: bool = Query(True),
+    user: User = Depends(required_user),
+) -> view_models.CollectionViewList:
+    """List collections visible to the current user."""
+
+    return await collection_service.list_collections_view(str(user.id), include_subscribed, page, page_size)
+
+
+@router.get("/collections/{collection_id}", response_model=view_models.Collection)
+async def get_collection_view(
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> view_models.Collection:
+    """Return one collection owned by the current user."""
+
+    return await collection_service.get_collection(str(user.id), collection_id)
+
+
+@router.put("/collections/{collection_id}", response_model=view_models.Collection)
+@audit(resource_type="collection", api_name="UpdateCollectionV2")
+async def update_collection_view(
+    collection_id: str,
+    body: view_models.CollectionUpdate,
+    user: User = Depends(required_user),
+) -> view_models.Collection:
+    """Update a collection owned by the current user."""
+
+    return await collection_service.update_collection(str(user.id), collection_id, body)
+
+
+@router.delete("/collections/{collection_id}", status_code=204)
+@audit(resource_type="collection", api_name="DeleteCollectionV2")
+async def delete_collection_view(
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> Response:
+    """Delete a collection owned by the current user. Idempotent."""
+
+    await collection_service.delete_collection(str(user.id), collection_id)
+    return Response(status_code=204)
+
+
+@router.post(
+    "/collections/{collection_id}/summary/generate",
+    response_model=view_models.CollectionSummaryTriggerResponse,
+)
+@audit(resource_type="collection", api_name="GenerateCollectionSummaryV2")
+async def generate_collection_summary_view(
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> view_models.CollectionSummaryTriggerResponse:
+    """Trigger background summary generation for one collection."""
+
+    collection = await collection_service.get_collection(str(user.id), collection_id)
+    if not collection:
+        raise HTTPException(status_code=404, detail="Collection not found")
+
+    task_triggered = await collection_summary_service.trigger_collection_summary_generation(collection)
+    if task_triggered:
+        return view_models.CollectionSummaryTriggerResponse(
+            collection_id=collection_id,
+            success=True,
+            message="Collection summary generation started",
+            summary_status="PENDING",
+        )
+    return view_models.CollectionSummaryTriggerResponse(
+        collection_id=collection_id,
+        success=False,
+        message="Collection summary generation already in progress or disabled",
+        summary_status="GENERATING",
+    )
+
+
+@router.get(
+    "/collections/{collection_id}/sharing",
+    response_model=view_models.SharingStatusResponse,
+)
+async def get_collection_sharing_status_view(
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> view_models.SharingStatusResponse:
+    """Return marketplace sharing status for a collection owned by the current user."""
+
+    try:
+        is_published, published_at = await marketplace_service.get_sharing_status(user.id, collection_id)
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except PermissionDeniedError:
+        raise HTTPException(status_code=403, detail="Permission denied")
+    return view_models.SharingStatusResponse(is_published=is_published, published_at=published_at)
+
+
+@router.post("/collections/{collection_id}/sharing", status_code=204)
+@audit(resource_type="collection", api_name="PublishCollectionV2")
+async def publish_collection_sharing_view(
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> Response:
+    """Publish a collection to the marketplace. Owner only."""
+
+    try:
+        await marketplace_service.publish_collection(user.id, collection_id)
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except PermissionDeniedError:
+        raise HTTPException(status_code=403, detail="Permission denied")
+    return Response(status_code=204)
+
+
+@router.delete("/collections/{collection_id}/sharing", status_code=204)
+@audit(resource_type="collection", api_name="UnpublishCollectionV2")
+async def unpublish_collection_sharing_view(
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> Response:
+    """Unpublish a collection from the marketplace. Owner only."""
+
+    try:
+        await marketplace_service.unpublish_collection(user.id, collection_id)
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except PermissionDeniedError:
+        raise HTTPException(status_code=403, detail="Permission denied")
+    return Response(status_code=204)

--- a/tests/unit_test/test_collection_v2_openapi_contract.py
+++ b/tests/unit_test/test_collection_v2_openapi_contract.py
@@ -1,0 +1,134 @@
+from fastapi import FastAPI
+
+from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
+from aperag.views.collections_v2 import router
+
+
+def _collection_v2_spec():
+    app = FastAPI(generate_unique_id_function=custom_generate_unique_id)
+    app.include_router(router, prefix="/api/v2")
+    return filter_public_openapi(build_full_openapi_spec(app))
+
+
+def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
+    return spec["paths"][path][method]["responses"][status]["content"]["application/json"]["schema"]["$ref"]
+
+
+REQUIRED_PATHS = {
+    "/api/v2/collections",
+    "/api/v2/collections/{collection_id}",
+    "/api/v2/collections/test-mineru-token",
+    "/api/v2/collections/{collection_id}/summary/generate",
+    "/api/v2/collections/{collection_id}/sharing",
+}
+
+# Non-204 JSON routes that must have a $ref response schema.
+JSON_ROUTES = [
+    ("/api/v2/collections", "post", "Collection"),
+    ("/api/v2/collections", "get", "CollectionViewList"),
+    ("/api/v2/collections/{collection_id}", "get", "Collection"),
+    ("/api/v2/collections/{collection_id}", "put", "Collection"),
+    ("/api/v2/collections/test-mineru-token", "post", "MineruTokenTestResponse"),
+    (
+        "/api/v2/collections/{collection_id}/summary/generate",
+        "post",
+        "CollectionSummaryTriggerResponse",
+    ),
+    ("/api/v2/collections/{collection_id}/sharing", "get", "SharingStatusResponse"),
+]
+
+# Command-style routes that must respond with 204 and have no JSON body.
+NO_CONTENT_ROUTES = [
+    ("/api/v2/collections/{collection_id}", "delete"),
+    ("/api/v2/collections/{collection_id}/sharing", "post"),
+    ("/api/v2/collections/{collection_id}/sharing", "delete"),
+]
+
+
+def test_collection_v2_public_paths_present():
+    spec = _collection_v2_spec()
+    paths = spec["paths"]
+    for p in REQUIRED_PATHS:
+        assert p in paths, f"missing public path: {p}"
+
+
+def test_collection_v2_json_routes_use_explicit_response_schema():
+    spec = _collection_v2_spec()
+    for path, method, schema_name in JSON_ROUTES:
+        ref = _json_ref(spec, path, method)
+        assert ref == f"#/components/schemas/{schema_name}", (
+            f"{method.upper()} {path} expected $ref to {schema_name}, got {ref}"
+        )
+
+
+def test_collection_v2_command_routes_return_204_without_body():
+    spec = _collection_v2_spec()
+    for path, method in NO_CONTENT_ROUTES:
+        responses = spec["paths"][path][method]["responses"]
+        assert "204" in responses, f"{method.upper()} {path} must declare 204 response"
+        # 204 responses carry no content body.
+        assert "content" not in responses["204"], (
+            f"{method.upper()} {path} 204 response must not carry a JSON body"
+        )
+        # Command routes must not register a competing 200 JSON schema.
+        assert "200" not in responses, (
+            f"{method.upper()} {path} must not mix 204 with a 200 JSON response"
+        )
+
+
+def test_collection_v2_write_bodies_do_not_repeat_collection_id():
+    """Write routes taking {collection_id} path param must not repeat it in the body."""
+    spec = _collection_v2_spec()
+    # Collect every write method that takes `collection_id` as a path param.
+    offending = []
+    for path, operations in spec["paths"].items():
+        if "{collection_id}" not in path:
+            continue
+        for method, op in operations.items():
+            if method not in {"post", "put", "patch"}:
+                continue
+            body = op.get("requestBody")
+            if not body:
+                continue
+            json_schema = body.get("content", {}).get("application/json", {}).get("schema", {})
+            ref = json_schema.get("$ref")
+            if not ref:
+                continue
+            schema_name = ref.removeprefix("#/components/schemas/")
+            props = spec["components"]["schemas"][schema_name].get("properties", {})
+            if "collection_id" in props:
+                offending.append((method.upper(), path, schema_name))
+    assert not offending, f"write bodies must not repeat collection_id: {offending}"
+
+
+def test_collection_v2_does_not_occupy_documents_or_search_or_graph():
+    """#11a scope must leave documents/search/graph routes to #11b / #12 / #13."""
+    spec = _collection_v2_spec()
+    for path in spec["paths"]:
+        assert "/documents" not in path, f"collections_v2 must not own documents path: {path}"
+        assert "/searches" not in path, f"collections_v2 must not own search path: {path}"
+        assert "/graphs" not in path, f"collections_v2 must not own graph path: {path}"
+
+
+def test_collection_v2_no_duplicate_operation_ids():
+    spec = _collection_v2_spec()
+    op_ids = []
+    for operations in spec["paths"].values():
+        for method, op in operations.items():
+            if method in {"parameters", "summary", "description"}:
+                continue
+            op_id = op.get("operationId")
+            if op_id is not None:
+                op_ids.append(op_id)
+    assert len(op_ids) == len(set(op_ids)), f"duplicate operationIds: {op_ids}"
+
+
+def test_collection_v2_mineru_token_request_schema_is_typed():
+    """Mineru token request must be a typed schema, not a naked dict."""
+    spec = _collection_v2_spec()
+    req = spec["paths"]["/api/v2/collections/test-mineru-token"]["post"]["requestBody"]
+    ref = req["content"]["application/json"]["schema"]["$ref"]
+    schema_name = ref.removeprefix("#/components/schemas/")
+    assert schema_name == "MineruTokenTestRequest"
+    props = spec["components"]["schemas"][schema_name]["properties"]
+    assert "token" in props


### PR DESCRIPTION
## Summary

Introduces `aperag/views/collections_v2.py` under `/api/v2`, mirroring the
code-first contract pattern established by `providers_v2.py` in #1572 as part
of the `#11` collection/document/indexing hard-cut program, task **#16 / #11a**
(scope fixed by acting PM @weihong in the task thread).

- 10 v2 routes total: collection CRUD (POST/GET/GET/PUT/DELETE), summary trigger,
  mineru-token probe, sharing (GET/POST/DELETE).
- Every JSON route declares an **explicit `response_model=`**; command-style
  routes (`DELETE /collections/{id}`, `POST /sharing`, `DELETE /sharing`) return
  **204** with no body.
- Write routes keep `collection_id` **path-canonical** and never repeat it in the
  request body.
- New typed schemas: `CollectionSummaryTriggerResponse`,
  `MineruTokenTestRequest`, `MineruTokenTestResponse`. Existing
  `SharingStatusResponse` reused.
- Static `/collections/test-mineru-token` registered **before**
  `/collections/{collection_id}` to avoid FastAPI path shadowing.
- `tests/unit_test/test_collection_v2_openapi_contract.py` pins:
  - required public paths all in `openapi.public.json`
  - non-204 JSON routes use `$ref` response schemas
  - command routes declare 204 and carry no JSON body
  - write bodies do not repeat `collection_id`
  - scope guard: router does **not** occupy `/documents*` / `/searches*` / `/graphs*`
  - mineru request body is a typed schema, not naked dict
  - `duplicate_operation_ids == 0`

## Scope (per PM boundary for #11a)

**In**: `aperag/views/collections_v2.py`, necessary schemas in
`aperag/schema/view_models.py`, `aperag/app.py` router include,
focused `test_collection_v2_openapi_contract.py`.

**Explicitly out**: documents routes (leave for #17/#11b), search/graph
routes (stay on #12/#13 contract), marketplace routes, FE, indexing internals,
back-compat hacks.

## Local verification

- `make openapi-check` — pass
- `make lint` — pass (`ruff check` + `ruff format --check`)
- `uv run --extra test pytest tests/unit_test/test_collection_v2_openapi_contract.py tests/unit_test/test_openapi_spec.py -q` — **10 passed**
- `git diff --check` — pass
- Full app import sanity: public spec exports 5 unique `/api/v2/collections*`
  paths with 10 method-level operations.

## Test plan

- [ ] GitHub `lint-and-unit` green on head
- [ ] GitHub `e2e-http-smoke` green
- [ ] `@ApeRAG专家` / `@Weston` diff-scoped contract-owner CR
- [ ] `@符炫炜` consumer-angle CR (#14 evaluation uses `collection_id` string only, per sketch §3 — expected no blocker)
- [ ] Task #16 moves to `in_review` → `done` only after #15 demo validation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)