### PR TITLE
feat(evaluation_v2): PR-1b agent-runtime minimal runtime wiring (#20)

### DIFF
--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -33,6 +33,8 @@ from aperag.db.models import (
     EvaluationRun,
     EvaluationRunItem,
     EvaluationRunItemAttempt,
+    EvaluationRunItemAttemptStatus,
+    EvaluationRunItemStatus,
     EvaluationRunStatus,
 )
 from aperag.db.repositories.base import AsyncRepositoryProtocol
@@ -191,8 +193,6 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
         return await self._execute_query(_query)
 
     async def requeue_run_item(self, run_id: str, item_id: str) -> Optional[EvaluationRunItem]:
-        from aperag.db.models import EvaluationRunItemStatus  # local import to avoid cycle
-
         async def _operation(session: AsyncSession):
             stmt = select(EvaluationRunItem).where(
                 EvaluationRunItem.id == item_id,
@@ -207,6 +207,108 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
             await session.flush()
             await session.refresh(instance)
             return instance
+
+        return await self.execute_with_transaction(_operation)
+
+    # -- Worker-side helpers (PR-1b) ---------------------------------------
+    #
+    # These helpers intentionally do not filter by ``user_id``: the Celery
+    # worker receives only a ``run_id`` and must read/update run state on
+    # behalf of the run's owner. Authorization stays on the HTTP edge.
+
+    async def get_run_for_worker(self, run_id: str) -> Optional[EvaluationRun]:
+        """Load a run without scoping to a specific user — worker-side use only."""
+
+        async def _query(session: AsyncSession):
+            stmt = select(EvaluationRun).where(EvaluationRun.id == run_id)
+            return (await session.execute(stmt)).scalars().first()
+
+        return await self._execute_query(_query)
+
+    async def mark_run_item_running(self, item_id: str) -> Optional[EvaluationRunItem]:
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationRunItem).where(EvaluationRunItem.id == item_id)
+            item = (await session.execute(stmt)).scalars().first()
+            if not item:
+                return None
+            now = utc_now()
+            item.status = EvaluationRunItemStatus.RUNNING
+            item.attempt_count = (item.attempt_count or 0) + 1
+            item.gmt_updated = now
+            await session.flush()
+            await session.refresh(item)
+            return item
+
+        return await self.execute_with_transaction(_operation)
+
+    async def create_run_item_attempt(
+        self,
+        *,
+        run_id: str,
+        run_item_id: str,
+        attempt_no: int,
+        status: EvaluationRunItemAttemptStatus,
+        agent_chat_id: Optional[str] = None,
+        agent_turn_id: Optional[str] = None,
+        answer_text: Optional[str] = None,
+        error_message: Optional[str] = None,
+        latency_ms: Optional[int] = None,
+    ) -> EvaluationRunItemAttempt:
+        """Persist the outcome of a single worker turn dispatch."""
+
+        async def _operation(session: AsyncSession):
+            now = utc_now()
+            finished = (
+                now
+                if status
+                in (
+                    EvaluationRunItemAttemptStatus.COMPLETED,
+                    EvaluationRunItemAttemptStatus.FAILED,
+                    EvaluationRunItemAttemptStatus.CANCELLED,
+                )
+                else None
+            )
+            attempt = EvaluationRunItemAttempt(
+                run_id=run_id,
+                run_item_id=run_item_id,
+                attempt_no=attempt_no,
+                status=status,
+                agent_chat_id=agent_chat_id,
+                agent_turn_id=agent_turn_id,
+                answer_text=answer_text,
+                error_message=error_message,
+                latency_ms=latency_ms,
+                gmt_started=now,
+                gmt_finished=finished,
+            )
+            session.add(attempt)
+            await session.flush()
+            await session.refresh(attempt)
+            return attempt
+
+        return await self.execute_with_transaction(_operation)
+
+    async def finalize_run_item(
+        self,
+        *,
+        item_id: str,
+        status: EvaluationRunItemStatus,
+        latest_attempt_id: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> Optional[EvaluationRunItem]:
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationRunItem).where(EvaluationRunItem.id == item_id)
+            item = (await session.execute(stmt)).scalars().first()
+            if not item:
+                return None
+            item.status = status
+            if latest_attempt_id is not None:
+                item.latest_attempt_id = latest_attempt_id
+            item.error_message = error_message
+            item.gmt_updated = utc_now()
+            await session.flush()
+            await session.refresh(item)
+            return item
 
         return await self.execute_with_transaction(_operation)
 

--- a/aperag/evaluation_v2/services.py
+++ b/aperag/evaluation_v2/services.py
@@ -336,8 +336,18 @@ class EvaluationRunService:
         return resolved.id
 
     async def launch_run(self, run_id: str) -> None:
-        """Hand the run off to the async worker pipeline (Celery producer seam)."""
-        return None
+        """Hand the run off to the async worker pipeline (Celery producer seam).
+
+        The task implementation lives in :mod:`aperag.evaluation_v2.tasks`
+        and drains ``evaluation_run_items`` through
+        :func:`aperag.evaluation_v2.worker.execute_evaluation_run`. The
+        import is lazy so unit tests for create/list/cancel paths do not
+        have to stand up Celery just to exercise the service.
+        """
+
+        from aperag.evaluation_v2.tasks import run_evaluation_run
+
+        run_evaluation_run.delay(run_id)
 
     async def list_runs(
         self,

--- a/aperag/evaluation_v2/tasks.py
+++ b/aperag/evaluation_v2/tasks.py
@@ -12,25 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Async worker pipeline for evaluation-v2.
+"""Async worker pipeline for evaluation-v3 (#evaluation #20 / PR-1b).
 
-Phase 1 only scaffolds the module. The Phase 3 implementation will:
-
-1. Pick up queued runs, transition them to RUNNING.
-2. For each run item, create an isolated agent chat and dispatch a
-   Runtime V3 turn via `agent_runtime.runtime.agent_runtime_manager`.
-3. Wait for the turn to finalize, fetch the answer / reference artifacts,
-   and invoke the configured judge (`aperag.evaluation_v2.judges`).
-4. Persist attempt + item results and update run summary metrics.
-5. Handle cancellation and retries by respecting run status transitions.
-
-Keep this module import-safe; register Celery tasks here so they are
-discoverable by the worker autodiscover pass.
+Celery producer seam. ``run_evaluation_run(run_id)`` is the task name that
+``EvaluationRunService.launch_run`` dispatches via ``.delay(...)``; all
+state-machine logic lives in :mod:`aperag.evaluation_v2.worker` to keep
+this module a thin sync wrapper that is safe to import during test
+collection even when Celery / the agent runtime / Redis are unavailable.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
 
-async def run_evaluation_run(run_id: str) -> None:
-    """Phase 3 entrypoint. No-op until the worker pipeline lands."""
-    return None
+from config.celery import app
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(bind=True, name="aperag.evaluation_v2.tasks.run_evaluation_run")
+def run_evaluation_run(self, run_id: str) -> dict:
+    """Celery entrypoint. Runs :func:`execute_evaluation_run` in a fresh
+    event loop and returns a small status payload for worker logging.
+
+    The task is intentionally short-circuited when the run_id is unknown
+    or already terminal — the orchestration layer handles both cases
+    idempotently, so a re-dispatched Celery message is safe to replay.
+    """
+
+    # Lazy import: keeps this module import-safe when the agent runtime /
+    # chat service / DB are not configured (e.g. unit-test collection).
+    from aperag.evaluation_v2.worker import execute_evaluation_run
+
+    logger.info("evaluation worker picking up run %s", run_id)
+    final_status = asyncio.run(execute_evaluation_run(run_id))
+    final_status_value = final_status.value if hasattr(final_status, "value") else str(final_status)
+    logger.info("evaluation worker finished run %s with status %s", run_id, final_status_value)
+    return {"run_id": run_id, "status": final_status_value}

--- a/aperag/evaluation_v2/worker.py
+++ b/aperag/evaluation_v2/worker.py
@@ -1,0 +1,360 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime execution for evaluation-v3 runs (#evaluation #20 / PR-1b).
+
+``execute_evaluation_run`` is the state-machine orchestration the Celery
+task wraps. It loops ``evaluation_run_items`` read from value-copy snapshot
+columns — never joining back to mutable ``evaluation_dataset_items`` — and
+dispatches each item through ``dispatch_evaluation_turn``, the single
+mockable seam to the agent runtime.
+
+Everything that touches ``agent_runtime.runtime.agent_runtime_manager``
+lives in ``dispatch_evaluation_turn``; tests mock at that seam so they can
+exercise the full state-machine (QUEUED → RUNNING → COMPLETED/FAILED +
+``attempts`` + ``run.summary``) without re-asserting chat persistence or
+turn creation (those are the ``#13 Chat/agent-runtime`` test domain).
+
+PR-1b scope: do NOT implement judge scoring, ``best_score`` metric, or
+complex retry. Attempt status is purely ``COMPLETED``/``FAILED`` based on
+the turn's terminal status.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional
+
+from aperag.db.models import (
+    EvaluationRunItem,
+    EvaluationRunItemAttemptStatus,
+    EvaluationRunItemStatus,
+    EvaluationRunStatus,
+)
+from aperag.db.ops import AsyncDatabaseOps, async_db_ops
+from aperag.evaluation_v2.schemas import EvaluationRunSummary
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TurnDispatchOutcome:
+    """Outcome of a single evaluation-turn dispatch.
+
+    The worker records this verbatim into ``evaluation_run_item_attempts``
+    and derives the item status from ``status``. ``agent_chat_id`` and
+    ``agent_turn_id`` are free-form strings (not FKs into the chat tables)
+    so that chat/turn row deletion never breaks historical run snapshots —
+    the identifiers stay auditable even after the underlying records are
+    garbage-collected.
+    """
+
+    status: EvaluationRunItemAttemptStatus
+    agent_chat_id: Optional[str] = None
+    agent_turn_id: Optional[str] = None
+    answer_text: Optional[str] = None
+    error_message: Optional[str] = None
+    latency_ms: Optional[int] = None
+
+
+DispatchFn = Callable[..., Awaitable[TurnDispatchOutcome]]
+
+
+# ---------------------------------------------------------------------------
+# Mockable seam
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_evaluation_turn(
+    *,
+    user_id: str,
+    bot_id: str,
+    input_message: str,
+    timeout_seconds: float = 300.0,
+    poll_interval_seconds: float = 0.25,
+) -> TurnDispatchOutcome:
+    """Dispatch a single evaluation turn through ``agent_runtime_manager``.
+
+    This is the only place in the evaluation worker that imports
+    ``agent_runtime`` / ``chat_service``. Tests replace it via the
+    ``dispatch_fn`` parameter of ``execute_evaluation_run`` so they never
+    have to stand up the runtime, a Redis store, or a Celery broker.
+
+    The implementation MUST stay runtime-API-only: no HTTP side-channel
+    back to the bot router, no synchronous shortcut around
+    ``agent_runtime_manager`` — per the ``#13 agent-runtime`` contract.
+    """
+
+    # Local imports: keep the module import-safe for tests that do not
+    # stub the runtime (e.g. the router-level contract tests).
+    from aperag.agent_runtime.runtime import agent_runtime_manager
+    from aperag.agent_runtime.schemas import CreateTurnRequest
+    from aperag.db.models import AgentTurnStatus
+    from aperag.service.chat_service import chat_service_global
+
+    start = time.monotonic()
+    chat_view = await chat_service_global.create_chat(user_id, bot_id)
+    chat_id = chat_view.id
+
+    turn_request = CreateTurnRequest(query=input_message)
+    _chat, _bot, turn, _created = await agent_runtime_manager.turn_service.create_or_get_turn(
+        user_id, chat_id, turn_request
+    )
+
+    lease_owner = await agent_runtime_manager.claim_turn(turn.id)
+    if not lease_owner:
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.FAILED,
+            agent_chat_id=chat_id,
+            agent_turn_id=turn.id,
+            error_message="Could not claim turn for evaluation dispatch",
+            latency_ms=int((time.monotonic() - start) * 1000),
+        )
+
+    agent_runtime_manager.launch_turn(
+        turn=turn,
+        chat=_chat,
+        bot=_bot,
+        user=user_id,
+        request=turn_request,
+        lease_owner=lease_owner,
+    )
+
+    terminal_statuses = {
+        AgentTurnStatus.COMPLETED.value,
+        AgentTurnStatus.FAILED.value,
+        AgentTurnStatus.CANCELLED.value,
+    }
+
+    deadline = start + timeout_seconds
+    final_status: Optional[str] = None
+    while True:
+        current = await agent_runtime_manager.turn_service.db_ops.query_agent_turn(user_id, chat_id, turn.id)
+        status_value = (
+            current.status.value if current and hasattr(current.status, "value") else (current and current.status)
+        )
+        if status_value in terminal_statuses:
+            final_status = status_value
+            break
+        if time.monotonic() >= deadline:
+            try:
+                await agent_runtime_manager.cancel_turn(turn.id)
+            except Exception:  # noqa: BLE001 - best-effort cancel, still mark failed
+                logger.exception("cancel_turn failed for evaluation turn %s", turn.id)
+            return TurnDispatchOutcome(
+                status=EvaluationRunItemAttemptStatus.FAILED,
+                agent_chat_id=chat_id,
+                agent_turn_id=turn.id,
+                error_message=f"Evaluation turn timed out after {timeout_seconds:.0f}s",
+                latency_ms=int((time.monotonic() - start) * 1000),
+            )
+        await asyncio.sleep(poll_interval_seconds)
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+
+    if final_status == AgentTurnStatus.COMPLETED.value:
+        snapshot = await agent_runtime_manager.turn_service.get_turn_snapshot(user_id, chat_id, turn.id)
+        answer_text = _extract_answer_text(snapshot)
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.COMPLETED,
+            agent_chat_id=chat_id,
+            agent_turn_id=turn.id,
+            answer_text=answer_text,
+            latency_ms=latency_ms,
+        )
+
+    if final_status == AgentTurnStatus.CANCELLED.value:
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.CANCELLED,
+            agent_chat_id=chat_id,
+            agent_turn_id=turn.id,
+            latency_ms=latency_ms,
+        )
+
+    # FAILED
+    error_message = None
+    try:
+        turn_row = await agent_runtime_manager.turn_service.db_ops.query_agent_turn(user_id, chat_id, turn.id)
+        if turn_row is not None:
+            error_message = getattr(turn_row, "error_message", None)
+    except Exception:  # noqa: BLE001
+        logger.debug("could not read agent_turn error_message for %s", turn.id, exc_info=True)
+    return TurnDispatchOutcome(
+        status=EvaluationRunItemAttemptStatus.FAILED,
+        agent_chat_id=chat_id,
+        agent_turn_id=turn.id,
+        error_message=error_message or "Agent turn failed",
+        latency_ms=latency_ms,
+    )
+
+
+def _extract_answer_text(snapshot) -> str:
+    for artifact in snapshot.artifacts:
+        if artifact.artifact_id == snapshot.turn.answer_artifact_id or artifact.artifact_type == "answer":
+            text = (artifact.payload or {}).get("text") or (artifact.payload or {}).get("content")
+            if text:
+                return text
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# State-machine orchestration
+# ---------------------------------------------------------------------------
+
+
+_ITEM_STATUS_BY_ATTEMPT: dict[EvaluationRunItemAttemptStatus, EvaluationRunItemStatus] = {
+    EvaluationRunItemAttemptStatus.COMPLETED: EvaluationRunItemStatus.COMPLETED,
+    EvaluationRunItemAttemptStatus.FAILED: EvaluationRunItemStatus.FAILED,
+    EvaluationRunItemAttemptStatus.CANCELLED: EvaluationRunItemStatus.CANCELLED,
+}
+
+
+async def execute_evaluation_run(
+    run_id: str,
+    *,
+    db_ops: Optional[AsyncDatabaseOps] = None,
+    dispatch_fn: Optional[DispatchFn] = None,
+) -> EvaluationRunStatus:
+    """Execute an evaluation run end-to-end using only snapshot columns.
+
+    The Celery task wraps this with ``asyncio.run``. Tests call it directly
+    with in-memory fakes for ``db_ops`` and ``dispatch_fn``. Returns the
+    final run status so the caller can propagate it for observability.
+
+    Contract (per PR-1b hard points):
+      * Read run items from ``evaluation_run_items`` snapshot columns ONLY.
+        Never call ``list_all_evaluation_dataset_items`` here.
+      * Create one ``evaluation_run_item_attempt`` per dispatch, even when
+        the outcome is FAILED/CANCELLED.
+      * Run transitions QUEUED → RUNNING → COMPLETED (all items succeeded
+        or at least one completed) or FAILED (all items failed).
+      * ``run.summary`` is updated after every item so polling clients see
+        incremental progress.
+    """
+
+    ops = db_ops or async_db_ops
+    dispatch = dispatch_fn or dispatch_evaluation_turn
+
+    run = await ops.get_run_for_worker(run_id)
+    if run is None:
+        logger.warning("evaluation run %s vanished before worker could pick it up", run_id)
+        return EvaluationRunStatus.FAILED
+
+    if run.status in (
+        EvaluationRunStatus.COMPLETED,
+        EvaluationRunStatus.FAILED,
+        EvaluationRunStatus.CANCELLED,
+    ):
+        logger.info(
+            "evaluation run %s already in terminal status %s; worker skipping",
+            run_id,
+            run.status,
+        )
+        return run.status
+
+    items = await ops.list_all_run_items(run_id)
+    summary = EvaluationRunSummary(total=len(items), pending=len(items))
+    await ops.update_run_status(
+        run_id,
+        EvaluationRunStatus.RUNNING,
+        summary=summary.model_dump(),
+    )
+
+    user_id = run.user_id
+    bot_id = run.bot_id
+
+    for item in items:
+        await _process_run_item(
+            run=run,
+            item=item,
+            user_id=user_id,
+            bot_id=bot_id,
+            summary=summary,
+            ops=ops,
+            dispatch=dispatch,
+        )
+
+    final_status = _final_run_status(summary)
+    await ops.update_run_status(run_id, final_status, summary=summary.model_dump())
+    return final_status
+
+
+async def _process_run_item(
+    *,
+    run,
+    item: EvaluationRunItem,
+    user_id: str,
+    bot_id: str,
+    summary: EvaluationRunSummary,
+    ops: AsyncDatabaseOps,
+    dispatch: DispatchFn,
+) -> None:
+    """Drive one item through the state machine and persist its attempt."""
+
+    updated = await ops.mark_run_item_running(item.id)
+    attempt_no = updated.attempt_count if updated else 1
+    summary.pending = max(0, summary.pending - 1)
+    summary.running += 1
+    await ops.update_run_status(run.id, EvaluationRunStatus.RUNNING, summary=summary.model_dump())
+
+    try:
+        # Value-copy snapshot read — no dataset_items access.
+        outcome = await dispatch(
+            user_id=user_id,
+            bot_id=bot_id,
+            input_message=item.input_message,
+        )
+    except Exception as exc:  # noqa: BLE001 - translate runtime errors to FAILED attempt
+        logger.exception("dispatch_evaluation_turn crashed for run_item %s", item.id)
+        outcome = TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.FAILED,
+            error_message=f"dispatch crashed: {exc}",
+        )
+
+    attempt = await ops.create_run_item_attempt(
+        run_id=run.id,
+        run_item_id=item.id,
+        attempt_no=attempt_no,
+        status=outcome.status,
+        agent_chat_id=outcome.agent_chat_id,
+        agent_turn_id=outcome.agent_turn_id,
+        answer_text=outcome.answer_text,
+        error_message=outcome.error_message,
+        latency_ms=outcome.latency_ms,
+    )
+
+    final_item_status = _ITEM_STATUS_BY_ATTEMPT.get(outcome.status, EvaluationRunItemStatus.FAILED)
+    await ops.finalize_run_item(
+        item_id=item.id,
+        status=final_item_status,
+        latest_attempt_id=attempt.id,
+        error_message=outcome.error_message,
+    )
+
+    summary.running = max(0, summary.running - 1)
+    if final_item_status == EvaluationRunItemStatus.COMPLETED:
+        summary.completed += 1
+    elif final_item_status == EvaluationRunItemStatus.CANCELLED:
+        summary.cancelled += 1
+    else:
+        summary.failed += 1
+
+
+def _final_run_status(summary: EvaluationRunSummary) -> EvaluationRunStatus:
+    if summary.completed == 0 and summary.failed > 0 and summary.cancelled == 0:
+        return EvaluationRunStatus.FAILED
+    return EvaluationRunStatus.COMPLETED

--- a/config/celery.py
+++ b/config/celery.py
@@ -35,7 +35,7 @@ app.conf.update(
     task_send_sent_event=settings.celery_task_send_sent_event,
     task_track_started=settings.celery_task_track_started,
     # Auto-discover tasks in the aperag.tasks package
-    include=['config.celery_tasks', 'config.export_tasks'],
+    include=['config.celery_tasks', 'config.export_tasks', 'aperag.evaluation_v2.tasks'],
     # Enable detailed logging for celery workers - let our custom config handle formatting
     worker_log_format='[%(asctime)s: %(levelname)s/%(processName)s] %(name)s - %(message)s',
     worker_task_log_format='[%(asctime)s: %(levelname)s/%(processName)s] %(name)s - %(message)s',

--- a/tests/unit_test/test_evaluation_v2_worker.py
+++ b/tests/unit_test/test_evaluation_v2_worker.py
@@ -1,0 +1,386 @@
+"""Focused tests for the evaluation-v3 worker state machine (#evaluation #20 / PR-1b).
+
+Scope (per PR-1b hard points):
+
+* ``execute_evaluation_run`` reads ``evaluation_run_items`` snapshot columns
+  only — never ``evaluation_dataset_items``.
+* One attempt is persisted per item, even on failure.
+* Item status transitions: PENDING → RUNNING → COMPLETED/FAILED/CANCELLED.
+* Run status transitions: QUEUED/RUNNING → RUNNING → COMPLETED (any
+  success) or FAILED (all failed).
+* ``run.summary`` counters are updated incrementally; final summary
+  equals the number of completed/failed/cancelled items.
+* The worker module does not leak legacy Benchmark concepts
+  (``benchmark_``, ``dataset_version_id``).
+* ``EvaluationRunService.launch_run`` calls the Celery task ``.delay``
+  rather than the old no-op.
+
+Runtime integration (``agent_runtime_manager`` / chat persistence / turn
+creation) is deliberately NOT re-tested here; that surface is owned by
+the #13 agent-runtime suite and must stay mockable through the
+``dispatch_fn`` seam per @符炫炜's CR preview.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from pathlib import Path
+
+from aperag.db.models import (
+    EvaluationRun,
+    EvaluationRunItem,
+    EvaluationRunItemAttemptStatus,
+    EvaluationRunItemStatus,
+    EvaluationRunStatus,
+)
+from aperag.evaluation_v2 import worker
+from aperag.evaluation_v2.worker import (
+    TurnDispatchOutcome,
+    execute_evaluation_run,
+)
+
+# ---------------------------------------------------------------------------
+# In-memory fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeOps:
+    """Minimal AsyncDatabaseOps stand-in used by execute_evaluation_run.
+
+    Explicitly does NOT implement ``list_all_evaluation_dataset_items`` —
+    any accidental call would raise ``AttributeError`` and fail the test,
+    enforcing the "snapshot-only read" hard point.
+    """
+
+    def __init__(self, run: EvaluationRun, items: list[EvaluationRunItem]):
+        self._run = run
+        self._items = {item.id: item for item in items}
+        self.update_run_calls: list[tuple[EvaluationRunStatus, dict | None, str | None]] = []
+        self.attempts: list[dict] = []
+        self.finalized: list[tuple[str, EvaluationRunItemStatus, str | None, str | None]] = []
+        self.mark_running_calls: list[str] = []
+        self.dataset_items_accessed = False  # flipped only by the guard below
+
+    # --- the small subset of AsyncDatabaseOps the worker uses --------------
+
+    async def get_run_for_worker(self, run_id: str):
+        return self._run if self._run.id == run_id else None
+
+    async def list_all_run_items(self, run_id: str):
+        assert run_id == self._run.id
+        return list(self._items.values())
+
+    async def update_run_status(self, run_id, status, *, error_message=None, summary=None):
+        assert run_id == self._run.id
+        self.update_run_calls.append((status, summary, error_message))
+        self._run.status = status
+        if summary is not None:
+            self._run.summary = summary
+        return self._run
+
+    async def mark_run_item_running(self, item_id: str):
+        self.mark_running_calls.append(item_id)
+        item = self._items[item_id]
+        item.status = EvaluationRunItemStatus.RUNNING
+        item.attempt_count = (item.attempt_count or 0) + 1
+        return item
+
+    async def create_run_item_attempt(
+        self,
+        *,
+        run_id,
+        run_item_id,
+        attempt_no,
+        status,
+        agent_chat_id=None,
+        agent_turn_id=None,
+        answer_text=None,
+        error_message=None,
+        latency_ms=None,
+    ):
+        record = {
+            "id": f"attempt_{len(self.attempts) + 1:04d}",
+            "run_id": run_id,
+            "run_item_id": run_item_id,
+            "attempt_no": attempt_no,
+            "status": status,
+            "agent_chat_id": agent_chat_id,
+            "agent_turn_id": agent_turn_id,
+            "answer_text": answer_text,
+            "error_message": error_message,
+            "latency_ms": latency_ms,
+        }
+        self.attempts.append(record)
+        return types.SimpleNamespace(**record)
+
+    async def finalize_run_item(
+        self,
+        *,
+        item_id,
+        status,
+        latest_attempt_id=None,
+        error_message=None,
+    ):
+        self.finalized.append((item_id, status, latest_attempt_id, error_message))
+        item = self._items[item_id]
+        item.status = status
+        item.latest_attempt_id = latest_attempt_id
+        item.error_message = error_message
+        return item
+
+    # --- absence guard ------------------------------------------------------
+
+    def __getattr__(self, name):  # pragma: no cover - guard path
+        if name == "list_all_evaluation_dataset_items":
+            self.dataset_items_accessed = True
+            raise AssertionError(
+                "worker must not read evaluation_dataset_items; "
+                "attempted attribute access: list_all_evaluation_dataset_items"
+            )
+        raise AttributeError(name)
+
+
+def _make_run_and_items(*, item_count: int = 3) -> tuple[EvaluationRun, list[EvaluationRunItem]]:
+    run = EvaluationRun(
+        id="run_0001",
+        user_id="user_abc",
+        bot_id="bot_xyz",
+        dataset_id="eds_0001",
+        dataset_name="Smoke QA",
+        status=EvaluationRunStatus.QUEUED,
+        summary={"total": item_count, "pending": item_count, "running": 0, "completed": 0, "failed": 0, "cancelled": 0},
+    )
+    items = [
+        EvaluationRunItem(
+            id=f"item_{idx:04d}",
+            run_id=run.id,
+            source_dataset_item_id=f"edi_{idx:04d}",
+            case_key=f"case_{idx:04d}",
+            sort_key=idx,
+            input_message=f"What is {idx}?",
+            expected_answer=f"{idx}",
+            status=EvaluationRunItemStatus.PENDING,
+            attempt_count=0,
+        )
+        for idx in range(item_count)
+    ]
+    return run, items
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_execute_evaluation_run_success_transitions_all_items_to_completed():
+    run, items = _make_run_and_items(item_count=3)
+    ops = _FakeOps(run, items)
+    captured_inputs: list[str] = []
+
+    async def fake_dispatch(*, user_id, bot_id, input_message, **kwargs):
+        captured_inputs.append(input_message)
+        assert user_id == "user_abc"
+        assert bot_id == "bot_xyz"
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.COMPLETED,
+            agent_chat_id=f"chat_{input_message}",
+            agent_turn_id=f"turn_{input_message}",
+            answer_text=f"answer for {input_message}",
+            latency_ms=42,
+        )
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert final is EvaluationRunStatus.COMPLETED
+    assert run.status is EvaluationRunStatus.COMPLETED
+    assert [item.status for item in items] == [EvaluationRunItemStatus.COMPLETED] * 3
+    assert [a["status"] for a in ops.attempts] == [EvaluationRunItemAttemptStatus.COMPLETED] * 3
+    assert captured_inputs == [item.input_message for item in items]
+    assert ops.mark_running_calls == [item.id for item in items]
+    assert all(a["answer_text"] and a["agent_turn_id"] for a in ops.attempts)
+
+    final_summary = run.summary
+    assert final_summary["completed"] == 3
+    assert final_summary["failed"] == 0
+    assert final_summary["cancelled"] == 0
+    assert final_summary["running"] == 0
+    assert final_summary["pending"] == 0
+    assert final_summary["total"] == 3
+
+
+def test_execute_evaluation_run_tracks_incremental_progress_in_summary():
+    run, items = _make_run_and_items(item_count=2)
+    ops = _FakeOps(run, items)
+
+    async def fake_dispatch(**_):
+        return TurnDispatchOutcome(status=EvaluationRunItemAttemptStatus.COMPLETED, answer_text="ok")
+
+    asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    # First call: move run into RUNNING with fresh summary.
+    first_call = ops.update_run_calls[0]
+    assert first_call[0] is EvaluationRunStatus.RUNNING
+    assert first_call[1]["pending"] == 2 and first_call[1]["running"] == 0
+
+    # Intermediate RUNNING updates must reflect at least one completed item
+    # before the final COMPLETED transition.
+    running_snapshots = [call[1] for call in ops.update_run_calls if call[0] is EvaluationRunStatus.RUNNING]
+    assert any(s.get("completed", 0) >= 1 for s in running_snapshots[1:]), (
+        "summary should reflect completed items before the final run transition"
+    )
+
+    # Final update: COMPLETED.
+    assert ops.update_run_calls[-1][0] is EvaluationRunStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Failure path
+# ---------------------------------------------------------------------------
+
+
+def test_execute_evaluation_run_all_failed_sets_run_failed_and_records_attempts():
+    run, items = _make_run_and_items(item_count=2)
+    ops = _FakeOps(run, items)
+
+    async def fake_dispatch(**_):
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.FAILED,
+            agent_chat_id="chat_x",
+            agent_turn_id="turn_x",
+            error_message="boom",
+            latency_ms=10,
+        )
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert final is EvaluationRunStatus.FAILED
+    assert run.status is EvaluationRunStatus.FAILED
+    assert [item.status for item in items] == [EvaluationRunItemStatus.FAILED, EvaluationRunItemStatus.FAILED]
+    assert len(ops.attempts) == 2
+    for attempt in ops.attempts:
+        assert attempt["status"] is EvaluationRunItemAttemptStatus.FAILED
+        assert attempt["error_message"] == "boom"
+    assert run.summary["failed"] == 2 and run.summary["completed"] == 0
+
+
+def test_execute_evaluation_run_mixed_outcome_completes_run_and_records_both_attempts():
+    run, items = _make_run_and_items(item_count=2)
+    ops = _FakeOps(run, items)
+
+    outcomes = iter(
+        [
+            TurnDispatchOutcome(status=EvaluationRunItemAttemptStatus.COMPLETED, answer_text="ok"),
+            TurnDispatchOutcome(
+                status=EvaluationRunItemAttemptStatus.FAILED,
+                error_message="second item blew up",
+            ),
+        ]
+    )
+
+    async def fake_dispatch(**_):
+        return next(outcomes)
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    # One success is enough to mark the run COMPLETED; tracking failed stays in summary.
+    assert final is EvaluationRunStatus.COMPLETED
+    assert run.summary["completed"] == 1 and run.summary["failed"] == 1
+    assert [a["status"] for a in ops.attempts] == [
+        EvaluationRunItemAttemptStatus.COMPLETED,
+        EvaluationRunItemAttemptStatus.FAILED,
+    ]
+    assert [item.status for item in items] == [
+        EvaluationRunItemStatus.COMPLETED,
+        EvaluationRunItemStatus.FAILED,
+    ]
+
+
+def test_execute_evaluation_run_catches_dispatch_exception_and_records_failed_attempt():
+    run, items = _make_run_and_items(item_count=1)
+    ops = _FakeOps(run, items)
+
+    async def crashing_dispatch(**_):
+        raise RuntimeError("runtime unreachable")
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=crashing_dispatch))
+
+    assert final is EvaluationRunStatus.FAILED
+    assert items[0].status is EvaluationRunItemStatus.FAILED
+    assert len(ops.attempts) == 1
+    assert ops.attempts[0]["status"] is EvaluationRunItemAttemptStatus.FAILED
+    assert "runtime unreachable" in ops.attempts[0]["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_execute_evaluation_run_short_circuits_when_run_missing():
+    run, _ = _make_run_and_items()
+    ops = _FakeOps(run, [])
+    run.id = "run_present"
+
+    dispatched: list[str] = []
+
+    async def fake_dispatch(**kwargs):  # pragma: no cover - should not run
+        dispatched.append(kwargs["input_message"])
+        return TurnDispatchOutcome(status=EvaluationRunItemAttemptStatus.COMPLETED)
+
+    final = asyncio.run(execute_evaluation_run("missing_run", db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert final is EvaluationRunStatus.FAILED
+    assert ops.update_run_calls == [] and dispatched == []
+
+
+def test_execute_evaluation_run_short_circuits_when_run_already_terminal():
+    run, _ = _make_run_and_items()
+    run.status = EvaluationRunStatus.COMPLETED
+    ops = _FakeOps(run, [])
+
+    async def fake_dispatch(**_):  # pragma: no cover - should not run
+        raise AssertionError("dispatch_fn must not be invoked for a terminal run")
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert final is EvaluationRunStatus.COMPLETED
+    assert ops.update_run_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Static guard: worker must not leak legacy Benchmark concepts
+# ---------------------------------------------------------------------------
+
+
+def test_worker_module_source_has_no_benchmark_or_dataset_version_references():
+    source = Path(worker.__file__).read_text(encoding="utf-8").lower()
+    forbidden = ("benchmark_", "dataset_version_id", "/api/v2/bots", "httpx")
+    for token in forbidden:
+        assert token not in source, f"worker.py must not reference '{token}'"
+
+
+# ---------------------------------------------------------------------------
+# Service seam: launch_run calls the Celery task's .delay, not no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_evaluation_run_service_launch_run_dispatches_celery_task(monkeypatch):
+    from aperag.evaluation_v2 import services as services_module
+    from aperag.evaluation_v2 import tasks as tasks_module
+
+    calls: list[str] = []
+
+    class _FakeTask:
+        name = "aperag.evaluation_v2.tasks.run_evaluation_run"
+
+        def delay(self, run_id: str):
+            calls.append(run_id)
+
+    fake_task = _FakeTask()
+    monkeypatch.setattr(tasks_module, "run_evaluation_run", fake_task)
+
+    svc = services_module.EvaluationRunService(db_ops=object())
+    asyncio.run(svc.launch_run("run_abc123"))
+
+    assert calls == ["run_abc123"]


### PR DESCRIPTION
## Summary

PR-1b for `#evaluation #20`. Closes the runtime gap PR-1 left: `POST /api/v2/evaluation-runs` was creating queued runs that never executed because `launch_run` and `run_evaluation_run` were no-op stubs.

This PR wires the minimum state-machine per Weston `msg=a1fb130f` 6 hard points + PM `msg=59865d40` scope. Architecture follows @符炫炜's `msg=7bd6e8f0` CR preview: all agent-runtime interaction lives in a single mockable seam `dispatch_evaluation_turn`; orchestration `execute_evaluation_run` consumes it via a `dispatch_fn` parameter so tests drive the full state-machine without standing up the runtime / Redis / Celery or re-asserting `#13 Chat/agent-runtime` surface.

## Files

- **`aperag/db/repositories/evaluation_v2.py`** (+102): `get_run_for_worker`, `mark_run_item_running`, `create_run_item_attempt`, `finalize_run_item` — the minimal worker-side DB ops. Worker reads take no `user_id` (worker only has `run_id`; auth stays at HTTP edge).
- **`aperag/evaluation_v2/worker.py`** (new, +322):
  - `dispatch_evaluation_turn` — seam. Creates isolated chat via `chat_service_global`, calls `turn_service.create_or_get_turn` + `claim_turn` + `launch_turn`, polls `AgentTurnStatus` until terminal, extracts `answer_text` from `get_turn_snapshot` artifacts.
  - `execute_evaluation_run(run_id, *, db_ops=None, dispatch_fn=None)` — orchestration. QUEUED→RUNNING→COMPLETED/FAILED. Reads **only** `evaluation_run_items` snapshot columns. One `evaluation_run_item_attempt` per item even on failure. Incremental `run.summary` updates.
- **`aperag/evaluation_v2/tasks.py`** (+28/-21): Celery task registration wrapping `execute_evaluation_run` in `asyncio.run`, lazy imports keep module import-safe.
- **`aperag/evaluation_v2/services.py`** (+12/-1): `launch_run` now `run_evaluation_run.delay(run_id)` instead of `return None`.
- **`config/celery.py`** (+1/-1): `include=` entry for `aperag.evaluation_v2.tasks`.
- **`tests/unit_test/test_evaluation_v2_worker.py`** (new, +342): 9 focused tests.

## Hard points (msg=a1fb130f + msg=59865d40)

- [x] `launch_run()` triggers worker seam (Celery `.delay` via task)
- [x] `run_evaluation_run()` reads `evaluation_run_items` snapshot — never `evaluation_dataset_items` (enforced by `_FakeOps.__getattr__` guard)
- [x] `evaluation_run_item_attempts` written per item (COMPLETED / FAILED / CANCELLED)
- [x] Item state machine QUEUED/PENDING → RUNNING → COMPLETED/FAILED/CANCELLED
- [x] Run state machine QUEUED → RUNNING → COMPLETED (any success) or FAILED (all failed)
- [x] `run.summary` updated (total / pending / running / completed / failed / cancelled) with incremental pushes, not just final
- [x] Runtime call via `agent_runtime_manager` — no HTTP `/api/v2/bots*` side-channel (static guard test blocks `httpx` / `/api/v2/bots` tokens from the worker source)
- [x] Focused pytest covers success + failure + exception + short-circuit + snapshot-only-read + no-benchmark-refs
- [x] **Not done** (explicit per scope): judge scoring, `best_score`, complex retry — PR-C polish

## CR lane checklist

- **@Weston / 方案 + msg=a1fb130f hard points** — covered above.
- **@符炫炜 / #14 consumer-angle + msg=7bd6e8f0 mockable seam** — `dispatch_evaluation_turn` is the only runtime touch; tests inject `dispatch_fn` at that seam, no chat persistence / isolated chat re-assertion.
- **@Bryce / agent-runtime** — turn dispatch via `agent_runtime_manager` (not HTTP); no `agent_turn` / `turn_feedback` schema changes; run item ↔ agent turn through string identifier (not FK).
- **@ApeRAG专家 / contract-boundary** — no OpenAPI / router contract changes (PR-1 already switched); new tables untouched; `_extract_answer_text` mirrors existing `chat_completion_service._build_completion_content` artifact pattern.
- **@ziang / collection-document** — no collection / document / search / graph touch; evaluation only reads its own snapshot columns.

## Local gates

- `uv run --extra test pytest tests/unit_test/test_evaluation_v2_worker.py tests/unit_test/test_evaluation_v2_openapi_contract.py tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_openapi_spec.py -q` → **27 passed**
- `make lint` → All checks passed!
- `git diff --check` → clean

## Merge order

Per PM `msg=cda53e45`: **PR-1b first → PR-2 after**. After this merges, `#20` backend runtime is complete end-to-end; PR-2 (owned by @cuiwenbo) delivers the FE / docs / hurl on top.

## Test plan

- [x] Local pytest green
- [x] Local lint green
- [ ] GitHub `lint-and-unit` green
- [ ] (Optional per new gate) e2e not required for merge per `#all msg=e7f3f106`

🤖 Generated with [Claude Code](https://claude.com/claude-code)