### PR TITLE
#17 Documents v2 backend contract

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -46,6 +46,7 @@ from aperag.views.chat import router as chat_router
 from aperag.views.collections import router as collections_router
 from aperag.views.collections_v2 import router as collections_v2_router
 from aperag.views.config import router as config_router
+from aperag.views.documents_v2 import router as documents_v2_router
 from aperag.views.evaluation_v2 import router as evaluation_v2_router
 from aperag.views.export import router as export_router
 from aperag.views.graph import router as graph_router
@@ -112,6 +113,7 @@ app.include_router(agent_runtime_router, prefix="/api/v2")
 app.include_router(evaluation_v2_router, prefix="/api/v2")
 app.include_router(providers_v2_router, prefix="/api/v2")
 app.include_router(collections_v2_router, prefix="/api/v2")
+app.include_router(documents_v2_router, prefix="/api/v2")
 
 # Only include test router in dev mode
 if os.environ.get("DEPLOYMENT_MODE") == "dev":

--- a/aperag/schema/view_models.py
+++ b/aperag/schema/view_models.py
@@ -461,9 +461,27 @@ class DocumentList(PaginatedResponse):
     items: Optional[list[Document]] = None
 
 
+class DeleteDocumentsRequest(BaseModel):
+    document_ids: list[str] = Field(..., description="Document IDs to delete", min_length=1)
+
+
+class DeleteDocumentsResponse(BaseModel):
+    deleted_ids: list[str] = Field(..., description="Document IDs accepted for deletion")
+    status: Literal["success"] = Field(..., description="Batch deletion status")
+
+
 class RebuildIndexesRequest(BaseModel):
     index_types: list[Literal["VECTOR", "FULLTEXT", "GRAPH", "SUMMARY", "VISION"]] = Field(
         ..., description="Types of indexes to rebuild", min_length=1
+    )
+
+
+class RebuildIndexesResponse(BaseModel):
+    code: str = Field(..., description="Result code", examples=["200"])
+    message: str = Field(..., description="Human-readable rebuild status")
+    affected_documents: Optional[conint(ge=0)] = Field(
+        None,
+        description="Number of documents affected by a collection-level rebuild",
     )
 
 

