### PR TITLE
test: harden v2 OpenAPI contracts for provider/collection/documents/bot

### DIFF
--- a/tests/unit_test/test_bot_v2_openapi_contract.py
+++ b/tests/unit_test/test_bot_v2_openapi_contract.py
@@ -1,3 +1,5 @@
+import re
+
 from fastapi import FastAPI
 
 from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
@@ -17,6 +19,11 @@ def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
 def _request_schema(spec: dict, path: str, method: str) -> dict:
     request_ref = spec["paths"][path][method]["requestBody"]["content"]["application/json"]["schema"]["$ref"]
     return spec["components"]["schemas"][request_ref.removeprefix("#/components/schemas/")]
+
+
+# v1 bot routes still coexist with bots_v2 as a parallel path on main (#21 added parallel v2
+# without deleting v1). A v1-absence assertion is intentionally NOT added at this time; it will
+# be introduced by the #26 final sweep when the v1 bot surface is removed.
 
 
 def test_bot_v2_routes_are_public_and_typed():
@@ -39,9 +46,7 @@ def test_bot_v2_routes_are_public_and_typed():
     assert _json_ref(spec, "/api/v2/bots/{bot_id}", "put") == "#/components/schemas/Bot"
     assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats", "post") == "#/components/schemas/Chat"
     assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats", "get") == "#/components/schemas/ChatList"
-    assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}", "get") == (
-        "#/components/schemas/ChatDetails"
-    )
+    assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}", "get") == ("#/components/schemas/ChatDetails")
     assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}", "put") == "#/components/schemas/Chat"
     assert _json_ref(spec, "/api/v2/bots/{bot_id}/chats/{chat_id}/title", "post") == (
         "#/components/schemas/TitleGenerateResponse"
@@ -94,3 +99,68 @@ def test_bot_v2_operation_ids_are_unique():
     ]
 
     assert len(operation_ids) == len(set(operation_ids))
+
+
+def test_bot_v2_delete_routes_contract():
+    """Every DELETE route under bots_v2 must respect the command-vs-report contract:
+
+    - must not declare both 200 and 204 success responses
+    - if 204 is declared it must have no application/json body (pure command)
+
+    Generalizes ``test_bot_v2_delete_routes_return_204_without_body`` to cover every DELETE
+    route (new ones appear automatically).
+    """
+    spec = _bot_v2_spec()
+    checked = 0
+    for path, operations in spec["paths"].items():
+        op = operations.get("delete")
+        if not op:
+            continue
+        responses = op.get("responses") or {}
+        assert not ("200" in responses and "204" in responses), (
+            f"DELETE {path} must not mix 200 and 204 success responses; pick one"
+        )
+        if "204" in responses:
+            assert "content" not in (responses["204"] or {}), (
+                f"DELETE {path} 204 response must not carry an application/json body"
+            )
+        else:
+            assert "200" in responses, f"DELETE {path} must declare a 200 or 204 success response"
+        checked += 1
+    assert checked >= 1, "bots_v2 should expose at least one DELETE route to exercise this contract"
+
+
+def test_bot_v2_all_write_request_bodies_omit_path_params():
+    """Every POST/PUT/PATCH request body under bots_v2 must not redeclare path params.
+
+    Generalizes ``test_bot_v2_write_bodies_use_path_ids_as_canonical`` to all path params so
+    new write routes under ``/api/v2/bots/...`` are covered automatically.
+    """
+    spec = _bot_v2_spec()
+    components = spec["components"]["schemas"]
+    path_param_re = re.compile(r"\{([^{}]+)\}")
+
+    checked = 0
+    for path, methods in spec["paths"].items():
+        path_params = set(path_param_re.findall(path))
+        if not path_params:
+            continue
+        for method, operation in methods.items():
+            if method not in {"post", "put", "patch"}:
+                continue
+            request_body = (operation or {}).get("requestBody") or {}
+            json_schema = request_body.get("content", {}).get("application/json", {}).get("schema") or {}
+            ref = json_schema.get("$ref")
+            if not ref:
+                continue
+            schema_name = ref.removeprefix("#/components/schemas/")
+            properties = set(components[schema_name].get("properties", {}).keys())
+            overlap = path_params & properties
+            assert not overlap, (
+                f"{method.upper()} {path} request body {schema_name} duplicates path param(s) {sorted(overlap)}"
+            )
+            checked += 1
+
+    assert checked >= 1, (
+        f"Expected at least 1 write route with request body under bots_v2, but only inspected {checked}"
+    )

