### PR TITLE
feat(evaluation_v2): Phase 1 additive foundation for evaluation-v3 simplification (#evaluation #20 PR-0)

### DIFF
--- a/aperag/db/models.py
+++ b/aperag/db/models.py
@@ -244,6 +244,20 @@ class BenchmarkDatasetSourceType(str, Enum):
     MIGRATED_FROM_QUESTION_SET = "migrated_from_question_set"
 
 
+class EvaluationDatasetSourceType(str, Enum):
+    """Source type for an EvaluationDataset (simplified evaluation model).
+
+    Introduced by the evaluation-v3 simplification (Phase 1, additive only):
+    the wire contract drops the Benchmark / Dataset Version distinction and
+    exposes Dataset + Evaluation/Run only. This enum is the source-of-truth
+    equivalent of ``BenchmarkDatasetSourceType`` for the new layer.
+    """
+
+    MANUAL = "manual"
+    IMPORT = "import"
+    GENERATED = "generated"
+
+
 class EvaluationRunStatus(str, Enum):
     QUEUED = "queued"
     RUNNING = "running"
@@ -1207,6 +1221,66 @@ class BenchmarkCase(Base):
     case_metadata = Column(JSON, nullable=True)
     sort_key = Column(Integer, nullable=False, default=0)
     gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+
+
+class EvaluationDataset(Base):
+    """Dataset of evaluation QA items owned by a user.
+
+    Phase 1 of the evaluation-v3 simplification (additive only) introduces this
+    model alongside the existing ``BenchmarkDataset`` without touching it.
+    ``user_id`` anchors access control; ``collection_id`` is scope metadata
+    only and does NOT inherit collection sharing ACLs.
+    """
+
+    __tablename__ = "evaluation_datasets"
+    __table_args__ = (
+        Index("idx_evaluation_datasets_user", "user_id"),
+        Index("idx_evaluation_datasets_collection", "collection_id"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "eds_" + random_id()[:16])
+    user_id = Column(String(256), nullable=False)
+    collection_id = Column(String(24), nullable=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    source_type = Column(
+        EnumColumn(EvaluationDatasetSourceType),
+        nullable=False,
+        default=EvaluationDatasetSourceType.MANUAL,
+    )
+    schema_hint = Column(JSON, nullable=True)
+    item_count = Column(Integer, nullable=False, default=0)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    gmt_deleted = Column(DateTime(timezone=True), nullable=True, index=True)
+
+
+class EvaluationDatasetItem(Base):
+    """A single QA item inside an EvaluationDataset.
+
+    Phase 2 of the simplification will value-copy these fields into
+    ``evaluation_run_items`` at run-create time (snapshot-on-run) so that
+    edits to the dataset do not mutate historical run semantics.
+    """
+
+    __tablename__ = "evaluation_dataset_items"
+    __table_args__ = (
+        UniqueConstraint("dataset_id", "case_key", name="uq_evaluation_dataset_item_case_key"),
+        Index("idx_evaluation_dataset_items_dataset", "dataset_id"),
+    )
+
+    id = Column(String(32), primary_key=True, default=lambda: "edi_" + random_id()[:16])
+    dataset_id = Column(String(32), nullable=False)
+    case_key = Column(String(128), nullable=False)
+    input_message = Column(Text, nullable=False)
+    expected_answer = Column(Text, nullable=True)
+    reference_context = Column(Text, nullable=True)
+    tags = Column(JSON, nullable=True)
+    case_metadata = Column(JSON, nullable=True)
+    sort_key = Column(Integer, nullable=False, default=0)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+    gmt_deleted = Column(DateTime(timezone=True), nullable=True, index=True)
 
 
 class EvaluationRun(Base):

--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -28,6 +28,10 @@ from aperag.db.models import (
     BenchmarkDataset,
     BenchmarkDatasetVersion,
     BenchmarkDatasetVersionStatus,
+    Bot,
+    BotStatus,
+    EvaluationDataset,
+    EvaluationDatasetItem,
     EvaluationRun,
     EvaluationRunItem,
     EvaluationRunItemAttempt,
@@ -402,3 +406,263 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
             return instance
 
         return await self.execute_with_transaction(_operation)
+
+    # -- EvaluationDataset (evaluation-v3, Phase 1 additive) -----------------
+    #
+    # Helpers below operate on the new ``evaluation_datasets`` /
+    # ``evaluation_dataset_items`` tables. Phase 1 only adds these helpers; no
+    # production code path (benchmark service / views / runtime) calls into
+    # them yet. The contract switch happens in Phase 2.
+
+    async def create_evaluation_dataset(
+        self,
+        dataset: EvaluationDataset,
+        items: Optional[list[EvaluationDatasetItem]] = None,
+    ) -> EvaluationDataset:
+        async def _operation(session: AsyncSession):
+            session.add(dataset)
+            await session.flush()
+            if items:
+                for item in items:
+                    item.dataset_id = dataset.id
+                    session.add(item)
+                dataset.item_count = len(items)
+                await session.flush()
+            await session.refresh(dataset)
+            return dataset
+
+        return await self.execute_with_transaction(_operation)
+
+    async def get_evaluation_dataset(self, user_id: str, dataset_id: str) -> Optional[EvaluationDataset]:
+        async def _query(session: AsyncSession):
+            stmt = select(EvaluationDataset).where(
+                EvaluationDataset.id == dataset_id,
+                EvaluationDataset.user_id == user_id,
+                EvaluationDataset.gmt_deleted.is_(None),
+            )
+            return (await session.execute(stmt)).scalars().first()
+
+        return await self._execute_query(_query)
+
+    async def list_evaluation_datasets(
+        self,
+        user_id: str,
+        collection_id: Optional[str],
+        page: int,
+        page_size: int,
+    ) -> tuple[list[EvaluationDataset], int]:
+        async def _query(session: AsyncSession):
+            conditions = [
+                EvaluationDataset.user_id == user_id,
+                EvaluationDataset.gmt_deleted.is_(None),
+            ]
+            if collection_id:
+                conditions.append(EvaluationDataset.collection_id == collection_id)
+            base = select(EvaluationDataset).where(and_(*conditions))
+            total_stmt = select(func.count()).select_from(base.subquery())
+            total = (await session.execute(total_stmt)).scalar() or 0
+            stmt = (
+                base.order_by(EvaluationDataset.gmt_created.desc())
+                .offset(max(page - 1, 0) * page_size)
+                .limit(page_size)
+            )
+            rows = list((await session.execute(stmt)).scalars().all())
+            return rows, int(total)
+
+        return await self._execute_query(_query)
+
+    async def update_evaluation_dataset(
+        self,
+        user_id: str,
+        dataset_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Optional[EvaluationDataset]:
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationDataset).where(
+                EvaluationDataset.id == dataset_id,
+                EvaluationDataset.user_id == user_id,
+                EvaluationDataset.gmt_deleted.is_(None),
+            )
+            instance = (await session.execute(stmt)).scalars().first()
+            if not instance:
+                return None
+            if name is not None:
+                instance.name = name
+            if description is not None:
+                instance.description = description
+            instance.gmt_updated = utc_now()
+            await session.flush()
+            await session.refresh(instance)
+            return instance
+
+        return await self.execute_with_transaction(_operation)
+
+    async def soft_delete_evaluation_dataset(self, user_id: str, dataset_id: str) -> bool:
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationDataset).where(
+                EvaluationDataset.id == dataset_id,
+                EvaluationDataset.user_id == user_id,
+                EvaluationDataset.gmt_deleted.is_(None),
+            )
+            instance = (await session.execute(stmt)).scalars().first()
+            if not instance:
+                return False
+            now = utc_now()
+            instance.gmt_deleted = now
+            instance.gmt_updated = now
+            await session.flush()
+            return True
+
+        return await self.execute_with_transaction(_operation)
+
+    async def list_evaluation_dataset_items(
+        self, dataset_id: str, page: int, page_size: int
+    ) -> tuple[list[EvaluationDatasetItem], int]:
+        async def _query(session: AsyncSession):
+            conditions = [
+                EvaluationDatasetItem.dataset_id == dataset_id,
+                EvaluationDatasetItem.gmt_deleted.is_(None),
+            ]
+            base = select(EvaluationDatasetItem).where(and_(*conditions))
+            total_stmt = select(func.count()).select_from(base.subquery())
+            total = (await session.execute(total_stmt)).scalar() or 0
+            stmt = (
+                base.order_by(
+                    EvaluationDatasetItem.sort_key.asc(),
+                    EvaluationDatasetItem.gmt_created.asc(),
+                )
+                .offset(max(page - 1, 0) * page_size)
+                .limit(page_size)
+            )
+            rows = list((await session.execute(stmt)).scalars().all())
+            return rows, int(total)
+
+        return await self._execute_query(_query)
+
+    async def list_all_evaluation_dataset_items(self, dataset_id: str) -> list[EvaluationDatasetItem]:
+        async def _query(session: AsyncSession):
+            stmt = (
+                select(EvaluationDatasetItem)
+                .where(
+                    EvaluationDatasetItem.dataset_id == dataset_id,
+                    EvaluationDatasetItem.gmt_deleted.is_(None),
+                )
+                .order_by(
+                    EvaluationDatasetItem.sort_key.asc(),
+                    EvaluationDatasetItem.gmt_created.asc(),
+                )
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
+        return await self._execute_query(_query)
+
+    async def append_evaluation_dataset_items(
+        self, dataset_id: str, items: list[EvaluationDatasetItem]
+    ) -> list[EvaluationDatasetItem]:
+        async def _operation(session: AsyncSession):
+            for item in items:
+                item.dataset_id = dataset_id
+                session.add(item)
+            await session.flush()
+            dataset_stmt = select(EvaluationDataset).where(EvaluationDataset.id == dataset_id)
+            dataset = (await session.execute(dataset_stmt)).scalars().first()
+            if dataset is not None:
+                dataset.item_count = (dataset.item_count or 0) + len(items)
+                dataset.gmt_updated = utc_now()
+            for item in items:
+                await session.refresh(item)
+            return list(items)
+
+        return await self.execute_with_transaction(_operation)
+
+    async def update_evaluation_dataset_item(
+        self,
+        dataset_id: str,
+        item_id: str,
+        **fields,
+    ) -> Optional[EvaluationDatasetItem]:
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationDatasetItem).where(
+                EvaluationDatasetItem.id == item_id,
+                EvaluationDatasetItem.dataset_id == dataset_id,
+                EvaluationDatasetItem.gmt_deleted.is_(None),
+            )
+            instance = (await session.execute(stmt)).scalars().first()
+            if not instance:
+                return None
+            allowed = {
+                "case_key",
+                "input_message",
+                "expected_answer",
+                "reference_context",
+                "tags",
+                "case_metadata",
+                "sort_key",
+            }
+            for key, value in fields.items():
+                if key in allowed and value is not None:
+                    setattr(instance, key, value)
+            instance.gmt_updated = utc_now()
+            await session.flush()
+            await session.refresh(instance)
+            return instance
+
+        return await self.execute_with_transaction(_operation)
+
+    async def soft_delete_evaluation_dataset_item(self, dataset_id: str, item_id: str) -> bool:
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationDatasetItem).where(
+                EvaluationDatasetItem.id == item_id,
+                EvaluationDatasetItem.dataset_id == dataset_id,
+                EvaluationDatasetItem.gmt_deleted.is_(None),
+            )
+            instance = (await session.execute(stmt)).scalars().first()
+            if not instance:
+                return False
+            now = utc_now()
+            instance.gmt_deleted = now
+            instance.gmt_updated = now
+            dataset_stmt = select(EvaluationDataset).where(EvaluationDataset.id == dataset_id)
+            dataset = (await session.execute(dataset_stmt)).scalars().first()
+            if dataset is not None and (dataset.item_count or 0) > 0:
+                dataset.item_count = (dataset.item_count or 0) - 1
+                dataset.gmt_updated = now
+            await session.flush()
+            return True
+
+        return await self.execute_with_transaction(_operation)
+
+    # -- Default-bot resolver (evaluation-v3, Phase 1 additive) --------------
+
+    async def resolve_default_evaluation_bot(self, user_id: str, default_title: str) -> Optional[Bot]:
+        """Pick a bot for an evaluation run without an explicit ``bot_id``.
+
+        The resolver is DB-only (no HTTP bot route side-channel) and prefers
+        the user's active bot whose ``title`` equals ``default_title`` (the
+        caller passes ``DEFAULT_AGENT_BOT_TITLE``). Ties break on
+        ``gmt_created ASC`` so the result is deterministic. If no such bot
+        exists the resolver falls back to the oldest active bot for the user.
+        Only active, non-soft-deleted bots are considered.
+        """
+
+        async def _query(session: AsyncSession):
+            active_filter = and_(
+                Bot.user == user_id,
+                Bot.status == BotStatus.ACTIVE,
+                Bot.gmt_deleted.is_(None),
+            )
+            preferred_stmt = (
+                select(Bot)
+                .where(and_(active_filter, Bot.title == default_title))
+                .order_by(Bot.gmt_created.asc())
+                .limit(1)
+            )
+            preferred = (await session.execute(preferred_stmt)).scalars().first()
+            if preferred is not None:
+                return preferred
+
+            fallback_stmt = select(Bot).where(active_filter).order_by(Bot.gmt_created.asc()).limit(1)
+            return (await session.execute(fallback_stmt)).scalars().first()
+
+        return await self._execute_query(_query)

--- a/aperag/evaluation_v2/constants.py
+++ b/aperag/evaluation_v2/constants.py
@@ -1,0 +1,28 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Constants for the simplified evaluation module.
+
+Centralising these strings keeps default-resolution behaviour testable and
+prevents magic strings from scattering across service / repository / view
+layers. See ``resolve_default_evaluation_bot`` in
+``aperag.db.repositories.evaluation_v2``.
+"""
+
+# Title that identifies the system default Agent bot when a user does not
+# pass an explicit ``bot_id`` on evaluation-run creation. The resolver prefers
+# the user's active bot with this exact title; otherwise falls back to the
+# oldest active bot (``gmt_created ASC``); if none exists the service raises
+# a user-actionable ``ValidationException``.
+DEFAULT_AGENT_BOT_TITLE = "Default Agent Bot"

--- a/aperag/evaluation_v2/schemas.py
+++ b/aperag/evaluation_v2/schemas.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from aperag.db.models import (
     BenchmarkDatasetSourceType,
     BenchmarkDatasetVersionStatus,
+    EvaluationDatasetSourceType,
     EvaluationJudgeMode,
     EvaluationRunItemAttemptStatus,
     EvaluationRunItemStatus,
@@ -276,3 +277,100 @@ class RetryRunItemResponse(BaseModel):
 
 BenchmarkDatasetEnvelope.model_rebuild()
 EvaluationRunItemEnvelope.model_rebuild()
+
+
+# ---------------------------------------------------------------------------
+# EvaluationDataset (simplified evaluation model — evaluation-v3 Phase 1)
+# ---------------------------------------------------------------------------
+#
+# These schemas are added alongside the Benchmark* set so the new
+# ``EvaluationDataset`` / ``EvaluationDatasetItem`` tables can be exercised by
+# repository tests and by the Phase 2 service/view switch without touching the
+# still-live benchmark contract. The public API is NOT re-wired in Phase 1.
+
+
+class EvaluationDatasetItemCreate(BaseModel):
+    case_key: Optional[str] = Field(
+        None,
+        max_length=128,
+        description="Stable user-facing key. Auto-generated when omitted.",
+    )
+    input_message: str = Field(..., min_length=1)
+    expected_answer: Optional[str] = None
+    reference_context: Optional[str] = None
+    tags: Optional[list[str]] = None
+    case_metadata: Optional[dict[str, Any]] = None
+    sort_key: int = 0
+
+
+class EvaluationDatasetItemUpdate(BaseModel):
+    case_key: Optional[str] = Field(None, max_length=128)
+    input_message: Optional[str] = Field(None, min_length=1)
+    expected_answer: Optional[str] = None
+    reference_context: Optional[str] = None
+    tags: Optional[list[str]] = None
+    case_metadata: Optional[dict[str, Any]] = None
+    sort_key: Optional[int] = None
+
+
+class EvaluationDatasetCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = None
+    collection_id: Optional[str] = None
+    source_type: EvaluationDatasetSourceType = EvaluationDatasetSourceType.MANUAL
+    schema_hint: Optional[dict[str, Any]] = None
+    items: Optional[list[EvaluationDatasetItemCreate]] = None
+
+
+class EvaluationDatasetUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = None
+
+
+class EvaluationDatasetItemEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: str
+    dataset_id: str
+    case_key: str
+    input_message: str
+    expected_answer: Optional[str] = None
+    reference_context: Optional[str] = None
+    tags: Optional[list[str]] = None
+    case_metadata: Optional[dict[str, Any]] = None
+    sort_key: int
+    created_at: datetime = Field(validation_alias="gmt_created")
+    updated_at: datetime = Field(validation_alias="gmt_updated")
+
+
+class EvaluationDatasetEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: str
+    user_id: str
+    collection_id: Optional[str] = None
+    name: str
+    description: Optional[str] = None
+    source_type: EvaluationDatasetSourceType
+    schema_hint: Optional[dict[str, Any]] = None
+    item_count: int = 0
+    created_at: datetime = Field(validation_alias="gmt_created")
+    updated_at: datetime = Field(validation_alias="gmt_updated")
+
+
+class EvaluationDatasetListResponse(BaseModel):
+    items: list[EvaluationDatasetEnvelope] = Field(default_factory=list)
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
+
+
+class EvaluationDatasetItemListResponse(BaseModel):
+    items: list[EvaluationDatasetItemEnvelope] = Field(default_factory=list)
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
+
+
+class EvaluationDatasetItemsAppendRequest(BaseModel):
+    items: list[EvaluationDatasetItemCreate] = Field(default_factory=list)
+
+
+class EvaluationDatasetItemsAppendResponse(BaseModel):
+    items: list[EvaluationDatasetItemEnvelope] = Field(default_factory=list)

--- a/aperag/migration/versions/20260423170000-b9c8d7e6f1a2.py
+++ b/aperag/migration/versions/20260423170000-b9c8d7e6f1a2.py
@@ -1,0 +1,94 @@
+"""evaluation v3 phase 1: add evaluation_datasets and evaluation_dataset_items
+
+Purely additive foundation for the evaluation-v3 simplification. This
+revision only creates the two new tables that the Phase 2 contract switch
+will hook up to; it does not drop ``benchmark_*`` tables, does not touch
+``evaluation_runs`` / ``evaluation_run_items``, and does not change any
+public API. Old benchmark routes continue to run unchanged after this
+migration applies.
+
+Revision ID: b9c8d7e6f1a2
+Revises: a7b8c9d0e1f2
+Create Date: 2026-04-23 17:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b9c8d7e6f1a2"
+down_revision: Union[str, None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "evaluation_datasets",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("user_id", sa.String(length=256), nullable=False),
+        sa.Column("collection_id", sa.String(length=24), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("source_type", sa.String(length=70), nullable=False),
+        sa.Column("schema_hint", sa.JSON(), nullable=True),
+        sa.Column("item_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_deleted", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "idx_evaluation_datasets_user",
+        "evaluation_datasets",
+        ["user_id"],
+    )
+    op.create_index(
+        "idx_evaluation_datasets_collection",
+        "evaluation_datasets",
+        ["collection_id"],
+    )
+    op.create_index(
+        "ix_evaluation_datasets_gmt_deleted",
+        "evaluation_datasets",
+        ["gmt_deleted"],
+    )
+
+    op.create_table(
+        "evaluation_dataset_items",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("dataset_id", sa.String(length=32), nullable=False),
+        sa.Column("case_key", sa.String(length=128), nullable=False),
+        sa.Column("input_message", sa.Text(), nullable=False),
+        sa.Column("expected_answer", sa.Text(), nullable=True),
+        sa.Column("reference_context", sa.Text(), nullable=True),
+        sa.Column("tags", sa.JSON(), nullable=True),
+        sa.Column("case_metadata", sa.JSON(), nullable=True),
+        sa.Column("sort_key", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_deleted", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("dataset_id", "case_key", name="uq_evaluation_dataset_item_case_key"),
+    )
+    op.create_index(
+        "idx_evaluation_dataset_items_dataset",
+        "evaluation_dataset_items",
+        ["dataset_id"],
+    )
+    op.create_index(
+        "ix_evaluation_dataset_items_gmt_deleted",
+        "evaluation_dataset_items",
+        ["gmt_deleted"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_evaluation_dataset_items_gmt_deleted", table_name="evaluation_dataset_items")
+    op.drop_index("idx_evaluation_dataset_items_dataset", table_name="evaluation_dataset_items")
+    op.drop_table("evaluation_dataset_items")
+
+    op.drop_index("ix_evaluation_datasets_gmt_deleted", table_name="evaluation_datasets")
+    op.drop_index("idx_evaluation_datasets_collection", table_name="evaluation_datasets")
+    op.drop_index("idx_evaluation_datasets_user", table_name="evaluation_datasets")
+    op.drop_table("evaluation_datasets")


### PR DESCRIPTION
## Summary

Phase 1 / PR-0 of the evaluation-v3 simplification (`#evaluation #20`). **Pure additive**, no user-visible behaviour change, no public API change, no destructive migration. The benchmark contract keeps running unchanged after this merge. Phase 2 (PR-1) will perform the actual backend contract switch; Phase 3 (PR-2) handles FE.

Per Weston's condition (msg=c6459fca) this PR is an implementation stepping stone, not a user-value delivery.

## Write set

- **DB models** (`aperag/db/models.py`, additive only):
  - Add `EvaluationDataset` (owner-anchored via `user_id`, `collection_id` = scope metadata only, not a sharing ACL).
  - Add `EvaluationDatasetItem` (per-QA row with `sort_key`, `case_key` unique per dataset, stays soft-deletable).
  - Add `EvaluationDatasetSourceType` enum.
  - **No changes** to `EvaluationRun` / `EvaluationRunItem` / `Benchmark*` / any other table.

- **Pydantic schemas** (`aperag/evaluation_v2/schemas.py`, additive only):
  - Add `EvaluationDatasetCreate/Update/Envelope/ListResponse`, `EvaluationDatasetItemCreate/Update/Envelope/ListResponse`, and append request/response envelopes.
  - **Benchmark* schemas untouched.**

- **Constants** (`aperag/evaluation_v2/constants.py`, new file):
  - `DEFAULT_AGENT_BOT_TITLE = "Default Agent Bot"` — single source of truth for default-bot resolution.

- **Repository helpers** (`aperag/db/repositories/evaluation_v2.py`, appended only):
  - `create_evaluation_dataset`, `get_evaluation_dataset`, `list_evaluation_datasets`, `update_evaluation_dataset`, `soft_delete_evaluation_dataset`.
  - `list_evaluation_dataset_items`, `list_all_evaluation_dataset_items`, `append_evaluation_dataset_items`, `update_evaluation_dataset_item`, `soft_delete_evaluation_dataset_item`.
  - `resolve_default_evaluation_bot(user_id, default_title)` — DB-only resolver, prefers active bot with the given title, else oldest active bot (`gmt_created ASC`). No HTTP bot-route side-channels.
  - **Existing `Benchmark*` / run helpers are left as-is.**

- **Alembic migration** `aperag/migration/versions/20260423170000-b9c8d7e6f1a2.py` (`down_revision = "a7b8c9d0e1f2"`):
  - `upgrade()` creates only the two new tables + their indexes + the unique `(dataset_id, case_key)` constraint.
  - No DROP / no TRUNCATE / no ALTER on any existing table.
  - `downgrade()` just drops the two new tables.

## Out of scope / Phase 2+

This PR intentionally does **not**:
- drop `benchmark_*` tables or alter `evaluation_runs` / `evaluation_run_items`.
- change public API (`/api/v2/benchmark-datasets*` continues to exist).
- wire the new repo helpers into any view/service (they are callable only from future Phase 2 code).
- touch FE, i18n, docs, hurl, contract tests.
- implement the worker/tasks snapshot-on-run execution path (Phase 2 / PR-1).

## Test plan

- [x] `uv run --extra test pytest tests/unit_test/test_evaluation_v2_openapi_contract.py tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_openapi_spec.py -q` → **17 passed** (no regression on existing contract gates)
- [x] `make lint` → `All checks passed!` / `235 files already formatted`
- [x] `make openapi-check` → exit 0
- [x] `git diff --check main...HEAD` → clean
- [ ] CI `lint-and-unit` green (UT is the only gate per new merge口径)
- [ ] 1× diff-scoped no-blocker CR

## Follow-up PRs

- **PR-1 Backend destructive contract switch** (next): TRUNCATE + drop benchmark tables, alter `evaluation_runs` / `evaluation_run_items`, delete `Benchmark*` schemas/services/views, wire `evaluation_dataset_service` + `resolve_default_evaluation_bot` + snapshot-on-run, `evaluation_v2/tasks.py` snapshot execution path, contract test positive + negative assertions.
- **PR-2 FE + docs + polish**: regenerate `api-v2/schema.d.ts`, `features/evaluation/*` typed adapter, new `/workspace/collections/[collectionId]/evaluations/page.tsx`, delete `/benchmarks` page, `test_web_typed_api_contract.py` boundary, i18n / `web/global.ts`, docs + hurl.

## Related

- Base: `main @ 0b44202e` (post #29 / PR #1587 merge).
- Task: `#evaluation #20` — Evaluation v3 simplification.
- Design baseline: thread `#evaluation:4b66ca3a` design report + msg=659ba863 + msg=38d7e74d patches.
- Merge gate: 1 no-blocker CR + `lint-and-unit` SUCCESS + `mergeStateStatus=CLEAN` → admin merge (e2e not gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)