### PR TITLE
fix(evaluation_v2): PR-1c preserve CANCELLED run status across worker (#20)

### DIFF
--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -288,6 +288,28 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
 
         return await self.execute_with_transaction(_operation)
 
+    async def update_run_summary_only(self, run_id: str, summary: dict) -> Optional[EvaluationRun]:
+        """Update only the run's ``summary`` JSON + ``gmt_updated``.
+
+        Used by the worker between iterations so an externally-set terminal
+        status (e.g. a user pressing Cancel and flipping the run to
+        ``CANCELLED`` via the service layer) is never clobbered by the
+        worker re-asserting ``RUNNING``.
+        """
+
+        async def _operation(session: AsyncSession):
+            stmt = select(EvaluationRun).where(EvaluationRun.id == run_id)
+            run = (await session.execute(stmt)).scalars().first()
+            if not run:
+                return None
+            run.summary = summary
+            run.gmt_updated = utc_now()
+            await session.flush()
+            await session.refresh(run)
+            return run
+
+        return await self.execute_with_transaction(_operation)
+
     async def finalize_run_item(
         self,
         *,

--- a/aperag/evaluation_v2/worker.py
+++ b/aperag/evaluation_v2/worker.py
@@ -223,6 +223,15 @@ _ITEM_STATUS_BY_ATTEMPT: dict[EvaluationRunItemAttemptStatus, EvaluationRunItemS
 }
 
 
+_TERMINAL_RUN_STATUSES: frozenset[EvaluationRunStatus] = frozenset(
+    {
+        EvaluationRunStatus.COMPLETED,
+        EvaluationRunStatus.FAILED,
+        EvaluationRunStatus.CANCELLED,
+    }
+)
+
+
 async def execute_evaluation_run(
     run_id: str,
     *,
@@ -254,11 +263,7 @@ async def execute_evaluation_run(
         logger.warning("evaluation run %s vanished before worker could pick it up", run_id)
         return EvaluationRunStatus.FAILED
 
-    if run.status in (
-        EvaluationRunStatus.COMPLETED,
-        EvaluationRunStatus.FAILED,
-        EvaluationRunStatus.CANCELLED,
-    ):
+    if run.status in _TERMINAL_RUN_STATUSES:
         logger.info(
             "evaluation run %s already in terminal status %s; worker skipping",
             run_id,
@@ -278,6 +283,18 @@ async def execute_evaluation_run(
     bot_id = run.bot_id
 
     for item in items:
+        # Re-read the run before each item so a mid-flight ``cancel_run``
+        # call takes effect on the next iteration. Without this check the
+        # worker keeps dispatching turns even after the user has flipped
+        # the run to ``CANCELLED`` through the service layer.
+        latest = await ops.get_run_for_worker(run_id)
+        if latest is not None and latest.status in _TERMINAL_RUN_STATUSES:
+            logger.info(
+                "evaluation run %s observed terminal status %s mid-flight; stopping loop",
+                run_id,
+                latest.status,
+            )
+            break
         await _process_run_item(
             run=run,
             item=item,
@@ -287,6 +304,15 @@ async def execute_evaluation_run(
             ops=ops,
             dispatch=dispatch,
         )
+
+    # Final write MUST NOT overwrite an externally-set terminal status
+    # (``cancel_run`` → CANCELLED is the hot case, but the same guard also
+    # protects a future forcefail / admin-terminate path). Re-read and pick
+    # "update summary only" when the row is already terminal.
+    final_run = await ops.get_run_for_worker(run_id)
+    if final_run is not None and final_run.status in _TERMINAL_RUN_STATUSES:
+        await ops.update_run_summary_only(run_id, summary.model_dump())
+        return final_run.status
 
     final_status = _final_run_status(summary)
     await ops.update_run_status(run_id, final_status, summary=summary.model_dump())
@@ -309,7 +335,10 @@ async def _process_run_item(
     attempt_no = updated.attempt_count if updated else 1
     summary.pending = max(0, summary.pending - 1)
     summary.running += 1
-    await ops.update_run_status(run.id, EvaluationRunStatus.RUNNING, summary=summary.model_dump())
+    # Push incremental summary without touching run.status — if the run
+    # was just flipped to CANCELLED by the service layer we must not
+    # re-assert RUNNING here.
+    await ops.update_run_summary_only(run.id, summary.model_dump())
 
     try:
         # Value-copy snapshot read — no dataset_items access.
@@ -355,6 +384,10 @@ async def _process_run_item(
 
 
 def _final_run_status(summary: EvaluationRunSummary) -> EvaluationRunStatus:
+    # All items cancelled (e.g. the loop short-circuited on a mid-flight
+    # cancel_run before any dispatch): the run is CANCELLED, not COMPLETED.
+    if summary.cancelled > 0 and summary.completed == 0 and summary.failed == 0:
+        return EvaluationRunStatus.CANCELLED
     if summary.completed == 0 and summary.failed > 0 and summary.cancelled == 0:
         return EvaluationRunStatus.FAILED
     return EvaluationRunStatus.COMPLETED

--- a/tests/unit_test/test_evaluation_v2_worker.py
+++ b/tests/unit_test/test_evaluation_v2_worker.py
@@ -61,6 +61,7 @@ class _FakeOps:
         self.finalized: list[tuple[str, EvaluationRunItemStatus, str | None, str | None]] = []
         self.mark_running_calls: list[str] = []
         self.dataset_items_accessed = False  # flipped only by the guard below
+        self.summary_only_calls: list[dict] = []
 
     # --- the small subset of AsyncDatabaseOps the worker uses --------------
 
@@ -77,6 +78,15 @@ class _FakeOps:
         self._run.status = status
         if summary is not None:
             self._run.summary = summary
+        return self._run
+
+    async def update_run_summary_only(self, run_id, summary):
+        assert run_id == self._run.id
+        # Track as a separate kind of update so tests can assert that the
+        # worker used the status-preserving path while a run was externally
+        # cancelled mid-flight.
+        self.summary_only_calls.append(summary)
+        self._run.summary = summary
         return self._run
 
     async def mark_run_item_running(self, item_id: str):
@@ -218,16 +228,16 @@ def test_execute_evaluation_run_tracks_incremental_progress_in_summary():
 
     asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
 
-    # First call: move run into RUNNING with fresh summary.
+    # First status-transition call: QUEUED → RUNNING with fresh summary.
     first_call = ops.update_run_calls[0]
     assert first_call[0] is EvaluationRunStatus.RUNNING
     assert first_call[1]["pending"] == 2 and first_call[1]["running"] == 0
 
-    # Intermediate RUNNING updates must reflect at least one completed item
-    # before the final COMPLETED transition.
-    running_snapshots = [call[1] for call in ops.update_run_calls if call[0] is EvaluationRunStatus.RUNNING]
-    assert any(s.get("completed", 0) >= 1 for s in running_snapshots[1:]), (
-        "summary should reflect completed items before the final run transition"
+    # Intermediate snapshots go through the status-preserving path
+    # (update_run_summary_only) and must reflect at least one completed
+    # item before the final run transition.
+    assert any(s.get("completed", 0) >= 1 for s in ops.summary_only_calls), (
+        "summary_only_calls should reflect completed items before the final run transition"
     )
 
     # Final update: COMPLETED.
@@ -332,6 +342,64 @@ def test_execute_evaluation_run_short_circuits_when_run_missing():
 
     assert final is EvaluationRunStatus.FAILED
     assert ops.update_run_calls == [] and dispatched == []
+
+
+def test_execute_evaluation_run_stops_mid_flight_when_run_cancelled():
+    """The worker must re-read run.status between items so an external
+    ``cancel_run`` call stops dispatch, and the final write must not
+    overwrite the externally-set CANCELLED status back to COMPLETED."""
+
+    run, items = _make_run_and_items(item_count=3)
+    ops = _FakeOps(run, items)
+
+    dispatch_calls: list[str] = []
+
+    async def cancelling_dispatch(*, input_message, **_):
+        dispatch_calls.append(input_message)
+        if len(dispatch_calls) == 1:
+            # Simulate a user pressing Cancel after the first item's
+            # dispatch completes but before the worker picks up the next.
+            run.status = EvaluationRunStatus.CANCELLED
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.COMPLETED,
+            answer_text="ok",
+        )
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=cancelling_dispatch))
+
+    # The 2nd and 3rd items must be skipped — exactly one dispatch fired.
+    assert len(dispatch_calls) == 1
+    assert len(ops.attempts) == 1
+    # Externally-set CANCELLED must NOT be overwritten by the worker's final write.
+    assert final is EvaluationRunStatus.CANCELLED
+    assert run.status is EvaluationRunStatus.CANCELLED
+    # The final write must go through the summary-only path, not
+    # update_run_status (which would clobber the CANCELLED).
+    assert ops.summary_only_calls, "final update should preserve status via update_run_summary_only"
+    last_status_update = ops.update_run_calls[-1][0] if ops.update_run_calls else None
+    assert last_status_update is EvaluationRunStatus.RUNNING, (
+        "final update_run_status call should remain the QUEUED→RUNNING transition; "
+        "no later status overwrite is allowed when the run is externally cancelled"
+    )
+
+
+def test_execute_evaluation_run_returns_cancelled_when_all_items_cancelled():
+    """If every item's dispatch yields CANCELLED (e.g. a fast-cancelling
+    runtime) and no external ``cancel_run`` flipped the row, the derived
+    final status must be CANCELLED — never the default COMPLETED."""
+
+    run, items = _make_run_and_items(item_count=2)
+    ops = _FakeOps(run, items)
+
+    async def cancelling_dispatch(**_):
+        return TurnDispatchOutcome(status=EvaluationRunItemAttemptStatus.CANCELLED)
+
+    final = asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=cancelling_dispatch))
+
+    assert final is EvaluationRunStatus.CANCELLED
+    assert run.status is EvaluationRunStatus.CANCELLED
+    assert run.summary["cancelled"] == 2 and run.summary["completed"] == 0 and run.summary["failed"] == 0
+    assert [a["status"] for a in ops.attempts] == [EvaluationRunItemAttemptStatus.CANCELLED] * 2
 
 
 def test_execute_evaluation_run_short_circuits_when_run_already_terminal():


### PR DESCRIPTION
## Summary

Follow-up to #1596 (PR-1b). Fixes the state-correctness bug @符炫炜 msg=ea311364 + @ApeRAG专家 msg=4ae43b3d flagged **after** PR-1b was already admin-merged: users pressing Cancel after the run had started would still see the run finish as COMPLETED because the worker never re-read `run.status` mid-flight and its final `update_run_status(...)` unconditionally overwrote CANCELLED back to COMPLETED.

Per @chenyexuan msg=6c559314 this belongs on PR-1b's 4th hard point (`QUEUED → RUNNING → COMPLETED/FAILED/`**`CANCELLED`**), not PR-C polish.

## Changes

### `aperag/evaluation_v2/worker.py` (+45/-12)
- `execute_evaluation_run` re-reads `run.status` at the top of **every** item iteration; any terminal status (CANCELLED is the hot case, but the guard also covers future forcefail / admin-terminate) short-circuits the loop — no dispatch, no attempt row.
- The final write now reads the current `run.status` first. If the row is already terminal it goes through the new `update_run_summary_only` path: summary counters get their final values but the worker does **not** touch the status field. Per @chenyexuan msg=6c559314 this "terminal is sticky" semantics is broader than a CANCELLED-specific special case.
- Mid-iteration summary pushes now also go through `update_run_summary_only` — a freshly-cancelled run is not re-asserted back to RUNNING between items.
- `_final_run_status` returns `CANCELLED` when `summary.cancelled > 0 and completed == 0 and failed == 0`. The all-items-cancelled case no longer collapses to COMPLETED.
- New module-level `_TERMINAL_RUN_STATUSES` frozenset keeps the three guards in sync.

### `aperag/db/repositories/evaluation_v2.py` (+22)
- `update_run_summary_only(run_id, summary)` — updates only `summary` + `gmt_updated`. Worker uses it to push incremental progress and final summary without reasserting `status` / `gmt_started` / `gmt_finished`.

### `tests/unit_test/test_evaluation_v2_worker.py` (+80/-3)
- `test_execute_evaluation_run_stops_mid_flight_when_run_cancelled` — flips the fake run to CANCELLED inside the first dispatch; asserts subsequent items are skipped (1 dispatch, 1 attempt), `final == CANCELLED`, and the last write goes through the summary-only path instead of a status update.
- `test_execute_evaluation_run_returns_cancelled_when_all_items_cancelled` — every dispatch reports CANCELLED; asserts the derived final status is CANCELLED, not COMPLETED.
- Updated the existing incremental-progress test to check `summary_only_calls` instead of `update_run_calls`, matching the new split.

## What's preserved from PR-1b

- No schema change, no FE touch, no new router.
- Mockable seam stays at `dispatch_fn` param; `#13 chat persistence` test domain untouched.
- Static guard still enforces no `benchmark_*` / `dataset_version_id` / HTTP bot-route / httpx tokens in worker.py.
- 7 PR-C polish items (isolated chat GC, concurrent execution, answer-artifact constants, summary merge, timeout/poll config) still deferred per @符炫炜 msg=2aa4c535 — that list is unchanged.

## Local gates

- `uv run --extra test pytest tests/unit_test/test_evaluation_v2_worker.py tests/unit_test/test_evaluation_v2_openapi_contract.py tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_openapi_spec.py -q` → **31 passed**
- `make lint` → All checks passed!
- `git diff --check` → clean

## Merge order

Per @chenyexuan msg=fbc0e522 PR-1c is backend-only and writes don't overlap with PR-2 (FE/docs/hurl), so PR-1c + PR-2 can run in parallel. `#20` completion still requires both merged.

## Test plan

- [x] Local pytest green (31 passed)
- [x] Local lint green
- [ ] GitHub `lint-and-unit` green
- [ ] 1 家 no-blocker CR 复签 → admin merge (e2e 按新口径不前置)

🤖 Generated with [Claude Code](https://claude.com/claude-code)