### PR TITLE
test(evaluation_v2): harden OpenAPI contract (v1 ghost guard + DELETE 204 + path-param coverage)

### DIFF
--- a/tests/unit_test/test_evaluation_v2_openapi_contract.py
+++ b/tests/unit_test/test_evaluation_v2_openapi_contract.py
@@ -1,3 +1,5 @@
+import re
+
 from fastapi import FastAPI
 
 from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
@@ -36,28 +38,18 @@ def test_evaluation_v2_routes_are_public_and_typed():
     for p in REQUIRED_PATHS:
         assert p in paths, f"missing public path {p}"
 
-    assert (
-        _json_ref(spec, "/api/v2/benchmark-datasets", "post")
-        == "#/components/schemas/BenchmarkDatasetEnvelope"
-    )
-    assert (
-        _json_ref(spec, "/api/v2/benchmark-datasets", "get")
-        == "#/components/schemas/BenchmarkDatasetListResponse"
-    )
+    assert _json_ref(spec, "/api/v2/benchmark-datasets", "post") == "#/components/schemas/BenchmarkDatasetEnvelope"
+    assert _json_ref(spec, "/api/v2/benchmark-datasets", "get") == "#/components/schemas/BenchmarkDatasetListResponse"
     assert (
         _json_ref(spec, "/api/v2/benchmark-datasets/{dataset_id}/versions", "post")
         == "#/components/schemas/BenchmarkDatasetVersionEnvelope"
     )
