### PR TITLE
refactor(web): switch documents read-side FE to v2 typed paths (#28 / #24b)

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -1,7 +1,6 @@
 import re
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -35,9 +34,7 @@ def test_evaluation_feature_uses_v2_typed_api_boundary():
     }
     joined = "\n".join(sources.values())
     feature_sources = "\n".join(
-        source
-        for path, source in sources.items()
-        if "/web/src/features/evaluation/" in str(path)
+        source for path, source in sources.items() if "/web/src/features/evaluation/" in str(path)
     )
 
     assert "/api/v1/evaluations" not in joined
@@ -48,9 +45,7 @@ def test_evaluation_feature_uses_v2_typed_api_boundary():
     assert "/api/v2/benchmark-datasets" in feature_sources
     assert "/api/v2/evaluation-runs" in feature_sources
 
-    benchmarks_panel = (
-        REPO_ROOT / "web/src/components/evaluation/benchmarks-panel.tsx"
-    ).read_text()
+    benchmarks_panel = (REPO_ROOT / "web/src/components/evaluation/benchmarks-panel.tsx").read_text()
     assert "String(value ?? '').toLowerCase()" in benchmarks_panel
 
 
@@ -72,11 +67,7 @@ def test_bot_feature_uses_v2_typed_api_boundary():
             if path.is_file() and path.suffix in {".ts", ".tsx"}:
                 sources[path] = path.read_text()
     joined = "\n".join(sources.values())
-    feature_sources = "\n".join(
-        source
-        for path, source in sources.items()
-        if "/web/src/features/bot/" in str(path)
-    )
+    feature_sources = "\n".join(source for path, source in sources.items() if "/web/src/features/bot/" in str(path))
 
     # Business code under these paths must not touch the v1 bot surface or the old
     # generated bots SDK directly.
@@ -96,18 +87,13 @@ def test_bot_feature_uses_v2_typed_api_boundary():
     # body would crash backend `chat_title_service.generate_title()` at
     # `max(1, turns)` / `min(max_length, 50)`, so the normaliser must never
     # emit `null` for any of the three required keys.
-    bot_client_api = (
-        REPO_ROOT / "web/src/features/bot/client-api.ts"
-    ).read_text()
+    bot_client_api = (REPO_ROOT / "web/src/features/bot/client-api.ts").read_text()
     assert "buildTitleGenerateRequest" in bot_client_api
     assert "toTitleLanguage" in bot_client_api
     assert "DEFAULT_TITLE_MAX_LENGTH = 20" in bot_client_api
     assert "DEFAULT_TITLE_TURNS = 1" in bot_client_api
     assert "DEFAULT_TITLE_LANGUAGE: TitleLanguage = 'zh-CN'" in bot_client_api
-    assert (
-        "max_length: input.max_length ?? DEFAULT_TITLE_MAX_LENGTH"
-        in bot_client_api
-    )
+    assert "max_length: input.max_length ?? DEFAULT_TITLE_MAX_LENGTH" in bot_client_api
     assert "turns: input.turns ?? DEFAULT_TITLE_TURNS" in bot_client_api
     # Guard the negative case: no `?? null` fallback for any of the three
     # required keys should reappear.
@@ -130,10 +116,8 @@ def test_collection_feature_uses_v2_typed_api_boundary():
         REPO_ROOT / "web/src/app/workspace/collections/page.tsx",
         REPO_ROOT / "web/src/app/workspace/collections/collection-form.tsx",
         REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/layout.tsx",
-        REPO_ROOT
-        / "web/src/app/workspace/collections/[collectionId]/collection-delete.tsx",
-        REPO_ROOT
-        / "web/src/app/workspace/collections/[collectionId]/collection-header.tsx",
+        REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/collection-delete.tsx",
+        REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/collection-header.tsx",
         REPO_ROOT / "web/src/components/providers/collection-provider.tsx",
         REPO_ROOT / "web/src/components/providers/bot-provider.tsx",
         REPO_ROOT / "web/src/features/collection",
