### PR TITLE
[codex] add bot v2 backend contract

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -42,6 +42,7 @@ from aperag.views.api_key import router as api_key_router
 from aperag.views.audit import router as audit_router
 from aperag.views.auth import router as auth_router
 from aperag.views.bot import router as bot_router
+from aperag.views.bots_v2 import router as bots_v2_router
 from aperag.views.chat import router as chat_router
 from aperag.views.collections import router as collections_router
 from aperag.views.collections_v2 import router as collections_v2_router
@@ -110,6 +111,7 @@ app.include_router(chat_router, prefix="/api/v1")
 app.include_router(openai_router, prefix="/v1")
 app.include_router(config_router, prefix="/api/v1/config")
 app.include_router(agent_runtime_router, prefix="/api/v2")
+app.include_router(bots_v2_router, prefix="/api/v2")
 app.include_router(evaluation_v2_router, prefix="/api/v2")
 app.include_router(providers_v2_router, prefix="/api/v2")
 app.include_router(collections_v2_router, prefix="/api/v2")

--- a/aperag/schema/view_models.py
+++ b/aperag/schema/view_models.py
@@ -207,6 +207,12 @@ class BotUpdate(BaseModel):
     config: Optional[BotConfig] = None
 
 
+class BotUpdateRequest(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    config: Optional[BotConfig] = None
+
+
 class Chat(BaseModel):
     id: Optional[str] = None
     title: Optional[str] = None

--- a/aperag/views/bots_v2.py
+++ b/aperag/views/bots_v2.py
@@ -1,0 +1,174 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+
+from aperag.db.models import User
+from aperag.exceptions import BusinessException
+from aperag.schema import view_models
+from aperag.service.bot_service import bot_service
+from aperag.service.chat_service import chat_service_global
+from aperag.service.chat_title_service import chat_title_service
+from aperag.utils.audit_decorator import audit
+from aperag.views.auth import required_user
+
+router = APIRouter(tags=["bots-v2"])
+
+
+@router.post("/bots", response_model=view_models.Bot)
+@audit(resource_type="bot", api_name="CreateBotV2")
+async def create_bot_v2_view(
+    request: Request,
+    body: view_models.BotCreate,
+    user: User = Depends(required_user),
+) -> view_models.Bot:
+    """Create an agent bot owned by the current user."""
+
+    return await bot_service.create_bot(str(user.id), body)
+
+
+@router.get("/bots", response_model=view_models.BotList)
+async def list_bots_v2_view(
+    user: User = Depends(required_user),
+) -> view_models.BotList:
+    """List bots owned by the current user."""
+
+    return await bot_service.list_bots(str(user.id))
+
+
+@router.get("/bots/{bot_id}", response_model=view_models.Bot)
+async def get_bot_v2_view(
+    bot_id: str,
+    user: User = Depends(required_user),
+) -> view_models.Bot:
+    """Return one bot owned by the current user."""
+
+    return await bot_service.get_bot(str(user.id), bot_id)
+
+
+@router.put("/bots/{bot_id}", response_model=view_models.Bot)
+@audit(resource_type="bot", api_name="UpdateBotV2")
+async def update_bot_v2_view(
+    request: Request,
+    bot_id: str,
+    body: view_models.BotUpdateRequest,
+    user: User = Depends(required_user),
+) -> view_models.Bot:
+    """Update one bot. The path bot_id is canonical."""
+
+    bot_update = view_models.BotUpdate(
+        title=body.title,
+        description=body.description,
+        config=body.config,
+    )
+    return await bot_service.update_bot(str(user.id), bot_id, bot_update)
+
+
+@router.delete("/bots/{bot_id}", status_code=204)
+@audit(resource_type="bot", api_name="DeleteBotV2")
+async def delete_bot_v2_view(
+    request: Request,
+    bot_id: str,
+    user: User = Depends(required_user),
+) -> Response:
+    """Delete one bot owned by the current user. Idempotent."""
+
+    await bot_service.delete_bot(str(user.id), bot_id)
+    return Response(status_code=204)
+
+
+@router.post("/bots/{bot_id}/chats", response_model=view_models.Chat)
+@audit(resource_type="chat", api_name="CreateChatV2")
+async def create_chat_v2_view(
+    request: Request,
+    bot_id: str,
+    user: User = Depends(required_user),
+) -> view_models.Chat:
+    """Create a chat under one agent bot."""
+
+    return await chat_service_global.create_chat(str(user.id), bot_id)
+
+
+@router.get("/bots/{bot_id}/chats", response_model=view_models.ChatList)
+async def list_chats_v2_view(
+    bot_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    user: User = Depends(required_user),
+) -> view_models.ChatList:
+    """List chats under one agent bot."""
+
+    return await chat_service_global.list_chats(str(user.id), bot_id, page, page_size)
+
+
+@router.get("/bots/{bot_id}/chats/{chat_id}", response_model=view_models.ChatDetails)
+async def get_chat_v2_view(
+    bot_id: str,
+    chat_id: str,
+    user: User = Depends(required_user),
+) -> view_models.ChatDetails:
+    """Return one chat with history."""
+
+    return await chat_service_global.get_chat(str(user.id), bot_id, chat_id)
+
+
+@router.put("/bots/{bot_id}/chats/{chat_id}", response_model=view_models.Chat)
+@audit(resource_type="chat", api_name="UpdateChatV2")
+async def update_chat_v2_view(
+    request: Request,
+    bot_id: str,
+    chat_id: str,
+    body: view_models.ChatUpdate,
+    user: User = Depends(required_user),
+) -> view_models.Chat:
+    """Update one chat. Path bot_id and chat_id are canonical."""
+
+    return await chat_service_global.update_chat(str(user.id), bot_id, chat_id, body)
+
+
+@router.delete("/bots/{bot_id}/chats/{chat_id}", status_code=204)
+@audit(resource_type="chat", api_name="DeleteChatV2")
+async def delete_chat_v2_view(
+    request: Request,
+    bot_id: str,
+    chat_id: str,
+    user: User = Depends(required_user),
+) -> Response:
+    """Delete one chat under one agent bot. Idempotent."""
+
+    await chat_service_global.delete_chat(str(user.id), bot_id, chat_id)
+    return Response(status_code=204)
+
+
+@router.post("/bots/{bot_id}/chats/{chat_id}/title", response_model=view_models.TitleGenerateResponse)
+async def generate_chat_title_v2_view(
+    bot_id: str,
+    chat_id: str,
+    body: view_models.TitleGenerateRequest = view_models.TitleGenerateRequest(),
+    user: User = Depends(required_user),
+) -> view_models.TitleGenerateResponse:
+    """Generate a title for one chat."""
+
+    try:
+        title = await chat_title_service.generate_title(
+            user_id=str(user.id),
+            bot_id=bot_id,
+            chat_id=chat_id,
+            max_length=body.max_length,
+            language=body.language,
+            turns=body.turns,
+        )
+        return view_models.TitleGenerateResponse(title=title)
+    except BusinessException as be:
+        raise HTTPException(status_code=400, detail={"error_code": be.error_code.name, "message": str(be)})

--- a/tests/unit_test/test_bot_v2_openapi_contract.py
+++ b/tests/unit_test/test_bot_v2_openapi_contract.py
@@ -1,0 +1,96 @@
+from fastapi import FastAPI
+
+from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
+from aperag.views.bots_v2 import router
+
+
+def _bot_v2_spec():
+    app = FastAPI(generate_unique_id_function=custom_generate_unique_id)
+    app.include_router(router, prefix="/api/v2")
+    return filter_public_openapi(build_full_openapi_spec(app))
+
+
+def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
+    return spec["paths"][path][method]["responses"][status]["content"]["application/json"]["schema"]["$ref"]
+
+
+def _request_schema(spec: dict, path: str, method: str) -> dict:
+    request_ref = spec["paths"][path][method]["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+    return spec["components"]["schemas"][request_ref.removeprefix("#/components/schemas/")]
+
+
+def test_bot_v2_routes_are_public_and_typed():
+    spec = _bot_v2_spec()
+    paths = spec["paths"]
+
+    required_paths = {
+        "/api/v2/bots",
+        "/api/v2/bots/{bot_id}",
+        "/api/v2/bots/{bot_id}/chats",
+        "/api/v2/bots/{bot_id}/chats/{chat_id}",
+        "/api/v2/bots/{bot_id}/chats/{chat_id}/title",
+    }
+
+    assert required_paths <= set(paths)
+
+    assert _json_ref(spec, "/api/v2/bots", "post") == "#/components/schemas/Bot"
+    assert _json_ref(spec, "/api/v2/bots", "get") == "#/components/schemas/BotList"
+    assert _json_ref(spec, "/api/v2/bots/{bot_id}", "get") == "#/components/schemas/Bot"
+    assert _json_ref(spec, "/api/v2/bots/{bot_id}", "put") == "#/components/schemas/Bot"
+    assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats", "post") == "#/components/schemas/Chat"
+    assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats", "get") == "#/components/schemas/ChatList"
+    assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}", "get") == (
+        "#/components/schemas/ChatDetails"
+    )
+    assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}", "put") == "#/components/schemas/Chat"
+    assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}/title", "post") == (
+        "#/components/schemas/TitleGenerateResponse"
+    )
+
+
+def test_bot_v2_delete_routes_return_204_without_body():
+    spec = _bot_v2_spec()
+
+    for path in ("/api/v2/bots/{bot_id}", "/api/v2/bots/{bot_id}/chats/{chat_id}"):
+        responses = spec["paths"][path]["delete"]["responses"]
+        assert "204" in responses, f"DELETE {path} must declare 204 response"
+        assert "content" not in responses["204"], f"DELETE {path} 204 response must not carry a JSON body"
+        assert "200" not in responses, f"DELETE {path} must not mix 204 with a 200 JSON response"
+
+
+def test_bot_v2_write_bodies_use_path_ids_as_canonical():
+    spec = _bot_v2_spec()
+
+    bot_update_schema = _request_schema(spec, "/api/v2/bots/{bot_id}", "put")
+    assert bot_update_schema["properties"].keys().isdisjoint({"id", "bot_id"})
+
+    chat_update_schema = _request_schema(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}", "put")
+    assert chat_update_schema["properties"].keys().isdisjoint({"id", "bot_id", "chat_id"})
+
+    title_schema = _request_schema(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}/title", "post")
+    assert title_schema["properties"].keys().isdisjoint({"bot_id", "chat_id"})
+
+    assert "requestBody" not in spec["paths"]["/api/v2/bots/{bot_id}/chats"]["post"]
+
+
+def test_bot_v2_scope_is_bot_crud_and_bot_chat_shell_only():
+    spec = _bot_v2_spec()
+
+    for path in spec["paths"]:
+        assert path.startswith("/api/v2/bots"), f"bots_v2 must not own standalone chat or other domain path: {path}"
+        assert "/documents" not in path, f"bots_v2 must not own chat document path: {path}"
+        assert "/feedback" not in path, f"bots_v2 must not own turn feedback path: {path}"
+        assert "/search" not in path, f"bots_v2 must not own chat search path: {path}"
+
+
+def test_bot_v2_operation_ids_are_unique():
+    spec = _bot_v2_spec()
+
+    operation_ids = [
+        operation["operationId"]
+        for path_item in spec["paths"].values()
+        for operation in path_item.values()
+        if isinstance(operation, dict) and "operationId" in operation
+    ]
+
+    assert len(operation_ids) == len(set(operation_ids))


### PR DESCRIPTION
## Summary
- Add code-first `/api/v2/bots` Bot CRUD contract.
- Add bot-scoped chat shell endpoints under `/api/v2/bots/{bot_id}/chats` for list/create/detail/update/delete/title.
- Add `BotUpdateRequest` so v2 update bodies do not repeat the path `bot_id`.
- Add focused OpenAPI contract tests for public visibility, explicit response schemas, 204 responses, path-canonical request bodies, scope boundaries, and unique operation IDs.

## Validation
- `uv run --extra test pytest tests/unit_test/test_bot_v2_openapi_contract.py -q`
- `uv run --extra test pytest tests/unit_test/test_bot_v2_openapi_contract.py tests/unit_test/test_openapi_spec.py -q`
- `make openapi-check`
- `make lint`
- `git diff --check`
