### PR TITLE
refactor(web): bot FE v2 typed-paths adapter (#25 / #22-takeover)

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -51,3 +51,41 @@ def test_evaluation_feature_uses_v2_typed_api_boundary():
         REPO_ROOT / "web/src/components/evaluation/benchmarks-panel.tsx"
     ).read_text()
     assert "String(value ?? '').toLowerCase()" in benchmarks_panel
+
+
+def test_bot_feature_uses_v2_typed_api_boundary():
+    checked_paths = [
+        REPO_ROOT / "web/src/app/workspace/bots",
+        REPO_ROOT / "web/src/app/workspace/layout.tsx",
+        REPO_ROOT / "web/src/components/providers/bot-provider.tsx",
+        REPO_ROOT / "web/src/components/evaluation/evaluation-runs-panel.tsx",
+        REPO_ROOT / "web/src/features/bot",
+    ]
+
+    sources = {}
+    for entry in checked_paths:
+        if entry.is_file():
+            sources[entry] = entry.read_text()
+            continue
+        for path in entry.rglob("*"):
+            if path.is_file() and path.suffix in {".ts", ".tsx"}:
+                sources[path] = path.read_text()
+    joined = "\n".join(sources.values())
+    feature_sources = "\n".join(
+        source
+        for path, source in sources.items()
+        if "/web/src/features/bot/" in str(path)
+    )
+
+    # Business code under these paths must not touch the v1 bot surface or the old
+    # generated bots SDK directly.
+    assert "/api/v1/bots" not in joined
+    assert "defaultApi.botsGet" not in joined
+    assert "defaultApi.botsPost" not in joined
+    assert "defaultApi.botsBotId" not in joined
+
+    # features/bot adapter must go through the typed v2 paths and not fall back to
+    # the old `@/api` SDK or raw fetch.
+    assert "from '@/api'" not in feature_sources
+    assert "fetch(" not in feature_sources
+    assert "/api/v2/bots" in feature_sources

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -90,14 +90,25 @@ def test_bot_feature_uses_v2_typed_api_boundary():
     assert "fetch(" not in feature_sources
     assert "/api/v2/bots" in feature_sources
 
-    # Title generate must build a fully-typed TitleGenerateRequest body. If a
-    # future edit drops either field or skips the locale normaliser, the
-    # generated TS schema would quietly allow an `{ language }`-only body and
-    # re-introduce the type risk @ApeRAG专家 caught on ff89876.
+    # Title generate must build a fully-typed TitleGenerateRequest body with
+    # runtime-safe concrete defaults. An under-specified `{ language }`-only
+    # body would crash backend `chat_title_service.generate_title()` at
+    # `max(1, turns)` / `min(max_length, 50)`, so the normaliser must never
+    # emit `null` for any of the three required keys.
     bot_client_api = (
         REPO_ROOT / "web/src/features/bot/client-api.ts"
     ).read_text()
     assert "buildTitleGenerateRequest" in bot_client_api
     assert "toTitleLanguage" in bot_client_api
-    assert "max_length: input.max_length ?? null" in bot_client_api
-    assert "turns: input.turns ?? null" in bot_client_api
+    assert "DEFAULT_TITLE_MAX_LENGTH = 20" in bot_client_api
+    assert "DEFAULT_TITLE_TURNS = 1" in bot_client_api
+    assert "DEFAULT_TITLE_LANGUAGE: TitleLanguage = 'zh-CN'" in bot_client_api
+    assert (
+        "max_length: input.max_length ?? DEFAULT_TITLE_MAX_LENGTH"
+        in bot_client_api
+    )
+    assert "turns: input.turns ?? DEFAULT_TITLE_TURNS" in bot_client_api
+    # Guard the negative case: no `?? null` fallback for any of the three
+    # required keys should reappear.
+    assert "max_length: input.max_length ?? null" not in bot_client_api
+    assert "turns: input.turns ?? null" not in bot_client_api

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -89,3 +89,15 @@ def test_bot_feature_uses_v2_typed_api_boundary():
     assert "from '@/api'" not in feature_sources
     assert "fetch(" not in feature_sources
     assert "/api/v2/bots" in feature_sources