@@ -149,9 +133,7 @@ def test_collection_feature_uses_v2_typed_api_boundary():
                 sources[path] = path.read_text()
     joined = "\n".join(sources.values())
     feature_sources = "\n".join(
-        source
-        for path, source in sources.items()
-        if "/web/src/features/collection/" in str(path)
+        source for path, source in sources.items() if "/web/src/features/collection/" in str(path)
     )
 
     # Business code under #24a scope must not reach the old generated
@@ -172,6 +154,67 @@ def test_collection_feature_uses_v2_typed_api_boundary():
     assert "/api/v2/collections" in feature_sources
 
 
+def test_document_feature_uses_v2_typed_api_boundary():
+    """#24b / #28 Document FE typed adapter boundary.
+
+    Document list/detail/delete/rebuild/download/object/preview call sites
+    must not reach the old generated ``defaultApi.collectionsCollectionIdDocuments*``
+    SDK or the v1 document path, and the ``features/document/*`` adapter must
+    only reach ``/api/v2/collections/{collection_id}/documents*`` typed paths
+    (no ``@/api`` fallback, no raw ``fetch(``). Upload/confirm/fetch-url stay
+    out of scope — they remain with the upload-flow hotfix and will be
+    migrated in a later slice.
+    """
+    workspace_documents = REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/documents"
+
+    document_scope_paths = [
+        workspace_documents / "page.tsx",
+        workspace_documents / "documents-table.tsx",
+        workspace_documents / "document-delete.tsx",
+        workspace_documents / "document-rebuild-index.tsx",
+        workspace_documents / "document-rebuild-failed-index.tsx",
+        workspace_documents / "[documentId]",
+        REPO_ROOT / "web/src/features/document",
+    ]
+
+    sources = {}
+    for entry in document_scope_paths:
+        if entry.is_file():
+            sources[entry] = entry.read_text()
+            continue
+        for path in entry.rglob("*"):
+            if path.is_file() and path.suffix in {".ts", ".tsx"}:
+                sources[path] = path.read_text()
+
+    # Upload-flow files under documents/upload/** are intentionally excluded
+    # from the #28 scope; drop any that slipped in via rglob.
+    sources = {path: text for path, text in sources.items() if "/documents/upload/" not in str(path)}
+
+    joined = "\n".join(sources.values())
+    feature_sources = "\n".join(text for path, text in sources.items() if "/web/src/features/document/" in str(path))
+
+    # Business code under #28 scope must not reach the old generated document
+    # SDK calls or the v1 document routes directly.
+    assert "defaultApi.collectionsCollectionIdDocumentsGet" not in joined
+    assert "defaultApi.collectionsCollectionIdDocumentsDocumentIdGet" not in joined
+    assert "defaultApi.collectionsCollectionIdDocumentsDocumentIdDelete" not in joined
+    assert "defaultApi.collectionsCollectionIdDocumentsDocumentIdRebuildIndexesPost" not in joined
+    assert "defaultApi.collectionsCollectionIdRebuildFailedIndexesPost" not in joined
+    assert "serverApi.defaultApi.getDocumentPreview" not in joined
+    assert "/api/v1/collections/" not in joined
+
+    # features/document adapter must only reach v2 typed paths and not fall
+    # back to the old `@/api` generated SDK or raw fetch.
+    assert "from '@/api'" not in feature_sources
+    assert "fetch(" not in feature_sources
+    assert "/api/v2/collections/{collection_id}/documents" in feature_sources
+
+    # The PDF preview viewer must use the v2 object URL helper rather than
+    # hand-building a v1 path.
+    document_detail = (workspace_documents / "[documentId]/document-detail.tsx").read_text()
+    assert "buildDocumentObjectUrl" in document_detail
+
+
 def test_documents_upload_regression_guards():
     """Regression guards for #前端 #16 document upload UX fixes.
 
@@ -186,15 +229,13 @@ def test_documents_upload_regression_guards():
        after a click.
     """
     upload_tsx = (
-        REPO_ROOT
-        / "web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx"
+        REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx"
     ).read_text()
     assert "() => stopUpload()" not in upload_tsx
     assert "() => () => stopUpload" not in upload_tsx
 
     table_tsx = (
-        REPO_ROOT
-        / "web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx"
+        REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx"
     ).read_text()
     assert "@ts-expect-error onPaginationChange" not in table_tsx
     assert "typeof updater === 'function'" in table_tsx

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -1,8 +1,9 @@
 'use client';