--- a/tests/unit_test/test_collection_v2_openapi_contract.py
+++ b/tests/unit_test/test_collection_v2_openapi_contract.py
@@ -1,3 +1,5 @@
+import re
+
 from fastapi import FastAPI
 
 from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
@@ -12,6 +14,24 @@ def _collection_v2_spec():
 
 def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
     return spec["paths"][path][method]["responses"][status]["content"]["application/json"]["schema"]["$ref"]
+
+
+# v1 collection CRUD/sharing ghost paths still wired in main pending #26 final sweep.
+# Strictly collection-scoped (no /documents, /graphs, /searches, /export, /marketplace —
+# those belong to other domain contract tests).
+COLLECTION_V1_GHOST_PATHS = frozenset(
+    {
+        "/api/v1/collections",
+        "/api/v1/collections/test-mineru-token",
+        "/api/v1/collections/{collection_id}",
+        "/api/v1/collections/{collection_id}/sharing",
+        "/api/v1/collections/{collection_id}/summary/generate",
+    }
+)
+
+
+def _collection_v1_ghosts(spec: dict) -> set[str]:
+    return {p for p in spec["paths"] if p in COLLECTION_V1_GHOST_PATHS}
 
 
 REQUIRED_PATHS = {
@@ -67,13 +87,9 @@ def test_collection_v2_command_routes_return_204_without_body():
         responses = spec["paths"][path][method]["responses"]
         assert "204" in responses, f"{method.upper()} {path} must declare 204 response"
         # 204 responses carry no content body.
-        assert "content" not in responses["204"], (
-            f"{method.upper()} {path} 204 response must not carry a JSON body"
-        )
+        assert "content" not in responses["204"], f"{method.upper()} {path} 204 response must not carry a JSON body"
         # Command routes must not register a competing 200 JSON schema.
-        assert "200" not in responses, (
-            f"{method.upper()} {path} must not mix 204 with a 200 JSON response"
-        )
+        assert "200" not in responses, f"{method.upper()} {path} must not mix 204 with a 200 JSON response"
 
 
 def test_collection_v2_write_bodies_do_not_repeat_collection_id():
@@ -132,3 +148,88 @@ def test_collection_v2_mineru_token_request_schema_is_typed():
     assert schema_name == "MineruTokenTestRequest"
     props = spec["components"]["schemas"][schema_name]["properties"]
     assert "token" in props
+
+
+def test_collection_v1_ghost_inventory_is_stable():
+    """v1 collection CRUD/sharing ghost paths in the full+public spec must stay within the pinned baseline.
+
+    The #26 final sweep is expected to remove entries from :data:`COLLECTION_V1_GHOST_PATHS`
+    (set will shrink); nothing should introduce new v1 collection CRUD/sharing routes.
+    """
+    from aperag.app import app
+
+    full_spec = build_full_openapi_spec(app)
+    public_spec = filter_public_openapi(full_spec)
+
+    for spec_name, spec in (("full", full_spec), ("public", public_spec)):
+        current = _collection_v1_ghosts(spec)
+        unexpected = current - COLLECTION_V1_GHOST_PATHS
+        assert not unexpected, (
+            f"{spec_name} spec introduced new v1 collection ghost path(s) {sorted(unexpected)}; "
+            "update COLLECTION_V1_GHOST_PATHS only if intentional"
+        )
+
+
+def test_collection_v2_delete_routes_contract():
+    """Every DELETE route under collections_v2 must respect the command-vs-report contract:
+
+    - must not declare both 200 and 204 success responses
+    - if 204 is declared it must have no application/json body (pure command)
+
+    Generalizes ``test_collection_v2_command_routes_return_204_without_body`` to cover every
+    DELETE route (new ones appear automatically).
+    """
+    spec = _collection_v2_spec()
+    checked = 0
+    for path, operations in spec["paths"].items():
+        op = operations.get("delete")
+        if not op:
+            continue
+        responses = op.get("responses") or {}
+        assert not ("200" in responses and "204" in responses), (
+            f"DELETE {path} must not mix 200 and 204 success responses; pick one"
+        )
+        if "204" in responses:
+            assert "content" not in (responses["204"] or {}), (
+                f"DELETE {path} 204 response must not carry an application/json body"
+            )
+        else:
+            assert "200" in responses, f"DELETE {path} must declare a 200 or 204 success response"
+        checked += 1
+    assert checked >= 1, "collections_v2 should expose at least one DELETE route to exercise this contract"
+
+
+def test_collection_v2_all_write_request_bodies_omit_path_params():
+    """Every POST/PUT/PATCH request body under collections_v2 must not redeclare path params.
+
+    Generalizes ``test_collection_v2_write_bodies_do_not_repeat_collection_id`` to all path params
+    (not just ``collection_id``) so future routes with additional path ids are covered automatically.
+    """
+    spec = _collection_v2_spec()
+    components = spec["components"]["schemas"]
+    path_param_re = re.compile(r"\{([^{}]+)\}")
+
+    checked = 0
+    for path, methods in spec["paths"].items():
+        path_params = set(path_param_re.findall(path))
+        if not path_params:
+            continue
+        for method, operation in methods.items():
+            if method not in {"post", "put", "patch"}:
+                continue
+            request_body = (operation or {}).get("requestBody") or {}
+            json_schema = request_body.get("content", {}).get("application/json", {}).get("schema") or {}
+            ref = json_schema.get("$ref")
+            if not ref:
+                continue
+            schema_name = ref.removeprefix("#/components/schemas/")
+            properties = set(components[schema_name].get("properties", {}).keys())
+            overlap = path_params & properties
+            assert not overlap, (
+                f"{method.upper()} {path} request body {schema_name} duplicates path param(s) {sorted(overlap)}"
+            )
+            checked += 1
+
+    assert checked >= 1, (
+        f"Expected at least 1 write route with request body under collections_v2, but only inspected {checked}"
+    )

--- a/tests/unit_test/test_documents_v2_openapi_contract.py
+++ b/tests/unit_test/test_documents_v2_openapi_contract.py
@@ -1,3 +1,5 @@
+import re
+
 from fastapi import FastAPI
 
 from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
@@ -17,6 +19,29 @@ def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
 def _request_schema(spec: dict, path: str, method: str) -> dict:
     request_ref = spec["paths"][path][method]["requestBody"]["content"]["application/json"]["schema"]["$ref"]
     return spec["components"]["schemas"][request_ref.removeprefix("#/components/schemas/")]
+
+
+# v1 documents ghost paths still wired in main pending #26 final sweep.
+# Strictly document-scoped subpaths under /api/v1/collections/{collection_id}/...
+DOCUMENTS_V1_GHOST_PATHS = frozenset(
+    {
+        "/api/v1/collections/{collection_id}/documents",
+        "/api/v1/collections/{collection_id}/documents/confirm",
+        "/api/v1/collections/{collection_id}/documents/fetch-url",
+        "/api/v1/collections/{collection_id}/documents/staged",
+        "/api/v1/collections/{collection_id}/documents/upload",
+        "/api/v1/collections/{collection_id}/documents/{document_id}",
+        "/api/v1/collections/{collection_id}/documents/{document_id}/download",
+        "/api/v1/collections/{collection_id}/documents/{document_id}/object",
+        "/api/v1/collections/{collection_id}/documents/{document_id}/preview",
+        "/api/v1/collections/{collection_id}/documents/{document_id}/rebuild_indexes",
+        "/api/v1/collections/{collection_id}/rebuild_failed_indexes",
+    }
+)
+
+
+def _documents_v1_ghosts(spec: dict) -> set[str]:
+    return {p for p in spec["paths"] if p in DOCUMENTS_V1_GHOST_PATHS}
 
 
 def test_documents_v2_routes_are_public_and_typed():
@@ -119,3 +144,91 @@ def test_documents_v2_operation_ids_are_unique():
     ]
 
     assert len(operation_ids) == len(set(operation_ids))
