### PR TITLE
refactor(web): collection+sharing FE v2 typed-paths adapter (#24a)

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -114,6 +114,63 @@ def test_bot_feature_uses_v2_typed_api_boundary():
     assert "turns: input.turns ?? null" not in bot_client_api
 
 
+def test_collection_feature_uses_v2_typed_api_boundary():
+    """#24a Collection + Sharing FE typed adapter boundary.
+
+    Business code under these paths must not call the old generated
+    `defaultApi.collections*` / `defaultApi.collectionsCollectionId*` /
+    `defaultApi.collectionsCollectionIdSharing*` SDK directly, and the
+    `features/collection/*` adapter must only reach `/api/v2/collections*`
+    typed paths (no `@/api` fallback, no raw `fetch(`). Document-specific
+    routes (`/documents*`) are deliberately out of scope — they stay with
+    the documents slice and the upload-flow hotfix.
+    """
+    checked_paths = [
+        REPO_ROOT / "web/src/app/workspace/collections/page.tsx",
+        REPO_ROOT / "web/src/app/workspace/collections/collection-form.tsx",
+        REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/layout.tsx",
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/collection-delete.tsx",
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/collection-header.tsx",
+        REPO_ROOT / "web/src/components/providers/collection-provider.tsx",
+        REPO_ROOT / "web/src/components/providers/bot-provider.tsx",
+        REPO_ROOT / "web/src/features/collection",
+    ]
+
+    sources = {}
+    for entry in checked_paths:
+        if entry.is_file():
+            sources[entry] = entry.read_text()
+            continue
+        for path in entry.rglob("*"):
+            if path.is_file() and path.suffix in {".ts", ".tsx"}:
+                sources[path] = path.read_text()
+    joined = "\n".join(sources.values())
+    feature_sources = "\n".join(
+        source
+        for path, source in sources.items()
+        if "/web/src/features/collection/" in str(path)
+    )
+
+    # Business code under #24a scope must not reach the old generated
+    # collection SDK or the v1 collections routes directly.
+    assert "defaultApi.collectionsGet" not in joined
+    assert "defaultApi.collectionsPost" not in joined
+    assert "defaultApi.collectionsCollectionIdGet" not in joined
+    assert "defaultApi.collectionsCollectionIdPut" not in joined
+    assert "defaultApi.collectionsCollectionIdDelete" not in joined
+    assert "defaultApi.collectionsCollectionIdSharingGet" not in joined
+    assert "defaultApi.collectionsCollectionIdSharingPost" not in joined
+    assert "defaultApi.collectionsCollectionIdSharingDelete" not in joined
+
+    # features/collection adapter must only reach v2 typed paths and not
+    # fall back to the old `@/api` generated SDK or raw fetch.
+    assert "from '@/api'" not in feature_sources
+    assert "fetch(" not in feature_sources
+    assert "/api/v2/collections" in feature_sources
+
+
 def test_documents_upload_regression_guards():
     """Regression guards for #前端 #16 document upload UX fixes.
 

--- a/web/src/app/workspace/collections/[collectionId]/collection-delete.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-delete.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
-import { apiClient } from '@/lib/api/client';
+import { deleteCollection } from '@/features/collection/client-api';
 import { Slot } from '@radix-ui/react-slot';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
@@ -32,13 +32,9 @@ export const CollectionDelete = ({
 
   const handleDelete = useCallback(async () => {
     if (collection?.id) {
-      const res = await apiClient.defaultApi.collectionsCollectionIdDelete({
-        collectionId: collection.id,
-      });
-      if (res?.status === 200) {
-        setDeleteVisible(false);
-        router.push('/workspace/collections');
-      }
+      await deleteCollection(collection.id);
+      setDeleteVisible(false);
+      router.push('/workspace/collections');
     }
   }, [collection?.id, router]);
 

--- a/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
@@ -23,7 +23,10 @@ import _ from 'lodash';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import { apiClient } from '@/lib/api/client';
+import {
+  publishCollectionSharing,
+  unpublishCollectionSharing,
+} from '@/features/collection/client-api';
 import { CollectionExport } from '@/components/collections/export-dialog';
 import {
   Calendar,
@@ -73,14 +76,10 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
         return;
       }
       if (checked) {
-        await apiClient.defaultApi.collectionsCollectionIdSharingPost({
-          collectionId: collection?.id,
-        });
+        await publishCollectionSharing(collection.id);
         toast.success(page_collections('published_success'));
       } else {
-        await apiClient.defaultApi.collectionsCollectionIdSharingDelete({
-          collectionId: collection?.id,
-        });
+        await unpublishCollectionSharing(collection.id);
         toast.success(page_collections('unpublished_success'));
       }
       await loadShare();

--- a/web/src/app/workspace/collections/[collectionId]/layout.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/layout.tsx
@@ -1,5 +1,8 @@
 import { CollectionProvider } from '@/components/providers/collection-provider';
-import { getServerApi } from '@/lib/api/server';
+import {
+  getCollection,
+  getCollectionSharingStatus,
+} from '@/features/collection/server-api';
 import { notFound } from 'next/navigation';
 
 export default async function ChatLayout({
@@ -10,22 +13,17 @@ export default async function ChatLayout({
   children: React.ReactNode;
 }>) {
   const { collectionId } = await params;
-  const serverApi = await getServerApi();
 
   let collection;
   let share;
 
   try {
     const [collectionRes, shareRes] = await Promise.all([
-      serverApi.defaultApi.collectionsCollectionIdGet({
-        collectionId,
-      }),
-      serverApi.defaultApi.collectionsCollectionIdSharingGet({
-        collectionId,
-      }),
+      getCollection(collectionId),
+      getCollectionSharingStatus(collectionId),
     ]);
-    collection = collectionRes.data;
-    share = shareRes.data;
+    collection = collectionRes ?? undefined;
+    share = shareRes ?? undefined;
   } catch (err) {
     console.log(err);
   }

--- a/web/src/app/workspace/collections/collection-form.tsx
+++ b/web/src/app/workspace/collections/collection-form.tsx
@@ -34,6 +34,10 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import {
+  createCollection,
+  updateCollection,
+} from '@/features/collection/client-api';
 import { apiClient } from '@/lib/api/client';
 import { cn, objectKeys } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -212,20 +216,15 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
     async (values: FormValueType) => {
       if (action === 'edit') {
         if (!collection?.id) return;
-        const res = await apiClient.defaultApi.collectionsCollectionIdPut({
-          collectionId: collection.id,
-          collectionUpdate: values,
-        });
-        if (res.data.id) {
+        const data = await updateCollection(collection.id, values);
+        if (data?.id) {
           toast.success(common_tips('update_success'));
           loadCollection();
         }
       }
       if (action === 'add') {
-        const res = await apiClient.defaultApi.collectionsPost({
-          collectionCreate: values,
-        });
-        if (res.data.id) {
+        const data = await createCollection(values);
+        if (data?.id) {
           toast.success(common_tips('create_success'));
           router.push('/workspace/collections');
         }

--- a/web/src/app/workspace/collections/page.tsx
+++ b/web/src/app/workspace/collections/page.tsx
@@ -1,4 +1,3 @@
-import { CollectionView } from '@/api';
 import {
   PageContainer,
   PageContent,
@@ -7,7 +6,8 @@ import {
   PageTitle,
 } from '@/components/page-container';
 
-import { getServerApi } from '@/lib/api/server';
+import { listCollections } from '@/features/collection/server-api';
+import type { CollectionView } from '@/features/collection/types';
 import { toJson } from '@/lib/utils';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
@@ -24,17 +24,16 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  const serverApi = await getServerApi();
   const page_collections = await getTranslations('page_collections');
 
   let collections: CollectionView[] = [];
   try {
-    const res = await serverApi.defaultApi.collectionsGet({
+    const data = await listCollections({
       page: 1,
       pageSize: 100,
       includeSubscribed: true,
     });
-    collections = res.data.items || [];
+    collections = data.items ?? [];
   } catch (err) {
     console.log(err);
   }

--- a/web/src/components/providers/bot-provider.tsx
+++ b/web/src/components/providers/bot-provider.tsx
@@ -3,7 +3,7 @@
 import { apiClient } from '@/lib/api/client';
 import { useCallback, useEffect, useState } from 'react';
 
-import { Collection, ModelSpec } from '@/api';
+import { ModelSpec } from '@/api';
 import {
   createBot,
   createBotChat,
@@ -13,6 +13,8 @@ import {
   updateBotChat,
 } from '@/features/bot/client-api';
 import type { Bot, Chat, ChatDetails } from '@/features/bot/types';
+import { listCollections } from '@/features/collection/client-api';
+import type { CollectionView } from '@/features/collection/types';
 import { useLocale } from 'next-intl';
 import { useParams, useRouter } from 'next/navigation';
 import { createContext, useContext } from 'react';
@@ -28,7 +30,7 @@ type BotContextProps = {
   bot?: Bot;
   chats: Chat[];
   mention: boolean;
-  collections: Collection[];
+  collections: CollectionView[];
   providerModels: ProviderModels;
   chatDelete?: (chat: Chat) => void;
   chatCreate?: () => void;
@@ -64,7 +66,7 @@ export const BotProvider = ({
   const router = useRouter();
   const locale = useLocale();
 
-  const [collections, setCollections] = useState<Collection[]>([]);
+  const [collections, setCollections] = useState<CollectionView[]>([]);
   const [providerModels, setProviderModels] = useState<ProviderModels>([]);
   const botChatsBasePath = workspace ? '/workspace/bots' : '/bots';
 
@@ -75,7 +77,7 @@ export const BotProvider = ({
           tag_filters: [{ operation: 'AND', tags: ['enable_for_agent'] }],
         },
       }),
-      apiClient.defaultApi.collectionsGet(),
+      listCollections(),
     ]);
 
     const items = modelRes.data.items?.map((m) => {
@@ -85,7 +87,7 @@ export const BotProvider = ({
         models: m.completion,
       };
     });
-    setCollections(collectionsRes.data.items || []);
+    setCollections(collectionsRes?.items ?? []);
     setProviderModels(items || []);
   }, []);
 

--- a/web/src/components/providers/collection-provider.tsx
+++ b/web/src/components/providers/collection-provider.tsx
@@ -2,8 +2,14 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { Collection, SharingStatusResponse } from '@/api';
-import { apiClient } from '@/lib/api/client';
+import {
+  getCollection,
+  getCollectionSharingStatus,
+} from '@/features/collection/client-api';
+import type {
+  Collection,
+  SharingStatusResponse,
+} from '@/features/collection/types';
 import { createContext, useContext } from 'react';
 
 type CollectionContextProps = {
@@ -43,20 +49,20 @@ export const CollectionProvider = ({
     if (!collection?.id) {
       return;
     }
-    const res = await apiClient.defaultApi.collectionsCollectionIdSharingGet({
-      collectionId: collection.id,
-    });
-    setShare(res.data);
+    const data = await getCollectionSharingStatus(collection.id);
+    if (data) {
+      setShare(data);
+    }
   }, [collection?.id]);
 
   const loadCollection = useCallback(async () => {
     if (!collection?.id) {
       return;
     }
-    const res = await apiClient.defaultApi.collectionsCollectionIdGet({
-      collectionId: collection.id,
-    });
-    setCollection(res.data);
+    const data = await getCollection(collection.id);
+    if (data) {
+      setCollection(data);
+    }
   }, [collection?.id]);
 
   useEffect(() => {

--- a/web/src/features/collection/client-api.ts
+++ b/web/src/features/collection/client-api.ts
@@ -1,0 +1,130 @@
+'use client';
+
+import { browserApiClient } from '@/lib/api/typed/browser';
+
+import type {
+  Collection,
+  CollectionCreate,
+  CollectionSummaryTriggerResponse,
+  CollectionUpdate,
+  CollectionViewList,
+  MineruTokenTestRequest,
+  MineruTokenTestResponse,
+  SharingStatusResponse,
+} from './types';
+
+export async function createCollection(
+  input: CollectionCreate,
+): Promise<Collection | undefined> {
+  const { data } = await browserApiClient.POST('/api/v2/collections', {
+    body: input,
+  });
+  return data;
+}
+
+export async function listCollections(options?: {
+  page?: number;
+  pageSize?: number;
+  includeSubscribed?: boolean;
+}): Promise<CollectionViewList | undefined> {
+  const { data } = await browserApiClient.GET('/api/v2/collections', {
+    params: {
+      query: {
+        page: options?.page ?? 1,
+        page_size: options?.pageSize ?? 50,
+        include_subscribed: options?.includeSubscribed ?? true,
+      },
+    },
+  });
+  return data;
+}
+
+export async function getCollection(
+  collectionId: string,
+): Promise<Collection | undefined> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/collections/{collection_id}',
+    {
+      params: { path: { collection_id: collectionId } },
+    },
+  );
+  return data;
+}
+
+export async function updateCollection(
+  collectionId: string,
+  input: CollectionUpdate,
+): Promise<Collection | undefined> {
+  const { data } = await browserApiClient.PUT(
+    '/api/v2/collections/{collection_id}',
+    {
+      params: { path: { collection_id: collectionId } },
+      body: input,
+    },
+  );
+  return data;
+}
+
+export async function deleteCollection(collectionId: string): Promise<void> {
+  await browserApiClient.DELETE('/api/v2/collections/{collection_id}', {
+    params: { path: { collection_id: collectionId } },
+  });
+}
+
+export async function triggerCollectionSummary(
+  collectionId: string,
+): Promise<CollectionSummaryTriggerResponse | undefined> {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/collections/{collection_id}/summary/generate',
+    {
+      params: { path: { collection_id: collectionId } },
+    },
+  );
+  return data;
+}
+
+export async function testMineruToken(
+  input: MineruTokenTestRequest,
+): Promise<MineruTokenTestResponse | undefined> {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/collections/test-mineru-token',
+    {
+      body: input,
+    },
+  );
+  return data;
+}
+
+export async function getCollectionSharingStatus(
+  collectionId: string,
+): Promise<SharingStatusResponse | undefined> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/collections/{collection_id}/sharing',
+    {
+      params: { path: { collection_id: collectionId } },
+    },
+  );
+  return data;
+}
+
+export async function publishCollectionSharing(
+  collectionId: string,
+): Promise<void> {
+  await browserApiClient.POST(
+    '/api/v2/collections/{collection_id}/sharing',
+    {
+      params: { path: { collection_id: collectionId } },
+    },
+  );
+}
+
+export async function unpublishCollectionSharing(
+  collectionId: string,
+): Promise<void> {
+  await browserApiClient.DELETE(
+    '/api/v2/collections/{collection_id}/sharing',
+    {
+      params: { path: { collection_id: collectionId } },
+    },
+  );
+}

--- a/web/src/features/collection/server-api.ts
+++ b/web/src/features/collection/server-api.ts
@@ -1,0 +1,48 @@
+import { createServerApiClient } from '@/lib/api/typed/server';
+
+import type {
+  Collection,
+  CollectionViewList,
+  SharingStatusResponse,
+} from './types';
+
+export async function listCollections(options?: {
+  page?: number;
+  pageSize?: number;
+  includeSubscribed?: boolean;
+}): Promise<CollectionViewList> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v2/collections', {
+    params: {
+      query: {
+        page: options?.page ?? 1,
+        page_size: options?.pageSize ?? 50,
+        include_subscribed: options?.includeSubscribed ?? true,
+      },
+    },
+  });
+  return data ?? {};
+}
+
+export async function getCollection(
+  collectionId: string,
+): Promise<Collection | null> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v2/collections/{collection_id}', {
+    params: { path: { collection_id: collectionId } },
+  });
+  return data ?? null;
+}
+
+export async function getCollectionSharingStatus(
+  collectionId: string,
+): Promise<SharingStatusResponse | null> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET(
+    '/api/v2/collections/{collection_id}/sharing',
+    {
+      params: { path: { collection_id: collectionId } },
+    },
+  );
+  return data ?? null;
+}

--- a/web/src/features/collection/types.ts
+++ b/web/src/features/collection/types.ts
@@ -1,0 +1,17 @@
+import type { components } from '@/api-v2/schema';
+
+export type Collection = components['schemas']['Collection'];
+export type CollectionCreate = components['schemas']['CollectionCreate'];
+export type CollectionUpdate = components['schemas']['CollectionUpdate'];
+export type CollectionView = components['schemas']['CollectionView'];
+export type CollectionViewList = components['schemas']['CollectionViewList'];
+
+export type SharingStatusResponse =
+  components['schemas']['SharingStatusResponse'];
+export type CollectionSummaryTriggerResponse =
+  components['schemas']['CollectionSummaryTriggerResponse'];
+
+export type MineruTokenTestRequest =
+  components['schemas']['MineruTokenTestRequest'];
+export type MineruTokenTestResponse =
+  components['schemas']['MineruTokenTestResponse'];


### PR DESCRIPTION
## Summary

Migrate the collection CRUD + sharing surface off the generated
`defaultApi.collections*` SDK onto the `/api/v2/collections*` typed
paths that `#1573 (#16 / #11a)` already landed. Mirrors the pattern
used by `features/providers/*` (`#1571`), `features/evaluation/*`
(`#1578`) and `features/bot/*` (`#1579`).

Scope is deliberately the **collection + sharing half of the original
`#24`** per PM @符炫炜's de-confliction (msg=137fb808): document read-side
is `#24b` (= `#28`, to be taken by @chenyexuan once their task A lands),
upload flow stays untouched (recently hotfixed in `#1580`) and final
v1 SDK removal is `#26`.

## Scope

**In**
- `web/src/features/collection/{client-api,server-api,types}.ts` — new
- `app/workspace/collections/page.tsx` — SSR list
- `app/workspace/collections/[collectionId]/layout.tsx` — SSR collection + sharing
- `app/workspace/collections/[collectionId]/collection-delete.tsx`
- `app/workspace/collections/[collectionId]/collection-header.tsx` — sharing toggle
- `app/workspace/collections/collection-form.tsx` — create / update
- `components/providers/collection-provider.tsx`
- `components/providers/bot-provider.tsx` — the `collectionsGet` call that backs the bot's collection picker
- `tests/unit_test/test_web_typed_api_contract.py` — new `test_collection_feature_uses_v2_typed_api_boundary`

**Out (deliberate)**
- Documents routes (`/documents*`) — `#24b` / `#28`
- Upload flow (`document-upload.tsx` etc.) — `#24b` / upload queue follow-up
- Search / graph / marketplace
- v1 route `/api/v1/collections/test-mineru-token` from `admin/configuration/parser-settings.tsx` still hits the v1 settings route (`settingsTestMineruTokenPost`), which is a separate slice — not touched here
- Final removal of `@/api` generated SDK — `#26`

## Contract / non-2xx / SSR notes

- Every adapter goes through `browserApiClient` / `createServerApiClient`, which keep the non-2xx throw semantic — no silent empty-state renders on 401/404/500.
- `BotProvider.collections` state was re-typed from `Collection[]` to `CollectionView[]` to match what `GET /api/v2/collections` actually returns (the generated `BotList`-style envelope with `items: CollectionView[]`).
- `CollectionProvider.loadShare` / `loadCollection` now use the typed `getCollectionSharingStatus` / `getCollection` helpers and only call `setState` when the response is non-null.
- `DELETE /api/v2/collections/{collection_id}` is now treated as 204 no-content on the FE side (no `res.status === 200` check).

## Local verification

- `uv run --extra test pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_openapi_spec.py -q` — **8 passed** (including the new `test_collection_feature_uses_v2_typed_api_boundary`)
- `make lint` — pass
- `git diff --check` — pass
- No backend changes → `make openapi-check` not re-run
- No `web/node_modules` in this agent workspace → targeted eslint / tsc will rely on GitHub `lint-and-unit`

## Test plan

- [ ] GitHub `lint-and-unit` green
- [ ] GitHub `e2e-http-smoke` green
- [ ] At least 1 diff-scoped CR no-blocker (per new `CR 1-of-N` merge policy @earayu2 msg=6a93f8f4)
  - @ApeRAG专家 / @Weston for typed-boundary / scope
  - @符炫炜 for `#14` consumer-angle (collection_id string semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)