### PR TITLE
fix(evaluation): preserve terminal run status in worker (#20)

### DIFF
--- a/aperag/evaluation_v2/worker.py
+++ b/aperag/evaluation_v2/worker.py
@@ -222,6 +222,12 @@ _ITEM_STATUS_BY_ATTEMPT: dict[EvaluationRunItemAttemptStatus, EvaluationRunItemS
     EvaluationRunItemAttemptStatus.CANCELLED: EvaluationRunItemStatus.CANCELLED,
 }
 
+_TERMINAL_RUN_STATUSES = {
+    EvaluationRunStatus.COMPLETED,
+    EvaluationRunStatus.FAILED,
+    EvaluationRunStatus.CANCELLED,
+}
+
 
 async def execute_evaluation_run(
     run_id: str,
@@ -241,7 +247,8 @@ async def execute_evaluation_run(
       * Create one ``evaluation_run_item_attempt`` per dispatch, even when
         the outcome is FAILED/CANCELLED.
       * Run transitions QUEUED → RUNNING → COMPLETED (all items succeeded
-        or at least one completed) or FAILED (all items failed).
+        or at least one completed), FAILED (all items failed), or CANCELLED
+        (external run cancellation or all items cancelled).
       * ``run.summary`` is updated after every item so polling clients see
         incremental progress.
     """
@@ -254,11 +261,7 @@ async def execute_evaluation_run(
         logger.warning("evaluation run %s vanished before worker could pick it up", run_id)
         return EvaluationRunStatus.FAILED
 
-    if run.status in (
-        EvaluationRunStatus.COMPLETED,
-        EvaluationRunStatus.FAILED,
-        EvaluationRunStatus.CANCELLED,
-    ):
+    if run.status in _TERMINAL_RUN_STATUSES:
         logger.info(
             "evaluation run %s already in terminal status %s; worker skipping",
             run_id,
@@ -278,6 +281,19 @@ async def execute_evaluation_run(
     bot_id = run.bot_id
 
     for item in items:
+        current_run = await ops.get_run_for_worker(run_id)
+        if current_run is None:
+            logger.warning("evaluation run %s vanished while worker was processing items", run_id)
+            return EvaluationRunStatus.FAILED
+        if current_run.status in _TERMINAL_RUN_STATUSES:
+            logger.info(
+                "evaluation run %s moved to terminal status %s; worker stops dispatching remaining items",
+                run_id,
+                current_run.status,
+            )
+            run.status = current_run.status
+            break
+
         await _process_run_item(
             run=run,
             item=item,
@@ -288,7 +304,12 @@ async def execute_evaluation_run(
             dispatch=dispatch,
         )
 
-    final_status = _final_run_status(summary)
+    latest_run = await ops.get_run_for_worker(run_id)
+    final_status = (
+        latest_run.status
+        if latest_run is not None and latest_run.status in _TERMINAL_RUN_STATUSES
+        else _final_run_status(summary)
+    )
     await ops.update_run_status(run_id, final_status, summary=summary.model_dump())
     return final_status
 
@@ -355,6 +376,8 @@ async def _process_run_item(
 
 
 def _final_run_status(summary: EvaluationRunSummary) -> EvaluationRunStatus:
+    if summary.completed == 0 and summary.failed == 0 and summary.cancelled > 0:
+        return EvaluationRunStatus.CANCELLED
     if summary.completed == 0 and summary.failed > 0 and summary.cancelled == 0:
         return EvaluationRunStatus.FAILED
     return EvaluationRunStatus.COMPLETED

--- a/tests/unit_test/test_evaluation_v2_worker.py
+++ b/tests/unit_test/test_evaluation_v2_worker.py
@@ -7,7 +7,8 @@ Scope (per PR-1b hard points):
 * One attempt is persisted per item, even on failure.
 * Item status transitions: PENDING → RUNNING → COMPLETED/FAILED/CANCELLED.
 * Run status transitions: QUEUED/RUNNING → RUNNING → COMPLETED (any
-  success) or FAILED (all failed).
+  success), FAILED (all failed), or CANCELLED (external cancellation or
+  all items cancelled).
 * ``run.summary`` counters are updated incrementally; final summary
   equals the number of completed/failed/cancelled items.
 * The worker module does not leak legacy Benchmark concepts
@@ -294,6 +295,56 @@ def test_execute_evaluation_run_mixed_outcome_completes_run_and_records_both_att
         EvaluationRunItemStatus.COMPLETED,
         EvaluationRunItemStatus.FAILED,
     ]
+
+
+def test_execute_evaluation_run_stops_mid_flight_when_run_cancelled():
+    run, items = _make_run_and_items(item_count=2)
+    ops = _FakeOps(run, items)
+    captured_inputs: list[str] = []
+
+    async def fake_dispatch(*, input_message, **_):
+        captured_inputs.append(input_message)
+        ops._run.status = EvaluationRunStatus.CANCELLED
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.COMPLETED,
+            answer_text="first item completed before cancellation",
+        )
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert final is EvaluationRunStatus.CANCELLED
+    assert run.status is EvaluationRunStatus.CANCELLED
+    assert captured_inputs == [items[0].input_message]
+    assert len(ops.attempts) == 1
+    assert items[0].status is EvaluationRunItemStatus.COMPLETED
+    assert items[1].status is EvaluationRunItemStatus.PENDING
+    assert run.summary["completed"] == 1
+    assert run.summary["pending"] == 1
+    assert run.summary["running"] == 0
+
+
+def test_execute_evaluation_run_returns_cancelled_when_all_items_cancelled():
+    run, items = _make_run_and_items(item_count=2)
+    ops = _FakeOps(run, items)
+
+    async def fake_dispatch(**_):
+        return TurnDispatchOutcome(status=EvaluationRunItemAttemptStatus.CANCELLED)
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert final is EvaluationRunStatus.CANCELLED
+    assert run.status is EvaluationRunStatus.CANCELLED
+    assert [item.status for item in items] == [
+        EvaluationRunItemStatus.CANCELLED,
+        EvaluationRunItemStatus.CANCELLED,
+    ]
+    assert [attempt["status"] for attempt in ops.attempts] == [
+        EvaluationRunItemAttemptStatus.CANCELLED,
+        EvaluationRunItemAttemptStatus.CANCELLED,
+    ]
+    assert run.summary["cancelled"] == 2
+    assert run.summary["completed"] == 0
+    assert run.summary["failed"] == 0
 
 
 def test_execute_evaluation_run_catches_dispatch_exception_and_records_failed_attempt():

--- a/tests/unit_test/test_evaluation_v2_worker.py
+++ b/tests/unit_test/test_evaluation_v2_worker.py
@@ -347,6 +347,32 @@ def test_execute_evaluation_run_returns_cancelled_when_all_items_cancelled():
     assert run.summary["failed"] == 0
 
 
+def test_execute_evaluation_run_does_not_overwrite_externally_failed_run_status():
+    run, items = _make_run_and_items(item_count=2)
+    ops = _FakeOps(run, items)
+    captured_inputs: list[str] = []
+
+    async def fake_dispatch(*, input_message, **_):
+        captured_inputs.append(input_message)
+        ops._run.status = EvaluationRunStatus.FAILED
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.COMPLETED,
+            answer_text="first item completed before external force-fail",
+        )
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert final is EvaluationRunStatus.FAILED
+    assert run.status is EvaluationRunStatus.FAILED
+    assert captured_inputs == [items[0].input_message]
+    assert len(ops.attempts) == 1
+    assert items[0].status is EvaluationRunItemStatus.COMPLETED
+    assert items[1].status is EvaluationRunItemStatus.PENDING
+    assert run.summary["completed"] == 1
+    assert run.summary["pending"] == 1
+    assert run.summary["running"] == 0
+
+
 def test_execute_evaluation_run_catches_dispatch_exception_and_records_failed_attempt():
     run, items = _make_run_and_items(item_count=1)
     ops = _FakeOps(run, items)


### PR DESCRIPTION
## Summary

Fixes the PR-1b cancellation correctness race in the evaluation worker.

- Re-read run status before dispatching each run item and stop dispatching if the run has moved to any terminal state.
- Preserve externally terminal run status at final summary update instead of overwriting it with worker-derived COMPLETED/FAILED.
- Treat all-cancelled item outcomes as a CANCELLED run.
- Add focused tests for mid-flight cancellation, all-cancelled outcomes, and generic terminal-status preservation.

## Root Cause

PR #1596 made the worker executable but only checked terminal run status at startup. If `cancel_run` marked a run CANCELLED while the worker was in progress, the worker could continue dispatching remaining items and then overwrite the terminal status with COMPLETED.

## Validation

- `uv run --extra test pytest tests/unit_test/test_evaluation_v2_worker.py tests/unit_test/test_evaluation_v2_openapi_contract.py -q` → 19 passed
- `make lint` → passed
- `git diff --check` → passed