+
+
+def test_documents_v1_ghost_inventory_is_stable():
+    """v1 documents ghost paths in the full+public spec must stay within the pinned baseline.
+
+    The #26 final sweep is expected to remove entries from :data:`DOCUMENTS_V1_GHOST_PATHS`
+    (set will shrink); nothing should introduce new v1 documents routes.
+    """
+    from aperag.app import app
+
+    full_spec = build_full_openapi_spec(app)
+    public_spec = filter_public_openapi(full_spec)
+
+    for spec_name, spec in (("full", full_spec), ("public", public_spec)):
+        current = _documents_v1_ghosts(spec)
+        unexpected = current - DOCUMENTS_V1_GHOST_PATHS
+        assert not unexpected, (
+            f"{spec_name} spec introduced new v1 documents ghost path(s) {sorted(unexpected)}; "
+            "update DOCUMENTS_V1_GHOST_PATHS only if intentional"
+        )
+
+
+def test_documents_v2_delete_routes_contract():
+    """Every DELETE route under documents_v2 must respect the command-vs-report contract.
+
+    Generalizes the single-route assertion in
+    ``test_documents_v2_delete_and_request_bodies_are_path_canonical`` so future DELETE routes
+    are covered automatically. The contract is:
+
+    - a DELETE route must not declare both 200 and 204 success responses
+    - if 204 is declared it must have no application/json body (pure command)
+    - a 200 JSON DELETE (e.g. bulk delete returning per-item status) is allowed
+    """
+    spec = _documents_v2_spec()
+    checked = 0
+    for path, operations in spec["paths"].items():
+        op = operations.get("delete")
+        if not op:
+            continue
+        responses = op.get("responses") or {}
+        assert not ("200" in responses and "204" in responses), (
+            f"DELETE {path} must not mix 200 and 204 success responses; pick one"
+        )
+        if "204" in responses:
+            assert "content" not in (responses["204"] or {}), (
+                f"DELETE {path} 204 response must not carry an application/json body"
+            )
+        else:
+            assert "200" in responses, f"DELETE {path} must declare a 200 or 204 success response"
+        checked += 1
+    assert checked >= 1, "documents_v2 should expose at least one DELETE route to exercise this contract"
+
+
+def test_documents_v2_all_write_request_bodies_omit_path_params():
+    """Every POST/PUT/PATCH request body under documents_v2 must not redeclare path params.
+
+    Generalizes the hardcoded list in
+    ``test_documents_v2_delete_and_request_bodies_are_path_canonical`` so new write routes are
+    covered automatically.
+    """
+    spec = _documents_v2_spec()
+    components = spec["components"]["schemas"]
+    path_param_re = re.compile(r"\{([^{}]+)\}")
+
+    checked = 0
+    for path, methods in spec["paths"].items():
+        path_params = set(path_param_re.findall(path))
+        if not path_params:
+            continue
+        for method, operation in methods.items():
+            if method not in {"post", "put", "patch"}:
+                continue
+            request_body = (operation or {}).get("requestBody") or {}
+            json_schema = request_body.get("content", {}).get("application/json", {}).get("schema") or {}
+            ref = json_schema.get("$ref")
+            if not ref:
+                continue
+            schema_name = ref.removeprefix("#/components/schemas/")
+            properties = set(components[schema_name].get("properties", {}).keys())
+            overlap = path_params & properties
+            assert not overlap, (
+                f"{method.upper()} {path} request body {schema_name} duplicates path param(s) {sorted(overlap)}"
+            )
+            checked += 1
+
+    assert checked >= 1, (
+        f"Expected at least 1 write route with request body under documents_v2, but only inspected {checked}"
+    )