-import { Document, DocumentPreview } from '@/api';
 import { getDocumentStatusColor } from '@/app/workspace/collections/tools';
 import { FormatDate } from '@/components/format-date';
 import { buildDocumentAssetUrl, Markdown } from '@/components/markdown';
+import { buildDocumentObjectUrl } from '@/features/document/client-api';
+import type { Document, DocumentPreview } from '@/features/document/types';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -169,7 +170,11 @@ export const DocumentDetail = ({
         {hasPdfPreview && (
           <TabsContent value="pdf">
             <PDFDocument
-              file={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v1/collections/${collection.id}/documents/${document.id}/object?path=${documentPreview.converted_pdf_object_path}`}
+              file={buildDocumentObjectUrl(
+                collection.id ?? '',
+                document.id ?? '',
+                documentPreview.converted_pdf_object_path ?? '',
+              )}
               onLoadSuccess={({ numPages }: { numPages: number }) => {
                 setNumPages(numPages);
               }}

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/page.tsx
@@ -3,7 +3,10 @@ import {
   PageContent,
   PageHeader,
 } from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
+import {
+  getDocument,
+  getDocumentPreview,
+} from '@/features/document/server-api';
 import { toJson } from '@/lib/utils';
 import _ from 'lodash';
 import { CollectionHeader } from '../../collection-header';
@@ -15,21 +18,11 @@ export default async function Page({
   params: Promise<{ collectionId: string; documentId: string }>;
 }) {
   const { collectionId, documentId } = await params;
-  const serverApi = await getServerApi();
 
-  const [documentRes, documentPreviewRes] = await Promise.all([
-    serverApi.defaultApi.collectionsCollectionIdDocumentsDocumentIdGet({
-      collectionId,
-      documentId,
-    }),
-    serverApi.defaultApi.getDocumentPreview({
-      collectionId,
-      documentId,
-    }),
+  const [document, documentPreview] = await Promise.all([
+    getDocument(collectionId, documentId),
+    getDocumentPreview(collectionId, documentId),
   ]);
-
-  const document = toJson(documentRes.data);
-  const documentPreview = toJson(documentPreviewRes.data);
 
   return (
     <PageContainer>
@@ -44,13 +37,16 @@ export default async function Page({
             href: `/workspace/collections/${collectionId}/documents`,
           },
           {
-            title: _.truncate(document.name || '', { length: 30 }),
+            title: _.truncate(document?.name || '', { length: 30 }),
           },
         ]}
       />
       <CollectionHeader />
       <PageContent className="h-[100%]">
-        <DocumentDetail document={document} documentPreview={documentPreview} />
+        <DocumentDetail
+          document={toJson(document)}
+          documentPreview={toJson(documentPreview)}
+        />
       </PageContent>
     </PageContainer>
   );

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-delete.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-delete.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Document } from '@/api';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import {
   AlertDialog,
@@ -13,7 +12,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { apiClient } from '@/lib/api/client';
+import { deleteDocument } from '@/features/document/client-api';
+import type { Document } from '@/features/document/types';
 import { Slot } from '@radix-ui/react-slot';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
@@ -36,19 +36,10 @@ export const DocumentDelete = ({
 
   const handleDelete = async () => {
     if (!collection.id || !document.id) return;
-    const res =
-      await apiClient.defaultApi.collectionsCollectionIdDocumentsDocumentIdDelete(
-        {
-          collectionId: collection.id,
-          documentId: document.id,
-        },
-      );
-
-    if (res.status === 200) {
-      toast.success(common_tips('delete_success'));
-      setVisible(false);
-      setTimeout(router.refresh, 300);
-    }
+    await deleteDocument(collection.id, document.id);
+    toast.success(common_tips('delete_success'));
+    setVisible(false);
+    setTimeout(router.refresh, 300);
   };
 
   return (

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-failed-index.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-failed-index.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { apiClient } from '@/lib/api/client';
+import { rebuildFailedDocumentIndexes } from '@/features/document/client-api';
 import { Slot } from '@radix-ui/react-slot';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
@@ -33,14 +33,9 @@ export const DocumentReBuildFailedIndex = ({
 
   const handleRebuild = async () => {
     if (!collection.id) return;
-    const res =
-      await apiClient.defaultApi.collectionsCollectionIdRebuildFailedIndexesPost(
-        {
-          collectionId: collection.id,
-        },
-      );
+    const res = await rebuildFailedDocumentIndexes(collection.id);
 
-    if (res.data.code === '200') {
+    if (res?.code === '200') {
       toast.success(page_documents('index_rebuild_failed_success'));
       setVisible(false);
       setTimeout(router.refresh, 300);

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Document, RebuildIndexesRequestIndexTypesEnum } from '@/api';
+import { RebuildIndexesRequestIndexTypesEnum } from '@/api';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -15,7 +15,8 @@ import {
 } from '@/components/ui/dialog';
 import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
-import { apiClient } from '@/lib/api/client';
+import { rebuildDocumentIndexes } from '@/features/document/client-api';
+import type { Document } from '@/features/document/types';
 import { cn, objectKeys } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Slot } from '@radix-ui/react-slot';
@@ -75,29 +76,20 @@ export const DocumentReBuildIndex = ({
       return;
     }
 
-    const res =
-      await apiClient.defaultApi.collectionsCollectionIdDocumentsDocumentIdRebuildIndexesPost(
-        {
-          collectionId: collection.id,
-          documentId: file.id,
-          rebuildIndexesRequest: {
-            index_types: values.index_types,
-          },
-        },
-      );
+    await rebuildDocumentIndexes(collection.id, file.id, {
+      index_types: values.index_types,
+    });
 
-    if (res.status === 200) {
-      toast.success(
-        page_documents('index_rebuild_with', {
-          types: values.index_types
-            .map((type) => page_collections(`index_type_${type}.title`))
-            .join(', '),
-        }),
-      );
+    toast.success(
+      page_documents('index_rebuild_with', {
+        types: values.index_types
+          .map((type) => page_collections(`index_type_${type}.title`))
+          .join(', '),
+      }),
+    );
 
-      setVisible(false);
-      setTimeout(router.refresh, 300);
-    }
+    setVisible(false);
+    setTimeout(router.refresh, 300);
   };
 
   return (

--- a/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
@@ -27,7 +27,9 @@ import {
 import * as React from 'react';
 import { defaultStyles, FileIcon } from 'react-file-icon';
 
-import { Document, RebuildIndexesRequestIndexTypesEnum } from '@/api';
+import { RebuildIndexesRequestIndexTypesEnum } from '@/api';
+
+import type { Document } from '@/features/document/types';
 
 import { DataGrid, DataGridPagination } from '@/components/data-grid';
 import { FormatDate } from '@/components/format-date';

--- a/web/src/app/workspace/collections/[collectionId]/documents/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/page.tsx
@@ -3,7 +3,8 @@ import {
   PageContent,
   PageHeader,
 } from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
+import { listDocuments } from '@/features/document/server-api';
+import type { Document } from '@/features/document/types';
 import { parsePageParams, toJson } from '@/lib/utils';
 import { getTranslations } from 'next-intl/server';
 import { CollectionHeader } from '../collection-header';
@@ -18,23 +19,29 @@ export default async function Page({
 }>) {
   const { collectionId } = await params;
   const { page, pageSize, search } = await searchParams;
-  const serverApi = await getServerApi();
+  const { page: parsedPage, pageSize: parsedPageSize } = parsePageParams({
+    page,
+    pageSize,
+  });
 
   const page_collections = await getTranslations('page_collections');
   const page_documents = await getTranslations('page_documents');
 
-  const [documentsRes] = await Promise.all([
-    serverApi.defaultApi.collectionsCollectionIdDocumentsGet({
-      collectionId,
-      ...parsePageParams({ page, pageSize }),
+  let documents: Document[] = [];
+  let pageCount = 0;
+  try {
+    const data = await listDocuments(collectionId, {
+      page: parsedPage,
+      pageSize: parsedPageSize,
       sortBy: 'created',
       sortOrder: 'desc',
       search,
-    }),
-  ]);
-
-  //@ts-expect-error api define has a bug
-  const documents = toJson(documentsRes.data.items || []);
+    });
+    documents = data.items ?? [];
+    pageCount = data.total_pages ?? 0;
+  } catch (err) {
+    console.log(err);
+  }
 
   return (
     <PageContainer>
@@ -51,10 +58,7 @@ export default async function Page({
       />
       <CollectionHeader />
       <PageContent>
-        <DocumentsTable
-          data={documents}
-          pageCount={documentsRes.data.total_pages}
-        />
+        <DocumentsTable data={toJson(documents)} pageCount={pageCount} />
       </PageContent>
     </PageContainer>
   );

--- a/web/src/features/document/client-api.ts
+++ b/web/src/features/document/client-api.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { browserApiClient } from '@/lib/api/typed/browser';
+
+import type {
+  DeleteDocumentsRequest,
+  DeleteDocumentsResponse,
+  Document,
+  DocumentList,
+  DocumentPreview,
+  RebuildIndexesRequest,
+  RebuildIndexesResponse,
+} from './types';
+
+export type ListDocumentsOptions = {
+  page?: number;
+  pageSize?: number;
+  sortBy?: 'name' | 'created' | 'updated' | 'size' | 'status';
+  sortOrder?: 'asc' | 'desc';
+  search?: string;
+};
+
+export async function listDocuments(
+  collectionId: string,
+  options?: ListDocumentsOptions,
+): Promise<DocumentList | undefined> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/collections/{collection_id}/documents',
+    {
+      params: {
+        path: { collection_id: collectionId },
+        query: {
+          page: options?.page ?? 1,
+          page_size: options?.pageSize ?? 10,
+          sort_by: options?.sortBy ?? 'created',
+          sort_order: options?.sortOrder ?? 'desc',
+          search: options?.search,
+        },
+      },
+    },
+  );
+  return data;
+}
+
+export async function getDocument(
+  collectionId: string,
+  documentId: string,
+): Promise<Document | undefined> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/collections/{collection_id}/documents/{document_id}',
+    {
+      params: {
+        path: { collection_id: collectionId, document_id: documentId },
+      },
+    },
+  );
+  return data;
+}
+
+export async function getDocumentPreview(
+  collectionId: string,
+  documentId: string,
+): Promise<DocumentPreview | undefined> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/collections/{collection_id}/documents/{document_id}/preview',
+    {
+      params: {
+        path: { collection_id: collectionId, document_id: documentId },
+      },
+    },
+  );
+  return data;
+}
+
+export async function deleteDocument(
+  collectionId: string,
+  documentId: string,
+): Promise<void> {
+  await browserApiClient.DELETE(
+    '/api/v2/collections/{collection_id}/documents/{document_id}',
+    {
+      params: {
+        path: { collection_id: collectionId, document_id: documentId },
+      },
+    },
+  );
+}
+
+export async function deleteDocuments(
+  collectionId: string,
+  input: DeleteDocumentsRequest,
+): Promise<DeleteDocumentsResponse | undefined> {
+  const { data } = await browserApiClient.DELETE(
+    '/api/v2/collections/{collection_id}/documents',
+    {
+      params: { path: { collection_id: collectionId } },
+      body: input,
+    },
+  );
+  return data;
+}
+
+export async function rebuildDocumentIndexes(
+  collectionId: string,
+  documentId: string,
+  input: RebuildIndexesRequest,
+): Promise<RebuildIndexesResponse | undefined> {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/collections/{collection_id}/documents/{document_id}/rebuild_indexes',
+    {
+      params: {
+        path: { collection_id: collectionId, document_id: documentId },
+      },
+      body: input,
+    },
+  );
+  return data;
+}
+
+export async function rebuildFailedDocumentIndexes(
+  collectionId: string,
+): Promise<RebuildIndexesResponse | undefined> {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/collections/{collection_id}/rebuild_failed_indexes',
+    {
+      params: { path: { collection_id: collectionId } },
+    },
+  );
+  return data;
+}
+
+// Binary routes (download / object) are consumed directly as URLs by the
+// browser or embedded viewers (e.g. react-pdf), not through the typed JSON
+// client. Keep the URL shape as first-class helpers so all call sites agree
+// on the v2 path and the `path` query param on /object.
+
+const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+export function buildDocumentDownloadUrl(
+  collectionId: string,
+  documentId: string,
+): string {
+  return `${BASE_PATH}/api/v2/collections/${collectionId}/documents/${documentId}/download`;
+}
+
+export function buildDocumentObjectUrl(
+  collectionId: string,
+  documentId: string,
+  objectPath: string,
+): string {
+  const query = new URLSearchParams({ path: objectPath });
+  return `${BASE_PATH}/api/v2/collections/${collectionId}/documents/${documentId}/object?${query.toString()}`;
+}

--- a/web/src/features/document/server-api.ts
+++ b/web/src/features/document/server-api.ts
@@ -1,0 +1,66 @@
+import { createServerApiClient } from '@/lib/api/typed/server';
+
+import type { Document, DocumentList, DocumentPreview } from './types';
+
+export type ListDocumentsServerOptions = {
+  page?: number;
+  pageSize?: number;
+  sortBy?: 'name' | 'created' | 'updated' | 'size' | 'status';
+  sortOrder?: 'asc' | 'desc';
+  search?: string;
+};
+
+export async function listDocuments(
+  collectionId: string,
+  options?: ListDocumentsServerOptions,
+): Promise<DocumentList> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET(
+    '/api/v2/collections/{collection_id}/documents',
+    {
+      params: {
+        path: { collection_id: collectionId },
+        query: {
+          page: options?.page ?? 1,
+          page_size: options?.pageSize ?? 10,
+          sort_by: options?.sortBy ?? 'created',
+          sort_order: options?.sortOrder ?? 'desc',
+          search: options?.search,
+        },
+      },
+    },
+  );
+  return data ?? {};
+}
+
+export async function getDocument(
+  collectionId: string,
+  documentId: string,
+): Promise<Document | null> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET(
+    '/api/v2/collections/{collection_id}/documents/{document_id}',
+    {
+      params: {
+        path: { collection_id: collectionId, document_id: documentId },
+      },
+    },
+  );
+  return data ?? null;
+}
+
+export async function getDocumentPreview(
+  collectionId: string,
+  documentId: string,
+): Promise<DocumentPreview | null> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET(
+    '/api/v2/collections/{collection_id}/documents/{document_id}/preview',
+    {
+      params: {
+        path: { collection_id: collectionId, document_id: documentId },
+      },
+    },
+  );
+  return data ?? null;
+}

--- a/web/src/features/document/types.ts
+++ b/web/src/features/document/types.ts
@@ -1,0 +1,15 @@
+import type { components } from '@/api-v2/schema';
+
+export type Document = components['schemas']['Document'];
+export type DocumentList = components['schemas']['DocumentList'];
+export type DocumentPreview = components['schemas']['DocumentPreview'];
+
+export type RebuildIndexesRequest =
+  components['schemas']['RebuildIndexesRequest'];
+export type RebuildIndexesResponse =
+  components['schemas']['RebuildIndexesResponse'];
+
+export type DeleteDocumentsRequest =
+  components['schemas']['DeleteDocumentsRequest'];
+export type DeleteDocumentsResponse =
+  components['schemas']['DeleteDocumentsResponse'];


### PR DESCRIPTION
## Summary

Migrate the collection-scoped document surface off the generated `defaultApi.collectionsCollectionIdDocuments*` SDK onto the `/api/v2/collections/{collection_id}/documents*` typed paths. Mirrors the adapter pattern from #24a (PR #1581 `features/collection/*`).

Scope stays narrow per PM + @ziang decision on the #28 split: only **read / list / delete / rebuild / download / object / preview**. Upload/confirm/fetch-url stay with the upload-flow hotfix (#1580) and will be migrated in a later slice. Collection CRUD/sharing, bot, evaluation and the final `@/api` delete are deliberately out of scope.

## Write set

- **New** `web/src/features/document/{client-api,server-api,types}.ts` — reaches the v2 typed paths for: `GET /documents` (→ `DocumentList`), `GET/DELETE /documents/{document_id}`, `GET /preview`, bulk `DELETE /documents`, `POST /documents/{document_id}/rebuild_indexes`, `POST /rebuild_failed_indexes`. Binary routes (`/download`, `/object`) are exposed as URL helpers (`buildDocumentDownloadUrl`, `buildDocumentObjectUrl`) since react-pdf consumes URLs directly.
- **SSR**: `documents/page.tsx` (list) + `documents/[documentId]/page.tsx` (detail + preview) now go through `listDocuments` / `getDocument` / `getDocumentPreview`.
- **CSR**: `document-delete.tsx`, `document-rebuild-index.tsx`, `document-rebuild-failed-index.tsx` call the typed adapter; non-2xx now propagates through the browser client's throw middleware (the old `res.status === 200` gate was incorrect for DELETE 204 anyway).
- **Viewer**: `[documentId]/document-detail.tsx` swaps the hand-built `/api/v1/collections/…/object?path=…` URL for `buildDocumentObjectUrl` so the PDF viewer hits `/api/v2/.../object`.
- **Type swap**: `documents-table.tsx` `Document` type moves from `@/api` to `features/document/types`. `RebuildIndexesRequestIndexTypesEnum` (runtime enum) stays on `@/api` per the same precedent #24a used for `CollectionViewStatusEnum` — tracked by #26 final sweep.
- **Static gate**: `test_document_feature_uses_v2_typed_api_boundary` in `tests/unit_test/test_web_typed_api_contract.py` hard-gates the boundary:
  - no `defaultApi.collectionsCollectionIdDocuments*` / `defaultApi.collectionsCollectionIdRebuildFailedIndexesPost` / `serverApi.defaultApi.getDocumentPreview` / `/api/v1/collections/` under the document scope;
  - `features/document/*` only reaches `/api/v2/collections/{collection_id}/documents`, no `@/api` fallback, no raw `fetch(`;
  - PDF viewer must use `buildDocumentObjectUrl`.

## Out of scope / not touched

- `documents/upload/**` (upload / confirm / fetch-url) — stays with upload hotfix / follow-up slice (per @ziang edge).
- `collection-*` files / `features/collection/*` (#24a scope, already merged).
- `bot` / `evaluation` / backend `aperag/**`.
- `#26` final sweep (delete `@/api` + other SDK enum leftovers).

## Test plan

- [x] `uv run --extra test pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_documents_v2_openapi_contract.py tests/unit_test/test_openapi_spec.py -q` → **12 passed**
- [x] `make lint` → `All checks passed!` / `235 files already formatted`
- [x] `ruff check` / `ruff format --check` on updated test file → clean
- [x] `git diff --check main...HEAD` → clean
- [ ] CI `lint-and-unit` + `openapi-check` green
- [ ] 1× diff-scoped no-blocker CR (per new merge gate: 1 CR + UT/lint-and-unit green suffices, e2e not gated)

## Related

- Base: `main @ c911ffe` (post #1581 merge + Task A #1582 merge).
- Unlocks: `#26` final sweep (@cuiwenbo) after this merges.
- CR owner: @ziang (`#17` documents v2 backend owner) or any agent satisfying the 1-CR gate per @earayu2's 16:13 口径.

🤖 Generated with [Claude Code](https://claude.com/claude-code)