+    assert _json_ref(spec, "/api/v2/evaluation-runs", "post") == "#/components/schemas/EvaluationRunEnvelope"
     assert (
-        _json_ref(spec, "/api/v2/evaluation-runs", "post") == "#/components/schemas/EvaluationRunEnvelope"
+        _json_ref(spec, "/api/v2/evaluation-runs/{run_id}", "get") == "#/components/schemas/EvaluationRunDetailResponse"
     )
     assert (
-        _json_ref(spec, "/api/v2/evaluation-runs/{run_id}", "get")
-        == "#/components/schemas/EvaluationRunDetailResponse"
-    )
-    assert (
-        _json_ref(spec, "/api/v2/evaluation-runs/{run_id}/cancel", "post")
-        == "#/components/schemas/CancelRunResponse"
+        _json_ref(spec, "/api/v2/evaluation-runs/{run_id}/cancel", "post") == "#/components/schemas/CancelRunResponse"
     )
     assert (
         _json_ref(spec, "/api/v2/evaluation-runs/{run_id}/items/{item_id}/retry", "post")
@@ -69,9 +61,9 @@ def test_evaluation_v2_write_request_bodies_omit_path_params():
     spec = _evaluation_v2_spec()
     components = spec["components"]["schemas"]
 
-    create_version_ref = spec["paths"]["/api/v2/benchmark-datasets/{dataset_id}/versions"]["post"][
-        "requestBody"
-    ]["content"]["application/json"]["schema"]["$ref"]
+    create_version_ref = spec["paths"]["/api/v2/benchmark-datasets/{dataset_id}/versions"]["post"]["requestBody"][
+        "content"
+    ]["application/json"]["schema"]["$ref"]
     create_version_schema = components[create_version_ref.removeprefix("#/components/schemas/")]
     assert "dataset_id" not in create_version_schema.get("properties", {})
 
@@ -84,3 +76,70 @@ def test_evaluation_v2_operation_ids_are_unique():
             if isinstance(operation, dict) and operation.get("operationId"):
                 op_ids.append(operation["operationId"])
     assert len(op_ids) == len(set(op_ids))
+
+
+def test_full_app_spec_has_no_v1_evaluation_or_question_set_paths():
+    from aperag.app import app
+
+    full_spec = build_full_openapi_spec(app)
+    public_spec = filter_public_openapi(full_spec)
+
+    for spec_name, spec in (("full", full_spec), ("public", public_spec)):
+        ghost = sorted(
+            path
+            for path in spec["paths"]
+            if path.startswith("/api/v1/evaluations") or path.startswith("/api/v1/question-sets")
+        )
+        assert not ghost, f"{spec_name} spec must not expose v1 evaluation/question-set paths; found {ghost}"
+
+
+def test_evaluation_v2_delete_benchmark_dataset_has_no_json_body():
+    spec = _evaluation_v2_spec()
+    responses = spec["paths"]["/api/v2/benchmark-datasets/{dataset_id}"]["delete"]["responses"]
+
+    assert "204" in responses, "DELETE /benchmark-datasets/{dataset_id} must expose a 204 response"
+    assert "200" not in responses, "DELETE /benchmark-datasets/{dataset_id} must not declare a 200 response"
+
+    # The success response must be a bare 204 with no body schema.
+    success_content = (responses["204"] or {}).get("content") or {}
+    assert "application/json" not in success_content, (
+        "DELETE /benchmark-datasets/{dataset_id} 204 response must not carry an application/json body"
+    )
+
+
+def test_evaluation_v2_all_write_request_bodies_omit_path_params():
+    """Every POST/PUT/PATCH request body under evaluation_v2 must not redeclare path params.
+
+    Generalizes ``test_evaluation_v2_write_request_bodies_omit_path_params`` so new write routes
+    (BenchmarkDatasetCreate / BenchmarkDatasetUpdate / EvaluationRunCreate / future additions)
+    are covered automatically.
+    """
+
+    spec = _evaluation_v2_spec()
+    components = spec["components"]["schemas"]
+    path_param_re = re.compile(r"\{([^{}]+)\}")
+
+    checked = 0
+    for path, methods in spec["paths"].items():
+        path_params = set(path_param_re.findall(path))
+        if not path_params:
+            continue
+        for method, operation in methods.items():
+            if method not in {"post", "put", "patch"}:
+                continue
+            request_body = (operation or {}).get("requestBody") or {}
+            json_schema = request_body.get("content", {}).get("application/json", {}).get("schema") or {}
+            ref = json_schema.get("$ref")
+            if not ref:
+                continue
+            schema_name = ref.removeprefix("#/components/schemas/")
+            properties = set(components[schema_name].get("properties", {}).keys())
+            overlap = path_params & properties
+            assert not overlap, (
+                f"{method.upper()} {path} request body {schema_name} duplicates path param(s) {sorted(overlap)}"
+            )
+            checked += 1
+
+    assert checked >= 2, (
+        f"Expected at least 2 write routes with request bodies under evaluation_v2 router, but only inspected {checked}"
+    )


### PR DESCRIPTION
## Summary
Follow-up on #14a (PR #1574) non-blocking CR feedback. Adds three contract-test assertions to `tests/unit_test/test_evaluation_v2_openapi_contract.py` so future refactors cannot:
- re-introduce `/api/v1/evaluations*` or `/api/v1/question-sets*` ghost routers,
- turn `DELETE /api/v2/benchmark-datasets/{dataset_id}` into a JSON-body endpoint,
- duplicate path params inside POST/PUT/PATCH request bodies.

No runtime changes; tests-only gate.

## New assertions
1. **`test_full_app_spec_has_no_v1_evaluation_or_question_set_paths`** — imports the full `aperag.app.app`, builds both the full spec and the public-filtered spec, and asserts 0 paths start with `/api/v1/evaluations` or `/api/v1/question-sets`.
2. **`test_evaluation_v2_delete_benchmark_dataset_has_no_json_body`** — asserts `DELETE /api/v2/benchmark-datasets/{dataset_id}` has a `204` response, no `200` response, and no `application/json` body on the success response.
3. **`test_evaluation_v2_all_write_request_bodies_omit_path_params`** — generalizes the existing single-schema check; iterates every `POST/PUT/PATCH` with a JSON request body under the evaluation_v2 router and asserts path params are not redeclared as body properties. Covers `BenchmarkDatasetCreate` / `BenchmarkDatasetUpdate` / `BenchmarkDatasetVersionCreate` / `EvaluationRunCreate` automatically, plus any future additions.

Pattern mirrors `tests/unit_test/test_provider_v2_openapi_contract.py` and the existing `test_evaluation_v2_write_request_bodies_omit_path_params`.

## Scope / non-goals
- Does **not** touch `aperag/views/evaluation_v2.py` or `aperag/evaluation_v2/**` runtime.
- Does **not** touch FE or any other domain (`#24` collection/document / `#26` final sweep / bot / collection / provider).

## Test plan
- [x] `uv run --extra test pytest tests/unit_test/test_evaluation_v2_openapi_contract.py tests/unit_test/test_openapi_spec.py -q` → **9 passed**
- [x] `make openapi-check` → exit 0
- [x] `make lint` → `All checks passed!` / `235 files already formatted`
- [ ] Required GitHub gates green + `mergeStateStatus=CLEAN`
- [ ] 1× diff-scoped no-blocker CR (per new merge gate: 1 reviewer suffices)

## Related
- Base: `main @ 4d13b5a` (commit `4d13b5aef47ecc293fe06f640c3f8128de086243` — PR #1580 merge point)
- Follows #14a (PR #1574) non-blocking contract follow-up promised by @符炫炜

🤖 Generated with [Claude Code](https://claude.com/claude-code)