### PR TITLE
fix: upgrade litellm for security alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "numpy>=2.1.3",
     "pipmaster<1.0.0,>=0.5.4",
     "pytablewriter<2.0.0,>=1.2.1",
-    "litellm>=v1.80.0",
+    "litellm>=1.83.0",
     "requests",
     "asyncpg>=0.30.0",
     "markitdown[all]>=0.1.5",

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.0.0,<4.0.0" },
     { name = "jsonref", specifier = ">=1.1.0" },
     { name = "langchain", specifier = ">=0.3.23,<1.0.0" },
-    { name = "litellm", specifier = ">=1.80.0" },
+    { name = "litellm", specifier = ">=1.83.0" },
     { name = "llama-index", specifier = ">=0.12.28,<1.0.0" },
     { name = "llama-index-embeddings-langchain", specifier = ">=0.3.0,<1.0.0" },
     { name = "llama-index-vector-stores-qdrant", specifier = ">=0.6.0,<1.0.0" },
@@ -2863,7 +2863,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.80.0"
+version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2879,9 +2879,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrade `litellm` from 1.80.0 to 1.83.0 to cover the critical/high Dependabot alerts.
- Normalize the project dependency specifier from `>=v1.80.0` to `>=1.83.0`.
- Refresh `uv.lock`; no other package versions changed.

## Validation
- `uv lock --check`
- LiteLLM API import smoke for completion/acompletion/embedding/arerank/cache types
- `uv run --extra test pytest tests/unit_test/llm/test_litellm_cache_key.py tests/unit_test/llm/test_rerank_service.py -q`
- `uv run ruff check pyproject.toml aperag/llm/completion/completion_service.py aperag/llm/embed/embedding_service.py aperag/llm/rerank/rerank_service.py aperag/llm/litellm_cache.py aperag/llm/litellm_logging.py aperag/llm/litellm_track.py`
- `make lint`
- `git diff --check`
