### PR TITLE
Upgrade pytest security dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ test = [
     "tabulate<1.0.0,>=0.9.0",
     "pytablewriter<2.0.0,>=1.0.0",
     "pytest",
-    "pytest-asyncio",
+    "pytest-asyncio>=1.3.0,<1.4.0a0",
     "pytest-benchmark>=5.1.0",
     "pytest-cov>=6.2.1",
     "moto",

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ requires-dist = [
     { name = "pytablewriter", marker = "extra == 'test'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-aioboto3", marker = "extra == 'test'", specifier = ">=0.6.0" },
-    { name = "pytest-asyncio", marker = "extra == 'test'" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0,<1.4.0a0" },
     { name = "pytest-benchmark", marker = "extra == 'test'", specifier = ">=5.1.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
@@ -4857,17 +4857,18 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -4887,14 +4888,15 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.26.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade `pytest` from `8.3.5` to `9.0.3` to address the open Dependabot alert
- keep `pytest-asyncio` on the latest stable line by constraining it to `>=1.3.0,<1.4.0a0`
- refresh `uv.lock`

## Why
The repository globally allows prereleases, so a plain pytest lock refresh selected `pytest-asyncio 1.4.0a1`. This PR keeps the security fix while avoiding a prerelease async test plugin in the test extra.

## Validation
- `uv lock --check`
- `git diff --check`
- `uv run --extra test pytest tests/unit_test/test_openapi_spec.py tests/unit_test/test_mcp_server.py -q`
- `uv run --extra test pytest tests/unit_test/test_document_service_fetch_url.py tests/unit_test/concurrent_control/test_lock_manager.py -q`
- `make lint`