--- a/aperag/views/documents_v2.py
+++ b/aperag/views/documents_v2.py
@@ -1,0 +1,209 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, File, Query, Request, Response, UploadFile
+from starlette.responses import StreamingResponse
+
+from aperag.db.models import User
+from aperag.schema import view_models
+from aperag.service.document_service import document_service
+from aperag.utils.audit_decorator import audit
+from aperag.views.auth import required_user
+
+router = APIRouter(tags=["documents-v2"])
+
+
+@router.post("/collections/{collection_id}/documents", response_model=view_models.DocumentList)
+@audit(resource_type="document", api_name="CreateDocumentsV2")
+async def create_documents_v2_view(
+    request: Request,
+    collection_id: str,
+    files: list[UploadFile] = File(...),
+    user: User = Depends(required_user),
+) -> view_models.DocumentList:
+    return await document_service.create_documents(str(user.id), collection_id, files)
+
+
+@router.get("/collections/{collection_id}/documents", response_model=view_models.DocumentList)
+async def list_documents_v2_view(
+    collection_id: str,
+    page: int = Query(1, ge=1, description="Page number (1-based)"),
+    page_size: int = Query(10, ge=1, le=100, description="Number of items per page"),
+    sort_by: Literal["name", "created", "updated", "size", "status"] = Query(
+        "created",
+        description="Field to sort by",
+    ),
+    sort_order: Literal["asc", "desc"] = Query("desc", description="Sort order"),
+    search: str | None = Query(None, description="Search documents by name"),
+    user: User = Depends(required_user),
+) -> view_models.DocumentList:
+    result = await document_service.list_documents(
+        user=str(user.id),
+        collection_id=collection_id,
+        page=page,
+        page_size=page_size,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        search=search,
+    )
+    return view_models.DocumentList.model_validate(result.model_dump())
+
+
+@router.get("/collections/{collection_id}/documents/staged", response_model=view_models.StagedDocumentsResponse)
+async def list_staged_documents_v2_view(
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> view_models.StagedDocumentsResponse:
+    return await document_service.get_staged_documents(str(user.id), collection_id)
+
+
+@router.get("/collections/{collection_id}/documents/{document_id}", response_model=view_models.Document)
+async def get_document_v2_view(
+    collection_id: str,
+    document_id: str,
+    user: User = Depends(required_user),
+) -> view_models.Document:
+    return await document_service.get_document(str(user.id), collection_id, document_id)
+
+
+@router.get(
+    "/collections/{collection_id}/documents/{document_id}/download",
+    response_class=StreamingResponse,
+    responses={200: {"content": {"application/octet-stream": {}}}},
+)
+@audit(resource_type="document", api_name="DownloadDocumentV2")
+async def download_document_v2_view(
+    request: Request,
+    collection_id: str,
+    document_id: str,
+    user: User = Depends(required_user),
+) -> StreamingResponse:
+    return await document_service.download_document(str(user.id), collection_id, document_id)
+
+
+@router.delete("/collections/{collection_id}/documents/{document_id}", status_code=204)
+@audit(resource_type="document", api_name="DeleteDocumentV2")
+async def delete_document_v2_view(
+    request: Request,
+    collection_id: str,
+    document_id: str,
+    user: User = Depends(required_user),
+) -> Response:
+    await document_service.delete_document(str(user.id), collection_id, document_id)
+    return Response(status_code=204)
+
+
+@router.delete("/collections/{collection_id}/documents", response_model=view_models.DeleteDocumentsResponse)
+@audit(resource_type="document", api_name="DeleteDocumentsV2")
+async def delete_documents_v2_view(
+    request: Request,
+    collection_id: str,
+    body: view_models.DeleteDocumentsRequest,
+    user: User = Depends(required_user),
+) -> view_models.DeleteDocumentsResponse:
+    result = await document_service.delete_documents(str(user.id), collection_id, body.document_ids)
+    return view_models.DeleteDocumentsResponse.model_validate(result)
+
+
+@router.get(
+    "/collections/{collection_id}/documents/{document_id}/preview",
+    response_model=view_models.DocumentPreview,
+)
+async def get_document_preview_v2_view(
+    collection_id: str,
+    document_id: str,
+    user: User = Depends(required_user),
+) -> view_models.DocumentPreview:
+    return await document_service.get_document_preview(str(user.id), collection_id, document_id)
+
+
+@router.get(
+    "/collections/{collection_id}/documents/{document_id}/object",
+    response_class=StreamingResponse,
+    responses={200: {"content": {"application/octet-stream": {}}}, 206: {"content": {"application/octet-stream": {}}}},
+)
+async def get_document_object_v2_view(
+    collection_id: str,
+    document_id: str,
+    path: str,
+    request: Request,
+    user: User = Depends(required_user),
+) -> StreamingResponse:
+    range_header = request.headers.get("range")
+    return await document_service.get_document_object(str(user.id), collection_id, document_id, path, range_header)
+
+
+@router.post(
+    "/collections/{collection_id}/documents/{document_id}/rebuild_indexes",
+    response_model=view_models.RebuildIndexesResponse,
+)
+@audit(resource_type="document", api_name="RebuildDocumentIndexesV2")
+async def rebuild_document_indexes_v2_view(
+    request: Request,
+    collection_id: str,
+    document_id: str,
+    body: view_models.RebuildIndexesRequest,
+    user: User = Depends(required_user),
+) -> view_models.RebuildIndexesResponse:
+    result = await document_service.rebuild_document_indexes(str(user.id), collection_id, document_id, body.index_types)
+    return view_models.RebuildIndexesResponse.model_validate(result)
+
+
+@router.post(
+    "/collections/{collection_id}/rebuild_failed_indexes",
+    response_model=view_models.RebuildIndexesResponse,
+)
+@audit(resource_type="collection", api_name="RebuildFailedIndexesV2")
+async def rebuild_failed_indexes_v2_view(
+    request: Request,
+    collection_id: str,
+    user: User = Depends(required_user),
+) -> view_models.RebuildIndexesResponse:
+    result = await document_service.rebuild_failed_indexes(str(user.id), collection_id)
+    return view_models.RebuildIndexesResponse.model_validate(result)
+
+
+@router.post("/collections/{collection_id}/documents/upload", response_model=view_models.UploadDocumentResponse)
+@audit(resource_type="document", api_name="UploadDocumentV2")
+async def upload_document_v2_view(
+    request: Request,
+    collection_id: str,
+    file: UploadFile = File(...),
+    user: User = Depends(required_user),
+) -> view_models.UploadDocumentResponse:
+    return await document_service.upload_document(str(user.id), collection_id, file)
+
+
+@router.post("/collections/{collection_id}/documents/confirm", response_model=view_models.ConfirmDocumentsResponse)
+@audit(resource_type="document", api_name="ConfirmDocumentsV2")
+async def confirm_documents_v2_view(
+    request: Request,
+    collection_id: str,
+    body: view_models.ConfirmDocumentsRequest,
+    user: User = Depends(required_user),
+) -> view_models.ConfirmDocumentsResponse:
+    return await document_service.confirm_documents(str(user.id), collection_id, body.document_ids)
+
+
+@router.post("/collections/{collection_id}/documents/fetch-url", response_model=view_models.FetchUrlResponse)
+@audit(resource_type="document", api_name="FetchUrlDocumentV2")
+async def fetch_url_document_v2_view(
+    request: Request,
+    collection_id: str,
+    body: view_models.FetchUrlRequest,
+    user: User = Depends(required_user),
+) -> view_models.FetchUrlResponse:
+    return await document_service.fetch_url_documents(str(user.id), collection_id, body.urls)

--- a/tests/unit_test/test_documents_v2_openapi_contract.py
+++ b/tests/unit_test/test_documents_v2_openapi_contract.py
@@ -1,0 +1,121 @@
+from fastapi import FastAPI
+
+from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
+from aperag.views.documents_v2 import router
+
+
+def _documents_v2_spec():
+    app = FastAPI(generate_unique_id_function=custom_generate_unique_id)
+    app.include_router(router, prefix="/api/v2")
+    return filter_public_openapi(build_full_openapi_spec(app))
+
+
+def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
+    return spec["paths"][path][method]["responses"][status]["content"]["application/json"]["schema"]["$ref"]
+
+
+def _request_schema(spec: dict, path: str, method: str) -> dict:
+    request_ref = spec["paths"][path][method]["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+    return spec["components"]["schemas"][request_ref.removeprefix("#/components/schemas/")]
+
+
+def test_documents_v2_routes_are_public_and_typed():
+    spec = _documents_v2_spec()
+    paths = spec["paths"]
+
+    required_paths = {
+        "/api/v2/collections/{collection_id}/documents",
+        "/api/v2/collections/{collection_id}/documents/staged",
+        "/api/v2/collections/{collection_id}/documents/{document_id}",
+        "/api/v2/collections/{collection_id}/documents/{document_id}/download",
+        "/api/v2/collections/{collection_id}/documents/{document_id}/preview",
+        "/api/v2/collections/{collection_id}/documents/{document_id}/object",
+        "/api/v2/collections/{collection_id}/documents/{document_id}/rebuild_indexes",
+        "/api/v2/collections/{collection_id}/rebuild_failed_indexes",
+        "/api/v2/collections/{collection_id}/documents/upload",
+        "/api/v2/collections/{collection_id}/documents/confirm",
+        "/api/v2/collections/{collection_id}/documents/fetch-url",
+    }
+
+    assert required_paths <= set(paths)
+    assert not any("/graph" in path or "/searches" in path for path in paths)
+
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents", "post") == (
+        "#/components/schemas/DocumentList"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents", "get") == (
+        "#/components/schemas/DocumentList"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents/staged", "get") == (
+        "#/components/schemas/StagedDocumentsResponse"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents/{document_id}", "get") == (
+        "#/components/schemas/Document"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents", "delete") == (
+        "#/components/schemas/DeleteDocumentsResponse"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents/{document_id}/preview", "get") == (
+        "#/components/schemas/DocumentPreview"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents/{document_id}/rebuild_indexes", "post") == (
+        "#/components/schemas/RebuildIndexesResponse"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/rebuild_failed_indexes", "post") == (
+        "#/components/schemas/RebuildIndexesResponse"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents/upload", "post") == (
+        "#/components/schemas/UploadDocumentResponse"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents/confirm", "post") == (
+        "#/components/schemas/ConfirmDocumentsResponse"
+    )
+    assert _json_ref(spec, "/api/v2/collections/{collection_id}/documents/fetch-url", "post") == (
+        "#/components/schemas/FetchUrlResponse"
+    )
+
+
+def test_documents_v2_delete_and_request_bodies_are_path_canonical():
+    spec = _documents_v2_spec()
+
+    single_delete_responses = spec["paths"]["/api/v2/collections/{collection_id}/documents/{document_id}"]["delete"][
+        "responses"
+    ]
+    assert "204" in single_delete_responses
+    assert "200" not in single_delete_responses
+    assert "content" not in single_delete_responses["204"]
+
+    bulk_delete_schema = _request_schema(spec, "/api/v2/collections/{collection_id}/documents", "delete")
+    assert "document_ids" in bulk_delete_schema["properties"]
+    assert "collection_id" not in bulk_delete_schema["properties"]
+    assert "document_id" not in bulk_delete_schema["properties"]
+
+    rebuild_schema = _request_schema(
+        spec,
+        "/api/v2/collections/{collection_id}/documents/{document_id}/rebuild_indexes",
+        "post",
+    )
+    assert "index_types" in rebuild_schema["properties"]
+    assert "collection_id" not in rebuild_schema["properties"]
+    assert "document_id" not in rebuild_schema["properties"]
+
+    confirm_schema = _request_schema(spec, "/api/v2/collections/{collection_id}/documents/confirm", "post")
+    assert "document_ids" in confirm_schema["properties"]
+    assert "collection_id" not in confirm_schema["properties"]
+
+    fetch_url_schema = _request_schema(spec, "/api/v2/collections/{collection_id}/documents/fetch-url", "post")
+    assert "urls" in fetch_url_schema["properties"]
+    assert "collection_id" not in fetch_url_schema["properties"]
+
+
+def test_documents_v2_operation_ids_are_unique():
+    spec = _documents_v2_spec()
+
+    operation_ids = [
+        operation["operationId"]
+        for path_item in spec["paths"].values()
+        for operation in path_item.values()
+        if isinstance(operation, dict) and "operationId" in operation
+    ]
+
+    assert len(operation_ids) == len(set(operation_ids))


### PR DESCRIPTION
## Summary
- Add `/api/v2` documents router for CRUD, staged/upload/confirm/fetch-url, preview/object/download, and rebuild trigger contracts.
- Add explicit Pydantic request/response models for bulk delete and rebuild responses, including `DocumentList` for list responses.
- Add focused OpenAPI contract tests for public path visibility, response schema refs, 204 delete semantics, path-canonical request bodies, and duplicate operation IDs.

## Scope
- Backend-only documents v2 contract.
- Does not touch collection CRUD/sharing, graph/search, marketplace, FE, or indexing internals.

## Validation
- `uv run --extra test pytest tests/unit_test/test_documents_v2_openapi_contract.py tests/unit_test/test_openapi_spec.py -q`
- `uv run ruff check aperag/views/documents_v2.py aperag/schema/view_models.py aperag/app.py tests/unit_test/test_documents_v2_openapi_contract.py`
- `make openapi-check`
- `make lint`
- `git diff --check`
- `uv run python -m py_compile aperag/views/documents_v2.py tests/unit_test/test_documents_v2_openapi_contract.py`