### PR TITLE
fix(modularization): marketplace follow-up typed empty list + notFound guard (#4)

### DIFF
--- a/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/page.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/page.tsx
@@ -18,7 +18,7 @@ export default async function Page({
     getMarketplaceCollection(collectionId),
     getMarketplaceCollectionDocumentPreview(collectionId, documentId),
   ]);
-  if (!collection) {
+  if (!collection || !documentPreview) {
     notFound();
   }
 

--- a/web/src/features/marketplace/server-api.ts
+++ b/web/src/features/marketplace/server-api.ts
@@ -12,15 +12,28 @@ export async function listMarketplaceCollections(options?: {
   pageSize?: number;
 }): Promise<SharedCollectionList> {
   const client = await createServerApiClient();
+  const page = options?.page ?? 1;
+  const pageSize = options?.pageSize ?? 100;
   const { data } = await client.GET('/api/v1/marketplace/collections', {
     params: {
       query: {
-        page: options?.page ?? 1,
-        page_size: options?.pageSize ?? 100,
+        page,
+        page_size: pageSize,
       },
     },
   });
-  return data ?? {};
+  // `SharedCollectionList` has `items/total/page/page_size` all required;
+  // absent body means "no collections yet", so return a typed empty list
+  // rather than `{}` (which would violate the type contract and silently
+  // mask a malformed response with missing pagination).
+  return (
+    data ?? {
+      items: [],
+      total: 0,
+      page,
+      page_size: pageSize,
+    }
+  );
 }
 
 export async function getMarketplaceCollection(
@@ -49,14 +62,16 @@ export async function listMarketplaceCollectionDocuments(
   },
 ): Promise<MarketplaceDocumentList> {
   const client = await createServerApiClient();
+  const page = options?.page ?? 1;
+  const pageSize = options?.pageSize ?? 20;
   const { data } = await client.GET(
     '/api/v1/marketplace/collections/{collection_id}/documents',
     {
       params: {
         path: { collection_id: collectionId },
         query: {
-          page: options?.page ?? 1,
-          page_size: options?.pageSize ?? 20,
+          page,
+          page_size: pageSize,
           sort_by: options?.sortBy,
           sort_order: options?.sortOrder,
           search: options?.search,
@@ -64,7 +79,19 @@ export async function listMarketplaceCollectionDocuments(
       },
     },
   );
-  return data ?? {};
+  // `DocumentList` fields are all optional, so `{}` is technically valid,
+  // but fall back to a typed empty list for consistency with
+  // `listMarketplaceCollections` and so consumers can rely on `items`
+  // being iterable.
+  return (
+    data ?? {
+      items: [],
+      total: 0,
+      page,
+      page_size: pageSize,
+      total_pages: 0,
+    }
+  );
 }
 
 export async function getMarketplaceCollectionDocumentPreview(


### PR DESCRIPTION
## Summary
Post-merge follow-up on #1611 (`feat(modularization): phase 1b batch 3 FE typed adapter for marketplace`) addressing @dongdong msg=8dcd47d0 and @Weston msg=7236e9ec findings. Scope exactly 3 fixes per @架构师 msg=c4fc1b61 / @Weston msg=fa1028ed / @符炫炜 msg=5630655c.

- **`listMarketplaceCollections()`** fallback shape now satisfies the typed `SharedCollectionList` contract. `items`/`total`/`page`/`page_size` are required in the schema — the previous `data ?? {}` violated that contract and could silently hide a malformed response. Fallback is now `{ items: [], total: 0, page, page_size }` with the caller's requested page/page_size.
- **`listMarketplaceCollectionDocuments()`** uses the same typed-empty-list fallback (`{ items: [], total: 0, page, page_size, total_pages: 0 }`). `DocumentList` fields are nullable so `{}` was technically legal, but a typed empty list matches the `SharedCollectionList` pattern and lets callers treat `items` as always iterable.
- **`documents/[documentId]/page.tsx`** adds `documentPreview` to the `notFound()` guard alongside `collection`, so a null preview is no longer passed into a non-nullable prop on `<DocumentDetail>`.

## Out of scope
- No fixture changes (legacy 44 / raw schema 11 / route-data 19 unchanged).
- No boundary / contract test changes.
- No marketplace architecture reopen; no new domain, no API path rename.

## Baseline
- Branch base: `main @ 65d4b9fc` (= #1611 marketplace batch merged).

## Test plan
- [x] `yarn lint --quiet` clean
- [x] `uv run pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py` → 18 passed
- [ ] Manual: render `/marketplace`, open a collection's documents list, open a document detail (existing + missing doc id → 404).
- [ ] GitHub CI: `lint-and-unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)