### PR TITLE
refactor(modularization): Phase 1b batch 4 — provider domain (bot-provider) (#4)

### DIFF
--- a/tests/boundaries/web_legacy_api_allowlist.txt
+++ b/tests/boundaries/web_legacy_api_allowlist.txt
@@ -38,7 +38,6 @@ web/src/components/chat/message-reference.tsx
 web/src/components/chat/message-timestamp.tsx
 web/src/components/collections/export-dialog.tsx
 web/src/components/providers/app-provider.tsx
-web/src/components/providers/bot-provider.tsx
 web/src/components/user-avatar.tsx
 web/src/lib/api/client.ts
 web/src/lib/api/server.ts

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -278,6 +278,78 @@ def test_marketplace_feature_uses_v2_typed_api_boundary():
     assert "from '@/features/marketplace/server-api'" in graph_page_tsx
 
 
+def test_provider_feature_uses_v2_typed_api_boundary():
+    """#4 Phase 1b batch 4 — provider domain.
+
+    Migrates `components/providers/bot-provider.tsx` off the legacy
+    `apiClient.defaultApi.availableModelsPost` + `ModelSpec from '@/api'` and
+    onto the existing `features/providers/*` adapter (`getAvailableModels` +
+    `ModelSpec` from `@/features/providers/types`). The `features/providers`
+    adapter was migrated in an earlier phase to the typed
+    `/api/v2/providers/*` surface, so this batch only swaps the caller and
+    does **not** introduce new feature surface, new v2 routes, or change
+    fallback semantics.
+
+    Scope: `components/providers/bot-provider.tsx` + `features/providers/**`
+    only. Two cross-domain residues are deliberately **deferred** and must
+    stay out of scope:
+
+    1. `app/workspace/collections/collection-form.tsx` also calls
+       `availableModelsPost` + imports `ModelSpec` via `@/api`, but the same
+       file imports `TitleGenerateRequestLanguageEnum` (collection/legacy
+       form concern). A partial file migration would still leave the file
+       on the legacy-api allowlist, masking the "allowlist row = file is
+       legacy-free" invariant. Deferred to the future collection batch.
+    2. `components/providers/app-provider.tsx` is auth domain
+       (`loginPost/registerPost/logoutPost` + `/api/v1/auth/*`), not
+       provider. Deferred to the future identity/auth batch; no
+       `features/auth/*` exists yet.
+    """
+    checked_paths = [
+        REPO_ROOT / "web/src/components/providers/bot-provider.tsx",
+        REPO_ROOT / "web/src/features/providers",
+    ]
+
+    sources: dict[Path, str] = {}
+    for entry in checked_paths:
+        if entry.is_file():
+            sources[entry] = entry.read_text()
+            continue
+        for path in entry.rglob("*"):
+            if path.is_file() and path.suffix in {".ts", ".tsx"}:
+                sources[path] = path.read_text()
+    joined = "\n".join(sources.values())
+    feature_sources = "\n".join(
+        source
+        for path, source in sources.items()
+        if "/web/src/features/providers/" in str(path)
+    )
+
+    # Negative: the two scoped files must not reach the legacy SDK, the
+    # `availableModelsPost` method, or the indirect `getServerApi` route-data
+    # path.
+    assert "from '@/api'" not in joined
+    assert "apiClient.defaultApi.availableModelsPost" not in joined
+    assert "serverApi.defaultApi.availableModelsPost" not in joined
+    assert "defaultApi.availableModelsPost" not in joined
+    assert "getServerApi" not in joined
+
+    # Positive: the feature adapter must only reach v2 provider typed paths
+    # and not fall back to the old `@/api` generated SDK or raw fetch.
+    assert "from '@/api'" not in feature_sources
+    assert "fetch(" not in feature_sources
+    assert "'/api/v2/providers/available-models'" in feature_sources
+
+    # Positive: the migrated caller wires through the feature adapter and
+    # imports the domain-scoped `ModelSpec` alias from `features/providers`.
+    bot_provider = sources[
+        REPO_ROOT / "web/src/components/providers/bot-provider.tsx"
+    ]
+    assert "from '@/features/providers/client-api'" in bot_provider
+    assert "from '@/features/providers/types'" in bot_provider
+    assert "getAvailableModels(" in bot_provider
+
+
 def test_prompt_feature_uses_v2_typed_api_boundary():
     """#4 Phase 1b batch 1 — prompt domain (FE `features/prompt`, backend
     canonical owner stays `model_platform` per v2 map).

--- a/web/src/components/chat/chat-input.tsx
+++ b/web/src/components/chat/chat-input.tsx
@@ -1,9 +1,9 @@
 import {
   ChatDetails,
   Collection,
-  ModelSpec,
   UploadDocumentResponseStatusEnum,
 } from '@/api';
+import type { ModelSpec } from '@/features/providers/types';
 import { PageContent } from '@/components/page-container';
 import { useBotContext } from '@/components/providers/bot-provider';
 import { Button } from '@/components/ui/button';
@@ -308,7 +308,7 @@ export const ChatInput = ({
     providerModels?.forEach((provider) => {
       provider.models?.forEach((m) => {
         if (m.tags?.some((t) => t === 'default_for_agent_completion')) {
-          defaultModel = m.model;
+          defaultModel = m.model ?? undefined;
         }
         if (m.model === modelName) {
           includesCurrentModel = true;

--- a/web/src/components/providers/bot-provider.tsx
+++ b/web/src/components/providers/bot-provider.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { apiClient } from '@/lib/api/client';
 import { useCallback, useEffect, useState } from 'react';
 
-import { ModelSpec } from '@/api';
 import {
   createBot,
   createBotChat,
@@ -15,6 +13,8 @@ import {
 import type { Bot, Chat, ChatDetails } from '@/features/bot/types';
 import { listCollections } from '@/features/collection/client-api';
 import type { CollectionView } from '@/features/collection/types';
+import { getAvailableModels } from '@/features/providers/client-api';
+import type { ModelSpec } from '@/features/providers/types';
 import { useLocale } from 'next-intl';
 import { useParams, useRouter } from 'next/navigation';
 import { createContext, useContext } from 'react';
@@ -71,24 +71,18 @@ export const BotProvider = ({
   const botChatsBasePath = workspace ? '/workspace/bots' : '/bots';
 
   const loadData = useCallback(async () => {
-    const [modelRes, collectionsRes] = await Promise.all([
-      apiClient.defaultApi.availableModelsPost({
-        tagFilterRequest: {
-          tag_filters: [{ operation: 'AND', tags: ['enable_for_agent'] }],
-        },
-      }),
+    const [models, collectionsRes] = await Promise.all([
+      getAvailableModels([['enable_for_agent']]),
       listCollections(),
     ]);
 
-    const items = modelRes.data.items?.map((m) => {
-      return {
-        label: m.label,
-        name: m.name,
-        models: m.completion,
-      };
-    });
+    const items: ProviderModels = models.map((m) => ({
+      label: m.label ?? undefined,
+      name: m.name ?? undefined,
+      models: m.completion ?? undefined,
+    }));
     setCollections(collectionsRes?.items ?? []);
-    setProviderModels(items || []);
+    setProviderModels(items);
   }, []);
 
   const botCreate = useCallback(async () => {


### PR DESCRIPTION
## Summary

Phase 1b batch 4 — **provider domain**. Migrates `components/providers/bot-provider.tsx` off the legacy `apiClient.defaultApi.availableModelsPost` + `ModelSpec from '@/api'` and onto the existing `features/providers/*` adapter. `features/providers` was migrated to `/api/v2/providers/*` in an earlier phase; this batch only swaps the caller — no new feature surface, no API path rename, no fallback-semantics change.

**Main scope (Option 3 — PM / Weston / dongdong / 符炫炜 / ApeRAG专家 consensus msg=62894b9f / d8b5415c / f5b71b79 / 195a5b63 / faf04b29)**

- `web/src/components/providers/bot-provider.tsx`
  - Drops `import { ModelSpec } from '@/api'` + `import { apiClient } from '@/lib/api/client'`
  - Uses `getAvailableModels([['enable_for_agent']])` from `@/features/providers/client-api`
  - Uses `ModelSpec` from `@/features/providers/types`
  - Narrows `null → undefined` at the map boundary so `ProviderModels` view-model shape stays stable
- `tests/unit_test/test_web_typed_api_contract.py` — adds `test_provider_feature_uses_v2_typed_api_boundary`, scope limited to `components/providers/bot-provider.tsx` + `features/providers/**` (deliberately does not scan `collection-form.tsx` or `app-provider.tsx`)
- `tests/boundaries/web_legacy_api_allowlist.txt` — removes `web/src/components/providers/bot-provider.tsx` → **44 → 43**

**Necessary type-propagation cascade — `chat-input.tsx`** (architect rule formalized msg=9e4212ef / Weston msg=32f55ad8)

Switching bot-provider's `ModelSpec` source from the legacy SDK to the typed schema changes `ProviderModels[i].models[j]`'s field nullability (`string | null` vs `string`). `chat-input.tsx` consumes those typed models via `useBotContext`, so it needs a type-compat fixup:
- Replace `import { ModelSpec } from '@/api'` with `import type { ModelSpec } from '@/features/providers/types'` (other legacy imports `ChatDetails` / `Collection` / `UploadDocumentResponseStatusEnum` stay — **not** migrated in this batch)
- `defaultModel = m.model ?? undefined` to narrow typed schema nullability

Per the three cascade-admission conditions (architect msg=9e4212ef): (a) upstream typed source change directly caused the compile error, (b) cascade only swaps the type source and narrows null, no call-site migration, (c) file still has other legacy imports so it stays on the legacy allowlist. **`chat-input.tsx` remains on the legacy allowlist and is not counted as a batch reduction**.

## Deferred (locked by PM msg=62894b9f)

- `app/workspace/collections/collection-form.tsx` — voluntary partial migration rejected. Same file mixes provider (`availableModelsPost`) and collection (`TitleGenerateRequestLanguageEnum`) legacy imports. Full migration owned by the future collection batch.
- `components/providers/app-provider.tsx` — auth domain (`loginPost` / `registerPost` / `logoutPost` + `/api/v1/auth/*`), not provider. Deferred to the future identity/auth batch; no `features/auth/*` exists yet.

## Fixture delta

| Fixture | Before | After |
| --- | --- | --- |
| `tests/boundaries/web_legacy_api_allowlist.txt` | 44 | **43** (drops `components/providers/bot-provider.tsx`) |
| `tests/boundaries/web_raw_schema_allowlist.txt` | 11 | 11 (unchanged) |
| `tests/boundaries/web_route_data_allowlist.txt` | 19 | 19 (unchanged) |

## Local verification

- `pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py` — **19 passed** (including the new `test_provider_feature_uses_v2_typed_api_boundary`).
- `npm run lint` — clean, no warnings.
- `npx tsc --noEmit` — **30 errors (= main baseline)**; cascade fully recovered, net new TS errors = 0.

## Test plan

- [ ] GitHub `lint-and-unit` passes
- [ ] `e2e-http-smoke` passes (provider suite may stay IN_PROGRESS per Phase 1a/1b/quota/marketplace merge precedent — not blocking)
- [ ] Diff-scoped CR: `bot-provider.tsx` main migration; `chat-input.tsx` cascade strictly limited to `ModelSpec` import + one narrow; fixture diff strictly `44 → 43`; contract test negative scope does not scan `chat-input.tsx` / `collection-form.tsx` / `app-provider.tsx`
- [ ] `mergeable=MERGEABLE`, admin squash merge after first no-blocker CR + `lint-and-unit` green (per Phase 1a/1b/quota/marketplace precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)