+
+    # Title generate must build a fully-typed TitleGenerateRequest body. If a
+    # future edit drops either field or skips the locale normaliser, the
+    # generated TS schema would quietly allow an `{ language }`-only body and
+    # re-introduce the type risk @ApeRAG专家 caught on ff89876.
+    bot_client_api = (
+        REPO_ROOT / "web/src/features/bot/client-api.ts"
+    ).read_text()
+    assert "buildTitleGenerateRequest" in bot_client_api
+    assert "toTitleLanguage" in bot_client_api
+    assert "max_length: input.max_length ?? null" in bot_client_api
+    assert "turns: input.turns ?? null" in bot_client_api

--- a/web/src/app/workspace/bots/[botId]/chats/[chatId]/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/chats/[chatId]/page.tsx
@@ -5,7 +5,7 @@ import {
   PageContent,
   PageHeader,
 } from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
+import { getBotChat } from '@/features/bot/server-api';
 import _ from 'lodash';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
@@ -19,19 +19,17 @@ export default async function Page({
   }>;
 }) {
   const { botId, chatId } = await params;
-  const serverApi = await getServerApi();
   const page_chat = await getTranslations('page_chat');
 
   let chat;
 
   try {
-    const res = await serverApi.defaultApi.botsBotIdChatsChatIdGet({
-      botId,
-      chatId,
-    });
-    chat = res.data;
+    chat = await getBotChat(botId, chatId);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (err) {
+    notFound();
+  }
+  if (!chat) {
     notFound();
   }
 

--- a/web/src/app/workspace/bots/[botId]/chats/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/chats/page.tsx
@@ -1,11 +1,11 @@
-import { Chat } from '@/api';
 import { BotSectionNav } from '@/components/evaluation/bot-section-nav';
 import {
   PageContainer,
   PageContent,
   PageHeader,
 } from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
+import { listBotChats } from '@/features/bot/server-api';
+import type { Chat } from '@/features/bot/types';
 import _ from 'lodash';
 import { getTranslations } from 'next-intl/server';
 import { redirect } from 'next/navigation';
@@ -15,17 +15,10 @@ export default async function Page({
 }: Readonly<{
   params: Promise<{ botId: string }>;
 }>) {
-  const apiServer = await getServerApi();
   const page_chat = await getTranslations('page_chat');
   const { botId } = await params;
-  const chatsRes = await apiServer.defaultApi.botsBotIdChatsGet({
-    botId,
-    page: 1,
-    pageSize: 1,
-  });
-
-  //@ts-expect-error api define has a bug
-  const chat: Chat | undefined = _.first(chatsRes.data.items || []);
+  const chatsRes = await listBotChats(botId, { page: 1, pageSize: 1 });
+  const chat: Chat | undefined = _.first(chatsRes.items ?? []);
 
   if (chat) {
     redirect(`/workspace/bots/${botId}/chats/${chat.id}`);

--- a/web/src/app/workspace/bots/[botId]/evaluation/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/evaluation/page.tsx
@@ -5,8 +5,8 @@ import {
   PageContent,
   PageHeader,
 } from '@/components/page-container';
+import { getBot } from '@/features/bot/server-api';
 import { listEvaluationRuns } from '@/features/evaluation/server-api';
-import { getServerApi } from '@/lib/api/server';
 import { toJson } from '@/lib/utils';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
@@ -20,17 +20,17 @@ export default async function Page({
 }) {
   const { botId } = await params;
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
-  const serverApi = await getServerApi();
   const pageBot = await getTranslations('page_bot');
   const pageBotEvaluation = await getTranslations('page_bot_evaluation');
 
   let bot;
 
   try {
-    const botRes = await serverApi.defaultApi.botsBotIdGet({
-      botId,
-    });
-    bot = toJson(botRes.data);
+    const botRes = await getBot(botId);
+    if (!botRes) {
+      notFound();
+    }
+    bot = toJson(botRes);
   } catch {
     notFound();
   }

--- a/web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx
@@ -5,11 +5,11 @@ import {
   PageContent,
   PageHeader,
 } from '@/components/page-container';
+import { getBot } from '@/features/bot/server-api';
 import {
   getEvaluationRunDetail,
   listEvaluationRunItems,
 } from '@/features/evaluation/server-api';
-import { getServerApi } from '@/lib/api/server';
 import { toJson } from '@/lib/utils';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
@@ -33,17 +33,17 @@ export default async function Page({
     notFound();
   }
 
-  const serverApi = await getServerApi();
   const pageBot = await getTranslations('page_bot');
   const pageBotEvaluation = await getTranslations('page_bot_evaluation');
 
   let bot;
 
   try {
-    const botRes = await serverApi.defaultApi.botsBotIdGet({
-      botId: resolvedBotId,
-    });
-    bot = toJson(botRes.data);
+    const botRes = await getBot(resolvedBotId);
+    if (!botRes) {
+      notFound();
+    }
+    bot = toJson(botRes);
   } catch {
     notFound();
   }

--- a/web/src/app/workspace/layout.tsx
+++ b/web/src/app/workspace/layout.tsx
@@ -1,4 +1,3 @@
-import { Chat } from '@/api';
 import { AppLogo } from '@/components/app-topbar';
 import {
   Sidebar,
@@ -7,6 +6,8 @@ import {
   SidebarInset,
   SidebarProvider,
 } from '@/components/ui/sidebar';
+import { listBotChats, listBots } from '@/features/bot/server-api';
+import type { Chat } from '@/features/bot/types';
 import { getServerApi } from '@/lib/api/server';
 import { toJson } from '@/lib/utils';
 import { redirect } from 'next/navigation';
@@ -34,18 +35,13 @@ export default async function Layout({
     redirect(`/auth/signin?callbackUrl=${encodeURIComponent('/workspace')}`);
   }
 
-  const botsRes = await apiServer.defaultApi.botsGet();
-  const bot = botsRes.data.items?.find((item) => item.type === 'agent');
+  const botsRes = await listBots();
+  const bot = botsRes.items?.find((item) => item.type === 'agent') ?? undefined;
   let chats: Chat[] = [];
 
   if (bot?.id) {
-    const chatsRes = await apiServer.defaultApi.botsBotIdChatsGet({
-      botId: bot.id,
-      page: 1,
-      pageSize: 100,
-    });
-    //@ts-expect-error api define has a bug
-    chats = chatsRes.data.items || [];
+    const chatsRes = await listBotChats(bot.id, { page: 1, pageSize: 100 });
+    chats = chatsRes.items ?? [];
   }
 
   return (

--- a/web/src/components/evaluation/evaluation-runs-panel.tsx
+++ b/web/src/components/evaluation/evaluation-runs-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, useTransition } from 'react';
 
-import type { Bot } from '@/api';
+import type { Bot } from '@/features/bot/types';
 import { FormatDate } from '@/components/format-date';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';

--- a/web/src/components/providers/bot-provider.tsx
+++ b/web/src/components/providers/bot-provider.tsx
@@ -3,7 +3,16 @@
 import { apiClient } from '@/lib/api/client';
 import { useCallback, useEffect, useState } from 'react';
 
-import { Bot, Chat, ChatDetails, Collection, ModelSpec } from '@/api';
+import { Collection, ModelSpec } from '@/api';
+import {
+  createBot,
+  createBotChat,
+  deleteBotChat,
+  generateBotChatTitle,
+  listBotChats,
+  updateBotChat,
+} from '@/features/bot/client-api';
+import type { Bot, Chat, ChatDetails } from '@/features/bot/types';
 import { useLocale } from 'next-intl';
 import { useParams, useRouter } from 'next/navigation';
 import { createContext, useContext } from 'react';
@@ -81,33 +90,25 @@ export const BotProvider = ({
   }, []);
 
   const botCreate = useCallback(async () => {
-    const createRes = await apiClient.defaultApi.botsPost({
-      botCreate: {
-        title: 'Default Agent Bot',
-        type: 'agent',
-      },
+    const created = await createBot({
+      title: 'Default Agent Bot',
+      type: 'agent',
     });
-    if (createRes.data.id) {
-      setBot(createRes.data);
+    if (created?.id) {
+      setBot(created);
     }
   }, []);
 
   const chatsReload = useCallback(async () => {
     if (!bot?.id) return;
-    const chatsRes = await apiClient.defaultApi.botsBotIdChatsGet({
-      botId: bot.id,
-    });
-    //@ts-expect-error api define has a bug
-    setChats(chatsRes.data.items || []);
+    const chatsRes = await listBotChats(bot.id);
+    setChats(chatsRes?.items ?? []);
   }, [bot?.id]);
 
   const chatDelete = useCallback(
     async (chat: Chat) => {
       if (!chat.bot_id || !chat.id) return;
-      await apiClient.defaultApi.botsBotIdChatsChatIdDelete({
-        botId: chat.bot_id,
-        chatId: chat.id,
-      });
+      await deleteBotChat(chat.bot_id, chat.id);
 
       if (params.chatId === chat.id) {
         const item = chats?.find((c) => c.id !== chat.id);
@@ -124,24 +125,12 @@ export const BotProvider = ({
   const chatRename = useCallback(
     async (chat: Chat) => {
       if (chat.title !== 'New Chat' || !chat.id || !chat.bot_id) return;
-      const titleRes = await apiClient.defaultApi.botsBotIdChatsChatIdTitlePost(
-        {
-          chatId: chat.id,
-          botId: chat.bot_id,
-          titleGenerateRequest: {
-            language: locale,
-          },
-        },
-      );
-      const title = titleRes.data.title;
+      const titleRes = await generateBotChatTitle(chat.bot_id, chat.id, {
+        language: locale,
+      });
+      const title = titleRes?.title;
       if (title) {
-        await apiClient.defaultApi.botsBotIdChatsChatIdPut({
-          chatId: chat.id,
-          botId: chat.bot_id,
-          chatUpdate: {
-            title,
-          },
-        });
+        await updateBotChat(chat.bot_id, chat.id, { title });
         chatsReload();
       }
     },
@@ -150,15 +139,10 @@ export const BotProvider = ({
 
   const chatCreate = useCallback(async () => {
     if (!bot?.id) return;
-    const res = await apiClient.defaultApi.botsBotIdChatsPost({
-      botId: bot.id,
-      chatCreate: {
-        title: '',
-      },
-    });
+    const created = await createBotChat(bot.id);
 
-    if (res.data.id) {
-      const url = `${botChatsBasePath}/${bot.id}/chats/${res.data.id}`;
+    if (created?.id) {
+      const url = `${botChatsBasePath}/${bot.id}/chats/${created.id}`;
       router.push(url);
       chatsReload();
     }

--- a/web/src/features/bot/client-api.ts
+++ b/web/src/features/bot/client-api.ts
@@ -1,0 +1,130 @@
+'use client';
+
+import { browserApiClient } from '@/lib/api/typed/browser';
+
+import type {
+  Bot,
+  BotCreate,
+  BotList,
+  BotUpdateRequest,
+  Chat,
+  ChatDetails,
+  ChatList,
+  ChatUpdate,
+  TitleGenerateRequest,
+  TitleGenerateResponse,
+} from './types';
+
+export async function createBot(input: BotCreate): Promise<Bot | undefined> {
+  const { data } = await browserApiClient.POST('/api/v2/bots', {
+    body: input,
+  });
+  return data;
+}
+
+export async function listBots(): Promise<BotList | undefined> {
+  const { data } = await browserApiClient.GET('/api/v2/bots');
+  return data;
+}
+
+export async function getBot(botId: string): Promise<Bot | undefined> {
+  const { data } = await browserApiClient.GET('/api/v2/bots/{bot_id}', {
+    params: { path: { bot_id: botId } },
+  });
+  return data;
+}
+
+export async function updateBot(
+  botId: string,
+  input: BotUpdateRequest,
+): Promise<Bot | undefined> {
+  const { data } = await browserApiClient.PUT('/api/v2/bots/{bot_id}', {
+    params: { path: { bot_id: botId } },
+    body: input,
+  });
+  return data;
+}
+
+export async function deleteBot(botId: string): Promise<void> {
+  await browserApiClient.DELETE('/api/v2/bots/{bot_id}', {
+    params: { path: { bot_id: botId } },
+  });
+}
+
+export async function listBotChats(
+  botId: string,
+  options?: { page?: number; pageSize?: number },
+): Promise<ChatList | undefined> {
+  const { data } = await browserApiClient.GET('/api/v2/bots/{bot_id}/chats', {
+    params: {
+      path: { bot_id: botId },
+      query: {
+        page: options?.page ?? 1,
+        page_size: options?.pageSize ?? 50,
+      },
+    },
+  });
+  return data;
+}
+
+export async function getBotChat(
+  botId: string,
+  chatId: string,
+): Promise<ChatDetails | undefined> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/bots/{bot_id}/chats/{chat_id}',
+    {
+      params: { path: { bot_id: botId, chat_id: chatId } },
+    },
+  );
+  return data;
+}
+
+export async function createBotChat(botId: string): Promise<Chat | undefined> {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/bots/{bot_id}/chats',
+    {
+      params: { path: { bot_id: botId } },
+    },
+  );
+  return data;
+}
+
+export async function updateBotChat(
+  botId: string,
+  chatId: string,
+  input: ChatUpdate,
+): Promise<Chat | undefined> {
+  const { data } = await browserApiClient.PUT(
+    '/api/v2/bots/{bot_id}/chats/{chat_id}',
+    {
+      params: { path: { bot_id: botId, chat_id: chatId } },
+      body: input,
+    },
+  );
+  return data;
+}
+
+export async function deleteBotChat(
+  botId: string,
+  chatId: string,
+): Promise<void> {
+  await browserApiClient.DELETE('/api/v2/bots/{bot_id}/chats/{chat_id}', {
+    params: { path: { bot_id: botId, chat_id: chatId } },
+  });
+}
+
+export async function generateBotChatTitle(
+  botId: string,
+  chatId: string,
+  input: TitleGenerateRequest,
+): Promise<TitleGenerateResponse | undefined> {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/bots/{bot_id}/chats/{chat_id}/title',
+    {
+      params: { path: { bot_id: botId, chat_id: chatId } },
+      body: input,
+    },
+  );
+  return data;
+}

--- a/web/src/features/bot/client-api.ts
+++ b/web/src/features/bot/client-api.ts
@@ -15,6 +15,54 @@ import type {
   TitleGenerateResponse,
 } from './types';
 
+type TitleLanguage = NonNullable<TitleGenerateRequest['language']>;
+
+const SUPPORTED_TITLE_LANGUAGES: readonly TitleLanguage[] = [
+  'zh-CN',
+  'en-US',
+  'ja-JP',
+  'ko-KR',
+] as const;
+
+/**
+ * Narrow an arbitrary `next-intl` locale / UI string down to the
+ * `TitleGenerateRequest['language']` enum the backend accepts. Any input
+ * outside the supported set falls back to `null`, which triggers the backend
+ * default (`zh-CN` per v2 schema).
+ */
+export function toTitleLanguage(
+  value: string | null | undefined,
+): TitleGenerateRequest['language'] {
+  if (value == null) {
+    return null;
+  }
+  return (SUPPORTED_TITLE_LANGUAGES as readonly string[]).includes(value)
+    ? (value as TitleLanguage)
+    : null;
+}
+
+export type TitleGenerateInput = {
+  language?: string | null;
+  max_length?: number | null;
+  turns?: number | null;
+};
+
+/**
+ * Build a fully-typed `TitleGenerateRequest` body from a caller-friendly
+ * input. Each required field is always set (defaulting to `null` so the
+ * backend applies its own default) and `language` is normalised to the
+ * generated schema's enum union.
+ */
+export function buildTitleGenerateRequest(
+  input: TitleGenerateInput = {},
+): TitleGenerateRequest {
+  return {
+    max_length: input.max_length ?? null,
+    language: toTitleLanguage(input.language),
+    turns: input.turns ?? null,
+  };
+}
+
 export async function createBot(input: BotCreate): Promise<Bot | undefined> {
   const { data } = await browserApiClient.POST('/api/v2/bots', {
     body: input,
@@ -117,13 +165,14 @@ export async function deleteBotChat(
 export async function generateBotChatTitle(
   botId: string,
   chatId: string,
-  input: TitleGenerateRequest,
+  input: TitleGenerateInput = {},
 ): Promise<TitleGenerateResponse | undefined> {
+  const body = buildTitleGenerateRequest(input);
   const { data } = await browserApiClient.POST(
     '/api/v2/bots/{bot_id}/chats/{chat_id}/title',
     {
       params: { path: { bot_id: botId, chat_id: chatId } },
-      body: input,
+      body,
     },
   );
   return data;

--- a/web/src/features/bot/client-api.ts
+++ b/web/src/features/bot/client-api.ts
@@ -24,21 +24,33 @@ const SUPPORTED_TITLE_LANGUAGES: readonly TitleLanguage[] = [
   'ko-KR',
 ] as const;
 
+// Runtime-safe defaults for the `TitleGenerateRequest` body. The backend
+// Pydantic schema advertises defaults (20 / "zh-CN" / 1), but
+// `aperag/views/bots_v2.py` forwards the parsed values straight into
+// `chat_title_service.generate_title()` where `max(1, turns)` /
+// `min(max_length, 50)` would raise a TypeError on `null`. The FE adapter
+// therefore must send concrete values rather than relying on backend
+// fallback.
+const DEFAULT_TITLE_MAX_LENGTH = 20;
+const DEFAULT_TITLE_TURNS = 1;
+const DEFAULT_TITLE_LANGUAGE: TitleLanguage = 'zh-CN';
+
 /**
  * Narrow an arbitrary `next-intl` locale / UI string down to the
  * `TitleGenerateRequest['language']` enum the backend accepts. Any input
- * outside the supported set falls back to `null`, which triggers the backend
- * default (`zh-CN` per v2 schema).
+ * outside the supported set falls back to the product default language
+ * (`zh-CN`) instead of `null`, because the backend service would forward a
+ * `null` straight into `generate_title()` and crash.
  */
 export function toTitleLanguage(
   value: string | null | undefined,
-): TitleGenerateRequest['language'] {
+): TitleLanguage {
   if (value == null) {
-    return null;
+    return DEFAULT_TITLE_LANGUAGE;
   }
   return (SUPPORTED_TITLE_LANGUAGES as readonly string[]).includes(value)
     ? (value as TitleLanguage)
-    : null;
+    : DEFAULT_TITLE_LANGUAGE;
 }
 
 export type TitleGenerateInput = {
@@ -49,17 +61,18 @@ export type TitleGenerateInput = {
 
 /**
  * Build a fully-typed `TitleGenerateRequest` body from a caller-friendly
- * input. Each required field is always set (defaulting to `null` so the
- * backend applies its own default) and `language` is normalised to the
- * generated schema's enum union.
+ * input. Each required field is always filled with a runtime-safe concrete
+ * default (`max_length: 20`, `turns: 1`, `language: "zh-CN"`) instead of
+ * `null`, because the backend does not apply Pydantic defaults when the
+ * FastAPI route has already parsed an explicit value.
  */
 export function buildTitleGenerateRequest(
   input: TitleGenerateInput = {},
 ): TitleGenerateRequest {
   return {
-    max_length: input.max_length ?? null,
+    max_length: input.max_length ?? DEFAULT_TITLE_MAX_LENGTH,
     language: toTitleLanguage(input.language),
-    turns: input.turns ?? null,
+    turns: input.turns ?? DEFAULT_TITLE_TURNS,
   };
 }
 

--- a/web/src/features/bot/server-api.ts
+++ b/web/src/features/bot/server-api.ts
@@ -1,0 +1,48 @@
+import { createServerApiClient } from '@/lib/api/typed/server';
+
+import type { Bot, BotList, ChatDetails, ChatList } from './types';
+
+export async function listBots(): Promise<BotList> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v2/bots');
+  return data ?? {};
+}
+
+export async function getBot(botId: string): Promise<Bot | null> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v2/bots/{bot_id}', {
+    params: { path: { bot_id: botId } },
+  });
+  return data ?? null;
+}
+
+export async function listBotChats(
+  botId: string,
+  options?: { page?: number; pageSize?: number },
+): Promise<ChatList> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v2/bots/{bot_id}/chats', {
+    params: {
+      path: { bot_id: botId },
+      query: {
+        page: options?.page ?? 1,
+        page_size: options?.pageSize ?? 50,
+      },
+    },
+  });
+  return data ?? {};
+}
+
+export async function getBotChat(
+  botId: string,
+  chatId: string,
+): Promise<ChatDetails | null> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET(
+    '/api/v2/bots/{bot_id}/chats/{chat_id}',
+    {
+      params: { path: { bot_id: botId, chat_id: chatId } },
+    },
+  );
+  return data ?? null;
+}

--- a/web/src/features/bot/types.ts
+++ b/web/src/features/bot/types.ts
@@ -1,0 +1,16 @@
+import type { components } from '@/api-v2/schema';
+
+export type Bot = components['schemas']['Bot'];
+export type BotList = components['schemas']['BotList'];
+export type BotCreate = components['schemas']['BotCreate'];
+export type BotUpdateRequest = components['schemas']['BotUpdateRequest'];
+
+export type Chat = components['schemas']['Chat'];
+export type ChatList = components['schemas']['ChatList'];
+export type ChatDetails = components['schemas']['ChatDetails'];
+export type ChatUpdate = components['schemas']['ChatUpdate'];
+
+export type TitleGenerateRequest =
+  components['schemas']['TitleGenerateRequest'];
+export type TitleGenerateResponse =
+  components['schemas']['TitleGenerateResponse'];


### PR DESCRIPTION
## Summary

Switches bot detail/list/chat shell consumers from the old generated
`defaultApi.bots*` SDK to a new typed adapter under
`web/src/features/bot/*`, built on `openapi-fetch` and the v2 OpenAPI
schema. Mirrors the pattern established by `features/providers/*` in
#1571 and `features/evaluation/*` in #1578.

This closes task **#25** on `#all` (takeover of the original #22 after
@dongdong went offline), per @earayu2's instruction.

## Scope

**In**
- `web/src/features/bot/{client-api,server-api,types.ts}` — new
- `web/src/components/providers/bot-provider.tsx` — CSR switch
- `web/src/app/workspace/layout.tsx` — SSR default-bot + chats
- `web/src/app/workspace/bots/[botId]/chats/page.tsx` — SSR first chat
- `web/src/app/workspace/bots/[botId]/chats/[chatId]/page.tsx` — SSR chat detail
- `web/src/app/workspace/bots/[botId]/evaluation/page.tsx` — SSR bot header
- `web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx` — SSR bot header
- `web/src/components/evaluation/evaluation-runs-panel.tsx` — `Bot` type import from `@/api` → `@/features/bot/types` (closes external gap @Weston flagged in #1578)
- `tests/unit_test/test_web_typed_api_contract.py` — new static boundary assertion

**Out (deliberate)**
- Collection / document FE adapter (`#24`), evaluation FE, provider FE
- Old generated `defaultApi.bots*` SDK and `@/api` bot re-exports — stay for other callers, deleted in `#23 / #26` final sweep
- Backend
- `web/src/lib/api/{client,server}.ts` — not touched; other non-bot generated callers still use them
- `#前端 #16` upload regression (separate PR)

## Contract notes (aligned with preview CRs from @weihong / @ApeRAG专家 / @bryce / @Weston)

- SSR/CSR both go through `createServerApiClient` / `browserApiClient`, which keep the non-2xx throw semantic; `bot-provider` and SSR pages no longer silently render empty list / undefined bot on 401/404/500.
- `BotList` / `ChatList` consumed directly off the generated v2 schema (`components['schemas']['BotList'|'ChatList']`); SSR default-bot lookup drops the `@ts-expect-error api define has a bug` override and reads `items` off the typed envelope.
- `POST /api/v2/bots/{bot_id}/chats` is now called with no body (was sending `{ title: '' }`).
- `PUT /api/v2/bots/{bot_id}` body uses `BotUpdateRequest` (never wired up here, but `features/bot/client-api.ts::updateBot` stays path-canonical).
- Title generate POST continues to pass only the `TitleGenerateRequest` body; path `bot_id` / `chat_id` are canonical.
- DELETE routes for bot and chat are treated as 204/no-content on both sides.

## Local verification

- `uv run --extra test pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_collection_v2_openapi_contract.py tests/unit_test/test_openapi_spec.py -q` — **13 passed**
- `make lint` — pass
- `make openapi-check` — pass (no backend changes, still clean)
- `git diff --check` — pass
- `grep` gate: `/api/v1/bots` / `defaultApi.botsGet` / `defaultApi.botsPost` / `defaultApi.botsBotId*` absent from `web/src/app/workspace/bots`, `web/src/app/workspace/layout.tsx`, `web/src/components/providers/bot-provider.tsx`, `web/src/components/evaluation/evaluation-runs-panel.tsx`, `web/src/features/bot/*`
- Targeted `eslint` / `tsc --noEmit` weren't rerun locally because this agent workspace has no `web/node_modules` installed; will rely on GitHub `lint-and-unit` gate

## Test plan

- [ ] GitHub `lint-and-unit` green on head
- [ ] GitHub `e2e-http-smoke` green
- [ ] `@bryce` Bot contract-owner diff-scoped CR on the v2 typed paths
- [ ] `@ApeRAG专家` / `@Weston` diff-scoped CR on the FE typed boundary + scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)