### PR TITLE
fix(web): documents upload UX regressions (#前端 #16)

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -112,3 +112,31 @@ def test_bot_feature_uses_v2_typed_api_boundary():
     # required keys should reappear.
     assert "max_length: input.max_length ?? null" not in bot_client_api
     assert "turns: input.turns ?? null" not in bot_client_api
+
+
+def test_documents_upload_regression_guards():
+    """Regression guards for #前端 #16 document upload UX fixes.
+
+    1. `document-upload.tsx` must not auto-abort the bulk upload on unmount.
+       The old `useEffect(() => () => stopUpload(), [stopUpload])` killed
+       in-flight uploads when the user navigated away in the same tab,
+       making the uploader appear to silently stop.
+    2. `documents-table.tsx` must handle TanStack Table's
+       `onPaginationChange` updater as both a value and a function. The
+       old `@ts-expect-error` variant threw at runtime whenever TanStack
+       dispatched a plain value, reverting the visible page to page 1
+       after a click.
+    """
+    upload_tsx = (
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx"
+    ).read_text()
+    assert "() => stopUpload()" not in upload_tsx
+    assert "() => () => stopUpload" not in upload_tsx
+
+    table_tsx = (
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx"
+    ).read_text()
+    assert "@ts-expect-error onPaginationChange" not in table_tsx
+    assert "typeof updater === 'function'" in table_tsx

--- a/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
@@ -386,15 +386,22 @@ export function DocumentsTable({
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,
     pageCount,
-    onPaginationChange: (fn) => {
-      // @ts-expect-error onPaginationChange
-      const { pageIndex, pageSize } = fn({
+    // TanStack Table's `onPaginationChange` handler receives an
+    // `Updater<PaginationState>` — either a `PaginationState` value or a
+    // `(old: PaginationState) => PaginationState` function. Treating it as
+    // only a function (as the previous `@ts-expect-error` version did) would
+    // throw at runtime whenever TanStack dispatches a plain value, silently
+    // eating pagination clicks. Handle both shapes explicitly.
+    onPaginationChange: (updater) => {
+      const current = {
         pageIndex: query.page - 1,
         pageSize: query.pageSize,
-      });
+      };
+      const next =
+        typeof updater === 'function' ? updater(current) : updater;
       handleSearch({
-        page: pageIndex + 1,
-        pageSize,
+        page: next.pageIndex + 1,
+        pageSize: next.pageSize,
       });
     },
     getCoreRowModel: getCoreRowModel(),

--- a/web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
@@ -204,7 +204,12 @@ export const DocumentUpload = () => {
     uploadControllerRef.current = null;
   }, []);
 
-  useEffect(() => () => stopUpload(), [stopUpload]);
+  // Intentionally no unmount-cleanup auto-abort: a bulk upload must survive
+  // same-tab navigation (e.g. user switches to another workspace page while
+  // uploads are still in flight). The trade-off is that in-flight HTTP
+  // requests keep running without UI state after unmount; a cross-page
+  // persistent upload queue is tracked for #24 / follow-up. The "Stop" button
+  // in the uploader still calls `stopUpload()` explicitly.
 
   const startUpload = useCallback(
     (docs: DocumentsWithFile[]) => {


### PR DESCRIPTION
## Summary

Two narrow regression fixes for **#前端 #16** (documents upload UX)
that @earayu2 surfaced after the recent v2 refactor. Scope is kept
minimal; a cross-page persistent upload queue stays out and is tracked
for `#24` / follow-up, per PM guidance (@weihong msg=aa078fa2).

1. **Stop silently aborting bulk uploads on unmount.**  
   `document-upload.tsx:207` had `useEffect(() => () => stopUpload(),
   [stopUpload])`. Any in-tab route change while an upload batch was
   pending triggered the cleanup, which aborted the `AbortController`
   and killed every queued request without user intent — this is the
   "离页后所有上传停止" symptom the user reported. The explicit "Stop"
   button in the uploader still calls `stopUpload()` on user intent.
2. **Make pagination clicks on the documents list idempotent.**  
   `documents-table.tsx:389` called TanStack Table's
   `onPaginationChange` updater as if it was always a function, hidden
   behind `@ts-expect-error`. TanStack's actual contract is
   `Updater<T> = T | ((old: T) => T)`. Whenever TanStack dispatched a
   plain value, `fn(...)` threw and the click was silently swallowed,
   snapping the visible page back to page 1 — this is the "翻页按钮点
   了又回第一页" symptom. Fix handles both shapes explicitly.
3. **Static regression guards in `test_web_typed_api_contract.py`.**
   - `document-upload.tsx` must not re-introduce
     `useEffect(() => () => stopUpload...)`.
   - `documents-table.tsx` must keep the explicit `typeof updater ===
     'function'` branch and must not re-introduce `@ts-expect-error
     onPaginationChange`.

`UPLOAD_CONCURRENCY` stays at `5` per PM guidance: the user's original
reading of "3" was obsolete and any further raise requires backend /
celery queue capacity evidence that's out of this hotfix scope.

## Scope

**In**
- `web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx`
- `web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx`
- `tests/unit_test/test_web_typed_api_contract.py`

**Out (deliberate)**
- Cross-page persistent upload queue → `#24` or follow-up
- Bot/collection/document/evaluation FE adapters → their own PRs
- Backend / `UPLOAD_CONCURRENCY` / v1 hard-delete sweep

## Cost / caveat

After this change, when the user leaves the uploader mid-batch, the
in-flight HTTP requests keep running on the network side but the
progress UI state is lost (no cross-page queue yet). This is a
deliberate trade-off called out inline and in PM comment msg=aa078fa2:
the alternative of the previous behaviour (silently abort) was worse
because users reliably lost uploads.

## Local verification

- `uv run --extra test pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_openapi_spec.py -q` — **6 passed** (including the new `test_documents_upload_regression_guards`)
- `make lint` — pass
- `git diff --check` — pass
- No backend changes → `make openapi-check` not needed
- No `web/node_modules` in this agent workspace → targeted eslint / tsc will rely on GitHub `lint-and-unit` gate

## Test plan

- [ ] GitHub `lint-and-unit` green on head
- [ ] GitHub `e2e-http-smoke` green
- [ ] Browser live repro (needs a working web dev env):
  - Upload a batch of 50+ docs, navigate to another workspace page while upload is pending → network tab should still show in-flight POSTs (no silent abort).
  - On the documents list page with 120 docs and `pageSize=50`, click "next page" / "previous page" → URL updates and the displayed page advances (no snap-back to page 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)