### PR TITLE
feat(modularization): phase 1b batch 1 FE typed adapter for prompt (#4)

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -89,6 +89,74 @@ def test_api_key_feature_uses_v2_typed_api_boundary():
     assert "serverApi.defaultApi.apikeysGet" not in page_tsx
 
 
+def test_prompt_feature_uses_v2_typed_api_boundary():
+    """#4 Phase 1b batch 1 — prompt domain (FE `features/prompt`, backend
+    canonical owner stays `model_platform` per v2 map).
+
+    Same pattern as `test_api_key_feature_uses_v2_typed_api_boundary`:
+    the Prompt Settings page and its client/server callers must only reach
+    `/api/v1/prompts/user` + `/api/v1/prompts/user/{prompt_type}` through the
+    typed openapi-fetch client behind `features/prompt/*`. Phase 1b does not
+    rename the API path or touch the OpenAPI shape — the `prompt_type` enum
+    and richer response component are known gaps tracked for the later
+    `model_platform` API hard-cut phase.
+
+    Negative assertions are scoped to `app/workspace/prompts/**` and
+    `features/prompt/**` so legitimate uses of "prompt" vocabulary in
+    adjacent places (e.g. `page_prompts` i18n, provider/model prompt fields)
+    stay unaffected. The scope also catches the indirect `getServerApi`
+    route-data regression.
+    """
+    checked_paths = [
+        REPO_ROOT / "web/src/app/workspace/prompts",
+        REPO_ROOT / "web/src/features/prompt",
+    ]
+
+    sources = {
+        path: path.read_text()
+        for root in checked_paths
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix in {".ts", ".tsx"}
+    }
+    joined = "\n".join(sources.values())
+    feature_sources = "\n".join(
+        source
+        for path, source in sources.items()
+        if "/web/src/features/prompt/" in str(path)
+    )
+
+    # Negative: the domain scope must not reach the old generated SDK,
+    # its indirect `getServerApi` path, or the v1 prompt types imported
+    # via `@/api`.
+    assert "from '@/api'" not in joined
+    assert "apiClient.defaultApi.promptsUser" not in joined
+    assert "serverApi.defaultApi.promptsUser" not in joined
+    assert "defaultApi.promptsUserGet" not in joined
+    assert "defaultApi.promptsUserPut" not in joined
+    assert "defaultApi.promptsUserPromptTypeDelete" not in joined
+    assert "getServerApi" not in joined
+
+    # Positive: the adapter must only reach the typed v1 prompt paths
+    # through the typed openapi client. Phase 1b does not rename the API
+    # path — the v1→v2 hard-cut is deferred to the `model_platform` phase.
+    assert "from '@/api'" not in feature_sources
+    assert "fetch(" not in feature_sources
+    assert "'/api/v1/prompts/user'" in feature_sources
+    assert "'/api/v1/prompts/user/{prompt_type}'" in feature_sources
+
+    # Positive: the business caller wiring goes through the feature adapter.
+    settings_tsx = (
+        REPO_ROOT / "web/src/app/workspace/prompts/prompt-settings.tsx"
+    ).read_text()
+    assert "from '@/features/prompt/client-api'" in settings_tsx
+    assert "from '@/features/prompt/types'" in settings_tsx
+
+    page_tsx = (
+        REPO_ROOT / "web/src/app/workspace/prompts/page.tsx"
+    ).read_text()
+    assert "from '@/features/prompt/server-api'" in page_tsx
+
+
 def test_evaluation_feature_uses_v2_typed_api_boundary():
     """Evaluation v3 simplification: FE must only touch the new
     `/api/v2/evaluation-datasets*` and `/api/v2/evaluation-runs*` surface.

--- a/web/src/app/workspace/prompts/page.tsx
+++ b/web/src/app/workspace/prompts/page.tsx
@@ -5,15 +5,13 @@ import {
   PageHeader,
   PageTitle,
 } from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
+import { getUserPrompts } from '@/features/prompt/server-api';
 import { toJson } from '@/lib/utils';
 import { getTranslations } from 'next-intl/server';
 import { PromptSettings } from './prompt-settings';
 
 export default async function Page() {
-  const serverApi = await getServerApi();
-  const res = await serverApi.defaultApi.promptsUserGet();
-  const data = res.data;
+  const data = await getUserPrompts();
   const page_prompts = await getTranslations('page_prompts');
 
   return (

--- a/web/src/app/workspace/prompts/prompt-settings.tsx
+++ b/web/src/app/workspace/prompts/prompt-settings.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { PromptDetail, UserPromptsResponse } from '@/api';
+import {
+  deleteUserPrompt,
+  updateUserPrompts,
+} from '@/features/prompt/client-api';
+import type {
+  PromptDetail,
+  UserPromptsResponse,
+} from '@/features/prompt/types';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -22,7 +29,6 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
-import { apiClient } from '@/lib/api/client';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
@@ -52,10 +58,8 @@ const PromptCard = ({ promptType, detail, onSaved }: PromptCardProps) => {
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      await apiClient.defaultApi.promptsUserPut({
-        updateUserPromptsRequest: {
-          prompts: { [promptType]: content },
-        },
+      await updateUserPrompts({
+        prompts: { [promptType]: content },
       });
       toast.success(page_prompts('toast.save_success'));
       onSaved();
@@ -65,9 +69,7 @@ const PromptCard = ({ promptType, detail, onSaved }: PromptCardProps) => {
   }, [content, promptType, page_prompts, onSaved]);
 
   const handleReset = useCallback(async () => {
-    await apiClient.defaultApi.promptsUserPromptTypeDelete({
-      promptType: promptType as never,
-    });
+    await deleteUserPrompt(promptType);
     toast.success(page_prompts('toast.reset_success'));
     setResetOpen(false);
     onSaved();

--- a/web/src/features/prompt/client-api.ts
+++ b/web/src/features/prompt/client-api.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { browserApiClient } from '@/lib/api/typed/browser';
+
+import type { PromptType, UpdateUserPromptsRequest } from './types';
+
+export async function updateUserPrompts(input: UpdateUserPromptsRequest) {
+  const { data } = await browserApiClient.PUT('/api/v1/prompts/user', {
+    body: input,
+  });
+  return data;
+}
+
+export async function deleteUserPrompt(promptType: PromptType) {
+  await browserApiClient.DELETE('/api/v1/prompts/user/{prompt_type}', {
+    params: {
+      path: { prompt_type: promptType },
+    },
+  });
+}

--- a/web/src/features/prompt/server-api.ts
+++ b/web/src/features/prompt/server-api.ts
@@ -1,0 +1,12 @@
+import { createServerApiClient } from '@/lib/api/typed/server';
+
+import type { UserPromptsResponse } from './types';
+
+export async function getUserPrompts(): Promise<UserPromptsResponse> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v1/prompts/user', {});
+  // The typed schema currently types the response as `{ [key: string]: unknown }`.
+  // Cast at the adapter boundary so consumers see the runtime shape
+  // (see `types.ts` for the technical-debt note).
+  return (data ?? {}) as UserPromptsResponse;
+}

--- a/web/src/features/prompt/types.ts
+++ b/web/src/features/prompt/types.ts
@@ -1,0 +1,26 @@
+import type { components } from '@/api-v2/schema';
+
+export type PromptsPayload = components['schemas']['PromptsPayload'];
+
+export type UpdateUserPromptsRequest =
+  components['schemas']['UpdateUserPromptsRequest'];
+
+// The current `/api/v1/prompts/user` GET response is typed as
+// `{ [key: string]: unknown }` in the generated schema, and the
+// `/api/v1/prompts/user/{prompt_type}` DELETE path param is a plain string.
+// Phase 1b does not change the OpenAPI shape (the v1→v2 hard-cut is the
+// job of the later `model_platform` API phase). These domain-boundary
+// types mirror the current runtime shape so the api-key-style adapter
+// pattern (cast once at the adapter boundary, typed from there) can
+// still hold. Track under the `model_platform` breaking-changes table:
+// upgrade `GET /prompts/user` to a concrete `UserPromptsResponse`
+// component and enum `prompt_type` path param.
+export type PromptType = keyof PromptsPayload;
+
+export interface PromptDetail {
+  content?: string;
+  source?: 'user' | 'system' | 'hardcoded' | string;
+  customized?: boolean;
+}
+
+export type UserPromptsResponse = Partial<Record<PromptType, PromptDetail>>;


### PR DESCRIPTION
## Summary
Phase 1b batch 1 of the FE legacy SDK hard-delete milestone (task #4 of `#模块化重构`). Same pattern as Phase 1a #1607 but for the `prompt` domain.

- **Adapter**: new `web/src/features/prompt/{types,client-api,server-api}.ts` wrapping the typed `/api/v1/prompts/user` + `/api/v1/prompts/user/{prompt_type}` paths. Backend canonical owner stays `model_platform` per the v2 map; FE namespace is `features/prompt`. No OpenAPI path rename — the v1→v2 hard-cut belongs to the later `model_platform` API/domain phase (Weston msg=b60c4796 / 架构师 msg=3b6aeb57 / dongdong msg=42f8c4ed).
- **Typed-schema gap handling**: the typed schema currently returns `{[key: string]: unknown}` for `GET /prompts/user` and exposes `prompt_type` as a plain string. Per 架构师 msg=3b6aeb57, `features/prompt/types.ts` aliases only `PromptsPayload` + `UpdateUserPromptsRequest` from the schema, and defines `PromptType` / `PromptDetail` / `UserPromptsResponse` as domain-boundary types mirroring the runtime shape. The adapter casts at the boundary — UI components see typed values.
- **Caller migration** (per dongdong msg=63c7b181 covering the indirect legacy path):
  - `app/workspace/prompts/page.tsx`: `serverApi.defaultApi.promptsUserGet()` → `getUserPrompts()` (removes the `getServerApi` indirect legacy path)
  - `app/workspace/prompts/prompt-settings.tsx`: `apiClient.defaultApi.promptsUserPut/.promptsUserPromptTypeDelete` → `updateUserPrompts / deleteUserPrompt`; `@/api` type imports (`PromptDetail, UserPromptsResponse`) → `@/features/prompt/types`
- **Contract test**: new `test_prompt_feature_uses_v2_typed_api_boundary` in `tests/unit_test/test_web_typed_api_contract.py`. Positive: adapter reaches typed v1 paths; page/settings import from `@/features/prompt/*`. Negative: no `@/api` import, no `defaultApi.promptsUser*` calls, no `getServerApi` usage in scope. Scope: `app/workspace/prompts/**` + `features/prompt/**` so `page_prompts` i18n and provider/model prompt fields stay unaffected.

## Legacy reduction evidence (double boundary, per 符炫炜 msg=58ff0002)
- **legacy-api-boundary**: `prompt-settings.tsx` (direct `@/api` import) — 1 file → 0
- **route-data-boundary**: `page.tsx` (indirect `getServerApi` legacy SDK path) — 1 file → 0

Both will rebase and drop from the Phase 0 allowlist fixtures once `chenyexuan/modularization-phase0` lands.

## Technical debt tracked for the `model_platform` breaking-changes table
- `GET /prompts/user` needs a concrete `UserPromptsResponse` component in the OpenAPI schema.
- `DELETE /prompts/user/{prompt_type}` path param should be an enum.

## Out of scope (per Weston msg=1da08691)
- No `model_platform` API hard-cut (Phase 2+ scope).
- No `components/shared` hard-move (independent cleanup phase).
- No provider/model prompt fields or any other domain callers.

## Baseline
- Branch base: `main @ 8990329f` (= Phase 1a merged).

## Test plan
- [x] `yarn lint --quiet` clean
- [x] `uv run pytest tests/unit_test/test_web_typed_api_contract.py -x` → 12 passed
- [ ] Manual: render `/workspace/prompts`, save + reset a prompt, confirm the page rerenders.
- [ ] GitHub CI: `lint-and-unit` on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)