### PR TITLE
refactor(modularization): Phase 1b batch 5 — collection domain (core + export) (#4)

### DIFF
--- a/tests/boundaries/web_legacy_api_allowlist.txt
+++ b/tests/boundaries/web_legacy_api_allowlist.txt
@@ -9,7 +9,6 @@ web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx
 web/src/app/workspace/audit-logs/audit-log-detail.tsx
 web/src/app/workspace/audit-logs/audit-log-table.tsx
 web/src/app/workspace/audit-logs/page.tsx
-web/src/app/workspace/collections/[collectionId]/collection-header.tsx
 web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
 web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx
 web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
@@ -23,8 +22,6 @@ web/src/app/workspace/collections/[collectionId]/search/search-delete.tsx
 web/src/app/workspace/collections/[collectionId]/search/search-result-drawer.tsx
 web/src/app/workspace/collections/[collectionId]/search/search-table.tsx
 web/src/app/workspace/collections/[collectionId]/search/search-test.tsx
-web/src/app/workspace/collections/collection-form.tsx
-web/src/app/workspace/collections/collection-list.tsx
 web/src/app/workspace/collections/feature-visibility.ts
 web/src/app/workspace/collections/tools.ts
 web/src/components/chat/agent-turn-card.tsx
@@ -36,7 +33,6 @@ web/src/components/chat/message-parts-ai.tsx
 web/src/components/chat/message-parts-user.tsx
 web/src/components/chat/message-reference.tsx
 web/src/components/chat/message-timestamp.tsx
-web/src/components/collections/export-dialog.tsx
 web/src/components/providers/app-provider.tsx
 web/src/components/user-avatar.tsx
 web/src/lib/api/client.ts

--- a/tests/boundaries/web_route_data_allowlist.txt
+++ b/tests/boundaries/web_route_data_allowlist.txt
@@ -15,5 +15,4 @@ web/src/app/workspace/collections/[collectionId]/graph/collection-graph.tsx
 web/src/app/workspace/collections/[collectionId]/search/page.tsx
 web/src/app/workspace/collections/[collectionId]/search/search-delete.tsx
 web/src/app/workspace/collections/[collectionId]/search/search-test.tsx
-web/src/app/workspace/collections/collection-form.tsx
 web/src/app/workspace/layout.tsx

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -550,22 +550,39 @@ def test_bot_feature_uses_v2_typed_api_boundary():
 
 
 def test_collection_feature_uses_v2_typed_api_boundary():
-    """#24a Collection + Sharing FE typed adapter boundary.
+    """Collection + Sharing FE typed adapter boundary.
+
+    Extended in #4 Phase 1b batch 5 ("Option B — core + export") to also
+    cover the collection-form / collection-list / collection-header /
+    export-dialog callers and the export-task adapter. Two residues are
+    deliberately **deferred** and must stay out of scope:
+
+    - `app/workspace/collections/feature-visibility.ts` imports
+      `RebuildIndexesRequestIndexTypesEnum` / `SearchResultItem*` from
+      `@/api` — indexing/retrieval domain, not collection — deferred to
+      the document/indexing batch.
+    - `app/workspace/collections/tools.ts` imports `DocumentStatusEnum`
+      from `@/api` — document domain — deferred to the document batch.
+    - `[collectionId]/documents/**`, `graph/**`, `graph-showcase/**`,
+      `search/**` subtrees stay in their own domain batches.
 
     Business code under these paths must not call the old generated
     `defaultApi.collections*` / `defaultApi.collectionsCollectionId*` /
-    `defaultApi.collectionsCollectionIdSharing*` SDK directly, and the
-    `features/collection/*` adapter must only reach `/api/v2/collections*`
-    typed paths (no `@/api` fallback, no raw `fetch(`). Document-specific
-    routes (`/documents*`) are deliberately out of scope — they stay with
-    the documents slice and the upload-flow hotfix.
+    `defaultApi.collectionsCollectionIdSharing*` /
+    `defaultApi.availableModelsPost` / `defaultApi.createExportTask` /
+    `defaultApi.getExportTask` SDK directly, and the
+    `features/collection/*` adapter must only reach
+    `/api/v2/collections*` typed paths (plus the still-v1 export-task
+    paths) without a `@/api` fallback or raw `fetch(`.
     """
     checked_paths = [
         REPO_ROOT / "web/src/app/workspace/collections/page.tsx",
         REPO_ROOT / "web/src/app/workspace/collections/collection-form.tsx",
+        REPO_ROOT / "web/src/app/workspace/collections/collection-list.tsx",
         REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/layout.tsx",
         REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/collection-delete.tsx",
         REPO_ROOT / "web/src/app/workspace/collections/[collectionId]/collection-header.tsx",
+        REPO_ROOT / "web/src/components/collections/export-dialog.tsx",
         REPO_ROOT / "web/src/components/providers/collection-provider.tsx",
         REPO_ROOT / "web/src/components/providers/bot-provider.tsx",
         REPO_ROOT / "web/src/features/collection",
@@ -584,7 +601,7 @@ def test_collection_feature_uses_v2_typed_api_boundary():
         source for path, source in sources.items() if "/web/src/features/collection/" in str(path)
     )
 
-    # Business code under #24a scope must not reach the old generated
+    # Business code under scope must not reach the old generated
     # collection SDK or the v1 collections routes directly.
     assert "defaultApi.collectionsGet" not in joined
     assert "defaultApi.collectionsPost" not in joined
@@ -595,11 +612,72 @@ def test_collection_feature_uses_v2_typed_api_boundary():
     assert "defaultApi.collectionsCollectionIdSharingPost" not in joined
     assert "defaultApi.collectionsCollectionIdSharingDelete" not in joined
 
+    # #4 batch 5 additions: the collection-form provider call and the
+    # export-dialog task calls must be gone from the four migrated
+    # callers. `@/api` is banned across the migrated call-sites; the
+    # `features/providers::getAvailableModels` cross-domain adapter call
+    # is allowed and is not what these negative assertions target.
+    form_tsx = sources[
+        REPO_ROOT / "web/src/app/workspace/collections/collection-form.tsx"
+    ]
+    list_tsx = sources[
+        REPO_ROOT / "web/src/app/workspace/collections/collection-list.tsx"
+    ]
+    header_tsx = sources[
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/collection-header.tsx"
+    ]
+    export_dialog_tsx = sources[
+        REPO_ROOT / "web/src/components/collections/export-dialog.tsx"
+    ]
+    migrated_joined = "\n".join(
+        [form_tsx, list_tsx, header_tsx, export_dialog_tsx]
+    )
+    assert "from '@/api'" not in migrated_joined
+    assert "apiClient.defaultApi.availableModelsPost" not in migrated_joined
+    assert "apiClient.defaultApi.createExportTask" not in migrated_joined
+    assert "apiClient.defaultApi.getExportTask" not in migrated_joined
+    assert "defaultApi.createExportTask" not in migrated_joined
+    assert "defaultApi.getExportTask" not in migrated_joined
+
+    # Positive: migrated callers wire through the feature adapter(s).
+    assert "from '@/features/providers/client-api'" in form_tsx
+    assert "from '@/features/collection/types'" in form_tsx
+    assert "from '@/features/collection/types'" in list_tsx
+    assert "from '@/features/collection/types'" in header_tsx
+    assert "from '@/features/collection/client-api'" in export_dialog_tsx
+    assert "from '@/features/collection/types'" in export_dialog_tsx
+
     # features/collection adapter must only reach v2 typed paths and not
-    # fall back to the old `@/api` generated SDK or raw fetch.
+    # fall back to the old `@/api` generated SDK or raw fetch. The still-v1
+    # export-task paths are allowed as Phase 1b typed-wrapping, not a v1→v2
+    # rename.
     assert "from '@/api'" not in feature_sources
     assert "fetch(" not in feature_sources
     assert "/api/v2/collections" in feature_sources
+    assert "'/api/v1/collections/{collection_id}/export'" in feature_sources
+    assert "'/api/v1/export-tasks/{task_id}'" in feature_sources
+
+    # Positive: schema-derived types + fail-fast export-task adapter.
+    types_ts = (REPO_ROOT / "web/src/features/collection/types.ts").read_text()
+    assert "NonNullable<CollectionView['status']>" in types_ts
+    assert (
+        "NonNullable<\n  components['schemas']['TitleGenerateRequest']['language']\n>"
+        in types_ts
+    )
+    assert "satisfies readonly TitleLanguage[]" in types_ts
+    assert "components['schemas']['ExportTaskResponse']" in types_ts
+
+    client_api_ts = (
+        REPO_ROOT / "web/src/features/collection/client-api.ts"
+    ).read_text()
+    # `createExportTask` / `getExportTask` return typed schema components
+    # with `export_task_id` + `status` as required fields; an empty body
+    # means the backend broke its contract, so the adapter must throw
+    # instead of returning a typed-shape-missing `{}` (new server/client
+    # adapter gate, #1612 / #1611 follow-up).
+    assert "createExportTask: empty response body" in client_api_ts
+    assert "getExportTask: empty response body" in client_api_ts
 
 
 def test_document_feature_uses_v2_typed_api_boundary():

--- a/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { CollectionViewStatusEnum } from '@/api';
+import type { CollectionStatus } from '@/features/collection/types';
 import { FormatDate } from '@/components/format-date';
 import { PageContent } from '@/components/page-container';
 import { Button } from '@/components/ui/button';
@@ -46,9 +46,7 @@ import { toast } from 'sonner';
 import { CollectionDelete } from './collection-delete';
 
 export const CollectionHeader = ({ className }: { className?: string }) => {
-  const badgeColor: {
-    [key in CollectionViewStatusEnum]: string;
-  } = {
+  const badgeColor: Record<CollectionStatus, string> = {
     ACTIVE: 'bg-green-700',
     INACTIVE: 'bg-red-500',
     DELETED: 'bg-gray-500',

--- a/web/src/app/workspace/collections/collection-form.tsx
+++ b/web/src/app/workspace/collections/collection-form.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { ModelSpec, TitleGenerateRequestLanguageEnum } from '@/api';
+import {
+  TITLE_LANGUAGES,
+  type TitleLanguage,
+} from '@/features/collection/types';
+import type { ModelSpec } from '@/features/providers/types';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -38,7 +42,7 @@ import {
   createCollection,
   updateCollection,
 } from '@/features/collection/client-api';
-import { apiClient } from '@/lib/api/client';
+import { getAvailableModels } from '@/features/providers/client-api';
 import { cn, objectKeys } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import _ from 'lodash';
@@ -73,7 +77,7 @@ const collectionSchema = z
       enable_vision: z.boolean(),
       completion: collectionModelSchema,
       embedding: collectionModelSchema,
-      language: z.enum(Object.values(TitleGenerateRequestLanguageEnum)),
+      language: z.enum(TITLE_LANGUAGES),
     }),
   })
   .refine(
@@ -143,7 +147,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
         model: '',
         model_service_provider: '',
       },
-      language: locale,
+      language: locale as TitleLanguage,
     },
   };
 
@@ -186,27 +190,21 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
    * set completion、embedding models used in model select component
    */
   const loadModels = useCallback(async () => {
-    const res = await apiClient.defaultApi.availableModelsPost({
-      tagFilterRequest: {
-        tag_filters: [{ operation: 'AND', tags: ['enable_for_collection'] }],
-      },
-    });
-    const completion = res.data.items?.map((m) => {
-      return {
-        label: m.label,
-        name: m.name,
-        models: m.completion,
-      };
-    });
-    const embedding = res.data.items?.map((m) => {
-      return {
-        label: m.label,
-        name: m.name,
-        models: m.embedding,
-      };
-    });
-    setCompletionModels(completion || []);
-    setEmbeddingModels(embedding || []);
+    const models = await getAvailableModels([['enable_for_collection']]);
+    setCompletionModels(
+      models.map((m) => ({
+        label: m.label ?? undefined,
+        name: m.name ?? undefined,
+        models: m.completion ?? undefined,
+      })),
+    );
+    setEmbeddingModels(
+      models.map((m) => ({
+        label: m.label ?? undefined,
+        name: m.name ?? undefined,
+        models: m.embedding ?? undefined,
+      })),
+    );
   }, []);
 
   /**

--- a/web/src/app/workspace/collections/collection-list.tsx
+++ b/web/src/app/workspace/collections/collection-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CollectionView } from '@/api';
+import type { CollectionView } from '@/features/collection/types';
 import { FormatDate } from '@/components/format-date';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -119,7 +119,9 @@ export const CollectionList = ({
                           )}
                         />
                         <div className="text-muted-foreground">
-                          {_.upperFirst(_.lowerCase(collection.status))}
+                          {_.upperFirst(
+                            _.lowerCase(collection.status ?? undefined),
+                          )}
                         </div>
                       </div>
                     </CardFooter>

--- a/web/src/components/collections/export-dialog.tsx
+++ b/web/src/components/collections/export-dialog.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { ExportTaskResponse } from '@/api';
+import {
+  createExportTask,
+  getExportTask,
+} from '@/features/collection/client-api';
+import type { ExportTaskResponse } from '@/features/collection/types';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -11,7 +15,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Progress } from '@/components/ui/progress';
-import { apiClient } from '@/lib/api/client';
 import { Slot } from '@radix-ui/react-slot';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -51,8 +54,7 @@ export const CollectionExport = ({
       stopPolling();
       pollingRef.current = setInterval(async () => {
         try {
-          const res = await apiClient.defaultApi.getExportTask({ taskId });
-          const data = res.data;
+          const data = await getExportTask(taskId);
           setTaskStatus(data);
 
           if (data.status === 'COMPLETED') {
@@ -88,8 +90,7 @@ export const CollectionExport = ({
 
   const handleStartExport = useCallback(async () => {
     try {
-      const res = await apiClient.defaultApi.createExportTask({ collectionId });
-      const data = res.data;
+      const data = await createExportTask(collectionId);
       setTaskStatus(data);
       setStep('processing');
       startPolling(data.export_task_id);

--- a/web/src/features/collection/client-api.ts
+++ b/web/src/features/collection/client-api.ts
@@ -8,6 +8,7 @@ import type {
   CollectionSummaryTriggerResponse,
   CollectionUpdate,
   CollectionViewList,
+  ExportTaskResponse,
   MineruTokenTestRequest,
   MineruTokenTestResponse,
   SharingStatusResponse,
@@ -127,4 +128,40 @@ export async function unpublishCollectionSharing(
       params: { path: { collection_id: collectionId } },
     },
   );
+}
+
+export async function createExportTask(
+  collectionId: string,
+): Promise<ExportTaskResponse> {
+  const { data } = await browserApiClient.POST(
+    '/api/v1/collections/{collection_id}/export',
+    {
+      params: { path: { collection_id: collectionId } },
+    },
+  );
+  // `ExportTaskResponse` has `export_task_id` + `status` as required fields.
+  // An empty body here means the backend broke its contract; fail fast so
+  // the dialog surfaces a real error instead of silently polling a task with
+  // no id.
+  if (!data) {
+    throw new Error('createExportTask: empty response body');
+  }
+  return data;
+}
+
+export async function getExportTask(
+  taskId: string,
+): Promise<ExportTaskResponse> {
+  const { data } = await browserApiClient.GET(
+    '/api/v1/export-tasks/{task_id}',
+    {
+      params: { path: { task_id: taskId } },
+    },
+  );
+  // Same contract: a single-resource GET must return the typed shape or the
+  // backend is broken. Polling "{}" would otherwise loop forever.
+  if (!data) {
+    throw new Error('getExportTask: empty response body');
+  }
+  return data;
 }

--- a/web/src/features/collection/types.ts
+++ b/web/src/features/collection/types.ts
@@ -6,6 +6,8 @@ export type CollectionUpdate = components['schemas']['CollectionUpdate'];
 export type CollectionView = components['schemas']['CollectionView'];
 export type CollectionViewList = components['schemas']['CollectionViewList'];
 
+export type CollectionStatus = NonNullable<CollectionView['status']>;
+
 export type SharingStatusResponse =
   components['schemas']['SharingStatusResponse'];
 export type CollectionSummaryTriggerResponse =
@@ -15,3 +17,16 @@ export type MineruTokenTestRequest =
   components['schemas']['MineruTokenTestRequest'];
 export type MineruTokenTestResponse =
   components['schemas']['MineruTokenTestResponse'];
+
+export type TitleLanguage = NonNullable<
+  components['schemas']['TitleGenerateRequest']['language']
+>;
+
+export const TITLE_LANGUAGES = [
+  'zh-CN',
+  'en-US',
+  'ja-JP',
+  'ko-KR',
+] as const satisfies readonly TitleLanguage[];
+
+export type ExportTaskResponse = components['schemas']['ExportTaskResponse'];


### PR DESCRIPTION
## Summary

Phase 1b batch 5 — **collection domain, Option B (core + export)**. Migrates four collection-domain callers off the legacy `@/api` SDK onto the typed `features/collection/*` + `features/providers/*` adapters. Deferred files per PM Option B ruling (msg=dd9ec891).

## Scope (PM/Weston/dongdong/符炫炜/ApeRAG专家 consensus msg=dd9ec891 / 377d8601 / be99a6df / 87176b69 / f2cb2039)

**4 files migrated and dropped from legacy allowlist**
- `web/src/app/workspace/collections/collection-form.tsx`
  - Swaps `ModelSpec` + `TitleGenerateRequestLanguageEnum` for schema-derived `TitleLanguage` / `TITLE_LANGUAGES` (from `features/collection/types`) + `ModelSpec` (from `features/providers/types`)
  - Replaces `apiClient.defaultApi.availableModelsPost` with the existing `features/providers::getAvailableModels` cross-domain adapter call
- `web/src/app/workspace/collections/collection-list.tsx`
  - Swaps `CollectionView` to the typed source
  - Null-narrows `collection.status` at the `_.lowerCase` call-site
- `web/src/app/workspace/collections/[collectionId]/collection-header.tsx`
  - Uses `NonNullable<CollectionView['status']>` alias instead of the legacy `CollectionViewStatusEnum` class
- `web/src/components/collections/export-dialog.tsx`
  - Switches to new `features/collection/client-api::{createExportTask, getExportTask}` adapters
  - Adapters wrap still-v1 `/api/v1/collections/{id}/export` + `/api/v1/export-tasks/{task_id}` paths (Phase 1b typed-wrap, no rename)
  - **Throws on empty response body** because `ExportTaskResponse` has `export_task_id` + `status` as required fields — server/client adapter gate forbids a `data ?? {}` fallback (msg=f2cb2039 / dd9ec891)

**Feature adapter surface additions** (`features/collection/*` already on raw-schema allowlist, no new row)
- `types.ts`: `CollectionStatus`, `TitleLanguage`, `TITLE_LANGUAGES` (as `satisfies readonly TitleLanguage[]`), `ExportTaskResponse` — all schema-derived via `NonNullable<>` / `components['schemas']`
- `client-api.ts`: `createExportTask(collectionId)` + `getExportTask(taskId)` — both typed, both throw on empty body

**Contract test**: extends the existing `test_collection_feature_uses_v2_typed_api_boundary` with the 4-file migrated scope + positive assertions for schema-derived types and fail-fast export-task adapter (no new batch-specific test, per msg=dd9ec891).

## Deferred (locked by PM msg=dd9ec891)

- `app/workspace/collections/feature-visibility.ts` — `RebuildIndexesRequestIndexTypesEnum` / `SearchResultItem*` are indexing / retrieval domain enums; deferred to the document/indexing batch (no hand-written enum unions in collection batch).
- `app/workspace/collections/tools.ts` — `DocumentStatusEnum` belongs to the document domain; deferred to the document batch.
- `[collectionId]/documents/**`, `graph/**`, `graph-showcase/**`, `search/**` subtrees stay in their own domain batches.

## Fixture delta

| Fixture | Before | After |
| --- | --- | --- |
| `tests/boundaries/web_legacy_api_allowlist.txt` | 43 | **39** (drops 4: collection-form / collection-list / collection-header / export-dialog) |
| `tests/boundaries/web_route_data_allowlist.txt` | 19 | **18** (drops collection-form.tsx — it was the only migrated file in this allowlist) |
| `tests/boundaries/web_raw_schema_allowlist.txt` | 11 | 11 (unchanged — `features/collection/types.ts` already on allowlist) |

## Local verification

- `pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py` — **19 passed**
- `npm run lint` — clean, no warnings
- `npx tsc --noEmit` — **29 errors (main baseline was 30)**; one pre-existing `collections/page.tsx` error resolved as collateral of unifying `CollectionView` type source between page.tsx and collection-list.tsx; no new errors introduced

## Test plan

- [ ] GitHub `lint-and-unit` passes
- [ ] `e2e-http-smoke` passes
- [ ] Diff-scoped CR per reviewer-locked gate: 4-file migrated scope + 2 deferred; schema-derived types (no hand-written enum unions); export-task adapter `throw` (no `{}` fallback); contract test extends (not duplicates) existing; fixture delta strictly `43→39 / 11 / 19→18`
- [ ] `mergeable=MERGEABLE`, admin squash merge after first no-blocker CR + `lint-and-unit` green + smoke green (per Phase 1a/1b/quota/marketplace/provider precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)