--- a/tests/unit_test/test_provider_v2_openapi_contract.py
+++ b/tests/unit_test/test_provider_v2_openapi_contract.py
@@ -1,3 +1,5 @@
+import re
+
 from fastapi import FastAPI
 
 from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
@@ -12,6 +14,33 @@ def _provider_v2_spec():
 
 def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
     return spec["paths"][path][method]["responses"][status]["content"]["application/json"]["schema"]["$ref"]
+
+
+# Known v1 ghost paths in the provider domain. v1 LLM provider / default-models /
+# available-models routes are still wired in main pending the #26 final sweep;
+# this baseline pins the current inventory so we catch unexpected regrowth but
+# allow the #26 sweep to shrink it (subset semantics).
+PROVIDER_V1_GHOST_PATHS = frozenset(
+    {
+        "/api/v1/available_models",
+        "/api/v1/default_models",
+        "/api/v1/llm_configuration",
+        "/api/v1/llm_provider_models",
+        "/api/v1/llm_providers",
+        "/api/v1/llm_providers/{provider_name}",
+        "/api/v1/llm_providers/{provider_name}/models",
+        "/api/v1/llm_providers/{provider_name}/models/{api}/{model}",
+        "/api/v1/llm_providers/{provider_name}/publish",
+    }
+)
+
+
+def _provider_v1_ghosts(spec: dict) -> set[str]:
+    return {
+        p
+        for p in spec["paths"]
+        if p.startswith("/api/v1/llm_") or p in {"/api/v1/default_models", "/api/v1/available_models"}
+    }
 
 
 def test_provider_v2_routes_are_public_and_typed():
