### PR TITLE
fix: update e2e HTTP tests for v2 routes

### DIFF
--- a/tests/e2e_http/hurl/full/11_document_full.hurl
+++ b/tests/e2e_http/hurl/full/11_document_full.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/collections
+POST {{base_url}}/api/v2/collections
 Content-Type: application/json
 {
   "title": "Document Full {{run_id}}",
@@ -39,7 +39,7 @@ jsonpath "$.id" == "{{collection_id}}"
 jsonpath "$.config.enable_vector" == true
 jsonpath "$.config.enable_fulltext" == true
 
-POST {{base_url}}/api/v1/collections/{{collection_id}}/documents/upload
+POST {{base_url}}/api/v2/collections/{{collection_id}}/documents/upload
 [MultipartFormData]
 file: file,tests/e2e_http/testdata/full-document.txt; type=text/plain
 HTTP 200
@@ -50,14 +50,14 @@ jsonpath "$.document_id" == "{{document_id}}"
 jsonpath "$.status" == "UPLOADED"
 jsonpath "$.filename" == "tests/e2e_http/testdata/full-document.txt"
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}/documents/staged
+GET {{base_url}}/api/v2/collections/{{collection_id}}/documents/staged
 HTTP 200
 [Asserts]
 jsonpath "$.documents[0].document_id" == "{{document_id}}"
 jsonpath "$.documents[0].status" == "UPLOADED"
 jsonpath "$.total" == 1
 
-POST {{base_url}}/api/v1/collections/{{collection_id}}/documents/confirm
+POST {{base_url}}/api/v2/collections/{{collection_id}}/documents/confirm
 Content-Type: application/json
 {
   "document_ids": ["{{document_id}}"]
@@ -67,7 +67,7 @@ HTTP 200
 jsonpath "$.confirmed_count" == 1
 jsonpath "$.failed_count" == 0
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}/documents
+GET {{base_url}}/api/v2/collections/{{collection_id}}/documents
 HTTP 200
 [Asserts]
 jsonpath "$.items[0].id" == "{{document_id}}"
@@ -76,7 +76,7 @@ jsonpath "$.items[0].status" exists
 jsonpath "$.items[0].fulltext_index_status" exists
 jsonpath "$.total" == 1
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}
+GET {{base_url}}/api/v2/collections/{{collection_id}}/documents/{{document_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{document_id}}"
@@ -88,7 +88,7 @@ jsonpath "$.graph_index_status" == "SKIPPED"
 jsonpath "$.summary_index_status" == "SKIPPED"
 jsonpath "$.vision_index_status" == "SKIPPED"
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}/preview
+GET {{base_url}}/api/v2/collections/{{collection_id}}/documents/{{document_id}}/preview
 HTTP 200
 [Asserts]
 jsonpath "$.doc_object_path" == "original.txt"
@@ -98,7 +98,7 @@ jsonpath "$.markdown_content" exists
 jsonpath "$.chunks" exists
 jsonpath "$.vision_chunks" exists
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}/documents?search=full-document&sort_by=status&sort_order=asc
+GET {{base_url}}/api/v2/collections/{{collection_id}}/documents?search=full-document&sort_by=status&sort_order=asc
 HTTP 200
 [Asserts]
 jsonpath "$.items[0].id" == "{{document_id}}"
@@ -136,24 +136,21 @@ jsonpath "$.items[0].items" exists
 DELETE {{base_url}}/api/v1/collections/{{collection_id}}/searches/{{search_id}}
 HTTP 200
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}/download
+GET {{base_url}}/api/v2/collections/{{collection_id}}/documents/{{document_id}}/download
 HTTP 200
 [Asserts]
 header "content-disposition" contains "attachment"
 header "content-disposition" contains "full-document.txt"
 
-POST {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}/rebuild_indexes
+POST {{base_url}}/api/v2/collections/{{collection_id}}/documents/{{document_id}}/rebuild_indexes
 Content-Type: application/json
 {
   "index_types": ["FULLTEXT"]
 }
 HTTP 200
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}
-HTTP 200
-[Asserts]
-jsonpath "$.id" == "{{document_id}}"
-jsonpath "$.status" == "DELETED"
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}/documents/{{document_id}}
+HTTP 204
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}
-HTTP 200
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}
+HTTP 204

