### PR TITLE
docs(modularization): document bounded redesign policy

### DIFF
--- a/docs/modularization/roadmap.md
+++ b/docs/modularization/roadmap.md
@@ -67,6 +67,15 @@ Hard limits:
   hurl, or migration tests depending on the touched surface.
 - Redesign must stay within the current domain / task scope. Reviewers
   may request a split if the rewrite crosses into another phase.
+- Opportunistic refactors must be directly adjacent to the current
+  migration boundary: the same feature adapter, migrated caller, route
+  shell, or typed error/fallback rule. Broad DRY cleanup across already
+  merged domains must be a separate cleanup PR, not hidden inside a
+  domain migration.
+- Shared helpers should be introduced only after the repeated behavior
+  is stable across endpoints. Do not abstract over distinct semantics
+  such as `throw`, `notFound`, and typed empty-list fallback until the
+  helper can preserve each required response shape.
 - Temporary bridge or shim code must name the phase or PR that deletes
   it. Long-term compatibility shims are not accepted by default.
 - If a behavior shift is intentional and not strictly compatible, it

--- a/docs/modularization/roadmap.md
+++ b/docs/modularization/roadmap.md
@@ -36,6 +36,41 @@ Current baseline: `main @ 6a89865f` after PR #1613.
   remaining legacy imports stays in the allowlist.
 - Domain ownership follows API and data semantics, not directory names.
   Cross-domain calls must go through canonical feature/domain contracts.
+- Bounded redesign is allowed inside the current domain slice. A
+  modularization PR may rewrite old code when that produces a cleaner
+  canonical boundary, provided the behavior contract is explicit, tests
+  are added or updated, and the PR does not expand into another phase or
+  domain.
+
+## Bounded redesign policy
+
+Small modularization PRs are not limited to mechanical file moves or
+import replacement. They may refactor, redesign, or rewrite legacy code
+inside the current slice when the change is needed to land the target
+domain boundary cleanly.
+
+Allowed examples:
+
+- replace legacy enum classes with schema-derived types and typed consts,
+- replace ambiguous adapter fallbacks with typed empty-list or fail-fast
+  behavior,
+- collapse a legacy service/helper into the new domain contract when the
+  old shape would force a permanent shim,
+- rewrite a route shell to expose the canonical contract directly.
+
+Hard limits:
+
+- Behavior changes must be explicit in the PR body. OpenAPI response
+  shape, hurl payload, DB migration, FE contract, and user-visible
+  behavior changes must be listed.
+- Tests must cover the new boundary: unit, typed-contract, boundary,
+  hurl, or migration tests depending on the touched surface.
+- Redesign must stay within the current domain / task scope. Reviewers
+  may request a split if the rewrite crosses into another phase.
+- Temporary bridge or shim code must name the phase or PR that deletes
+  it. Long-term compatibility shims are not accepted by default.
+- If a behavior shift is intentional and not strictly compatible, it
+  must be recorded in the relevant breaking-change table or PR notes.
 
 ## Phase timeline
 


### PR DESCRIPTION
## Summary

Documents @earayu2's roadmap-level guidance that modularization PRs may do bounded refactoring / redesign / rewrite inside the current domain slice when it produces a cleaner canonical boundary.

The policy records:
- redesign is allowed inside the active domain/task scope
- behavior changes must be explicit in PR notes or breaking tables
- tests must cover the new boundary
- scope still cannot cross phases/domains without a split
- temporary bridges/shims must name their deletion phase

## Scope

Doc-only roadmap update. No runtime code, tests, fixtures, OpenAPI, or generated schema changes.

## Validation

- `git diff --check`
