### PR TITLE
feat(evaluation_v2): Phase 2 destructive contract switch to simplified Dataset + Run API (#evaluation #20 PR-1)

### DIFF
--- a/aperag/db/models.py
+++ b/aperag/db/models.py
@@ -232,25 +232,12 @@ class EvaluationItemStatus(str, Enum):
     FAILED = "FAILED"
 
 
-class BenchmarkDatasetVersionStatus(str, Enum):
-    DRAFT = "draft"
-    PUBLISHED = "published"
-    ARCHIVED = "archived"
-
-
-class BenchmarkDatasetSourceType(str, Enum):
-    MANUAL = "manual"
-    IMPORT = "import"
-    MIGRATED_FROM_QUESTION_SET = "migrated_from_question_set"
-
-
 class EvaluationDatasetSourceType(str, Enum):
-    """Source type for an EvaluationDataset (simplified evaluation model).
+    """Origin of an ``EvaluationDataset``.
 
-    Introduced by the evaluation-v3 simplification (Phase 1, additive only):
-    the wire contract drops the Benchmark / Dataset Version distinction and
-    exposes Dataset + Evaluation/Run only. This enum is the source-of-truth
-    equivalent of ``BenchmarkDatasetSourceType`` for the new layer.
+    The simplified evaluation model exposes only ``Dataset`` + ``Run`` to
+    users. ``source_type`` lets the backend distinguish how the items were
+    created (manual entry, file import, LLM-generated).
     """
 
     MANUAL = "manual"
@@ -1154,80 +1141,12 @@ class PromptTemplate(Base):
     gmt_deleted = Column(DateTime(timezone=True), nullable=True, index=True)
 
 
-# ===== Evaluation v2 (new evaluation product line on top of Agent Runtime V3) =====
-
-
-class BenchmarkDataset(Base):
-    __tablename__ = "benchmark_datasets"
-    __table_args__ = (
-        Index("idx_benchmark_datasets_user", "user_id"),
-        Index("idx_benchmark_datasets_collection", "collection_id"),
-    )
-
-    id = Column(String(32), primary_key=True, default=lambda: "bds_" + random_id()[:16])
-    user_id = Column(String(256), nullable=False)
-    collection_id = Column(String(24), nullable=True)
-    name = Column(String(255), nullable=False)
-    description = Column(Text, nullable=True)
-    source_type = Column(
-        EnumColumn(BenchmarkDatasetSourceType),
-        nullable=False,
-        default=BenchmarkDatasetSourceType.MANUAL,
-    )
-    schema_hint = Column(JSON, nullable=True)
-    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
-    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
-    gmt_deleted = Column(DateTime(timezone=True), nullable=True, index=True)
-
-
-class BenchmarkDatasetVersion(Base):
-    __tablename__ = "benchmark_dataset_versions"
-    __table_args__ = (
-        UniqueConstraint("dataset_id", "version", name="uq_benchmark_dataset_version"),
-        Index("idx_benchmark_dataset_versions_dataset", "dataset_id"),
-        Index("idx_benchmark_dataset_versions_status", "status"),
-    )
-
-    id = Column(String(32), primary_key=True, default=lambda: "bdv_" + random_id()[:16])
-    dataset_id = Column(String(32), nullable=False)
-    version = Column(Integer, nullable=False)
-    version_name = Column(String(255), nullable=True)
-    status = Column(
-        EnumColumn(BenchmarkDatasetVersionStatus),
-        nullable=False,
-        default=BenchmarkDatasetVersionStatus.PUBLISHED,
-    )
-    case_count = Column(Integer, nullable=False, default=0)
-    source_snapshot = Column(JSON, nullable=True)
-    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
-    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
-    gmt_published = Column(DateTime(timezone=True), nullable=True)
-
-
-class BenchmarkCase(Base):
-    __tablename__ = "benchmark_cases"
-    __table_args__ = (
-        UniqueConstraint("dataset_version_id", "case_key", name="uq_benchmark_case_version_key"),
-        Index("idx_benchmark_cases_version", "dataset_version_id"),
-    )
-
-    id = Column(String(32), primary_key=True, default=lambda: "bc_" + random_id()[:16])
-    dataset_version_id = Column(String(32), nullable=False)
-    case_key = Column(String(128), nullable=False)
-    input_message = Column(Text, nullable=False)
-    expected_answer = Column(Text, nullable=True)
-    reference_context = Column(Text, nullable=True)
-    tags = Column(JSON, nullable=True)
-    case_metadata = Column(JSON, nullable=True)
-    sort_key = Column(Integer, nullable=False, default=0)
-    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+# ===== Evaluation (simplified: Dataset + Run model, no Benchmark/Version layer) =====
 
 
 class EvaluationDataset(Base):
     """Dataset of evaluation QA items owned by a user.
 
-    Phase 1 of the evaluation-v3 simplification (additive only) introduces this
-    model alongside the existing ``BenchmarkDataset`` without touching it.
     ``user_id`` anchors access control; ``collection_id`` is scope metadata
     only and does NOT inherit collection sharing ACLs.
     """
@@ -1256,11 +1175,11 @@ class EvaluationDataset(Base):
 
 
 class EvaluationDatasetItem(Base):
-    """A single QA item inside an EvaluationDataset.
+    """A single QA item inside an ``EvaluationDataset``.
 
-    Phase 2 of the simplification will value-copy these fields into
-    ``evaluation_run_items`` at run-create time (snapshot-on-run) so that
-    edits to the dataset do not mutate historical run semantics.
+    At run-create time these fields are value-copied into
+    ``evaluation_run_items`` (snapshot-on-run) so later edits or soft-deletes
+    of the dataset item do not mutate historical run semantics.
     """
 
     __tablename__ = "evaluation_dataset_items"
@@ -1289,13 +1208,20 @@ class EvaluationRun(Base):
         Index("idx_evaluation_runs_user", "user_id"),
         Index("idx_evaluation_runs_bot", "bot_id"),
         Index("idx_evaluation_runs_status", "status"),
-        Index("idx_evaluation_runs_dataset_version", "dataset_version_id"),
+        Index("idx_evaluation_runs_dataset", "dataset_id"),
+        Index("idx_evaluation_runs_collection", "collection_id"),
     )
 
     id = Column(String(32), primary_key=True, default=lambda: "er_" + random_id()[:16])
     user_id = Column(String(256), nullable=False)
-    bot_id = Column(String(24), nullable=False)
-    dataset_version_id = Column(String(32), nullable=False)
+    bot_id = Column(String(24), nullable=False)  # resolved at create-time, immutable
+    dataset_id = Column(String(32), nullable=False)
+    # Snapshot of dataset.collection_id so run list can filter by collection scope
+    # even after the dataset is soft-deleted or its collection_id is updated.
+    collection_id = Column(String(24), nullable=True)
+    # Snapshot of dataset.name for run list/detail UIs — avoids joining back to
+    # evaluation_datasets when the dataset has been soft-deleted.
+    dataset_name = Column(String(255), nullable=True)
     name = Column(String(255), nullable=True)
     bot_config_snapshot = Column(JSON, nullable=True)
     model_config_snapshot = Column(JSON, nullable=True)
@@ -1316,15 +1242,25 @@ class EvaluationRun(Base):
 class EvaluationRunItem(Base):
     __tablename__ = "evaluation_run_items"
     __table_args__ = (
-        UniqueConstraint("run_id", "case_id", name="uq_evaluation_run_item_run_case"),
         Index("idx_evaluation_run_items_run", "run_id"),
         Index("idx_evaluation_run_items_status", "status"),
     )
 
     id = Column(String(32), primary_key=True, default=lambda: "eri_" + random_id()[:16])
     run_id = Column(String(32), nullable=False)
-    case_id = Column(String(32), nullable=False)
+    # Audit-only back-reference to the source dataset item. Not an FK; soft- or
+    # hard-delete of the dataset item must NOT cascade into historical run items.
+    source_dataset_item_id = Column(String(32), nullable=True)
     case_key = Column(String(128), nullable=False)