--- a/tests/e2e_http/hurl/full/12_bot.hurl
+++ b/tests/e2e_http/hurl/full/12_bot.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/bots
+POST {{base_url}}/api/v2/bots
 Content-Type: application/json
 {
   "title": "Bot Full {{run_id}}",
@@ -21,18 +21,18 @@ jsonpath "$.id" == "{{bot_id}}"
 jsonpath "$.title" == "Bot Full {{run_id}}"
 jsonpath "$.type" == "agent"
 
-GET {{base_url}}/api/v1/bots
+GET {{base_url}}/api/v2/bots
 HTTP 200
 [Asserts]
 body contains "\"id\":\"{{bot_id}}\""
 
-GET {{base_url}}/api/v1/bots/{{bot_id}}
+GET {{base_url}}/api/v2/bots/{{bot_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{bot_id}}"
 jsonpath "$.description" == "HTTP full bot coverage"
 
-POST {{base_url}}/api/v1/collections
+POST {{base_url}}/api/v2/collections
 Content-Type: application/json
 {
   "title": "Bot Collection {{run_id}}",
@@ -54,7 +54,7 @@ collection_id: jsonpath "$.id"
 jsonpath "$.id" == "{{collection_id}}"
 jsonpath "$.config.source" == "system"
 
-PUT {{base_url}}/api/v1/bots/{{bot_id}}
+PUT {{base_url}}/api/v2/bots/{{bot_id}}
 Content-Type: application/json
 {
   "title": "Bot Full {{run_id}} Updated",
@@ -89,7 +89,7 @@ jsonpath "$.config.agent.system_prompt_template" == "You are Bot Full {{run_id}}
 jsonpath "$.config.agent.query_prompt_template" == "Answer the request: {query}"
 jsonpath "$.config.agent.collections[0].id" == "{{collection_id}}"
 
-GET {{base_url}}/api/v1/bots/{{bot_id}}
+GET {{base_url}}/api/v2/bots/{{bot_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{bot_id}}"
@@ -97,8 +97,8 @@ jsonpath "$.title" == "Bot Full {{run_id}} Updated"
 jsonpath "$.config.agent.completion.model" == "google/gemini-2.5-flash"
 jsonpath "$.config.agent.collections[0].id" == "{{collection_id}}"
 
-DELETE {{base_url}}/api/v1/bots/{{bot_id}}
+DELETE {{base_url}}/api/v2/bots/{{bot_id}}
 HTTP 204
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}
-HTTP 200
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}
+HTTP 204

--- a/tests/e2e_http/hurl/full/13_chat_http.hurl
+++ b/tests/e2e_http/hurl/full/13_chat_http.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/bots
+POST {{base_url}}/api/v2/bots
 Content-Type: application/json
 {
   "title": "Chat Bot {{run_id}}",
@@ -32,7 +32,7 @@ bot_id: jsonpath "$.id"
 jsonpath "$.id" == "{{bot_id}}"
 jsonpath "$.config.agent.completion.model" == "google/gemini-2.5-flash"
 
-POST {{base_url}}/api/v1/bots/{{bot_id}}/chats
+POST {{base_url}}/api/v2/bots/{{bot_id}}/chats
 HTTP 200
 [Captures]
 chat_id: jsonpath "$.id"
@@ -40,12 +40,12 @@ chat_id: jsonpath "$.id"
 jsonpath "$.id" == "{{chat_id}}"
 jsonpath "$.bot_id" == "{{bot_id}}"
 
-GET {{base_url}}/api/v1/bots/{{bot_id}}/chats?page=1&page_size=20
+GET {{base_url}}/api/v2/bots/{{bot_id}}/chats?page=1&page_size=20
 HTTP 200
 [Asserts]
 jsonpath "$.items[0].id" == "{{chat_id}}"
 
-PUT {{base_url}}/api/v1/bots/{{bot_id}}/chats/{{chat_id}}
+PUT {{base_url}}/api/v2/bots/{{bot_id}}/chats/{{chat_id}}
 Content-Type: application/json
 {
   "title": "Chat Title {{run_id}}"
@@ -55,7 +55,7 @@ HTTP 200
 jsonpath "$.id" == "{{chat_id}}"
 jsonpath "$.title" == "Chat Title {{run_id}}"
 
-GET {{base_url}}/api/v1/bots/{{bot_id}}/chats/{{chat_id}}
+GET {{base_url}}/api/v2/bots/{{bot_id}}/chats/{{chat_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{chat_id}}"
@@ -80,8 +80,8 @@ jsonpath "$.model" == "aperag"
 jsonpath "$.choices[0].message.role" == "assistant"
 jsonpath "$.choices[0].message.content" exists
 
-DELETE {{base_url}}/api/v1/bots/{{bot_id}}/chats/{{chat_id}}
+DELETE {{base_url}}/api/v2/bots/{{bot_id}}/chats/{{chat_id}}
 HTTP 204
 
-DELETE {{base_url}}/api/v1/bots/{{bot_id}}
+DELETE {{base_url}}/api/v2/bots/{{bot_id}}
 HTTP 204

--- a/tests/e2e_http/hurl/full/14_graph_http.hurl
+++ b/tests/e2e_http/hurl/full/14_graph_http.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/collections
+POST {{base_url}}/api/v2/collections
 Content-Type: application/json
 {
   "title": "Graph Full {{run_id}}",
@@ -58,5 +58,5 @@ HTTP 400
 header "content-type" contains "application/json"
 body contains "max_nodes must be between 1 and 10000"
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}
-HTTP 200
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}
+HTTP 204

--- a/tests/e2e_http/hurl/full/15_agent_runtime_v3.hurl
+++ b/tests/e2e_http/hurl/full/15_agent_runtime_v3.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/bots
+POST {{base_url}}/api/v2/bots
 Content-Type: application/json
 {
   "title": "Agent Runtime V3 {{run_id}}",
@@ -29,7 +29,7 @@ HTTP 200
 [Captures]
 bot_id: jsonpath "$.id"
 
-POST {{base_url}}/api/v1/bots/{{bot_id}}/chats
+POST {{base_url}}/api/v2/bots/{{bot_id}}/chats
 HTTP 200
 [Captures]
 chat_id: jsonpath "$.id"
@@ -82,8 +82,8 @@ jsonpath "$.status" == "CANCELLED"
 GET {{base_url}}/api/v2/agent/artifacts/not-found-{{run_id}}
 HTTP 404
 
-DELETE {{base_url}}/api/v1/bots/{{bot_id}}/chats/{{chat_id}}
+DELETE {{base_url}}/api/v2/bots/{{bot_id}}/chats/{{chat_id}}
 HTTP 204
 
-DELETE {{base_url}}/api/v1/bots/{{bot_id}}
+DELETE {{base_url}}/api/v2/bots/{{bot_id}}
 HTTP 204

--- a/tests/e2e_http/hurl/full/16_evaluation_v2.hurl
+++ b/tests/e2e_http/hurl/full/16_evaluation_v2.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/collections
+POST {{base_url}}/api/v2/collections
 Content-Type: application/json
 {
   "title": "Evaluation V2 Collection {{run_id}}",
@@ -28,7 +28,7 @@ collection_id: jsonpath "$.id"
 jsonpath "$.id" == "{{collection_id}}"
 jsonpath "$.config.source" == "system"
 
-POST {{base_url}}/api/v1/bots
+POST {{base_url}}/api/v2/bots
 Content-Type: application/json
 {
   "title": "Evaluation V2 Bot {{run_id}}",
@@ -42,7 +42,7 @@ bot_id: jsonpath "$.id"
 jsonpath "$.id" == "{{bot_id}}"
 jsonpath "$.type" == "agent"
 
-POST {{base_url}}/api/v2/benchmark-datasets
+POST {{base_url}}/api/v2/evaluation-datasets
 Content-Type: application/json
 {
   "name": "Evaluation Dataset {{run_id}}",
@@ -52,55 +52,8 @@ Content-Type: application/json
   "schema_hint": {
     "language": "en-US",
     "contract": "evaluation-v2"
-  }
-}
-HTTP 200
-[Captures]
-dataset_id: jsonpath "$.id"
-[Asserts]
-jsonpath "$.id" == "{{dataset_id}}"
-jsonpath "$.collection_id" == "{{collection_id}}"
-jsonpath "$.name" == "Evaluation Dataset {{run_id}}"
-jsonpath "$.source_type" == "manual"
-jsonpath "$.schema_hint.language" == "en-US"
-
-GET {{base_url}}/api/v2/benchmark-datasets?collection_id={{collection_id}}&page=1&page_size=20
-HTTP 200
-[Asserts]
-jsonpath "$.items[0].id" == "{{dataset_id}}"
-jsonpath "$.items[0].collection_id" == "{{collection_id}}"
-jsonpath "$.pagination.total" == 1
-jsonpath "$.pagination.offset" == 0
-jsonpath "$.pagination.limit" == 20
-
-GET {{base_url}}/api/v2/benchmark-datasets/{{dataset_id}}
-HTTP 200
-[Asserts]
-jsonpath "$.id" == "{{dataset_id}}"
-jsonpath "$.name" == "Evaluation Dataset {{run_id}}"
-jsonpath "$.latest_version" == null
-
-PUT {{base_url}}/api/v2/benchmark-datasets/{{dataset_id}}
-Content-Type: application/json
-{
-  "name": "Evaluation Dataset {{run_id}} Updated",
-  "description": "Evaluation dataset updated"
-}
-HTTP 200
-[Asserts]
-jsonpath "$.id" == "{{dataset_id}}"
-jsonpath "$.name" == "Evaluation Dataset {{run_id}} Updated"
-jsonpath "$.description" == "Evaluation dataset updated"
-
-POST {{base_url}}/api/v2/benchmark-datasets/{{dataset_id}}/versions
-Content-Type: application/json
-{
-  "version_name": "Initial Version {{run_id}}",
-  "source_snapshot": {
-    "collection_id": "{{collection_id}}",
-    "snapshot_type": "manual"
   },
-  "cases": [
+  "items": [
     {
       "case_key": "hello-case",
       "input_message": "Say hello in one sentence.",
@@ -127,35 +80,51 @@ Content-Type: application/json
 }
 HTTP 200
 [Captures]
-dataset_version_id: jsonpath "$.id"
+dataset_id: jsonpath "$.id"
 [Asserts]
-jsonpath "$.id" == "{{dataset_version_id}}"
-jsonpath "$.dataset_id" == "{{dataset_id}}"
-jsonpath "$.version" == 1
-jsonpath "$.version_name" == "Initial Version {{run_id}}"
-jsonpath "$.status" == "published"
-jsonpath "$.case_count" == 2
-jsonpath "$.source_snapshot.collection_id" == "{{collection_id}}"
+jsonpath "$.id" == "{{dataset_id}}"
+jsonpath "$.collection_id" == "{{collection_id}}"
+jsonpath "$.name" == "Evaluation Dataset {{run_id}}"
+jsonpath "$.source_type" == "manual"
+jsonpath "$.schema_hint.language" == "en-US"
+jsonpath "$.item_count" == 2
 
-GET {{base_url}}/api/v2/benchmark-datasets/{{dataset_id}}/versions
+GET {{base_url}}/api/v2/evaluation-datasets?collection_id={{collection_id}}&page=1&page_size=20
 HTTP 200
 [Asserts]
-jsonpath "$.items[0].id" == "{{dataset_version_id}}"
-jsonpath "$.items[0].dataset_id" == "{{dataset_id}}"
-jsonpath "$.items[0].case_count" == 2
+jsonpath "$.items[0].id" == "{{dataset_id}}"
+jsonpath "$.items[0].collection_id" == "{{collection_id}}"
+jsonpath "$.items[0].item_count" == 2
 jsonpath "$.pagination.total" == 1
+jsonpath "$.pagination.offset" == 0
+jsonpath "$.pagination.limit" == 20
 
-GET {{base_url}}/api/v2/benchmark-datasets/{{dataset_id}}/versions/{{dataset_version_id}}
+GET {{base_url}}/api/v2/evaluation-datasets/{{dataset_id}}
 HTTP 200
 [Asserts]
-jsonpath "$.id" == "{{dataset_version_id}}"
-jsonpath "$.version" == 1
-jsonpath "$.status" == "published"
-jsonpath "$.case_count" == 2
+jsonpath "$.id" == "{{dataset_id}}"
+jsonpath "$.name" == "Evaluation Dataset {{run_id}}"
+jsonpath "$.item_count" == 2
 
-GET {{base_url}}/api/v2/benchmark-datasets/{{dataset_id}}/versions/{{dataset_version_id}}/cases?page=1&page_size=100
+PUT {{base_url}}/api/v2/evaluation-datasets/{{dataset_id}}
+Content-Type: application/json
+{
+  "name": "Evaluation Dataset {{run_id}} Updated",
+  "description": "Evaluation dataset updated"
+}
 HTTP 200
 [Asserts]
+jsonpath "$.id" == "{{dataset_id}}"
+jsonpath "$.name" == "Evaluation Dataset {{run_id}} Updated"
+jsonpath "$.description" == "Evaluation dataset updated"
+
+GET {{base_url}}/api/v2/evaluation-datasets/{{dataset_id}}/items?page=1&page_size=100
+HTTP 200
+[Captures]
+dataset_item_id: jsonpath "$.items[0].id"
+[Asserts]
+jsonpath "$.items[0].id" == "{{dataset_item_id}}"
+jsonpath "$.items[0].dataset_id" == "{{dataset_id}}"
 jsonpath "$.items[0].case_key" == "hello-case"
 jsonpath "$.items[0].input_message" == "Say hello in one sentence."
 jsonpath "$.items[0].tags[0]" == "smoke"
@@ -164,19 +133,18 @@ jsonpath "$.items[1].sort_key" == 1
 jsonpath "$.pagination.total" == 2
 jsonpath "$.pagination.limit" == 100
 
-GET {{base_url}}/api/v2/benchmark-datasets/{{dataset_id}}
+GET {{base_url}}/api/v2/evaluation-datasets/{{dataset_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{dataset_id}}"
-jsonpath "$.latest_version.id" == "{{dataset_version_id}}"
-jsonpath "$.latest_version.case_count" == 2
+jsonpath "$.item_count" == 2
 
 POST {{base_url}}/api/v2/evaluation-runs
 Content-Type: application/json
 {
   "name": "Evaluation Run {{run_id}}",
   "bot_id": "{{bot_id}}",
-  "dataset_version_id": "{{dataset_version_id}}",
+  "dataset_id": "{{dataset_id}}",
   "judge": {
     "mode": "exact_match"
   },
@@ -193,7 +161,8 @@ run_id_v2: jsonpath "$.id"
 [Asserts]
 jsonpath "$.id" == "{{run_id_v2}}"
 jsonpath "$.bot_id" == "{{bot_id}}"
-jsonpath "$.dataset_version_id" == "{{dataset_version_id}}"
+jsonpath "$.dataset_id" == "{{dataset_id}}"
+jsonpath "$.collection_id" == "{{collection_id}}"
 jsonpath "$.name" == "Evaluation Run {{run_id}}"
 jsonpath "$.status" == "queued"
 jsonpath "$.judge_config.mode" == "exact_match"
@@ -206,6 +175,7 @@ HTTP 200
 [Asserts]
 jsonpath "$.items[0].id" == "{{run_id_v2}}"
 jsonpath "$.items[0].status" == "queued"
+jsonpath "$.items[0].dataset_id" == "{{dataset_id}}"
 jsonpath "$.items[0].summary.total" == 2
 jsonpath "$.pagination.total" == 1
 jsonpath "$.pagination.limit" == 20
@@ -215,6 +185,7 @@ HTTP 200
 [Asserts]
 jsonpath "$.run.id" == "{{run_id_v2}}"
 jsonpath "$.run.status" == "queued"
+jsonpath "$.run.dataset_id" == "{{dataset_id}}"
 jsonpath "$.summary.total" == 2
 jsonpath "$.summary.pending" == 2
 jsonpath "$.progress.percent" == 0
@@ -226,6 +197,7 @@ run_item_id: jsonpath "$.items[0].id"
 [Asserts]
 jsonpath "$.items[0].id" == "{{run_item_id}}"
 jsonpath "$.items[0].run_id" == "{{run_id_v2}}"
+jsonpath "$.items[0].source_dataset_item_id" == "{{dataset_item_id}}"
 jsonpath "$.items[0].case_key" == "hello-case"
 jsonpath "$.items[0].status" == "pending"
 jsonpath "$.items[0].attempt_count" == 0

--- a/tests/e2e_http/hurl/full/17_chat_collection_flow.hurl
+++ b/tests/e2e_http/hurl/full/17_chat_collection_flow.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/collections
+POST {{base_url}}/api/v2/collections
 Content-Type: application/json
 {
   "title": "Chat Collection Flow {{run_id}}",
@@ -39,7 +39,7 @@ jsonpath "$.id" == "{{collection_id}}"
 jsonpath "$.config.enable_vector" == true
 jsonpath "$.config.enable_fulltext" == true
 
-POST {{base_url}}/api/v1/collections/{{collection_id}}/documents/upload
+POST {{base_url}}/api/v2/collections/{{collection_id}}/documents/upload
 [MultipartFormData]
 file: file,tests/e2e_http/testdata/full-document.txt; type=text/plain
 HTTP 200
@@ -49,7 +49,7 @@ document_id: jsonpath "$.document_id"
 jsonpath "$.document_id" == "{{document_id}}"
 jsonpath "$.status" == "UPLOADED"
 
-POST {{base_url}}/api/v1/collections/{{collection_id}}/documents/confirm
+POST {{base_url}}/api/v2/collections/{{collection_id}}/documents/confirm
 Content-Type: application/json
 {
   "document_ids": ["{{document_id}}"]
@@ -59,7 +59,7 @@ HTTP 200
 jsonpath "$.confirmed_count" == 1
 jsonpath "$.failed_count" == 0
 
-POST {{base_url}}/api/v1/bots
+POST {{base_url}}/api/v2/bots
 Content-Type: application/json
 {
   "title": "Collection Chat Flow {{run_id}}",
@@ -90,7 +90,7 @@ bot_id: jsonpath "$.id"
 jsonpath "$.id" == "{{bot_id}}"
 jsonpath "$.config.agent.collections[0].id" == "{{collection_id}}"
 
-POST {{base_url}}/api/v1/bots/{{bot_id}}/chats
+POST {{base_url}}/api/v2/bots/{{bot_id}}/chats
 HTTP 200
 [Captures]
 chat_id: jsonpath "$.id"
@@ -126,16 +126,14 @@ jsonpath "$.turn.bot_id" == "{{bot_id}}"
 jsonpath "$.timeline" exists
 jsonpath "$.artifacts" exists
 
-DELETE {{base_url}}/api/v1/bots/{{bot_id}}/chats/{{chat_id}}
+DELETE {{base_url}}/api/v2/bots/{{bot_id}}/chats/{{chat_id}}
 HTTP 204
 
-DELETE {{base_url}}/api/v1/bots/{{bot_id}}
+DELETE {{base_url}}/api/v2/bots/{{bot_id}}
 HTTP 204
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}
-HTTP 200
-[Asserts]
-jsonpath "$.id" == "{{document_id}}"
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}/documents/{{document_id}}
+HTTP 204
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}
-HTTP 200
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}
+HTTP 204

--- a/tests/e2e_http/hurl/smoke/02_collection.hurl
+++ b/tests/e2e_http/hurl/smoke/02_collection.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/collections
+POST {{base_url}}/api/v2/collections
 Content-Type: application/json
 {
   "title": "Smoke Collection {{run_id}}",
@@ -31,18 +31,18 @@ jsonpath "$.status" == "ACTIVE"
 jsonpath "$.config.source" == "system"
 jsonpath "$.config.enable_knowledge_graph" == false
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}
+GET {{base_url}}/api/v2/collections/{{collection_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{collection_id}}"
 jsonpath "$.type" == "document"
 
-GET {{base_url}}/api/v1/collections?page=1&page_size=50
+GET {{base_url}}/api/v2/collections?page=1&page_size=50
 HTTP 200
 [Asserts]
 header "content-type" contains "application/json"
 
-PUT {{base_url}}/api/v1/collections/{{collection_id}}
+PUT {{base_url}}/api/v2/collections/{{collection_id}}
 Content-Type: application/json
 {
   "title": "Smoke Collection {{run_id}} Updated",
@@ -61,8 +61,8 @@ HTTP 200
 jsonpath "$.id" == "{{collection_id}}"
 jsonpath "$.title" == "Smoke Collection {{run_id}} Updated"
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}
-HTTP 200
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}
+HTTP 204
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}
+GET {{base_url}}/api/v2/collections/{{collection_id}}
 HTTP 404

--- a/tests/e2e_http/hurl/smoke/03_document_basic.hurl
+++ b/tests/e2e_http/hurl/smoke/03_document_basic.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/collections
+POST {{base_url}}/api/v2/collections
 Content-Type: application/json
 {
   "title": "Document Smoke {{run_id}}",
@@ -25,7 +25,7 @@ HTTP 200
 [Captures]
 collection_id: jsonpath "$.id"
 
-POST {{base_url}}/api/v1/collections/{{collection_id}}/documents
+POST {{base_url}}/api/v2/collections/{{collection_id}}/documents
 [MultipartFormData]
 files: file,tests/e2e_http/testdata/minimal-document.txt; type=text/plain
 HTTP 200
@@ -37,7 +37,7 @@ jsonpath "$.items[0].id" == "{{document_id}}"
 jsonpath "$.items[0].name" == "tests/e2e_http/testdata/minimal-document.txt"
 jsonpath "$.items[0].graph_index_status" == "SKIPPED"
 
-GET {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}
+GET {{base_url}}/api/v2/collections/{{collection_id}}/documents/{{document_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{document_id}}"
@@ -46,11 +46,8 @@ jsonpath "$.graph_index_status" == "SKIPPED"
 jsonpath "$.summary_index_status" == "SKIPPED"
 jsonpath "$.vision_index_status" == "SKIPPED"
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}/documents/{{document_id}}
-HTTP 200
-[Asserts]
-jsonpath "$.id" == "{{document_id}}"
-jsonpath "$.status" == "DELETED"
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}/documents/{{document_id}}
+HTTP 204
 
-DELETE {{base_url}}/api/v1/collections/{{collection_id}}
-HTTP 200
+DELETE {{base_url}}/api/v2/collections/{{collection_id}}
+HTTP 204

--- a/tests/e2e_http/hurl/smoke/04_api_key.hurl
+++ b/tests/e2e_http/hurl/smoke/04_api_key.hurl
@@ -27,7 +27,7 @@ HTTP 200
 POST {{base_url}}/api/v1/logout
 HTTP 200
 
-GET {{base_url}}/api/v1/collections
+GET {{base_url}}/api/v2/collections
 Authorization: Bearer {{api_key_value}}
 HTTP 200
 
@@ -55,6 +55,6 @@ HTTP 200
 POST {{base_url}}/api/v1/logout
 HTTP 200
 
-GET {{base_url}}/api/v1/collections
+GET {{base_url}}/api/v2/collections
 Authorization: Bearer {{api_key_value}}
 HTTP 401

--- a/tests/e2e_http/scripts/run_chat_collection_flow.sh
+++ b/tests/e2e_http/scripts/run_chat_collection_flow.sh
@@ -36,19 +36,19 @@ chat_id=""
 cleanup() {
   if [[ -n "${chat_id}" && -n "${bot_id}" ]]; then
     curl -sS -o /dev/null -b "${COOKIE_JAR}" -X DELETE \
-      "${BASE_URL}/api/v1/bots/${bot_id}/chats/${chat_id}" || true
+      "${BASE_URL}/api/v2/bots/${bot_id}/chats/${chat_id}" || true
   fi
   if [[ -n "${bot_id}" ]]; then
     curl -sS -o /dev/null -b "${COOKIE_JAR}" -X DELETE \
-      "${BASE_URL}/api/v1/bots/${bot_id}" || true
+      "${BASE_URL}/api/v2/bots/${bot_id}" || true
   fi
   if [[ -n "${document_id}" && -n "${collection_id}" ]]; then
     curl -sS -o /dev/null -b "${COOKIE_JAR}" -X DELETE \
-      "${BASE_URL}/api/v1/collections/${collection_id}/documents/${document_id}" || true
+      "${BASE_URL}/api/v2/collections/${collection_id}/documents/${document_id}" || true
   fi
   if [[ -n "${collection_id}" ]]; then
     curl -sS -o /dev/null -b "${COOKIE_JAR}" -X DELETE \
-      "${BASE_URL}/api/v1/collections/${collection_id}" || true
+      "${BASE_URL}/api/v2/collections/${collection_id}" || true
   fi
   rm -f "${TMP_FILES[@]}"
 }
@@ -132,7 +132,7 @@ wait_for_document_indexes() {
 
   while (( attempt <= max_attempts )); do
     local body
-    body="$(request_json GET "/api/v1/collections/${collection_id}/documents/${document_id}")"
+    body="$(request_json GET "/api/v2/collections/${collection_id}/documents/${document_id}")"
     local vector_status
     local fulltext_status
     vector_status="$(jq -r '.vector_index_status // empty' <<<"${body}")"
@@ -203,7 +203,7 @@ request_json POST "/api/v1/login" "$(jq -nc \
   --arg password "${E2E_PASSWORD}" \
   '{username: $username, password: $password}')"
 
-collection_body="$(request_json POST "/api/v1/collections" "$(jq -nc \
+collection_body="$(request_json POST "/api/v2/collections" "$(jq -nc \
   --arg run_id "${E2E_RUN_ID}" \
   '{
     title: ("Chat Collection Flow Script " + $run_id),
@@ -231,11 +231,11 @@ collection_body="$(request_json POST "/api/v1/collections" "$(jq -nc \
 collection_id="$(jq -r '.id' <<<"${collection_body}")"
 
 upload_body="$(request_file_upload \
-  "/api/v1/collections/${collection_id}/documents/upload" \
+  "/api/v2/collections/${collection_id}/documents/upload" \
   "${ROOT_DIR}/tests/e2e_http/testdata/full-document.txt")"
 document_id="$(jq -r '.document_id' <<<"${upload_body}")"
 
-request_json POST "/api/v1/collections/${collection_id}/documents/confirm" "$(jq -nc \
+request_json POST "/api/v2/collections/${collection_id}/documents/confirm" "$(jq -nc \
   --arg document_id "${document_id}" \
   '{document_ids: [$document_id]}')"
 
@@ -250,7 +250,7 @@ search_body="$(request_json POST "/api/v1/collections/${collection_id}/searches"
 }')")"
 jq -e '(.items // []) | length > 0' <<<"${search_body}" >/dev/null
 
-bot_body="$(request_json POST "/api/v1/bots" "$(jq -nc \
+bot_body="$(request_json POST "/api/v2/bots" "$(jq -nc \
   --arg run_id "${E2E_RUN_ID}" \
   --arg collection_id "${collection_id}" \
   '{
@@ -273,7 +273,7 @@ bot_body="$(request_json POST "/api/v1/bots" "$(jq -nc \
   }')")"
 bot_id="$(jq -r '.id' <<<"${bot_body}")"
 
-chat_body="$(request_json POST "/api/v1/bots/${bot_id}/chats")"
+chat_body="$(request_json POST "/api/v2/bots/${bot_id}/chats")"
 chat_id="$(jq -r '.id' <<<"${chat_body}")"
 
 turn_body="$(request_json POST "/api/v2/agent/chats/${chat_id}/turns" "$(jq -nc \

--- a/tests/e2e_http/scripts/run_graph_index_flow.sh
+++ b/tests/e2e_http/scripts/run_graph_index_flow.sh
@@ -34,11 +34,11 @@ document_id=""
 cleanup() {
   if [[ -n "${document_id}" && -n "${collection_id}" ]]; then
     curl -sS -o /dev/null -b "${COOKIE_JAR}" -X DELETE \
-      "${BASE_URL}/api/v1/collections/${collection_id}/documents/${document_id}" || true
+      "${BASE_URL}/api/v2/collections/${collection_id}/documents/${document_id}" || true
   fi
   if [[ -n "${collection_id}" ]]; then
     curl -sS -o /dev/null -b "${COOKIE_JAR}" -X DELETE \
-      "${BASE_URL}/api/v1/collections/${collection_id}" || true
+      "${BASE_URL}/api/v2/collections/${collection_id}" || true
   fi
   rm -f "${TMP_FILES[@]}"
 }
@@ -122,7 +122,7 @@ wait_for_graph_index() {
 
   while (( attempt <= max_attempts )); do
     local body
-    body="$(request_json GET "/api/v1/collections/${collection_id}/documents/${document_id}")"
+    body="$(request_json GET "/api/v2/collections/${collection_id}/documents/${document_id}")"
     local graph_status
     graph_status="$(jq -r '.graph_index_status // empty' <<<"${body}")"
 
@@ -151,7 +151,7 @@ request_json POST "/api/v1/login" "$(jq -nc \
   --arg password "${E2E_PASSWORD}" \
   '{username: $username, password: $password}')"
 
-collection_body="$(request_json POST "/api/v1/collections" "$(jq -nc \
+collection_body="$(request_json POST "/api/v2/collections" "$(jq -nc \
   --arg run_id "${E2E_RUN_ID}" \
   '{
     title: ("Graph Index Flow Script " + $run_id),
@@ -179,11 +179,11 @@ collection_body="$(request_json POST "/api/v1/collections" "$(jq -nc \
 collection_id="$(jq -r '.id' <<<"${collection_body}")"
 
 upload_body="$(request_file_upload \
-  "/api/v1/collections/${collection_id}/documents/upload" \
+  "/api/v2/collections/${collection_id}/documents/upload" \
   "${ROOT_DIR}/tests/e2e_http/testdata/graph-document.txt")"
 document_id="$(jq -r '.document_id' <<<"${upload_body}")"
 
-request_json POST "/api/v1/collections/${collection_id}/documents/confirm" "$(jq -nc \
+request_json POST "/api/v2/collections/${collection_id}/documents/confirm" "$(jq -nc \
   --arg document_id "${document_id}" \
   '{document_ids: [$document_id]}')"
 

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -300,6 +300,80 @@ def test_final_sweep_v1_ghost_paths_are_gone_from_exported_spec():
         )
 
 
+def test_e2e_http_does_not_call_removed_v1_paths():
+    """HTTP e2e assets must not call routes removed by the final v1 sweep.
+
+    Search, graph, and upload-flow v1 routes are intentionally still allowed
+    because they were explicitly preserved in #26. This guard only blocks the
+    deleted bot shell, collection CRUD, and document read-side paths that broke
+    post-merge e2e smoke when Hurl still called `/api/v1/collections`.
+    """
+    e2e_root = REPO_ROOT / "tests/e2e_http"
+    sources = {
+        path: path.read_text()
+        for path in e2e_root.rglob("*")
+        if path.is_file() and path.suffix in {".hurl", ".sh"}
+    }
+
+    removed_route_patterns = {
+        r"/api/v1/bots(?:[/?\"\s]|\$\{)": "bot v1 routes were replaced by /api/v2/bots*",
+        r"/api/v1/collections(?:[?\"\s]|\Z)": "collection list/create must use /api/v2/collections",
+        r"/api/v1/collections/(?:\{\{collection_id\}\}|\$\{collection_id\})(?:[?\"\s]|\Z)": (
+            "collection get/update/delete must use /api/v2/collections/{collection_id}"
+        ),
+        r"/api/v1/collections/(?:\{\{collection_id\}\}|\$\{collection_id\})/documents(?:[?\"\s]|\Z)": (
+            "document list/create must use /api/v2/collections/{collection_id}/documents"
+        ),
+        r"/api/v1/collections/(?:\{\{collection_id\}\}|\$\{collection_id\})/documents/"
+        r"(?:\{\{document_id\}\}|\$\{document_id\})(?:[/?\"\s]|\Z)": (
+            "document detail/delete/download/preview/object/rebuild must use v2 document paths"
+        ),
+        r"/api/v1/collections/(?:\{\{collection_id\}\}|\$\{collection_id\})/rebuild_failed_indexes": (
+            "rebuild_failed_indexes must use /api/v2/collections/{collection_id}/rebuild_failed_indexes"
+        ),
+    }
+
+    offenders: list[str] = []
+    for path, source in sources.items():
+        for pattern, reason in removed_route_patterns.items():
+            if re.search(pattern, source):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {reason}")
+
+    assert not offenders, "e2e HTTP assets still call removed v1 route(s):\n" + "\n".join(sorted(offenders))
+
+
+def test_e2e_http_uses_simplified_evaluation_v2_contract():
+    """The full evaluation Hurl suite must follow the post-#1590 API.
+
+    ``/api/v2/benchmark-datasets*``, dataset versions, and
+    ``dataset_version_id`` were removed from the public evaluation contract.
+    Keep this static guard near the e2e assets so a backend contract switch
+    cannot leave provider/full Hurl coverage on dead routes again.
+    """
+    e2e_root = REPO_ROOT / "tests/e2e_http"
+    sources = {
+        path: path.read_text()
+        for path in e2e_root.rglob("*")
+        if path.is_file() and path.suffix in {".hurl", ".sh"}
+    }
+
+    forbidden = {
+        "/api/v2/benchmark-datasets": "use /api/v2/evaluation-datasets instead",
+        "/versions": "dataset version routes were removed from evaluation v2",
+        "dataset_version_id": "runs now use dataset_id and snapshot dataset items on creation",
+    }
+
+    offenders: list[str] = []
+    for path, source in sources.items():
+        for token, reason in forbidden.items():
+            if token in source:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {token} ({reason})")
+
+    assert not offenders, "e2e HTTP assets still use retired evaluation v2 contract token(s):\n" + "\n".join(
+        sorted(offenders)
+    )
+
+
 def test_documents_upload_regression_hardening():
     """Stronger #30 regression guards layered on top of the minimal
     `test_documents_upload_regression_guards`. The hotfix in #1580 left


### PR DESCRIPTION
## Summary
- switch smoke and full Hurl coverage from deleted v1 collection/bot/document read-side routes to the v2 replacements
- update scripted chat/graph business-flow cleanup and polling to v2 collection/document/bot paths
- add a static unit guard so e2e HTTP assets cannot reintroduce removed v1 bot/collection/document read-side paths while preserving v1 search/graph/upload routes

## Verification
- uv run --extra test pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_openapi_spec.py -q
- bash -n tests/e2e_http/scripts/run_chat_collection_flow.sh && bash -n tests/e2e_http/scripts/run_graph_index_flow.sh && git diff --check
- uv run ruff check tests/unit_test/test_web_typed_api_contract.py
- verified v2 OpenAPI paths used by Hurl exist via build_full_openapi_spec(app)

## Notes
- Root cause was post-#26 e2e still calling deleted `/api/v1/collections` routes; smoke failed at `tests/e2e_http/hurl/smoke/02_collection.hurl` with 404.
- v1 search and graph routes remain intentionally unchanged because #26 explicitly preserved them.