### PR TITLE
feat(modularization): phase 1a FE typed adapter for api-key (#3)

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -18,6 +18,77 @@ def test_server_typed_client_uses_api_root_not_legacy_v1_base_path():
     assert "if (!response.ok)" in server_source
 
 
+def test_api_key_feature_uses_v2_typed_api_boundary():
+    """#3 Phase 1a FE typed adapter skeleton + api-key sample migration.
+
+    The user-scoped API key pages (`app/workspace/api-keys/**`) and the new
+    `features/api-key/*` adapter must consume the typed OpenAPI client only.
+    Any regression to `@/api` legacy SDK or raw `apiClient.defaultApi.apikeys*`
+    calls inside this scope means the Phase 1a baseline (api-key moved off
+    the FE legacy SDK allowlist) has been unwound.
+
+    Negative assertions are scoped to `app/workspace/api-keys/**` and
+    `features/api-key/**` so legitimate uses of the string "api key" in
+    unrelated places (e.g. `features/providers` where `api_key` is a
+    provider credential field, not a user API key) stay unaffected.
+    """
+    checked_paths = [
+        REPO_ROOT / "web/src/app/workspace/api-keys",
+        REPO_ROOT / "web/src/features/api-key",
+    ]
+
+    sources = {
+        path: path.read_text()
+        for root in checked_paths
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix in {".ts", ".tsx"}
+    }
+    joined = "\n".join(sources.values())
+    feature_sources = "\n".join(
+        source
+        for path, source in sources.items()
+        if "/web/src/features/api-key/" in str(path)
+    )
+
+    # Negative: the domain scope must not reach the old generated SDK or
+    # the v1 ApiKey types imported via `@/api`.
+    assert "from '@/api'" not in joined
+    assert "apiClient.defaultApi.apikeys" not in joined
+    assert "serverApi.defaultApi.apikeys" not in joined
+    assert "defaultApi.apikeysGet" not in joined
+    assert "defaultApi.apikeysPost" not in joined
+    assert "defaultApi.apikeysApikeyIdPut" not in joined
+    assert "defaultApi.apikeysApikeyIdDelete" not in joined
+
+    # Positive: the adapter must only reach the typed v1 api-key paths
+    # through the typed openapi client. Phase 1a does not rename the API
+    # path — that is deferred to a later domain/API phase.
+    assert "from '@/api'" not in feature_sources
+    assert "fetch(" not in feature_sources
+    assert "'/api/v1/apikeys'" in feature_sources
+    assert "'/api/v1/apikeys/{apikey_id}'" in feature_sources
+
+    # Positive: the business caller wiring goes through the feature adapter,
+    # not the old generated SDK.
+    actions_tsx = (
+        REPO_ROOT
+        / "web/src/app/workspace/api-keys/api-key-actions.tsx"
+    ).read_text()
+    assert "from '@/features/api-key/client-api'" in actions_tsx
+    assert "from '@/features/api-key/types'" in actions_tsx
+
+    table_tsx = (
+        REPO_ROOT / "web/src/app/workspace/api-keys/api-key-table.tsx"
+    ).read_text()
+    assert "from '@/features/api-key/types'" in table_tsx
+
+    page_tsx = (
+        REPO_ROOT / "web/src/app/workspace/api-keys/page.tsx"
+    ).read_text()
+    assert "from '@/features/api-key/server-api'" in page_tsx
+    assert "serverApi.defaultApi.apikeysGet" not in page_tsx
+
+
 def test_evaluation_feature_uses_v2_typed_api_boundary():
     """Evaluation v3 simplification: FE must only touch the new
     `/api/v2/evaluation-datasets*` and `/api/v2/evaluation-runs*` surface.

--- a/web/src/app/workspace/api-keys/api-key-actions.tsx
+++ b/web/src/app/workspace/api-keys/api-key-actions.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { ApiKey } from '@/api';
+import {
+  createApiKey,
+  deleteApiKey,
+  updateApiKey,
+} from '@/features/api-key/client-api';
+import type { ApiKey } from '@/features/api-key/types';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -21,7 +26,6 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { apiClient } from '@/lib/api/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Slot } from '@radix-ui/react-slot';
 import copy from 'copy-to-clipboard';
@@ -67,22 +71,17 @@ export const ApiKeyActions = ({
 
   const handleCreateOrUpdate = useCallback(
     async (values: z.infer<typeof apiKeySchema>) => {
-      let res;
       if (action === 'edit' && apiKey?.id) {
-        res = await apiClient.defaultApi.apikeysApikeyIdPut({
-          apikeyId: apiKey.id,
-          apiKeyUpdate: values,
-        });
+        await updateApiKey(apiKey.id, values);
+        setCreateOrUpdateVisible(false);
+        setTimeout(router.refresh, 300);
+        return;
       }
       if (action === 'add') {
-        res = await apiClient.defaultApi.apikeysPost({
-          apiKeyCreate: values,
-        });
-      }
-      if (res?.status === 200) {
+        const created = await createApiKey(values);
         setCreateOrUpdateVisible(false);
-        if (action === 'add' && res.data) {
-          setCreatedApiKey(res.data);
+        if (created) {
+          setCreatedApiKey(created as ApiKey);
           setCreatedKeyVisible(true);
           form.reset({ description: '' });
           return;
@@ -95,13 +94,9 @@ export const ApiKeyActions = ({
 
   const handleDelete = useCallback(async () => {
     if (action === 'delete' && apiKey?.id) {
-      const res = await apiClient.defaultApi.apikeysApikeyIdDelete({
-        apikeyId: apiKey.id,
-      });
-      if (res?.status === 200) {
-        setDeleteVisible(false);
-        setTimeout(router.refresh, 300);
-      }
+      await deleteApiKey(apiKey.id);
+      setDeleteVisible(false);
+      setTimeout(router.refresh, 300);
     }
   }, [action, apiKey?.id, router]);
 

--- a/web/src/app/workspace/api-keys/api-key-table.tsx
+++ b/web/src/app/workspace/api-keys/api-key-table.tsx
@@ -31,7 +31,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-import { ApiKey } from '@/api';
+import type { ApiKey } from '@/features/api-key/types';
 import { FormatDate } from '@/components/format-date';
 import {
   ChevronDown,

--- a/web/src/app/workspace/api-keys/page.tsx
+++ b/web/src/app/workspace/api-keys/page.tsx
@@ -6,15 +6,13 @@ import {
   PageTitle,
 } from '@/components/page-container';
 
-import { getServerApi } from '@/lib/api/server';
+import { listApiKeys } from '@/features/api-key/server-api';
 import { toJson } from '@/lib/utils';
 import { getTranslations } from 'next-intl/server';
 import { ApiKeyTable } from './api-key-table';
 
 export default async function Page() {
-  const serverApi = await getServerApi();
-  const res = await serverApi.defaultApi.apikeysGet();
-  const data = res.data.items || [];
+  const data = await listApiKeys();
   const page_api_keys = await getTranslations('page_api_keys');
 
   return (

--- a/web/src/features/api-key/client-api.ts
+++ b/web/src/features/api-key/client-api.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { browserApiClient } from '@/lib/api/typed/browser';
+
+import type { ApiKeyCreate, ApiKeyUpdate } from './types';
+
+export async function createApiKey(input: ApiKeyCreate) {
+  const { data } = await browserApiClient.POST('/api/v1/apikeys', {
+    body: input,
+  });
+  return data;
+}
+
+export async function updateApiKey(apikeyId: string, input: ApiKeyUpdate) {
+  const { data } = await browserApiClient.PUT('/api/v1/apikeys/{apikey_id}', {
+    params: {
+      path: { apikey_id: apikeyId },
+    },
+    body: input,
+  });
+  return data;
+}
+
+export async function deleteApiKey(apikeyId: string) {
+  await browserApiClient.DELETE('/api/v1/apikeys/{apikey_id}', {
+    params: {
+      path: { apikey_id: apikeyId },
+    },
+  });
+}

--- a/web/src/features/api-key/server-api.ts
+++ b/web/src/features/api-key/server-api.ts
@@ -1,0 +1,9 @@
+import { createServerApiClient } from '@/lib/api/typed/server';
+
+import type { ApiKey } from './types';
+
+export async function listApiKeys(): Promise<ApiKey[]> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v1/apikeys', {});
+  return data?.items ?? [];
+}

--- a/web/src/features/api-key/types.ts
+++ b/web/src/features/api-key/types.ts
@@ -1,0 +1,9 @@
+import type { components } from '@/api-v2/schema';
+
+export type ApiKey = components['schemas']['ApiKey'];
+
+export type ApiKeyCreate = components['schemas']['ApiKeyCreate'];
+
+export type ApiKeyUpdate = components['schemas']['ApiKeyUpdate'];
+
+export type ApiKeyList = components['schemas']['ApiKeyList'];


### PR DESCRIPTION
## Summary
Phase 1a sample of the destructive-first FE legacy SDK hard-delete milestone (task #3 of `#模块化重构`).

- **Adapter**: new `web/src/features/api-key/{types,client-api,server-api}.ts` wrapping the typed `/api/v1/apikeys` + `/api/v1/apikeys/{apikey_id}` paths already present in `web/src/api-v2/schema.d.ts`. Follows the `features/bot` / `features/collection` / `features/evaluation` pattern. No OpenAPI path rename — v1→v2 hard-cut is deferred to a later API/domain phase (Weston msg=2e685896, 架构师 msg=e80d5ac3).
- **Caller migration (real route/page, per dongdong msg=f6e270ef)**:
  - `app/workspace/api-keys/page.tsx`: `serverApi.defaultApi.apikeysGet()` → `listApiKeys()`
  - `app/workspace/api-keys/api-key-table.tsx`: `ApiKey` type import from `@/api` → `@/features/api-key/types`
  - `app/workspace/api-keys/api-key-actions.tsx`: `apiClient.defaultApi.apikeysPost/Put/Delete` → `createApiKey / updateApiKey / deleteApiKey`
- **Contract test**: new `test_api_key_feature_uses_v2_typed_api_boundary` in `tests/unit_test/test_web_typed_api_contract.py`. Positive: adapter hits typed v1 paths; page/table/actions import from `@/features/api-key/*`. Negative: no `@/api` import, no `defaultApi.apikeys*` calls in scope. Scope limited to `app/workspace/api-keys/**` + `features/api-key/**` so the provider-credential `api_key` field in `features/providers/*` (different domain — 符炫炜 msg=63f5cf95 collision flag) is unaffected.

## Legacy `@/api` reduction
- **Before**: 2 files under `app/workspace/api-keys/**` imported from `@/api` (`api-key-table.tsx`, `api-key-actions.tsx`).
- **After**: 0 files in this scope import `@/api`. Phase 0 (task #2) will publish the full 52-file FE legacy allowlist fixture; this PR rebases to drop those two entries from the fixture as verifiable reduction evidence once it lands.

## Baseline
- Branch base: `main @ 2a36d88`.
- No OpenAPI schema regeneration, no backend / hurl / docs changes.
- Out of scope (per 符炫炜 msg=1a66bc6d / Weston msg=dd802275): no `components/shared` hard-move, no other domain callers, no API path rename.

## Test plan
- [x] `yarn lint --quiet` clean
- [x] `uv run pytest tests/unit_test/test_web_typed_api_contract.py -x` → 11 passed
- [ ] Manual: render `/workspace/api-keys` + create / edit / delete an API key via the new adapters
- [ ] GitHub CI: `lint-and-unit` on the PR

## Related
- Task #3 Phase 1a — FE typed adapter skeleton + api-key sample migration
- Task #4 Phase 1b/1c — FE legacy SDK hard-delete milestone (next, same owner)
- Task #2 Phase 0 — v2 target contract + executable deletion plan (chenyexuan, parallel; allowlist fixture will list api-key files; this PR will rebase to drop them post-Phase 0 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)