### PR TITLE
feat(modularization): phase 1b batch 2 FE typed adapter for quota (#4)

### DIFF
--- a/tests/boundaries/web_legacy_api_allowlist.txt
+++ b/tests/boundaries/web_legacy_api_allowlist.txt
@@ -30,8 +30,6 @@ web/src/app/workspace/collections/collection-form.tsx
 web/src/app/workspace/collections/collection-list.tsx
 web/src/app/workspace/collections/feature-visibility.ts
 web/src/app/workspace/collections/tools.ts
-web/src/app/workspace/quotas/page.tsx
-web/src/app/workspace/quotas/quota-radial-chart.tsx
 web/src/components/chat/agent-turn-card.tsx
 web/src/components/chat/chat-input.tsx
 web/src/components/chat/chat-messages.tsx

--- a/tests/boundaries/web_raw_schema_allowlist.txt
+++ b/tests/boundaries/web_raw_schema_allowlist.txt
@@ -5,5 +5,6 @@ web/src/features/document/types.ts
 web/src/features/evaluation/types.ts
 web/src/features/prompt/types.ts
 web/src/features/providers/types.ts
+web/src/features/quota/types.ts
 web/src/lib/api/typed/browser.ts
 web/src/lib/api/typed/server.ts

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -89,6 +89,75 @@ def test_api_key_feature_uses_v2_typed_api_boundary():
     assert "serverApi.defaultApi.apikeysGet" not in page_tsx
 
 
+def test_quota_feature_uses_v2_typed_api_boundary():
+    """#4 Phase 1b batch 2 — quota domain (workspace scope only).
+
+    The workspace Quotas page and its server caller must reach the typed
+    `/api/v1/quotas` endpoint through `features/quota/server-api`, not via
+    the legacy `@/api` generated SDK or its indirect `getServerApi` path.
+    The `GET /api/v1/quotas` typed response is a union
+    `UserQuotaInfo | UserQuotaList` because the endpoint is shared with
+    admin list views; the adapter narrows at its boundary so the page
+    never has to `as UserQuotaInfo`.
+
+    Scope: `app/workspace/quotas/**` + `features/quota/**`. Admin-side
+    quota callers (`admin/configuration/quota-settings.tsx`,
+    `admin/users/user-quota-action.tsx`) stay on the legacy SDK until the
+    later `governance` batch — they are out of this PR's scope.
+    """
+    checked_paths = [
+        REPO_ROOT / "web/src/app/workspace/quotas",
+        REPO_ROOT / "web/src/features/quota",
+    ]
+
+    sources = {
+        path: path.read_text()
+        for root in checked_paths
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix in {".ts", ".tsx"}
+    }
+    joined = "\n".join(sources.values())
+    feature_sources = "\n".join(
+        source
+        for path, source in sources.items()
+        if "/web/src/features/quota/" in str(path)
+    )
+
+    # Negative: workspace quota scope must not reach the old generated SDK
+    # (direct `@/api` import or indirect `getServerApi`), and must not
+    # call `serverApi.quotasApi.quotasGet` / `apiClient.quotasApi.*`.
+    assert "from '@/api'" not in joined
+    assert "serverApi.quotasApi.quotasGet" not in joined
+    assert "apiClient.quotasApi" not in joined
+    assert "getServerApi" not in joined
+
+    # Positive: the adapter must only reach the typed v1 quotas path
+    # through the typed openapi client.
+    assert "from '@/api'" not in feature_sources
+    assert "fetch(" not in feature_sources
+    assert "'/api/v1/quotas'" in feature_sources
+
+    # Positive: the adapter narrows the union (UserQuotaInfo | UserQuotaList)
+    # at the boundary so workspace callers never see an admin list.
+    server_api = (
+        REPO_ROOT / "web/src/features/quota/server-api.ts"
+    ).read_text()
+    assert "'items' in data" in server_api
+
+    # Positive: business caller wiring goes through the feature adapter
+    # and the page no longer casts `as UserQuotaInfo`.
+    page_tsx = (
+        REPO_ROOT / "web/src/app/workspace/quotas/page.tsx"
+    ).read_text()
+    assert "from '@/features/quota/server-api'" in page_tsx
+    assert "as UserQuotaInfo" not in page_tsx
+
+    chart_tsx = (
+        REPO_ROOT / "web/src/app/workspace/quotas/quota-radial-chart.tsx"
+    ).read_text()
+    assert "from '@/features/quota/types'" in chart_tsx
+
+
 def test_prompt_feature_uses_v2_typed_api_boundary():
     """#4 Phase 1b batch 1 — prompt domain (FE `features/prompt`, backend
     canonical owner stays `model_platform` per v2 map).

--- a/web/src/app/workspace/quotas/page.tsx
+++ b/web/src/app/workspace/quotas/page.tsx
@@ -6,16 +6,13 @@ import {
   PageTitle,
 } from '@/components/page-container';
 
-import { UserQuotaInfo } from '@/api';
-import { getServerApi } from '@/lib/api/server';
+import { getUserQuota } from '@/features/quota/server-api';
 import { getTranslations } from 'next-intl/server';
 import { QuotaRadialChart } from './quota-radial-chart';
 
 export default async function Page() {
-  const serverApi = await getServerApi();
-  const res = await serverApi.quotasApi.quotasGet();
+  const data = await getUserQuota();
   const page_quotas = await getTranslations('page_quota');
-  const data = res.data as UserQuotaInfo;
 
   return (
     <PageContainer>

--- a/web/src/app/workspace/quotas/quota-radial-chart.tsx
+++ b/web/src/app/workspace/quotas/quota-radial-chart.tsx
@@ -8,7 +8,7 @@ import {
   RadialBarChart,
 } from 'recharts';
 
-import { QuotaInfo } from '@/api';
+import type { QuotaInfo } from '@/features/quota/types';
 import { Badge } from '@/components/ui/badge';
 import {
   Card,

--- a/web/src/features/quota/server-api.ts
+++ b/web/src/features/quota/server-api.ts
@@ -1,0 +1,27 @@
+import { createServerApiClient } from '@/lib/api/typed/server';
+
+import type { UserQuotaInfo } from './types';
+
+// The typed `GET /api/v1/quotas` 200 response is a
+// `UserQuotaInfo | UserQuotaList` union because the endpoint is shared
+// between the workspace view (current user) and the admin list view
+// (admin query params). TypeScript cannot narrow the union by query
+// presence, so narrow at the adapter boundary: workspace callers never
+// pass admin query params, so the server must return the single-user
+// shape. If that contract is ever violated, throw explicitly — silently
+// rendering an admin list would be a user-facing regression. The split
+// into `/api/v2/quotas/me` + `/api/v2/admin/quotas` is tracked for the
+// later `governance` API hard-cut phase.
+export async function getUserQuota(): Promise<UserQuotaInfo> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v1/quotas', {});
+  if (!data) {
+    throw new Error('workspace quota endpoint returned no body');
+  }
+  if ('items' in data) {
+    throw new Error(
+      'workspace quota endpoint returned a list response; expected single user quota',
+    );
+  }
+  return data;
+}

--- a/web/src/features/quota/types.ts
+++ b/web/src/features/quota/types.ts
@@ -1,0 +1,5 @@
+import type { components } from '@/api-v2/schema';
+
+export type UserQuotaInfo = components['schemas']['UserQuotaInfo'];
+
+export type QuotaInfo = components['schemas']['QuotaInfo'];


### PR DESCRIPTION
## Summary
Phase 1b batch 2 of the FE legacy SDK hard-delete milestone (task #4). Same pattern as #1607 api-key / #1609 prompt but for the workspace `quota` domain. Admin-side quota callers stay on the legacy SDK until the later `governance` batch.

- **Adapter**: new `web/src/features/quota/{types,server-api}.ts` wrapping the typed `GET /api/v1/quotas`. No client-api — workspace is read-only; admin PUT/recalc migrate with the governance batch.
- **Union narrow at adapter boundary** (per Weston msg=2c5f50f6 / 符炫炜 msg=7f8dc3a3 / dongdong msg=6c1fd47b): the typed response is `UserQuotaInfo | UserQuotaList` because the endpoint is shared with admin list views. `getUserQuota()` uses `'items' in data` to discriminate and throws explicitly when a list shape is returned to a workspace caller — silently rendering empty quotas would be worse than a clear failure.
- **Caller migration**:
  - `app/workspace/quotas/page.tsx`: drops `getServerApi()` indirect legacy + the `as UserQuotaInfo` cast → `getUserQuota()`.
  - `app/workspace/quotas/quota-radial-chart.tsx`: `QuotaInfo` type import moves from `@/api` to `@/features/quota/types`.
- **Contract test**: new `test_quota_feature_uses_v2_typed_api_boundary`. Positive: typed path, `'items' in data` narrow, adapter imports, `as UserQuotaInfo` gone from page. Negative: no `@/api`, no `serverApi.quotasApi.quotasGet`, no `apiClient.quotasApi`, no `getServerApi`. Scope: `app/workspace/quotas/**` + `features/quota/**` only.

## Phase 0 fixture reductions
- `tests/boundaries/web_legacy_api_allowlist.txt`: **49 → 47** (drops `quotas/page.tsx` + `quotas/quota-radial-chart.tsx`).
- `tests/boundaries/web_raw_schema_allowlist.txt`: **9 → 10** (adds `features/quota/types.ts`; exact-lock fixture per Phase 0 contract).
- `tests/boundaries/web_route_data_allowlist.txt`: **unchanged**. The previous `quotas/page.tsx` used `serverApi.quotasApi.quotasGet` which does not match the route-data regex (`defaultApi|apiClient|browserApiClient|createServerApiClient`), so it was never in the route-data allowlist.

## Technical debt tracked for the `governance` API hard-cut breaking-changes table
- `GET /api/v1/quotas` currently serves both workspace (`UserQuotaInfo`) and admin (`UserQuotaList`) on the same path. Split into `GET /api/v2/quotas/me` + `GET /api/v2/admin/quotas` during the governance phase to eliminate the union response.

## Out of scope (per Weston msg=9e663eea)
- `admin/configuration/quota-settings.tsx` and `admin/users/user-quota-action.tsx` stay on the legacy SDK. They belong to the later governance/admin batch.
- No API path rename.
- No `components/shared` hard-move; no other domain caller migration.

## Baseline
- Branch base: `main @ e377e3ed` (= #1608 Phase 0 merged).

## Test plan
- [x] `yarn lint --quiet` clean
- [x] `uv run pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py` → 17 passed
- [ ] Manual: render `/workspace/quotas`, confirm the 4 quota cards render with real values.
- [ ] GitHub CI: `lint-and-unit` on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)