+    sort_key = Column(Integer, nullable=False, default=0)
+    # Snapshot fields are value-copied from the dataset item at run-create time.
+    # Run detail / list / attempt read paths must only read these columns and
+    # must never join back to mutable evaluation_dataset_items rows.
+    input_message = Column(Text, nullable=False)
+    expected_answer = Column(Text, nullable=True)
+    reference_context = Column(Text, nullable=True)
+    tags = Column(JSON, nullable=True)
+    case_metadata = Column(JSON, nullable=True)
     status = Column(
         EnumColumn(EvaluationRunItemStatus),
         nullable=False,

--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Data-access for the evaluation-v2 product line.
+"""Data-access for the simplified evaluation API.
 
-Tables: benchmark_datasets / benchmark_dataset_versions / benchmark_cases /
-evaluation_runs / evaluation_run_items / evaluation_run_item_attempts.
+Tables: ``evaluation_datasets`` / ``evaluation_dataset_items`` /
+``evaluation_runs`` / ``evaluation_run_items`` / ``evaluation_run_item_attempts``.
+The legacy ``benchmark_*`` tables were removed in the Phase 2 destructive
+migration; there is no Benchmark / Dataset Version concept here any more.
 """
 
 from typing import Optional
@@ -24,10 +26,6 @@ from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aperag.db.models import (
-    BenchmarkCase,
-    BenchmarkDataset,
-    BenchmarkDatasetVersion,
-    BenchmarkDatasetVersionStatus,
     Bot,
     BotStatus,
     EvaluationDataset,
@@ -42,208 +40,7 @@ from aperag.utils.utils import utc_now
 
 
 class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
-    """Read/write helpers for evaluation-v2 resources."""
-
-    # -- BenchmarkDataset ---------------------------------------------------
-
-    async def create_benchmark_dataset(self, dataset: BenchmarkDataset) -> BenchmarkDataset:
-        async def _operation(session: AsyncSession):
-            session.add(dataset)
-            await session.flush()
-            await session.refresh(dataset)
-            return dataset
-
-        return await self.execute_with_transaction(_operation)
-
-    async def get_benchmark_dataset(self, user_id: str, dataset_id: str) -> Optional[BenchmarkDataset]:
-        async def _query(session: AsyncSession):
-            stmt = select(BenchmarkDataset).where(
-                BenchmarkDataset.id == dataset_id,
-                BenchmarkDataset.user_id == user_id,
-                BenchmarkDataset.gmt_deleted.is_(None),
-            )
-            result = await session.execute(stmt)
-            return result.scalars().first()
-
-        return await self._execute_query(_query)
-
-    async def list_benchmark_datasets(
-        self,
-        user_id: str,
-        collection_id: Optional[str],
-        page: int,
-        page_size: int,
-    ) -> tuple[list[BenchmarkDataset], int]:
-        async def _query(session: AsyncSession):
-            conditions = [
-                BenchmarkDataset.user_id == user_id,
-                BenchmarkDataset.gmt_deleted.is_(None),
-            ]
-            if collection_id:
-                conditions.append(BenchmarkDataset.collection_id == collection_id)
-            base = select(BenchmarkDataset).where(and_(*conditions))
-
-            total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
-            rows = (
-                (
-                    await session.execute(
-                        base.order_by(BenchmarkDataset.gmt_created.desc())
-                        .offset((page - 1) * page_size)
-                        .limit(page_size)
-                    )
-                )
-                .scalars()
-                .all()
-            )
-            return list(rows), total
-
-        return await self._execute_query(_query)
-
-    async def update_benchmark_dataset(
-        self,
-        user_id: str,
-        dataset_id: str,
-        *,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-    ) -> Optional[BenchmarkDataset]:
-        async def _operation(session: AsyncSession):
-            stmt = select(BenchmarkDataset).where(
-                BenchmarkDataset.id == dataset_id,
-                BenchmarkDataset.user_id == user_id,
-                BenchmarkDataset.gmt_deleted.is_(None),
-            )
-            instance = (await session.execute(stmt)).scalars().first()
-            if not instance:
-                return None
-            if name is not None:
-                instance.name = name
-            if description is not None:
-                instance.description = description
-            instance.gmt_updated = utc_now()
-            await session.flush()
-            await session.refresh(instance)
-            return instance
-
-        return await self.execute_with_transaction(_operation)
-
-    async def soft_delete_benchmark_dataset(self, user_id: str, dataset_id: str) -> bool:
-        async def _operation(session: AsyncSession):
-            stmt = select(BenchmarkDataset).where(
-                BenchmarkDataset.id == dataset_id,
-                BenchmarkDataset.user_id == user_id,
-                BenchmarkDataset.gmt_deleted.is_(None),
-            )
-            instance = (await session.execute(stmt)).scalars().first()
-            if not instance:
-                return False
-            instance.gmt_deleted = utc_now()
-            await session.flush()
-            return True
-
-        return await self.execute_with_transaction(_operation)
-
-    # -- BenchmarkDatasetVersion -------------------------------------------
-
-    async def create_benchmark_dataset_version(
-        self,
-        dataset_id: str,
-        version: BenchmarkDatasetVersion,
-        cases: list[BenchmarkCase],
-    ) -> BenchmarkDatasetVersion:
-        async def _operation(session: AsyncSession):
-            version.dataset_id = dataset_id
-            session.add(version)
-            await session.flush()
-            await session.refresh(version)
-
-            for case in cases:
-                case.dataset_version_id = version.id
-                session.add(case)
-            if cases:
-                await session.flush()
-                version.case_count = len(cases)
-                await session.flush()
-                await session.refresh(version)
-            return version
-
-        return await self.execute_with_transaction(_operation)
-
-    async def next_dataset_version_number(self, dataset_id: str) -> int:
-        async def _query(session: AsyncSession):
-            stmt = select(func.coalesce(func.max(BenchmarkDatasetVersion.version), 0)).where(
-                BenchmarkDatasetVersion.dataset_id == dataset_id
-            )
-            return (await session.execute(stmt)).scalar_one() + 1
-
-        return await self._execute_query(_query)
-
-    async def get_dataset_version(self, version_id: str) -> Optional[BenchmarkDatasetVersion]:
-        async def _query(session: AsyncSession):
-            stmt = select(BenchmarkDatasetVersion).where(BenchmarkDatasetVersion.id == version_id)
-            return (await session.execute(stmt)).scalars().first()
-
-        return await self._execute_query(_query)
-
-    async def list_dataset_versions(self, dataset_id: str) -> list[BenchmarkDatasetVersion]:
-        async def _query(session: AsyncSession):
-            stmt = (
-                select(BenchmarkDatasetVersion)
-                .where(BenchmarkDatasetVersion.dataset_id == dataset_id)
-                .order_by(BenchmarkDatasetVersion.version.desc())
-            )
-            return list((await session.execute(stmt)).scalars().all())
-
-        return await self._execute_query(_query)
-
-    async def latest_published_version(self, dataset_id: str) -> Optional[BenchmarkDatasetVersion]:
-        async def _query(session: AsyncSession):
-            stmt = (
-                select(BenchmarkDatasetVersion)
-                .where(
-                    BenchmarkDatasetVersion.dataset_id == dataset_id,
-                    BenchmarkDatasetVersion.status == BenchmarkDatasetVersionStatus.PUBLISHED,
-                )
-                .order_by(BenchmarkDatasetVersion.version.desc())
-                .limit(1)
-            )
-            return (await session.execute(stmt)).scalars().first()
-
-        return await self._execute_query(_query)
-
-    # -- BenchmarkCase ------------------------------------------------------
-
-    async def list_cases_for_version(
-        self, version_id: str, page: int, page_size: int
-    ) -> tuple[list[BenchmarkCase], int]:
-        async def _query(session: AsyncSession):
-            base = select(BenchmarkCase).where(BenchmarkCase.dataset_version_id == version_id)
-            total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
-            rows = (
-                (
-                    await session.execute(
-                        base.order_by(BenchmarkCase.sort_key.asc(), BenchmarkCase.gmt_created.asc())
-                        .offset((page - 1) * page_size)
-                        .limit(page_size)
-                    )
-                )
-                .scalars()
-                .all()
-            )
-            return list(rows), total
-
-        return await self._execute_query(_query)
-
-    async def list_all_cases_for_version(self, version_id: str) -> list[BenchmarkCase]:
-        async def _query(session: AsyncSession):
-            stmt = (
-                select(BenchmarkCase)
-                .where(BenchmarkCase.dataset_version_id == version_id)
-                .order_by(BenchmarkCase.sort_key.asc(), BenchmarkCase.gmt_created.asc())
-            )
-            return list((await session.execute(stmt)).scalars().all())
-
-        return await self._execute_query(_query)
+    """Read/write helpers for evaluation resources."""
 
     # -- EvaluationRun ------------------------------------------------------
 
@@ -278,14 +75,20 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
     async def list_evaluation_runs(
         self,
         user_id: str,
-        bot_id: Optional[str],
-        page: int,
-        page_size: int,
+        bot_id: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        collection_id: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
     ) -> tuple[list[EvaluationRun], int]:
         async def _query(session: AsyncSession):
             conditions = [EvaluationRun.user_id == user_id]
             if bot_id:
                 conditions.append(EvaluationRun.bot_id == bot_id)
+            if dataset_id:
+                conditions.append(EvaluationRun.dataset_id == dataset_id)
+            if collection_id:
+                conditions.append(EvaluationRun.collection_id == collection_id)
             base = select(EvaluationRun).where(and_(*conditions))
             total = (await session.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
             rows = (

--- a/aperag/evaluation_v2/schemas.py
+++ b/aperag/evaluation_v2/schemas.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pydantic schemas for the evaluation-v2 orchestration API.
+"""Pydantic schemas for the simplified evaluation API.
 
-These types mirror the frozen contract (`contract freeze v1`) used by
-`aperag/views/evaluation_v2.py` and by the frontend client. Keep the wire
-shape here stable; runtime data access DTOs live next to the repositories.
+Public contract surface is two resource families only:
+
+* ``/api/v2/evaluation-datasets*`` — dataset + per-item CRUD.
+* ``/api/v2/evaluation-runs*``     — run lifecycle with snapshot-on-run items.
+
+There is no Benchmark / Dataset Version concept in this layer. See the
+``#evaluation #20`` design report for the full rationale and validation
+checklist. Run items are self-contained snapshots; read paths must never
+join back to the mutable ``evaluation_dataset_items`` rows.
 """
 
 from datetime import datetime
@@ -26,8 +32,6 @@ from typing import Any, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 from aperag.db.models import (
-    BenchmarkDatasetSourceType,
-    BenchmarkDatasetVersionStatus,
     EvaluationDatasetSourceType,
     EvaluationJudgeMode,
     EvaluationRunItemAttemptStatus,
@@ -36,257 +40,8 @@ from aperag.db.models import (
 )
 
 # ---------------------------------------------------------------------------
-# BenchmarkDataset
+# EvaluationDataset + items
 # ---------------------------------------------------------------------------
-
-
-class BenchmarkDatasetCreate(BaseModel):
-    name: str = Field(..., min_length=1, max_length=255)
-    description: Optional[str] = None
-    collection_id: Optional[str] = None
-    source_type: BenchmarkDatasetSourceType = BenchmarkDatasetSourceType.MANUAL
-    schema_hint: Optional[dict[str, Any]] = None
-
-
-class BenchmarkDatasetUpdate(BaseModel):
-    name: Optional[str] = Field(None, min_length=1, max_length=255)
-    description: Optional[str] = None
-
-
-class BenchmarkDatasetEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
-
-    id: str
-    user_id: str
-    collection_id: Optional[str] = None
-    name: str
-    description: Optional[str] = None
-    source_type: BenchmarkDatasetSourceType
-    schema_hint: Optional[dict[str, Any]] = None
-    created_at: datetime = Field(validation_alias="gmt_created")
-    updated_at: datetime = Field(validation_alias="gmt_updated")
-    latest_version: Optional["BenchmarkDatasetVersionEnvelope"] = None
-
-
-class EvaluationPagination(BaseModel):
-    total: int = 0
-    offset: int = 0
-    limit: int = 20
-
-
-class BenchmarkDatasetListResponse(BaseModel):
-    items: list[BenchmarkDatasetEnvelope] = Field(default_factory=list)
-    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
-
-
-# ---------------------------------------------------------------------------
-# BenchmarkDatasetVersion + BenchmarkCase
-# ---------------------------------------------------------------------------
-
-
-class BenchmarkCaseCreate(BaseModel):
-    case_key: Optional[str] = Field(
-        None,
-        max_length=128,
-        description="Stable user-facing key. Auto-generated when omitted.",
-    )
-    input_message: str = Field(..., min_length=1)
-    expected_answer: Optional[str] = None
-    reference_context: Optional[str] = None
-    tags: Optional[list[str]] = None
-    case_metadata: Optional[dict[str, Any]] = None
-    sort_key: int = 0
-
-
-class BenchmarkDatasetVersionCreate(BaseModel):
-    version_name: Optional[str] = Field(None, max_length=255)
-    source_snapshot: Optional[dict[str, Any]] = None
-    cases: list[BenchmarkCaseCreate] = Field(default_factory=list)
-
-
-class BenchmarkCaseEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
-
-    id: str
-    dataset_version_id: str
-    case_key: str
-    input_message: str
-    expected_answer: Optional[str] = None
-    reference_context: Optional[str] = None
-    tags: Optional[list[str]] = None
-    case_metadata: Optional[dict[str, Any]] = None
-    sort_key: int
-    created_at: datetime = Field(validation_alias="gmt_created")
-
-
-class BenchmarkDatasetVersionEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
-
-    id: str
-    dataset_id: str
-    version: int
-    version_name: Optional[str] = None
-    status: BenchmarkDatasetVersionStatus
-    case_count: int
-    source_snapshot: Optional[dict[str, Any]] = None
-    created_at: datetime = Field(validation_alias="gmt_created")
-    updated_at: datetime = Field(validation_alias="gmt_updated")
-    published_at: Optional[datetime] = Field(default=None, validation_alias="gmt_published")
-
-
-class BenchmarkDatasetVersionListResponse(BaseModel):
-    items: list[BenchmarkDatasetVersionEnvelope] = Field(default_factory=list)
-    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
-
-
-class BenchmarkCaseListResponse(BaseModel):
-    items: list[BenchmarkCaseEnvelope] = Field(default_factory=list)
-    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
-
-
-# ---------------------------------------------------------------------------
-# EvaluationRun lifecycle
-# ---------------------------------------------------------------------------
-
-
-class JudgeConfig(BaseModel):
-    mode: EvaluationJudgeMode = EvaluationJudgeMode.EXACT_MATCH
-    model: Optional[str] = None
-    model_service_provider: Optional[str] = None
-    prompt_template: Optional[str] = None
-    score_threshold: Optional[float] = Field(None, ge=0.0, le=1.0)
-    params: Optional[dict[str, Any]] = None
-
-
-class EvaluationRunCreate(BaseModel):
-    model_config = ConfigDict(protected_namespaces=())
-
-    name: Optional[str] = Field(None, max_length=255)
-    bot_id: str
-    dataset_version_id: str
-    judge: Optional[JudgeConfig] = None
-    bot_config_snapshot: Optional[dict[str, Any]] = None
-    model_config_snapshot: Optional[dict[str, Any]] = None
-
-
-class EvaluationRunSummary(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
-    total: int = Field(default=0, validation_alias="total_cases")
-    pending: int = 0
-    running: int = 0
-    completed: int = 0
-    failed: int = 0
-    cancelled: int = 0
-    avg_score: Optional[float] = Field(default=None, validation_alias="average_score")
-    pass_rate: Optional[float] = None
-
-
-class EvaluationRunProgress(BaseModel):
-    percent: Optional[int] = None
-    eta_ms: Optional[int] = None
-
-
-class EvaluationRunEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True, protected_namespaces=())
-
-    id: str
-    user_id: str
-    bot_id: str
-    dataset_version_id: str
-    name: Optional[str] = None
-    status: EvaluationRunStatus
-    summary: Optional[EvaluationRunSummary] = None
-    judge_config: Optional[JudgeConfig] = None
-    bot_config_snapshot: Optional[dict[str, Any]] = None
-    model_config_snapshot: Optional[dict[str, Any]] = None
-    error: Optional[str] = Field(default=None, validation_alias="error_message")
-    created_at: datetime = Field(validation_alias="gmt_created")
-    updated_at: datetime = Field(validation_alias="gmt_updated")
-    started_at: Optional[datetime] = Field(default=None, validation_alias="gmt_started")
-    finished_at: Optional[datetime] = Field(default=None, validation_alias="gmt_finished")
-
-
-class EvaluationRunListResponse(BaseModel):
-    items: list[EvaluationRunEnvelope] = Field(default_factory=list)
-    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
-
-
-class EvaluationRunItemEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
-
-    id: str
-    run_id: str
-    case_id: str
-    case_key: str
-    status: EvaluationRunItemStatus
-    best_score: Optional[Decimal] = None
-    latest_attempt_id: Optional[str] = None
-    latest_attempt: Optional["EvaluationRunItemAttemptEnvelope"] = None
-    attempt_count: int
-    error: Optional[str] = Field(default=None, validation_alias="error_message")
-    created_at: datetime = Field(validation_alias="gmt_created")
-    updated_at: datetime = Field(validation_alias="gmt_updated")
-
-
-class EvaluationRunItemListResponse(BaseModel):
-    items: list[EvaluationRunItemEnvelope] = Field(default_factory=list)
-    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
-
-
-class EvaluationRunItemAttemptEnvelope(BaseModel):
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
-
-    id: str
-    run_item_id: str
-    run_id: str
-    attempt_no: int
-    status: EvaluationRunItemAttemptStatus
-    agent_chat_id: Optional[str] = None
-    agent_turn_id: Optional[str] = None
-    answer_text: Optional[str] = None
-    judge_result: Optional[dict[str, Any]] = None
-    score: Optional[Decimal] = None
-    latency_ms: Optional[int] = None
-    token_usage: Optional[dict[str, Any]] = None
-    error: Optional[str] = Field(default=None, validation_alias="error_message")
-    retry_reason: Optional[str] = None
-    created_at: datetime = Field(validation_alias="gmt_created")
-    started_at: Optional[datetime] = Field(default=None, validation_alias="gmt_started")
-    finished_at: Optional[datetime] = Field(default=None, validation_alias="gmt_finished")
-
-
-class EvaluationRunItemAttemptList(BaseModel):
-    items: list[EvaluationRunItemAttemptEnvelope] = Field(default_factory=list)
-
-
-class EvaluationRunDetailResponse(BaseModel):
-    run: EvaluationRunEnvelope
-    summary: Optional[EvaluationRunSummary] = None
-    progress: Optional[EvaluationRunProgress] = None
-
-
-class CancelRunResponse(BaseModel):
-    run_id: str
-    status: EvaluationRunStatus
-
-
-class RetryRunItemResponse(BaseModel):
-    item: EvaluationRunItemEnvelope
-
-
-BenchmarkDatasetEnvelope.model_rebuild()
-EvaluationRunItemEnvelope.model_rebuild()
-
-
-# ---------------------------------------------------------------------------
-# EvaluationDataset (simplified evaluation model — evaluation-v3 Phase 1)
-# ---------------------------------------------------------------------------
-#
-# These schemas are added alongside the Benchmark* set so the new
-# ``EvaluationDataset`` / ``EvaluationDatasetItem`` tables can be exercised by
-# repository tests and by the Phase 2 service/view switch without touching the
-# still-live benchmark contract. The public API is NOT re-wired in Phase 1.
 
 
 class EvaluationDatasetItemCreate(BaseModel):
@@ -358,6 +113,12 @@ class EvaluationDatasetEnvelope(BaseModel):
     updated_at: datetime = Field(validation_alias="gmt_updated")
 
 
+class EvaluationPagination(BaseModel):
+    total: int = 0
+    offset: int = 0
+    limit: int = 20
+
+
 class EvaluationDatasetListResponse(BaseModel):
     items: list[EvaluationDatasetEnvelope] = Field(default_factory=list)
     pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
@@ -374,3 +135,152 @@ class EvaluationDatasetItemsAppendRequest(BaseModel):
 
 class EvaluationDatasetItemsAppendResponse(BaseModel):
     items: list[EvaluationDatasetItemEnvelope] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# EvaluationRun lifecycle
+# ---------------------------------------------------------------------------
+
+
+class JudgeConfig(BaseModel):
+    mode: EvaluationJudgeMode = EvaluationJudgeMode.EXACT_MATCH
+    model: Optional[str] = None
+    model_service_provider: Optional[str] = None
+    prompt_template: Optional[str] = None
+    score_threshold: Optional[float] = Field(None, ge=0.0, le=1.0)
+    params: Optional[dict[str, Any]] = None
+
+
+class EvaluationRunCreate(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+
+    dataset_id: str = Field(..., description="Required dataset id for this run")
+    bot_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional explicit bot id. When omitted the service resolves the "
+            "user's default bot (active bot with title "
+            "'Default Agent Bot' first, otherwise oldest active bot)."
+        ),
+    )
+    name: Optional[str] = Field(None, max_length=255)
+    judge: Optional[JudgeConfig] = None
+    bot_config_snapshot: Optional[dict[str, Any]] = None
+    model_config_snapshot: Optional[dict[str, Any]] = None
+
+
+class EvaluationRunSummary(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    total: int = Field(default=0, validation_alias="total_cases")
+    pending: int = 0
+    running: int = 0
+    completed: int = 0
+    failed: int = 0
+    cancelled: int = 0
+    avg_score: Optional[float] = Field(default=None, validation_alias="average_score")
+    pass_rate: Optional[float] = None
+
+
+class EvaluationRunProgress(BaseModel):
+    percent: Optional[int] = None
+    eta_ms: Optional[int] = None
+
+
+class EvaluationRunEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, protected_namespaces=())
+
+    id: str
+    user_id: str
+    bot_id: str
+    dataset_id: str
+    collection_id: Optional[str] = None
+    dataset_name: Optional[str] = None
+    name: Optional[str] = None
+    status: EvaluationRunStatus
+    summary: Optional[EvaluationRunSummary] = None
+    judge_config: Optional[JudgeConfig] = None
+    bot_config_snapshot: Optional[dict[str, Any]] = None
+    model_config_snapshot: Optional[dict[str, Any]] = None
+    error: Optional[str] = Field(default=None, validation_alias="error_message")
+    created_at: datetime = Field(validation_alias="gmt_created")
+    updated_at: datetime = Field(validation_alias="gmt_updated")
+    started_at: Optional[datetime] = Field(default=None, validation_alias="gmt_started")
+    finished_at: Optional[datetime] = Field(default=None, validation_alias="gmt_finished")
+
+
+class EvaluationRunListResponse(BaseModel):
+    items: list[EvaluationRunEnvelope] = Field(default_factory=list)
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
+
+
+class EvaluationRunItemEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: str
+    run_id: str
+    source_dataset_item_id: Optional[str] = None
+    case_key: str
+    sort_key: int
+    input_message: str
+    expected_answer: Optional[str] = None
+    reference_context: Optional[str] = None
+    tags: Optional[list[str]] = None
+    case_metadata: Optional[dict[str, Any]] = None
+    status: EvaluationRunItemStatus
+    best_score: Optional[Decimal] = None
+    latest_attempt_id: Optional[str] = None
+    latest_attempt: Optional["EvaluationRunItemAttemptEnvelope"] = None
+    attempt_count: int
+    error: Optional[str] = Field(default=None, validation_alias="error_message")
+    created_at: datetime = Field(validation_alias="gmt_created")
+    updated_at: datetime = Field(validation_alias="gmt_updated")
+
+
+class EvaluationRunItemListResponse(BaseModel):
+    items: list[EvaluationRunItemEnvelope] = Field(default_factory=list)
+    pagination: EvaluationPagination = Field(default_factory=EvaluationPagination)
+
+
+class EvaluationRunItemAttemptEnvelope(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: str
+    run_item_id: str
+    run_id: str
+    attempt_no: int
+    status: EvaluationRunItemAttemptStatus
+    agent_chat_id: Optional[str] = None
+    agent_turn_id: Optional[str] = None
+    answer_text: Optional[str] = None
+    judge_result: Optional[dict[str, Any]] = None
+    score: Optional[Decimal] = None
+    latency_ms: Optional[int] = None
+    token_usage: Optional[dict[str, Any]] = None
+    error: Optional[str] = Field(default=None, validation_alias="error_message")
+    retry_reason: Optional[str] = None
+    created_at: datetime = Field(validation_alias="gmt_created")
+    started_at: Optional[datetime] = Field(default=None, validation_alias="gmt_started")
+    finished_at: Optional[datetime] = Field(default=None, validation_alias="gmt_finished")
+
+
+class EvaluationRunItemAttemptList(BaseModel):
+    items: list[EvaluationRunItemAttemptEnvelope] = Field(default_factory=list)
+
+
+class EvaluationRunDetailResponse(BaseModel):
+    run: EvaluationRunEnvelope
+    summary: Optional[EvaluationRunSummary] = None
+    progress: Optional[EvaluationRunProgress] = None
+
+
+class CancelRunResponse(BaseModel):
+    run_id: str
+    status: EvaluationRunStatus
+
+
+class RetryRunItemResponse(BaseModel):
+    item: EvaluationRunItemEnvelope
+
+
+EvaluationRunItemEnvelope.model_rebuild()

--- a/aperag/evaluation_v2/services.py
+++ b/aperag/evaluation_v2/services.py
@@ -12,37 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Orchestration services for evaluation-v2.
+"""Orchestration services for the simplified evaluation API.
 
-These services sit between the FastAPI view layer and the async repository
-mixin on `AsyncDatabaseOps`. They own the write-time invariants (version
-numbering, run item creation, snapshot capture) while keeping the view code
-thin and the repository layer pure data access.
-
-Phase 1 only ships the synchronous CRUD path. The async worker pipeline
-(dispatching Runtime V3 turns, judging, aggregating summaries) lands in
-Phase 3 and will plug into `run_service.launch_run`.
+User-visible surface is ``Dataset + Evaluation/Run`` only. The dataset service
+owns CRUD for ``evaluation_datasets`` / ``evaluation_dataset_items``; the run
+service owns the run lifecycle and implements snapshot-on-run. Run detail /
+list / attempt read paths must only read ``evaluation_run_items`` snapshot
+columns and must never join back to mutable ``evaluation_dataset_items`` rows.
 """
 
 from typing import Optional
 
 from aperag.db.models import (
-    BenchmarkCase,
-    BenchmarkDataset,
-    BenchmarkDatasetVersion,
-    BenchmarkDatasetVersionStatus,
+    EvaluationDataset,
+    EvaluationDatasetItem,
     EvaluationRun,
     EvaluationRunItem,
     EvaluationRunItemStatus,
     EvaluationRunStatus,
 )
 from aperag.db.ops import AsyncDatabaseOps, async_db_ops
+from aperag.evaluation_v2.constants import DEFAULT_AGENT_BOT_TITLE
 from aperag.evaluation_v2.schemas import (
-    BenchmarkDatasetCreate,
-    BenchmarkDatasetEnvelope,
-    BenchmarkDatasetUpdate,
-    BenchmarkDatasetVersionCreate,
-    BenchmarkDatasetVersionEnvelope,
+    EvaluationDatasetCreate,
+    EvaluationDatasetEnvelope,
+    EvaluationDatasetItemCreate,
+    EvaluationDatasetItemEnvelope,
+    EvaluationDatasetItemUpdate,
+    EvaluationDatasetUpdate,
     EvaluationRunCreate,
     EvaluationRunDetailResponse,
     EvaluationRunEnvelope,
@@ -53,17 +50,14 @@ from aperag.evaluation_v2.schemas import (
     JudgeConfig,
 )
 from aperag.exceptions import ResourceNotFoundException, ValidationException
-from aperag.utils.utils import utc_now
 
 
-def _to_dataset_envelope(
-    dataset: BenchmarkDataset,
-    latest_version: Optional[BenchmarkDatasetVersion] = None,
-) -> BenchmarkDatasetEnvelope:
-    envelope = BenchmarkDatasetEnvelope.model_validate(dataset)
-    if latest_version is not None:
-        envelope.latest_version = BenchmarkDatasetVersionEnvelope.model_validate(latest_version)
-    return envelope
+def _to_dataset_envelope(dataset: EvaluationDataset) -> EvaluationDatasetEnvelope:
+    return EvaluationDatasetEnvelope.model_validate(dataset)
+
+
+def _to_dataset_item_envelope(item: EvaluationDatasetItem) -> EvaluationDatasetItemEnvelope:
+    return EvaluationDatasetItemEnvelope.model_validate(item)
 
 
 def _to_run_envelope(run: EvaluationRun) -> EvaluationRunEnvelope:
@@ -107,22 +101,59 @@ def _requeue_run_summary(
     return summary.model_dump()
 
 
-class BenchmarkDatasetService:
-    """Dataset + dataset-version CRUD."""
+def _auto_case_key(index: int) -> str:
+    return f"case_{index + 1:04d}"
+
+
+def _items_from_payload(
+    dataset_id: str,
+    payloads: list[EvaluationDatasetItemCreate],
+    start_index: int = 0,
+) -> list[EvaluationDatasetItem]:
+    seen_keys: set[str] = set()
+    items: list[EvaluationDatasetItem] = []
+    for offset, payload in enumerate(payloads):
+        idx = start_index + offset
+        key = (payload.case_key or _auto_case_key(idx)).strip()
+        if not key:
+            key = _auto_case_key(idx)
+        if key in seen_keys:
+            raise ValidationException(f"Duplicate case_key within dataset payload: {key}")
+        seen_keys.add(key)
+        items.append(
+            EvaluationDatasetItem(
+                dataset_id=dataset_id,
+                case_key=key,
+                input_message=payload.input_message,
+                expected_answer=payload.expected_answer,
+                reference_context=payload.reference_context,
+                tags=payload.tags,
+                case_metadata=payload.case_metadata,
+                sort_key=payload.sort_key if payload.sort_key is not None else idx,
+            )
+        )
+    return items
+
+
+class EvaluationDatasetService:
+    """CRUD + item management for ``evaluation_datasets`` / ``evaluation_dataset_items``."""
 
     def __init__(self, db_ops: Optional[AsyncDatabaseOps] = None):
         self.db_ops = db_ops or async_db_ops
 
-    async def create_dataset(self, user_id: str, request: BenchmarkDatasetCreate) -> BenchmarkDatasetEnvelope:
-        dataset = BenchmarkDataset(
+    async def create_dataset(self, user_id: str, request: EvaluationDatasetCreate) -> EvaluationDatasetEnvelope:
+        dataset = EvaluationDataset(
             user_id=user_id,
             collection_id=request.collection_id,
             name=request.name,
             description=request.description,
             source_type=request.source_type,
             schema_hint=request.schema_hint,
+            item_count=0,
         )
-        created = await self.db_ops.create_benchmark_dataset(dataset)
+        payload_items = list(request.items or [])
+        items = _items_from_payload(dataset_id="", payloads=payload_items)
+        created = await self.db_ops.create_evaluation_dataset(dataset, items)
         return _to_dataset_envelope(created)
 
     async def list_datasets(
@@ -131,187 +162,199 @@ class BenchmarkDatasetService:
         collection_id: Optional[str],
         page: int,
         page_size: int,
-    ) -> tuple[list[BenchmarkDatasetEnvelope], int]:
-        rows, total = await self.db_ops.list_benchmark_datasets(
-            user_id=user_id, collection_id=collection_id, page=page, page_size=page_size
+    ) -> tuple[list[EvaluationDatasetEnvelope], int]:
+        rows, total = await self.db_ops.list_evaluation_datasets(
+            user_id=user_id,
+            collection_id=collection_id,
+            page=page,
+            page_size=page_size,
         )
-        envelopes: list[BenchmarkDatasetEnvelope] = []
-        for dataset in rows:
-            latest = await self.db_ops.latest_published_version(dataset.id)
-            envelopes.append(_to_dataset_envelope(dataset, latest))
-        return envelopes, total
+        return [_to_dataset_envelope(r) for r in rows], total
 
-    async def get_dataset(self, user_id: str, dataset_id: str) -> BenchmarkDatasetEnvelope:
-        dataset = await self.db_ops.get_benchmark_dataset(user_id, dataset_id)
-        if not dataset:
-            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
-        latest = await self.db_ops.latest_published_version(dataset.id)
-        return _to_dataset_envelope(dataset, latest)
+    async def get_dataset(self, user_id: str, dataset_id: str) -> EvaluationDatasetEnvelope:
+        dataset = await self._require_dataset(user_id, dataset_id)
+        return _to_dataset_envelope(dataset)
 
     async def update_dataset(
         self,
         user_id: str,
         dataset_id: str,
-        request: BenchmarkDatasetUpdate,
-    ) -> BenchmarkDatasetEnvelope:
-        updated = await self.db_ops.update_benchmark_dataset(
+        request: EvaluationDatasetUpdate,
+    ) -> EvaluationDatasetEnvelope:
+        updated = await self.db_ops.update_evaluation_dataset(
             user_id,
             dataset_id,
             name=request.name,
             description=request.description,
         )
         if not updated:
-            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
+            raise ResourceNotFoundException("EvaluationDataset", dataset_id)
         return _to_dataset_envelope(updated)
 
     async def delete_dataset(self, user_id: str, dataset_id: str) -> None:
-        ok = await self.db_ops.soft_delete_benchmark_dataset(user_id, dataset_id)
+        ok = await self.db_ops.soft_delete_evaluation_dataset(user_id, dataset_id)
         if not ok:
-            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
+            raise ResourceNotFoundException("EvaluationDataset", dataset_id)
 
-    # Versions ------------------------------------------------------------
+    # Items ------------------------------------------------------------
 
-    async def create_version(
+    async def list_items(
         self,
         user_id: str,
         dataset_id: str,
-        request: BenchmarkDatasetVersionCreate,
-    ) -> BenchmarkDatasetVersionEnvelope:
-        dataset = await self.db_ops.get_benchmark_dataset(user_id, dataset_id)
-        if not dataset:
-            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
-        if not request.cases:
-            raise ValidationException("A dataset version must contain at least one case")
-
-        now = utc_now()
-        version_no = await self.db_ops.next_dataset_version_number(dataset_id)
-        version = BenchmarkDatasetVersion(
-            dataset_id=dataset_id,
-            version=version_no,
-            version_name=request.version_name,
-            status=BenchmarkDatasetVersionStatus.PUBLISHED,
-            case_count=0,
-            source_snapshot=request.source_snapshot,
-            gmt_published=now,
+        page: int,
+        page_size: int,
+    ) -> tuple[list[EvaluationDatasetItemEnvelope], int]:
+        await self._require_dataset(user_id, dataset_id)
+        rows, total = await self.db_ops.list_evaluation_dataset_items(
+            dataset_id=dataset_id, page=page, page_size=page_size
         )
+        return [_to_dataset_item_envelope(r) for r in rows], total
 
-        seen_keys: set[str] = set()
-        cases: list[BenchmarkCase] = []
-        for idx, payload in enumerate(request.cases):
-            key = (payload.case_key or f"case_{idx + 1:04d}").strip()
-            if key in seen_keys:
-                raise ValidationException(f"Duplicate case_key within version payload: {key}")
-            seen_keys.add(key)
-            cases.append(
-                BenchmarkCase(
-                    case_key=key,
-                    input_message=payload.input_message,
-                    expected_answer=payload.expected_answer,
-                    reference_context=payload.reference_context,
-                    tags=payload.tags,
-                    case_metadata=payload.case_metadata,
-                    sort_key=payload.sort_key or idx,
-                )
-            )
+    async def append_items(
+        self,
+        user_id: str,
+        dataset_id: str,
+        payloads: list[EvaluationDatasetItemCreate],
+    ) -> list[EvaluationDatasetItemEnvelope]:
+        dataset = await self._require_dataset(user_id, dataset_id)
+        start_index = dataset.item_count or 0
+        items = _items_from_payload(dataset_id=dataset.id, payloads=payloads, start_index=start_index)
+        created = await self.db_ops.append_evaluation_dataset_items(dataset.id, items)
+        return [_to_dataset_item_envelope(r) for r in created]
 
-        created = await self.db_ops.create_benchmark_dataset_version(dataset_id, version, cases)
-        return BenchmarkDatasetVersionEnvelope.model_validate(created)
+    async def update_item(
+        self,
+        user_id: str,
+        dataset_id: str,
+        item_id: str,
+        request: EvaluationDatasetItemUpdate,
+    ) -> EvaluationDatasetItemEnvelope:
+        await self._require_dataset(user_id, dataset_id)
+        updated = await self.db_ops.update_evaluation_dataset_item(
+            dataset_id=dataset_id,
+            item_id=item_id,
+            **request.model_dump(exclude_unset=True),
+        )
+        if not updated:
+            raise ResourceNotFoundException("EvaluationDatasetItem", item_id)
+        return _to_dataset_item_envelope(updated)
 
-    async def list_versions(self, user_id: str, dataset_id: str) -> list[BenchmarkDatasetVersionEnvelope]:
-        dataset = await self.db_ops.get_benchmark_dataset(user_id, dataset_id)
+    async def delete_item(self, user_id: str, dataset_id: str, item_id: str) -> None:
+        await self._require_dataset(user_id, dataset_id)
+        ok = await self.db_ops.soft_delete_evaluation_dataset_item(dataset_id, item_id)
+        if not ok:
+            raise ResourceNotFoundException("EvaluationDatasetItem", item_id)
+
+    async def list_all_items(self, dataset_id: str) -> list[EvaluationDatasetItem]:
+        return await self.db_ops.list_all_evaluation_dataset_items(dataset_id)
+
+    async def _require_dataset(self, user_id: str, dataset_id: str) -> EvaluationDataset:
+        dataset = await self.db_ops.get_evaluation_dataset(user_id, dataset_id)
         if not dataset:
-            raise ResourceNotFoundException("BenchmarkDataset", dataset_id)
-        rows = await self.db_ops.list_dataset_versions(dataset_id)
-        return [BenchmarkDatasetVersionEnvelope.model_validate(r) for r in rows]
-
-    async def get_version_envelope(
-        self, user_id: str, dataset_id: str, version_id: str
-    ) -> BenchmarkDatasetVersionEnvelope:
-        version = await self.get_version(user_id, version_id)
-        if version.dataset_id != dataset_id:
-            raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
-        return BenchmarkDatasetVersionEnvelope.model_validate(version)
-
-    async def get_version(self, user_id: str, version_id: str) -> BenchmarkDatasetVersion:
-        version = await self.db_ops.get_dataset_version(version_id)
-        if not version:
-            raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
-        dataset = await self.db_ops.get_benchmark_dataset(user_id, version.dataset_id)
-        if not dataset:
-            raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
-        return version
+            raise ResourceNotFoundException("EvaluationDataset", dataset_id)
+        return dataset
 
 
 class EvaluationRunService:
     """Evaluation run lifecycle: create / list / get / cancel / retry.
 
-    The worker pipeline that actually runs cases against Runtime V3 lives in
-    `aperag.evaluation_v2.tasks` and is wired in Phase 3. `launch_run` is the
-    single hand-off point the view layer uses, so Phase 3 can swap in the
-    Celery producer without touching the view.
+    ``create_run`` owns the snapshot-on-run transaction: value-copy dataset
+    items into ``evaluation_run_items``. Run detail / list / attempt read paths
+    only read these snapshot rows and never join the mutable
+    ``evaluation_dataset_items`` rows.
     """
 
     def __init__(
         self,
         db_ops: Optional[AsyncDatabaseOps] = None,
-        dataset_service: Optional[BenchmarkDatasetService] = None,
+        dataset_service: Optional[EvaluationDatasetService] = None,
     ):
         self.db_ops = db_ops or async_db_ops
-        self.dataset_service = dataset_service or BenchmarkDatasetService(self.db_ops)
+        self.dataset_service = dataset_service or EvaluationDatasetService(self.db_ops)
 
     async def create_run(self, user_id: str, request: EvaluationRunCreate) -> EvaluationRunEnvelope:
-        version = await self.dataset_service.get_version(user_id, request.dataset_version_id)
-        if version.status != BenchmarkDatasetVersionStatus.PUBLISHED:
-            raise ValidationException("Only published dataset versions can be evaluated")
-        bot = await self.db_ops.query_bot(user_id, request.bot_id)
-        if not bot:
-            raise ResourceNotFoundException("Bot", request.bot_id)
+        dataset = await self.dataset_service._require_dataset(user_id, request.dataset_id)
+        items = await self.dataset_service.list_all_items(dataset.id)
+        if not items:
+            raise ValidationException("Evaluation dataset has no items")
 
-        cases = await self.db_ops.list_all_cases_for_version(version.id)
-        if not cases:
-            raise ValidationException("Dataset version has no cases to evaluate")
+        bot_id = await self._resolve_bot_for_run(user_id, request.bot_id)
 
         judge_payload = request.judge.model_dump() if request.judge else None
         run = EvaluationRun(
             user_id=user_id,
-            bot_id=request.bot_id,
-            dataset_version_id=version.id,
+            bot_id=bot_id,
+            dataset_id=dataset.id,
+            collection_id=dataset.collection_id,
+            dataset_name=dataset.name,
             name=request.name,
             bot_config_snapshot=request.bot_config_snapshot,
             model_config_snapshot=request.model_config_snapshot,
             judge_config=judge_payload,
             status=EvaluationRunStatus.QUEUED,
-            summary=EvaluationRunSummary(total=len(cases), pending=len(cases)).model_dump(),
+            summary=EvaluationRunSummary(total=len(items), pending=len(items)).model_dump(),
         )
-        items = [
+        run_items = [
             EvaluationRunItem(
-                case_id=case.id,
-                case_key=case.case_key,
+                source_dataset_item_id=item.id,
+                case_key=item.case_key,
+                sort_key=item.sort_key,
+                # Value-copy snapshot — must not join back to mutable dataset items.
+                input_message=item.input_message,
+                expected_answer=item.expected_answer,
+                reference_context=item.reference_context,
+                tags=item.tags,
+                case_metadata=item.case_metadata,
             )
-            for case in cases
+            for item in items
         ]
 
-        created = await self.db_ops.create_evaluation_run(run, items)
+        created = await self.db_ops.create_evaluation_run(run, run_items)
         await self.launch_run(created.id)
         return _to_run_envelope(created)
 
-    async def launch_run(self, run_id: str) -> None:
-        """Hand the run off to the async worker pipeline.
+    async def _resolve_bot_for_run(self, user_id: str, explicit_bot_id: Optional[str]) -> str:
+        """Pick the bot for an evaluation run.
 
-        Phase 3 will replace this stub with a Celery producer call. Keeping
-        the seam here means the view layer and tests do not need to change.
+        Priority (no HTTP side-channels):
+          (a) explicit ``bot_id`` — must be active and user-owned;
+          (b) otherwise the user's active bot whose title matches
+              ``DEFAULT_AGENT_BOT_TITLE``;
+          (c) otherwise the user's oldest active bot (``gmt_created ASC``);
+          (d) no active bot → ``ValidationException``.
         """
+        if explicit_bot_id:
+            bot = await self.db_ops.query_bot(user_id, explicit_bot_id)
+            if not bot:
+                raise ValidationException("bot_id is not owned by the current user or is inactive")
+            return bot.id
+
+        resolved = await self.db_ops.resolve_default_evaluation_bot(user_id, default_title=DEFAULT_AGENT_BOT_TITLE)
+        if not resolved:
+            raise ValidationException("No bot available for evaluation run; specify bot_id explicitly")
+        return resolved.id
+
+    async def launch_run(self, run_id: str) -> None:
+        """Hand the run off to the async worker pipeline (Celery producer seam)."""
         return None
 
     async def list_runs(
         self,
         user_id: str,
         bot_id: Optional[str],
+        dataset_id: Optional[str],
+        collection_id: Optional[str],
         page: int,
         page_size: int,
     ) -> tuple[list[EvaluationRunEnvelope], int]:
         rows, total = await self.db_ops.list_evaluation_runs(
-            user_id=user_id, bot_id=bot_id, page=page, page_size=page_size
+            user_id=user_id,
+            bot_id=bot_id,
+            dataset_id=dataset_id,
+            collection_id=collection_id,
+            page=page,
+            page_size=page_size,
         )
         return [_to_run_envelope(r) for r in rows], total
 
@@ -341,12 +384,6 @@ class EvaluationRunService:
         return _to_run_envelope(updated)
 
     async def retry_run_item(self, user_id: str, run_id: str, item_id: str) -> EvaluationRunItemEnvelope:
-        """Re-queue a single run item for another attempt.
-
-        Per frozen contract the only retry surface is run-scoped item retry:
-        `POST /api/v2/evaluation-runs/{runId}/items/{itemId}/retry`. Phase 3
-        worker pipeline will pick the PENDING item and produce a new attempt.
-        """
         run = await self._require_run(user_id, run_id)
         item = await self.db_ops.get_run_item(item_id)
         if not item or item.run_id != run_id:
@@ -402,5 +439,5 @@ class EvaluationRunService:
         return run
 
 
-benchmark_dataset_service = BenchmarkDatasetService()
-evaluation_run_service = EvaluationRunService(dataset_service=benchmark_dataset_service)
+evaluation_dataset_service = EvaluationDatasetService()
+evaluation_run_service = EvaluationRunService(dataset_service=evaluation_dataset_service)

--- a/aperag/migration/versions/20260423180000-c1d2e3f4a5b7.py
+++ b/aperag/migration/versions/20260423180000-c1d2e3f4a5b7.py
@@ -1,0 +1,173 @@
+"""evaluation v3 phase 2: drop benchmark tables, switch evaluation runs to dataset snapshot
+
+Destructive migration that switches the evaluation schema onto the simplified
+Dataset + Run model. Prerequisites from the Phase 1 additive revision
+(``b9c8d7e6f1a2``): ``evaluation_datasets`` / ``evaluation_dataset_items``
+tables already exist.
+
+Steps in ``upgrade()``:
+
+1. Truncate the existing run tables. The public API was not formally
+   released; per ``#evaluation #20`` design + @earayu2 16:25 口径 there are
+   no production rows to preserve.
+2. Drop ``evaluation_runs.dataset_version_id`` and the matching index.
+3. Add the new ``evaluation_runs`` columns:
+   ``dataset_id`` (NOT NULL), ``collection_id`` (nullable), ``dataset_name``
+   (nullable snapshot). Indexes on ``dataset_id`` / ``collection_id``.
+4. Rewrite ``evaluation_run_items``: drop the ``case_id`` FK-style column
+   and its unique constraint; add ``source_dataset_item_id`` (audit, not an
+   FK), ``sort_key`` (NOT NULL), ``input_message`` (NOT NULL), plus the
+   nullable snapshot columns ``expected_answer``, ``reference_context``,
+   ``tags``, ``case_metadata``.
+5. Drop ``benchmark_cases``, ``benchmark_dataset_versions``,
+   ``benchmark_datasets``.
+
+``downgrade()`` is skeleton-only — it leaves the database at the cleared
+evaluation schema (empty ``evaluation_datasets`` / ``evaluation_dataset_items``)
+and does not resurrect the benchmark tables, because the simplified model is
+canonical going forward.
+
+Revision ID: c1d2e3f4a5b7
+Revises: b9c8d7e6f1a2
+Create Date: 2026-04-23 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c1d2e3f4a5b7"
+down_revision: Union[str, None] = "b9c8d7e6f1a2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1) Clear out existing evaluation runtime data — no production rows exist.
+    op.execute("TRUNCATE TABLE evaluation_run_item_attempts")
+    op.execute("TRUNCATE TABLE evaluation_run_items")
+    op.execute("TRUNCATE TABLE evaluation_runs")
+
+    # 2) evaluation_runs: drop dataset_version_id and reshape FK surface.
+    op.drop_index("idx_evaluation_runs_dataset_version", table_name="evaluation_runs")
+    op.drop_column("evaluation_runs", "dataset_version_id")
+
+    # 3) evaluation_runs: add the dataset-anchored columns.
+    op.add_column(
+        "evaluation_runs",
+        sa.Column("dataset_id", sa.String(length=32), nullable=False),
+    )
+    op.add_column(
+        "evaluation_runs",
+        sa.Column("collection_id", sa.String(length=24), nullable=True),
+    )
+    op.add_column(
+        "evaluation_runs",
+        sa.Column("dataset_name", sa.String(length=255), nullable=True),
+    )
+    op.create_index("idx_evaluation_runs_dataset", "evaluation_runs", ["dataset_id"])
+    op.create_index("idx_evaluation_runs_collection", "evaluation_runs", ["collection_id"])
+
+    # 4) evaluation_run_items: drop legacy case_* columns, add snapshot columns.
+    op.drop_constraint(
+        "uq_evaluation_run_item_run_case", "evaluation_run_items", type_="unique"
+    )
+    op.drop_column("evaluation_run_items", "case_id")
+
+    op.add_column(
+        "evaluation_run_items",
+        sa.Column("source_dataset_item_id", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "evaluation_run_items",
+        sa.Column("sort_key", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "evaluation_run_items",
+        sa.Column("input_message", sa.Text(), nullable=False, server_default=""),
+    )
+    # server_default seeded an empty string for the NOT NULL backfill; drop it
+    # so application code is forced to populate input_message explicitly.
+    op.alter_column("evaluation_run_items", "input_message", server_default=None)
+    op.add_column(
+        "evaluation_run_items",
+        sa.Column("expected_answer", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "evaluation_run_items",
+        sa.Column("reference_context", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "evaluation_run_items",
+        sa.Column("tags", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "evaluation_run_items",
+        sa.Column("case_metadata", sa.JSON(), nullable=True),
+    )
+
+    # 5) Drop the legacy benchmark tables.
+    op.drop_index("idx_benchmark_cases_version", table_name="benchmark_cases")
+    op.drop_table("benchmark_cases")
+
+    op.drop_index(
+        "idx_benchmark_dataset_versions_status", table_name="benchmark_dataset_versions"
+    )
+    op.drop_index(
+        "idx_benchmark_dataset_versions_dataset", table_name="benchmark_dataset_versions"
+    )
+    op.drop_table("benchmark_dataset_versions")
+
+    op.drop_index(
+        "ix_benchmark_datasets_gmt_deleted", table_name="benchmark_datasets"
+    )
+    op.drop_index("idx_benchmark_datasets_collection", table_name="benchmark_datasets")
+    op.drop_index("idx_benchmark_datasets_user", table_name="benchmark_datasets")
+    op.drop_table("benchmark_datasets")
+
+
+def downgrade() -> None:
+    # Skeleton-only downgrade: revert the evaluation_runs / run_items column
+    # reshape so the schema matches the Phase 1 state. We intentionally do NOT
+    # re-create the benchmark_* tables — the simplified model is canonical and
+    # the old layout was never released to production.
+    op.execute("TRUNCATE TABLE evaluation_run_item_attempts")
+    op.execute("TRUNCATE TABLE evaluation_run_items")
+    op.execute("TRUNCATE TABLE evaluation_runs")
+
+    op.drop_column("evaluation_run_items", "case_metadata")
+    op.drop_column("evaluation_run_items", "tags")
+    op.drop_column("evaluation_run_items", "reference_context")
+    op.drop_column("evaluation_run_items", "expected_answer")
+    op.drop_column("evaluation_run_items", "input_message")
+    op.drop_column("evaluation_run_items", "sort_key")
+    op.drop_column("evaluation_run_items", "source_dataset_item_id")
+    op.add_column(
+        "evaluation_run_items",
+        sa.Column("case_id", sa.String(length=32), nullable=False, server_default=""),
+    )
+    op.alter_column("evaluation_run_items", "case_id", server_default=None)
+    op.create_unique_constraint(
+        "uq_evaluation_run_item_run_case",
+        "evaluation_run_items",
+        ["run_id", "case_id"],
+    )
+
+    op.drop_index("idx_evaluation_runs_collection", table_name="evaluation_runs")
+    op.drop_index("idx_evaluation_runs_dataset", table_name="evaluation_runs")
+    op.drop_column("evaluation_runs", "dataset_name")
+    op.drop_column("evaluation_runs", "collection_id")
+    op.drop_column("evaluation_runs", "dataset_id")
+
+    op.add_column(
+        "evaluation_runs",
+        sa.Column(
+            "dataset_version_id", sa.String(length=32), nullable=False, server_default=""
+        ),
+    )
+    op.alter_column("evaluation_runs", "dataset_version_id", server_default=None)
+    op.create_index(
+        "idx_evaluation_runs_dataset_version", "evaluation_runs", ["dataset_version_id"]
+    )

--- a/aperag/views/evaluation_v2.py
+++ b/aperag/views/evaluation_v2.py
@@ -18,16 +18,16 @@ from fastapi import APIRouter, Depends, Query, Response
 
 from aperag.db.models import User
 from aperag.evaluation_v2.schemas import (
-    BenchmarkCaseEnvelope,
-    BenchmarkCaseListResponse,
-    BenchmarkDatasetCreate,
-    BenchmarkDatasetEnvelope,
-    BenchmarkDatasetListResponse,
-    BenchmarkDatasetUpdate,
-    BenchmarkDatasetVersionCreate,
-    BenchmarkDatasetVersionEnvelope,
-    BenchmarkDatasetVersionListResponse,
     CancelRunResponse,
+    EvaluationDatasetCreate,
+    EvaluationDatasetEnvelope,
+    EvaluationDatasetItemEnvelope,
+    EvaluationDatasetItemListResponse,
+    EvaluationDatasetItemsAppendRequest,
+    EvaluationDatasetItemsAppendResponse,
+    EvaluationDatasetItemUpdate,
+    EvaluationDatasetListResponse,
+    EvaluationDatasetUpdate,
     EvaluationPagination,
     EvaluationRunCreate,
     EvaluationRunDetailResponse,
@@ -37,8 +37,7 @@ from aperag.evaluation_v2.schemas import (
     EvaluationRunItemListResponse,
     EvaluationRunListResponse,
 )
-from aperag.evaluation_v2.services import benchmark_dataset_service, evaluation_run_service
-from aperag.exceptions import ResourceNotFoundException
+from aperag.evaluation_v2.services import evaluation_dataset_service, evaluation_run_service
 from aperag.views.auth import required_user
 
 router = APIRouter(tags=["evaluation-v2"])
@@ -70,108 +69,115 @@ async def _enrich_run_items(
     return list(await asyncio.gather(*[_enrich_run_item(user_id, run_id, item) for item in items]))
 
 
-@router.post("/benchmark-datasets", response_model=BenchmarkDatasetEnvelope)
-async def create_benchmark_dataset_view(
-    body: BenchmarkDatasetCreate,
+# ---------------------------------------------------------------------------
+# Evaluation datasets
+# ---------------------------------------------------------------------------
+
+
+@router.post("/evaluation-datasets", response_model=EvaluationDatasetEnvelope)
+async def create_evaluation_dataset_view(
+    body: EvaluationDatasetCreate,
     user: User = Depends(required_user),
-) -> BenchmarkDatasetEnvelope:
-    return await benchmark_dataset_service.create_dataset(str(user.id), body)
+) -> EvaluationDatasetEnvelope:
+    return await evaluation_dataset_service.create_dataset(str(user.id), body)
 
 
-@router.get("/benchmark-datasets", response_model=BenchmarkDatasetListResponse)
-async def list_benchmark_datasets_view(
+@router.get("/evaluation-datasets", response_model=EvaluationDatasetListResponse)
+async def list_evaluation_datasets_view(
     collection_id: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     user: User = Depends(required_user),
-) -> BenchmarkDatasetListResponse:
-    items, total = await benchmark_dataset_service.list_datasets(str(user.id), collection_id, page, page_size)
-    return BenchmarkDatasetListResponse(items=items, pagination=_pagination(total, page, page_size))
+) -> EvaluationDatasetListResponse:
+    items, total = await evaluation_dataset_service.list_datasets(str(user.id), collection_id, page, page_size)
+    return EvaluationDatasetListResponse(items=items, pagination=_pagination(total, page, page_size))
 
 
-@router.get("/benchmark-datasets/{dataset_id}", response_model=BenchmarkDatasetEnvelope)
-async def get_benchmark_dataset_view(
+@router.get("/evaluation-datasets/{dataset_id}", response_model=EvaluationDatasetEnvelope)
+async def get_evaluation_dataset_view(
     dataset_id: str,
     user: User = Depends(required_user),
-) -> BenchmarkDatasetEnvelope:
-    return await benchmark_dataset_service.get_dataset(str(user.id), dataset_id)
+) -> EvaluationDatasetEnvelope:
+    return await evaluation_dataset_service.get_dataset(str(user.id), dataset_id)
 
 
-@router.put("/benchmark-datasets/{dataset_id}", response_model=BenchmarkDatasetEnvelope)
-async def update_benchmark_dataset_view(
+@router.put("/evaluation-datasets/{dataset_id}", response_model=EvaluationDatasetEnvelope)
+async def update_evaluation_dataset_view(
     dataset_id: str,
-    body: BenchmarkDatasetUpdate,
+    body: EvaluationDatasetUpdate,
     user: User = Depends(required_user),
-) -> BenchmarkDatasetEnvelope:
-    return await benchmark_dataset_service.update_dataset(str(user.id), dataset_id, body)
+) -> EvaluationDatasetEnvelope:
+    return await evaluation_dataset_service.update_dataset(str(user.id), dataset_id, body)
 
 
-@router.delete("/benchmark-datasets/{dataset_id}", status_code=204)
-async def delete_benchmark_dataset_view(
+@router.delete("/evaluation-datasets/{dataset_id}", status_code=204)
+async def delete_evaluation_dataset_view(
     dataset_id: str,
     user: User = Depends(required_user),
 ) -> Response:
-    await benchmark_dataset_service.delete_dataset(str(user.id), dataset_id)
+    await evaluation_dataset_service.delete_dataset(str(user.id), dataset_id)
     return Response(status_code=204)
 
 
-@router.post(
-    "/benchmark-datasets/{dataset_id}/versions",
-    response_model=BenchmarkDatasetVersionEnvelope,
-)
-async def create_benchmark_dataset_version_view(
-    dataset_id: str,
-    body: BenchmarkDatasetVersionCreate,
-    user: User = Depends(required_user),
-) -> BenchmarkDatasetVersionEnvelope:
-    return await benchmark_dataset_service.create_version(str(user.id), dataset_id, body)
+# Items -------------------------------------------------------------------
 
 
 @router.get(
-    "/benchmark-datasets/{dataset_id}/versions",
-    response_model=BenchmarkDatasetVersionListResponse,
+    "/evaluation-datasets/{dataset_id}/items",
+    response_model=EvaluationDatasetItemListResponse,
 )
-async def list_benchmark_dataset_versions_view(
+async def list_evaluation_dataset_items_view(
     dataset_id: str,
-    user: User = Depends(required_user),
-) -> BenchmarkDatasetVersionListResponse:
-    items = await benchmark_dataset_service.list_versions(str(user.id), dataset_id)
-    return BenchmarkDatasetVersionListResponse(
-        items=items,
-        pagination=EvaluationPagination(total=len(items), offset=0, limit=len(items)),
-    )
-
-
-@router.get(
-    "/benchmark-datasets/{dataset_id}/versions/{version_id}",
-    response_model=BenchmarkDatasetVersionEnvelope,
-)
-async def get_benchmark_dataset_version_view(
-    dataset_id: str,
-    version_id: str,
-    user: User = Depends(required_user),
-) -> BenchmarkDatasetVersionEnvelope:
-    return await benchmark_dataset_service.get_version_envelope(str(user.id), dataset_id, version_id)
-
-
-@router.get(
-    "/benchmark-datasets/{dataset_id}/versions/{version_id}/cases",
-    response_model=BenchmarkCaseListResponse,
-)
-async def list_benchmark_cases_view(
-    dataset_id: str,
-    version_id: str,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=100, ge=1, le=500),
     user: User = Depends(required_user),
-) -> BenchmarkCaseListResponse:
-    version = await benchmark_dataset_service.get_version(str(user.id), version_id)
-    if version.dataset_id != dataset_id:
-        raise ResourceNotFoundException("BenchmarkDatasetVersion", version_id)
+) -> EvaluationDatasetItemListResponse:
+    items, total = await evaluation_dataset_service.list_items(str(user.id), dataset_id, page, page_size)
+    return EvaluationDatasetItemListResponse(items=items, pagination=_pagination(total, page, page_size))
 
-    rows, total = await benchmark_dataset_service.db_ops.list_cases_for_version(version_id, page, page_size)
-    items = [BenchmarkCaseEnvelope.model_validate(row) for row in rows]
-    return BenchmarkCaseListResponse(items=items, pagination=_pagination(total, page, page_size))
+
+@router.post(
+    "/evaluation-datasets/{dataset_id}/items",
+    response_model=EvaluationDatasetItemsAppendResponse,
+)
+async def append_evaluation_dataset_items_view(
+    dataset_id: str,
+    body: EvaluationDatasetItemsAppendRequest,
+    user: User = Depends(required_user),
+) -> EvaluationDatasetItemsAppendResponse:
+    created = await evaluation_dataset_service.append_items(str(user.id), dataset_id, list(body.items))
+    return EvaluationDatasetItemsAppendResponse(items=created)
+
+
+@router.put(
+    "/evaluation-datasets/{dataset_id}/items/{item_id}",
+    response_model=EvaluationDatasetItemEnvelope,
+)
+async def update_evaluation_dataset_item_view(
+    dataset_id: str,
+    item_id: str,
+    body: EvaluationDatasetItemUpdate,
+    user: User = Depends(required_user),
+) -> EvaluationDatasetItemEnvelope:
+    return await evaluation_dataset_service.update_item(str(user.id), dataset_id, item_id, body)
+
+
+@router.delete(
+    "/evaluation-datasets/{dataset_id}/items/{item_id}",
+    status_code=204,
+)
+async def delete_evaluation_dataset_item_view(
+    dataset_id: str,
+    item_id: str,
+    user: User = Depends(required_user),
+) -> Response:
+    await evaluation_dataset_service.delete_item(str(user.id), dataset_id, item_id)
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation runs
+# ---------------------------------------------------------------------------
 
 
 @router.post("/evaluation-runs", response_model=EvaluationRunEnvelope)
@@ -185,11 +191,15 @@ async def create_evaluation_run_view(
 @router.get("/evaluation-runs", response_model=EvaluationRunListResponse)
 async def list_evaluation_runs_view(
     bot_id: str | None = Query(default=None),
+    dataset_id: str | None = Query(default=None),
+    collection_id: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     user: User = Depends(required_user),
 ) -> EvaluationRunListResponse:
-    items, total = await evaluation_run_service.list_runs(str(user.id), bot_id, page, page_size)
+    items, total = await evaluation_run_service.list_runs(
+        str(user.id), bot_id, dataset_id, collection_id, page, page_size
+    )
     return EvaluationRunListResponse(items=items, pagination=_pagination(total, page, page_size))
 
 

--- a/tests/unit_test/test_evaluation_v2_openapi_contract.py
+++ b/tests/unit_test/test_evaluation_v2_openapi_contract.py
@@ -17,11 +17,10 @@ def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
 
 
 REQUIRED_PATHS = (
-    "/api/v2/benchmark-datasets",
-    "/api/v2/benchmark-datasets/{dataset_id}",
-    "/api/v2/benchmark-datasets/{dataset_id}/versions",
-    "/api/v2/benchmark-datasets/{dataset_id}/versions/{version_id}",
-    "/api/v2/benchmark-datasets/{dataset_id}/versions/{version_id}/cases",
+    "/api/v2/evaluation-datasets",
+    "/api/v2/evaluation-datasets/{dataset_id}",
+    "/api/v2/evaluation-datasets/{dataset_id}/items",
+    "/api/v2/evaluation-datasets/{dataset_id}/items/{item_id}",
     "/api/v2/evaluation-runs",
     "/api/v2/evaluation-runs/{run_id}",
     "/api/v2/evaluation-runs/{run_id}/cancel",
@@ -38,11 +37,15 @@ def test_evaluation_v2_routes_are_public_and_typed():
     for p in REQUIRED_PATHS:
         assert p in paths, f"missing public path {p}"
 
-    assert _json_ref(spec, "/api/v2/benchmark-datasets", "post") == "#/components/schemas/BenchmarkDatasetEnvelope"
-    assert _json_ref(spec, "/api/v2/benchmark-datasets", "get") == "#/components/schemas/BenchmarkDatasetListResponse"
+    assert _json_ref(spec, "/api/v2/evaluation-datasets", "post") == "#/components/schemas/EvaluationDatasetEnvelope"
+    assert _json_ref(spec, "/api/v2/evaluation-datasets", "get") == "#/components/schemas/EvaluationDatasetListResponse"
     assert (
-        _json_ref(spec, "/api/v2/benchmark-datasets/{dataset_id}/versions", "post")
-        == "#/components/schemas/BenchmarkDatasetVersionEnvelope"
+        _json_ref(spec, "/api/v2/evaluation-datasets/{dataset_id}/items", "get")
+        == "#/components/schemas/EvaluationDatasetItemListResponse"
+    )
+    assert (
+        _json_ref(spec, "/api/v2/evaluation-datasets/{dataset_id}/items", "post")
+        == "#/components/schemas/EvaluationDatasetItemsAppendResponse"
     )
     assert _json_ref(spec, "/api/v2/evaluation-runs", "post") == "#/components/schemas/EvaluationRunEnvelope"
     assert (
@@ -55,17 +58,6 @@ def test_evaluation_v2_routes_are_public_and_typed():
         _json_ref(spec, "/api/v2/evaluation-runs/{run_id}/items/{item_id}/retry", "post")
         == "#/components/schemas/EvaluationRunItemEnvelope"
     )
-
-
-def test_evaluation_v2_write_request_bodies_omit_path_params():
-    spec = _evaluation_v2_spec()
-    components = spec["components"]["schemas"]
-
-    create_version_ref = spec["paths"]["/api/v2/benchmark-datasets/{dataset_id}/versions"]["post"]["requestBody"][
-        "content"
-    ]["application/json"]["schema"]["$ref"]
-    create_version_schema = components[create_version_ref.removeprefix("#/components/schemas/")]
-    assert "dataset_id" not in create_version_schema.get("properties", {})
 
 
 def test_evaluation_v2_operation_ids_are_unique():
@@ -93,27 +85,61 @@ def test_full_app_spec_has_no_v1_evaluation_or_question_set_paths():
         assert not ghost, f"{spec_name} spec must not expose v1 evaluation/question-set paths; found {ghost}"
 
 
-def test_evaluation_v2_delete_benchmark_dataset_has_no_json_body():
+def test_evaluation_v2_benchmark_and_version_paths_removed():
+    """Negative gate: the simplified evaluation API must not leak the retired
+    ``Benchmark`` / ``Dataset Version`` concepts into the public contract."""
+
     spec = _evaluation_v2_spec()
-    responses = spec["paths"]["/api/v2/benchmark-datasets/{dataset_id}"]["delete"]["responses"]
+    leaked = sorted(
+        path for path in spec["paths"] if path.startswith("/api/v2/benchmark-datasets") or "/versions" in path
+    )
+    assert not leaked, f"evaluation_v2 router must not expose benchmark/version paths; found {leaked}"
 
-    assert "204" in responses, "DELETE /benchmark-datasets/{dataset_id} must expose a 204 response"
-    assert "200" not in responses, "DELETE /benchmark-datasets/{dataset_id} must not declare a 200 response"
+    components = spec.get("components", {}).get("schemas", {}) or {}
+    forbidden_schemas = sorted(name for name in components if name.startswith("Benchmark"))
+    assert not forbidden_schemas, f"evaluation_v2 spec must not export Benchmark* schemas; found {forbidden_schemas}"
 
-    # The success response must be a bare 204 with no body schema.
+
+def test_evaluation_run_create_requires_dataset_id_allows_optional_bot():
+    """``EvaluationRunCreate`` pins the simplified run contract:
+
+    - ``dataset_id`` is required;
+    - ``bot_id`` is optional (service resolves the default bot);
+    - legacy ``dataset_version_id`` must not appear.
+    """
+
+    spec = _evaluation_v2_spec()
+    components = spec["components"]["schemas"]
+    request_ref = spec["paths"]["/api/v2/evaluation-runs"]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]["$ref"]
+    schema = components[request_ref.removeprefix("#/components/schemas/")]
+    properties = schema.get("properties", {})
+    required = set(schema.get("required", []) or [])
+
+    assert "dataset_id" in properties
+    assert "dataset_id" in required
+    assert "bot_id" in properties
+    assert "bot_id" not in required
+    assert "dataset_version_id" not in properties
+
+
+def test_evaluation_v2_delete_dataset_has_no_json_body():
+    spec = _evaluation_v2_spec()
+    responses = spec["paths"]["/api/v2/evaluation-datasets/{dataset_id}"]["delete"]["responses"]
+
+    assert "204" in responses, "DELETE /evaluation-datasets/{dataset_id} must expose a 204 response"
+    assert "200" not in responses, "DELETE /evaluation-datasets/{dataset_id} must not declare a 200 response"
+
     success_content = (responses["204"] or {}).get("content") or {}
     assert "application/json" not in success_content, (
-        "DELETE /benchmark-datasets/{dataset_id} 204 response must not carry an application/json body"
+        "DELETE /evaluation-datasets/{dataset_id} 204 response must not carry an application/json body"
     )
 
 
 def test_evaluation_v2_all_write_request_bodies_omit_path_params():
-    """Every POST/PUT/PATCH request body under evaluation_v2 must not redeclare path params.
-
-    Generalizes ``test_evaluation_v2_write_request_bodies_omit_path_params`` so new write routes
-    (BenchmarkDatasetCreate / BenchmarkDatasetUpdate / EvaluationRunCreate / future additions)
-    are covered automatically.
-    """
+    """Every POST/PUT/PATCH request body under ``evaluation_v2`` must not
+    redeclare any path parameter as a body property."""
 
     spec = _evaluation_v2_spec()
     components = spec["components"]["schemas"]


### PR DESCRIPTION
## Summary

Phase 2 / PR-1 of the evaluation-v3 simplification (`#evaluation #20`). Switches the backend onto the simplified **Dataset + Evaluation/Run** contract and deletes the old `Benchmark*` / `Dataset Version` surface in one coordinated destructive PR, per @符炫炜 PM direction and @earayu2's explicit approval of destructive changes (msg=6a3ea78f). Builds on PR-0 additive foundation (#1588, `8554e51c`).

## Write set

### Public API
- **New routes** on `/api/v2/evaluation-datasets*`: create / list / get / update / soft-delete dataset, plus item list / append / update / soft-delete.
- **Rewrites** on `/api/v2/evaluation-runs*`: `EvaluationRunCreate` now takes `dataset_id` (required) + `bot_id` (optional); `GET /evaluation-runs` accepts `collection_id?` / `dataset_id?` / `bot_id?` filters.
- **Deletes** every `/api/v2/benchmark-datasets*` route (including `/versions*`).

### Service / runtime
- `EvaluationDatasetService` owns dataset + item CRUD, reusing the Phase 1 repository helpers.
- `EvaluationRunService.create_run` implements **snapshot-on-run**: value-copies each dataset item into `evaluation_run_items`. Run detail / list / attempt read paths only read snapshot columns and never join back to mutable dataset items.
- `_resolve_bot_for_run` delegates to the DB-only `resolve_default_evaluation_bot` helper: explicit `bot_id` → user-owned active; else active bot with `title == DEFAULT_AGENT_BOT_TITLE`; else oldest active bot; else `ValidationException`. No HTTP bot-route side-channels (Bryce edge).

### Schema / DB
- Drop SQLAlchemy models `BenchmarkDataset`, `BenchmarkDatasetVersion`, `BenchmarkCase` and their enums.
- Add `collection_id`, `dataset_name`, `dataset_id` (NOT NULL) to `EvaluationRun`; drop `dataset_version_id`.
- Reshape `EvaluationRunItem` to carry the self-contained snapshot columns (`source_dataset_item_id` audit-only, `case_key`, `sort_key`, `input_message`, `expected_answer`, `reference_context`, `tags`, `case_metadata`) and drop `case_id` + its unique constraint.
- Delete all `Benchmark*` pydantic schemas; remove all `Benchmark*` repository helpers.
- `list_evaluation_runs` grows optional `dataset_id` and `collection_id` filters (keyword-only, defaulting to `None`).

### New alembic revision `c1d2e3f4a5b7` (`down_revision = "b9c8d7e6f1a2"`)
- `upgrade()` TRUNCATEs run-related tables (no production data), drops `evaluation_runs.dataset_version_id`, adds the new run columns + indexes, reshapes `evaluation_run_items`, then drops `benchmark_cases` / `benchmark_dataset_versions` / `benchmark_datasets` + their indexes.
- `downgrade()` is skeleton-only: reverts the run/run_item column reshape but intentionally does **not** re-create the benchmark tables (simplified model is canonical).

### Contract tests
- `tests/unit_test/test_evaluation_v2_openapi_contract.py`:
  - `REQUIRED_PATHS` points at the new evaluation-datasets + evaluation-runs set.
  - Positive: pins new response-model refs.
  - **New negative**: `test_evaluation_v2_benchmark_and_version_paths_removed` rejects any `/benchmark-datasets*` or `/versions*` path and any `Benchmark*` schema in `components.schemas`.
  - **New**: `test_evaluation_run_create_requires_dataset_id_allows_optional_bot` asserts `dataset_id` required, `bot_id` optional, no `dataset_version_id`.
  - **New**: `test_evaluation_v2_delete_dataset_has_no_json_body` mirrors the benchmark-dataset 204 guard on the new DELETE path.
  - Generalised path-param omission gate retained.

## Out of scope (follow-ups)

- **PR-2 (FE + docs + polish)**: regenerate `web/src/api-v2/schema.d.ts`, rewrite `features/evaluation/*` adapter, add `/workspace/collections/[collectionId]/evaluations/page.tsx`, delete `/benchmarks/page.tsx`, update `test_web_typed_api_contract.py` evaluation boundary (positive + negative), i18n / `web/global.ts`, docs + hurl. Tracked separately.

## Test plan

- [x] `uv run --extra test pytest tests/unit_test/test_evaluation_v2_openapi_contract.py tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_openapi_spec.py -q` → **18 passed** (7 new/updated evaluation contract tests + 8 web typed-api contract tests + 3 openapi-spec tests)
- [x] `make lint` → `All checks passed!` / `235 files already formatted`
- [x] `make openapi-check` → exit 0
- [x] `git diff --check main...HEAD` → clean
- [ ] CI `lint-and-unit` green
- [ ] 1× diff-scoped no-blocker CR

## Related

- Base: `main @ 8554e51c` (PR-0 additive foundation #1588 merge point).
- Design baseline: `#evaluation #20` thread + design report + msg=659ba863 + msg=38d7e74d patches.
- Follows: @符炫炜 PR-1 scope decision (msg=271bd4a3), @Weston runtime-snapshot hard requirement (msg=d753d4ca).
- Merge gate: 1 no-blocker CR + `lint-and-unit` SUCCESS + `mergeStateStatus=CLEAN` → admin merge (e2e not gated per @earayu2 msg=e7f3f106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)