@@ -47,3 +76,82 @@ def test_provider_v2_model_create_request_uses_path_provider():
 
     assert request_schema_name == "LlmProviderModelCreateRequest"
     assert "provider_name" not in request_schema["properties"]
+
+
+def test_provider_v1_ghost_inventory_is_stable():
+    """v1 provider ghost paths in the exported full+public spec must stay within the pinned baseline.
+
+    Purpose is to prevent accidental regrowth: the #26 final sweep is expected to remove entries
+    from :data:`PROVIDER_V1_GHOST_PATHS` (set will shrink), but nothing in future refactors should
+    add new v1 llm/default-model/available-model routes.
+    """
+    from aperag.app import app
+
+    full_spec = build_full_openapi_spec(app)
+    public_spec = filter_public_openapi(full_spec)
+
+    for spec_name, spec in (("full", full_spec), ("public", public_spec)):
+        current = _provider_v1_ghosts(spec)
+        unexpected = current - PROVIDER_V1_GHOST_PATHS
+        assert not unexpected, (
+            f"{spec_name} spec introduced new v1 provider ghost path(s) {sorted(unexpected)}; "
+            "update PROVIDER_V1_GHOST_PATHS only if intentional"
+        )
+
+
+def test_provider_v2_delete_routes_contract():
+    """Every DELETE route under providers_v2 must respect the command-vs-report contract:
+
+    - must not declare both 200 and 204 success responses
+    - if 204 is declared it must have no application/json body (pure command)
+    """
+    spec = _provider_v2_spec()
+    checked = 0
+    for path, operations in spec["paths"].items():
+        op = operations.get("delete")
+        if not op:
+            continue
+        responses = op.get("responses") or {}
+        assert not ("200" in responses and "204" in responses), (
+            f"DELETE {path} must not mix 200 and 204 success responses; pick one"
+        )
+        if "204" in responses:
+            assert "content" not in (responses["204"] or {}), (
+                f"DELETE {path} 204 response must not carry an application/json body"
+            )
+        else:
+            assert "200" in responses, f"DELETE {path} must declare a 200 or 204 success response"
+        checked += 1
+    assert checked >= 1, "providers_v2 should expose at least one DELETE route to exercise this contract"
+
+
+def test_provider_v2_all_write_request_bodies_omit_path_params():
+    """Every POST/PUT/PATCH request body under providers_v2 must not redeclare path params."""
+    spec = _provider_v2_spec()
+    components = spec["components"]["schemas"]
+    path_param_re = re.compile(r"\{([^{}]+)\}")
+
+    checked = 0
+    for path, methods in spec["paths"].items():
+        path_params = set(path_param_re.findall(path))
+        if not path_params:
+            continue
+        for method, operation in methods.items():
+            if method not in {"post", "put", "patch"}:
+                continue
+            request_body = (operation or {}).get("requestBody") or {}
+            json_schema = request_body.get("content", {}).get("application/json", {}).get("schema") or {}
+            ref = json_schema.get("$ref")
+            if not ref:
+                continue
+            schema_name = ref.removeprefix("#/components/schemas/")
+            properties = set(components[schema_name].get("properties", {}).keys())
+            overlap = path_params & properties
+            assert not overlap, (
+                f"{method.upper()} {path} request body {schema_name} duplicates path param(s) {sorted(overlap)}"
+            )
+            checked += 1
+
+    assert checked >= 1, (
+        f"Expected at least 1 write route with request body under providers_v2, but only inspected {checked}"
+    )


