### PR TITLE
feat(modularization): phase 1b batch 3 FE typed adapter for marketplace (#4)

### DIFF
--- a/tests/boundaries/web_legacy_api_allowlist.txt
+++ b/tests/boundaries/web_legacy_api_allowlist.txt
@@ -3,12 +3,9 @@ web/src/app/admin/configuration/parser-settings.tsx
 web/src/app/admin/configuration/quota-settings.tsx
 web/src/app/admin/users/user-quota-action.tsx
 web/src/app/admin/users/users-data-table.tsx
-web/src/app/marketplace/collection-list.tsx
-web/src/app/marketplace/collections/[collectionId]/collection-header.tsx
 web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
 web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
 web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx
-web/src/app/marketplace/page.tsx
 web/src/app/workspace/audit-logs/audit-log-detail.tsx
 web/src/app/workspace/audit-logs/audit-log-table.tsx
 web/src/app/workspace/audit-logs/page.tsx

--- a/tests/boundaries/web_raw_schema_allowlist.txt
+++ b/tests/boundaries/web_raw_schema_allowlist.txt
@@ -3,6 +3,7 @@ web/src/features/bot/types.ts
 web/src/features/collection/types.ts
 web/src/features/document/types.ts
 web/src/features/evaluation/types.ts
+web/src/features/marketplace/types.ts
 web/src/features/prompt/types.ts
 web/src/features/providers/types.ts
 web/src/features/quota/types.ts

--- a/tests/boundaries/web_route_data_allowlist.txt
+++ b/tests/boundaries/web_route_data_allowlist.txt
@@ -6,11 +6,6 @@ web/src/app/admin/users/page.tsx
 web/src/app/admin/users/user-quota-action.tsx
 web/src/app/auth/signin/page.tsx
 web/src/app/layout.tsx
-web/src/app/marketplace/collections/[collectionId]/collection-header.tsx
-web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/page.tsx
-web/src/app/marketplace/collections/[collectionId]/documents/page.tsx
-web/src/app/marketplace/collections/[collectionId]/graph/page.tsx
-web/src/app/marketplace/page.tsx
 web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
 web/src/app/workspace/collections/[collectionId]/documents/upload/import/text-import.tsx
 web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -158,6 +158,126 @@ def test_quota_feature_uses_v2_typed_api_boundary():
     assert "from '@/features/quota/types'" in chart_tsx
 
 
+def test_marketplace_feature_uses_v2_typed_api_boundary():
+    """#4 Phase 1b batch 3 — marketplace domain.
+
+    Migrates only marketplace-owned API callers under `app/marketplace/**`
+    to `features/marketplace/*`. Per PM msg=7b4a3b06 / Weston msg=86bfb0cf
+    / dongdong msg=9b7cbaad / 架构师 msg=ca06ddd8, two categories of legacy
+    residue are **deliberately deferred** and must stay out of this test's
+    scope:
+
+    1. `app/marketplace/collections/[collectionId]/documents/{documents-table,
+       document-index-status,[documentId]/document-detail}.tsx` are document
+       subcomponents that currently hold document-domain legacy types and —
+       for `documents-table.tsx` — a mixed `SharedCollection` legacy type.
+       These deferred to the document batch or the marketplace/document
+       boundary cleanup. They still match `@/api` but are *not* in this
+       PR's scope, so the negative assertions below explicitly do not scan
+       them.
+    2. `app/workspace/collections/[collectionId]/graph/collection-graph.tsx`
+       uses `apiClient.defaultApi.marketplaceCollectionsCollectionIdGraphGet`
+       but belongs to the workspace graph tree; it is a cross-domain
+       graph/marketplace boundary item deferred to #5 or a later graph
+       cleanup. The negative assertions below do not scan workspace graph.
+
+    In other words, this test intentionally *does not* try to prove that
+    `marketplaceCollections*` is gone from the whole repo — only that the
+    six migrated callers and `features/marketplace/**` are clean.
+    """
+    migrated_callers = [
+        REPO_ROOT / "web/src/app/marketplace/page.tsx",
+        REPO_ROOT / "web/src/app/marketplace/collection-list.tsx",
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/collection-header.tsx",
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/documents/page.tsx",
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/page.tsx",
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/graph/page.tsx",
+    ]
+
+    feature_paths = [REPO_ROOT / "web/src/features/marketplace"]
+    feature_sources_by_path: dict[Path, str] = {}
+    for root in feature_paths:
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix in {".ts", ".tsx"}:
+                feature_sources_by_path[path] = path.read_text()
+
+    migrated_sources_by_path = {
+        path: path.read_text() for path in migrated_callers
+    }
+    scoped_joined = "\n".join(
+        [*migrated_sources_by_path.values(), *feature_sources_by_path.values()]
+    )
+    feature_sources = "\n".join(feature_sources_by_path.values())
+
+    # Negative: the six migrated callers + features/marketplace/** must not
+    # touch the legacy `@/api` SDK directly. Do not scan the deferred
+    # document subcomponents or workspace graph here.
+    assert "from '@/api'" not in scoped_joined
+    assert "apiClient.defaultApi.marketplaceCollections" not in scoped_joined
+    assert "serverApi.defaultApi.marketplaceCollections" not in scoped_joined
+    assert "defaultApi.marketplaceCollectionsGet" not in scoped_joined
+    assert "getServerApi" not in scoped_joined
+
+    # Positive: adapter only reaches the typed v1 marketplace paths.
+    assert "fetch(" not in feature_sources
+    assert "'/api/v1/marketplace/collections'" in feature_sources
+    assert (
+        "'/api/v1/marketplace/collections/{collection_id}'" in feature_sources
+    )
+    assert (
+        "'/api/v1/marketplace/collections/{collection_id}/documents'"
+        in feature_sources
+    )
+    assert (
+        "'/api/v1/marketplace/collections/{collection_id}/documents/{document_id}/preview'"
+        in feature_sources
+    )
+    assert (
+        "'/api/v1/marketplace/collections/{collection_id}/subscribe'"
+        in feature_sources
+    )
+
+    # Positive: callers wire through the feature adapter.
+    page_tsx = migrated_sources_by_path[
+        REPO_ROOT / "web/src/app/marketplace/page.tsx"
+    ]
+    assert "from '@/features/marketplace/server-api'" in page_tsx
+
+    list_tsx = migrated_sources_by_path[
+        REPO_ROOT / "web/src/app/marketplace/collection-list.tsx"
+    ]
+    assert "from '@/features/marketplace/types'" in list_tsx
+
+    header_tsx = migrated_sources_by_path[
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/collection-header.tsx"
+    ]
+    assert "from '@/features/marketplace/client-api'" in header_tsx
+    assert "from '@/features/marketplace/types'" in header_tsx
+
+    docs_page_tsx = migrated_sources_by_path[
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/documents/page.tsx"
+    ]
+    assert "from '@/features/marketplace/server-api'" in docs_page_tsx
+
+    doc_detail_page_tsx = migrated_sources_by_path[
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/page.tsx"
+    ]
+    assert "from '@/features/marketplace/server-api'" in doc_detail_page_tsx
+
+    graph_page_tsx = migrated_sources_by_path[
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/graph/page.tsx"
+    ]
+    assert "from '@/features/marketplace/server-api'" in graph_page_tsx
+
+
 def test_prompt_feature_uses_v2_typed_api_boundary():
     """#4 Phase 1b batch 1 — prompt domain (FE `features/prompt`, backend
     canonical owner stays `model_platform` per v2 map).

--- a/web/src/app/marketplace/collection-list.tsx
+++ b/web/src/app/marketplace/collection-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SharedCollection } from '@/api';
+import type { SharedCollection } from '@/features/marketplace/types';
 import { useAppContext } from '@/components/providers/app-provider';
 import { Badge } from '@/components/ui/badge';
 import {

--- a/web/src/app/marketplace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/collection-header.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { SharedCollection } from '@/api';
+import {
+  subscribeMarketplaceCollection,
+  unsubscribeMarketplaceCollection,
+} from '@/features/marketplace/client-api';
+import type { SharedCollection } from '@/features/marketplace/types';
 import { PageContent } from '@/components/page-container';
 import { useAppContext } from '@/components/providers/app-provider';
 import { Badge } from '@/components/ui/badge';
@@ -20,7 +24,6 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { apiClient } from '@/lib/api/client';
 import { cn } from '@/lib/utils';
 import _ from 'lodash';
 import { BookOpen, Files, Star, User, VectorSquare } from 'lucide-react';
@@ -63,17 +66,9 @@ export const CollectionHeader = ({
     }
 
     if (isSubscriber) {
-      await apiClient.defaultApi.marketplaceCollectionsCollectionIdSubscribeDelete(
-        {
-          collectionId: collection.id,
-        },
-      );
+      await unsubscribeMarketplaceCollection(collection.id);
     } else {
-      await apiClient.defaultApi.marketplaceCollectionsCollectionIdSubscribePost(
-        {
-          collectionId: collection.id,
-        },
-      );
+      await subscribeMarketplaceCollection(collection.id);
     }
     router.refresh();
   }, [collection.id, isSubscriber, router, signIn, user]);

--- a/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/page.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/page.tsx
@@ -1,6 +1,10 @@
 import { PageContainer, PageContent } from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
+import {
+  getMarketplaceCollection,
+  getMarketplaceCollectionDocumentPreview,
+} from '@/features/marketplace/server-api';
 import { toJson } from '@/lib/utils';
+import { notFound } from 'next/navigation';
 import { CollectionHeader } from '../../collection-header';
 import { DocumentDetail } from './document-detail';
 
@@ -10,28 +14,19 @@ export default async function Page({
   params: Promise<{ collectionId: string; documentId: string }>;
 }) {
   const { collectionId, documentId } = await params;
-  const serverApi = await getServerApi();
-
-  const [collectionRes, documentPreviewRes] = await Promise.all([
-    serverApi.defaultApi.marketplaceCollectionsCollectionIdGet({
-      collectionId,
-    }),
-    serverApi.defaultApi.marketplaceCollectionsCollectionIdDocumentsDocumentIdPreviewGet(
-      {
-        collectionId,
-        documentId,
-      },
-    ),
+  const [collection, documentPreview] = await Promise.all([
+    getMarketplaceCollection(collectionId),
+    getMarketplaceCollectionDocumentPreview(collectionId, documentId),
   ]);
-
-  const documentPreview = toJson(documentPreviewRes.data);
-  const collection = toJson(collectionRes.data);
+  if (!collection) {
+    notFound();
+  }
 
   return (
     <PageContainer>
       <CollectionHeader collection={collection} />
       <PageContent className="h-[100%]">
-        <DocumentDetail documentPreview={documentPreview} />
+        <DocumentDetail documentPreview={toJson(documentPreview)} />
       </PageContent>
     </PageContainer>
   );

--- a/web/src/app/marketplace/collections/[collectionId]/documents/page.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/page.tsx
@@ -1,5 +1,8 @@
 import { PageContainer, PageContent } from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
+import {
+  getMarketplaceCollection,
+  listMarketplaceCollectionDocuments,
+} from '@/features/marketplace/server-api';
 import { parsePageParams, toJson } from '@/lib/utils';
 import { notFound } from 'next/navigation';
 import { CollectionHeader } from '../collection-header';
@@ -14,13 +17,9 @@ export default async function Page({
 }>) {
   const { collectionId } = await params;
   const { page, pageSize, search } = await searchParams;
-  const serverApi = await getServerApi();
-  const [collectionRes, documentsRes] = await Promise.all([
-    serverApi.defaultApi.marketplaceCollectionsCollectionIdGet({
-      collectionId,
-    }),
-    serverApi.defaultApi.marketplaceCollectionsCollectionIdDocumentsGet({
-      collectionId,
+  const [collection, documents] = await Promise.all([
+    getMarketplaceCollection(collectionId),
+    listMarketplaceCollectionDocuments(collectionId, {
       ...parsePageParams({ page, pageSize }),
       sortBy: 'created',
       sortOrder: 'desc',
@@ -28,22 +27,21 @@ export default async function Page({
     }),
   ]);
 
-  //@ts-expect-error api define has a bug
-  const documents = toJson(documentsRes.data.items || []);
-  const collection = toJson(collectionRes.data);
-
   if (!collection) {
     notFound();
   }
 
+  const documentItems = toJson(documents.items || []);
+  const collectionJson = toJson(collection);
+
   return (
     <PageContainer>
-      <CollectionHeader collection={collection} />
+      <CollectionHeader collection={collectionJson} />
       <PageContent>
         <DocumentsTable
-          collection={collection}
-          data={documents}
-          pageCount={documentsRes.data.total_pages}
+          collection={collectionJson}
+          data={documentItems}
+          pageCount={documents.total_pages}
         />
       </PageContent>
     </PageContainer>

--- a/web/src/app/marketplace/collections/[collectionId]/graph/page.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/graph/page.tsx
@@ -1,6 +1,7 @@
 import { CollectionGraph } from '@/app/workspace/collections/[collectionId]/graph/collection-graph';
 import { PageContainer, PageContent } from '@/components/page-container';
-import { getServerApi } from '@/lib/api/server';
+import { getMarketplaceCollection } from '@/features/marketplace/server-api';
+import { notFound } from 'next/navigation';
 import { CollectionHeader } from '../collection-header';
 
 export default async function Page({
@@ -9,17 +10,15 @@ export default async function Page({
   params: Promise<{ collectionId: string }>;
 }>) {
   const { collectionId } = await params;
-  const serverApi = await getServerApi();
-  const [collectionRes] = await Promise.all([
-    serverApi.defaultApi.marketplaceCollectionsCollectionIdGet({
-      collectionId,
-    }),
-  ]);
+  const collection = await getMarketplaceCollection(collectionId);
+  if (!collection) {
+    notFound();
+  }
 
   return (
     <PageContainer>
       <div className="flex h-[calc(100vh-48px)] flex-col px-0">
-        <CollectionHeader collection={collectionRes.data} className="w-full" />
+        <CollectionHeader collection={collection} className="w-full" />
         <PageContent className="flex w-full flex-1 flex-col">
           <CollectionGraph marketplace={true} />
         </PageContent>

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -1,4 +1,3 @@
-import { SharedCollection } from '@/api';
 import {
   PageContainer,
   PageContent,
@@ -6,7 +5,8 @@ import {
   PageTitle,
 } from '@/components/page-container';
 import { Button } from '@/components/ui/button';
-import { getServerApi } from '@/lib/api/server';
+import { listMarketplaceCollections } from '@/features/marketplace/server-api';
+import type { SharedCollection } from '@/features/marketplace/types';
 import { BookOpen } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
@@ -15,16 +15,12 @@ import { CollectionList } from './collection-list';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
-  const serverApi = await getServerApi();
   const page_marketplace = await getTranslations('page_marketplace');
   const sidebar_workspace = await getTranslations('sidebar_workspace');
   let collections: SharedCollection[] = [];
   try {
-    const res = await serverApi.defaultApi.marketplaceCollectionsGet({
-      page: 1,
-      pageSize: 100,
-    });
-    collections = res.data.items || [];
+    const res = await listMarketplaceCollections({ page: 1, pageSize: 100 });
+    collections = res.items || [];
   } catch (err) {
     console.log(err);
   }

--- a/web/src/features/marketplace/client-api.ts
+++ b/web/src/features/marketplace/client-api.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { browserApiClient } from '@/lib/api/typed/browser';
+
+export async function subscribeMarketplaceCollection(collectionId: string) {
+  const { data } = await browserApiClient.POST(
+    '/api/v1/marketplace/collections/{collection_id}/subscribe',
+    {
+      params: {
+        path: { collection_id: collectionId },
+      },
+    },
+  );
+  return data;
+}
+
+export async function unsubscribeMarketplaceCollection(collectionId: string) {
+  await browserApiClient.DELETE(
+    '/api/v1/marketplace/collections/{collection_id}/subscribe',
+    {
+      params: {
+        path: { collection_id: collectionId },
+      },
+    },
+  );
+}

--- a/web/src/features/marketplace/server-api.ts
+++ b/web/src/features/marketplace/server-api.ts
@@ -1,0 +1,87 @@
+import { createServerApiClient } from '@/lib/api/typed/server';
+
+import type {
+  MarketplaceDocumentList,
+  MarketplaceDocumentPreview,
+  SharedCollection,
+  SharedCollectionList,
+} from './types';
+
+export async function listMarketplaceCollections(options?: {
+  page?: number;
+  pageSize?: number;
+}): Promise<SharedCollectionList> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET('/api/v1/marketplace/collections', {
+    params: {
+      query: {
+        page: options?.page ?? 1,
+        page_size: options?.pageSize ?? 100,
+      },
+    },
+  });
+  return data ?? {};
+}
+
+export async function getMarketplaceCollection(
+  collectionId: string,
+): Promise<SharedCollection | null> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET(
+    '/api/v1/marketplace/collections/{collection_id}',
+    {
+      params: {
+        path: { collection_id: collectionId },
+      },
+    },
+  );
+  return data ?? null;
+}
+
+export async function listMarketplaceCollectionDocuments(
+  collectionId: string,
+  options?: {
+    page?: number;
+    pageSize?: number;
+    sortBy?: string;
+    sortOrder?: string;
+    search?: string;
+  },
+): Promise<MarketplaceDocumentList> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET(
+    '/api/v1/marketplace/collections/{collection_id}/documents',
+    {
+      params: {
+        path: { collection_id: collectionId },
+        query: {
+          page: options?.page ?? 1,
+          page_size: options?.pageSize ?? 20,
+          sort_by: options?.sortBy,
+          sort_order: options?.sortOrder,
+          search: options?.search,
+        },
+      },
+    },
+  );
+  return data ?? {};
+}
+
+export async function getMarketplaceCollectionDocumentPreview(
+  collectionId: string,
+  documentId: string,
+): Promise<MarketplaceDocumentPreview | null> {
+  const client = await createServerApiClient();
+  const { data } = await client.GET(
+    '/api/v1/marketplace/collections/{collection_id}/documents/{document_id}/preview',
+    {
+      params: {
+        path: {
+          collection_id: collectionId,
+          document_id: documentId,
+        },
+      },
+    },
+  );
+  return data ?? null;
+}

--- a/web/src/features/marketplace/types.ts
+++ b/web/src/features/marketplace/types.ts
@@ -1,0 +1,19 @@
+import type { components } from '@/api-v2/schema';
+
+export type SharedCollection = components['schemas']['SharedCollection'];
+
+export type SharedCollectionList =
+  components['schemas']['SharedCollectionList'];
+
+// Marketplace endpoints return document/preview schemas shared with the
+// document feature but consumed here only under marketplace semantics.
+// Alias them locally with a marketplace prefix so the marketplace callers
+// never reach into `features/document/types` and never re-import `@/api`
+// legacy types. The underlying schema components are the source of truth;
+// the alias is purely a naming boundary.
+export type MarketplaceDocument = components['schemas']['Document'];
+
+export type MarketplaceDocumentList = components['schemas']['DocumentList'];
+
+export type MarketplaceDocumentPreview =
+  components['schemas']['DocumentPreview'];


### PR DESCRIPTION
## Summary
Phase 1b batch 3 of the FE legacy SDK hard-delete milestone (task #4). Migrates the 6 marketplace-owned API callers under `app/marketplace/**` to `features/marketplace/*` and the typed openapi-fetch client.

- **Adapter**: new `web/src/features/marketplace/{types,client-api,server-api}.ts` wrapping the typed `/api/v1/marketplace/collections*` paths already in `schema.d.ts`. No OpenAPI path rename.
- **Types (per PM msg=7b4a3b06)**: `SharedCollection` / `SharedCollectionList` alias from schema. For document/preview shapes returned by marketplace endpoints, uses marketplace-semantic local aliases (`MarketplaceDocument` / `MarketplaceDocumentList` / `MarketplaceDocumentPreview`) over the shared document schema — **does not modify `features/document/types`** and does not scatter hand-written types into page/component.
- **Caller migration (6 files)**:
  - `app/marketplace/page.tsx` → `listMarketplaceCollections`.
  - `app/marketplace/collection-list.tsx` → `SharedCollection` import from `@/features/marketplace/types`.
  - `app/marketplace/collections/[collectionId]/collection-header.tsx` → `subscribe/unsubscribeMarketplaceCollection` + type import.
  - `app/marketplace/collections/[collectionId]/documents/page.tsx` → `getMarketplaceCollection` + `listMarketplaceCollectionDocuments`; adds `notFound()` for missing collections.
  - `app/marketplace/collections/[collectionId]/documents/[documentId]/page.tsx` → `getMarketplaceCollection` + `getMarketplaceCollectionDocumentPreview`; adds `notFound()`.
  - `app/marketplace/collections/[collectionId]/graph/page.tsx` → `getMarketplaceCollection`; adds `notFound()`.
- **Contract test (per Weston msg=e9a0545b / 架构师 msg=ca06ddd8)**: new `test_marketplace_feature_uses_v2_typed_api_boundary`. The negative `@/api` / `defaultApi.marketplaceCollections*` / `getServerApi` scan is scoped to **only the 6 migrated callers + `features/marketplace/**`**. The test deliberately does not attempt to prove `marketplaceCollections*` is gone repo-wide — two deferred categories are excluded by design (see below).

## Deferred out of this PR (documented for reviewers)
1. **Marketplace document subcomponents** — `documents-table.tsx`, `document-index-status.tsx`, `document-detail.tsx` still import document-domain legacy types from `@/api`. `documents-table.tsx` additionally holds a legacy `SharedCollection` type alongside document types (per Weston msg=86bfb0cf — this is a mixed document+marketplace boundary, not pure document-type-only). These files stay on the legacy SDK until the document batch or a marketplace/document boundary cleanup.
2. **`app/workspace/collections/[collectionId]/graph/collection-graph.tsx`** — uses `apiClient.defaultApi.marketplaceCollectionsCollectionIdGraphGet` (per @dongdong msg=9b7cbaad). This is a cross-domain graph/marketplace boundary item that belongs with #5 graph or a later graph/marketplace cleanup. Not in this PR's fixture delta.

## Phase 0 fixture reductions (actual scan, not estimates)
- `tests/boundaries/web_legacy_api_allowlist.txt`: **47 → 44** (drop `marketplace/page.tsx`, `marketplace/collection-list.tsx`, `marketplace/collections/[collectionId]/collection-header.tsx`).
- `tests/boundaries/web_route_data_allowlist.txt`: **24 → 19** (drop `marketplace/page.tsx`, `marketplace/collections/[collectionId]/collection-header.tsx`, `marketplace/collections/[collectionId]/documents/page.tsx`, `marketplace/collections/[collectionId]/documents/[documentId]/page.tsx`, `marketplace/collections/[collectionId]/graph/page.tsx`).
- `tests/boundaries/web_raw_schema_allowlist.txt`: **10 → 11** (add `features/marketplace/types.ts`; exact-lock fixture per Phase 0 contract).

## Baseline
- Branch base: `main @ 067639cc` (= #1610 Phase 1b batch 2 merged).
- No OpenAPI schema regeneration, no backend / hurl / docs changes.

## Out of scope (per PM msg=7b4a3b06 + Weston/dongdong refinements)
- No `features/document/types` modification; no `DocumentVectorIndexStatusEnum` port; no `components/shared` hard-move; no admin/governance code; no API path rename; no MCP/backend changes.

## Test plan
- [x] `yarn lint --quiet` clean
- [x] `uv run pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py` → 18 passed
- [ ] Manual: render `/marketplace`, click a collection, subscribe/unsubscribe, open a document preview, open the knowledge-graph page.
- [ ] GitHub CI: `lint-and-unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)