### PR DESCRIPTION
## Summary

Task X follow-up to Task A / PR #1582 (evaluation_v2). Applies the same three generalizable contract assertions to the remaining v2 contract tests so they catch regressions automatically without requiring hardcoded path lists.

Test-only PR. **No aperag/views/*_v2.py or aperag/evaluation_v2/** runtime is touched.**

## Per-domain additions (3 assertions × 4 files, with domain-specific tuning)

- **v1 ghost inventory baseline** (subset semantics, allows #26 sweep to shrink)
  - `test_provider_v1_ghost_inventory_is_stable` — pins `/api/v1/llm_*`, `/api/v1/default_models`, `/api/v1/available_models`
  - `test_collection_v1_ghost_inventory_is_stable` — pins only CRUD/sharing subset (excludes documents/graphs/searches/export/marketplace which belong to other domain tests)
  - `test_documents_v1_ghost_inventory_is_stable` — pins document-specific `/api/v1/collections/{collection_id}/documents*` + `rebuild_failed_indexes`
  - **bot intentionally skipped**: v1 `/api/v1/bots*` still coexists as a parallel path on main per #21; the v1-absence assertion will land with the #26 final sweep.

- **Generic DELETE contract** — `test_{domain}_v2_delete_routes_contract` iterates every DELETE under the domain router:
  - must not declare both 200 and 204 success responses
  - if 204 is declared it must not carry an application/json body (pure command)
  - a 200-JSON DELETE (e.g. documents bulk delete returning per-item status) is allowed
  - generalizes the existing hardcoded per-path command-route checks

- **Generic write-body path-param omission** — `test_{domain}_v2_all_write_request_bodies_omit_path_params` iterates every POST/PUT/PATCH under the domain router and asserts request-body schemas do not redeclare any path param. Generalizes the domain-specific hardcoded checks so future routes with additional path ids are covered automatically.

## Local gates

- `uv run --extra test pytest tests/unit_test/test_{provider,collection,documents,bot}_v2_openapi_contract.py tests/unit_test/test_openapi_spec.py -q` → **31 passed**
- `make lint` → All checks passed!
- `uvx ruff format --check tests/unit_test/test_*_v2_openapi_contract.py` → clean (auto-formatted)
- `git diff --check` → clean

## Test plan

- [x] Pytest green locally
- [x] Lint green locally
- [ ] GitHub `lint-and-unit` green
- [ ] GitHub `E2E-Test` green (test-only PR, no runtime touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)