### PR TITLE
refactor(modularization): Phase 1b batch 6 — chat type shell (8 files) (#4)

### DIFF
--- a/tests/boundaries/web_legacy_api_allowlist.txt
+++ b/tests/boundaries/web_legacy_api_allowlist.txt
@@ -24,15 +24,7 @@ web/src/app/workspace/collections/[collectionId]/search/search-table.tsx
 web/src/app/workspace/collections/[collectionId]/search/search-test.tsx
 web/src/app/workspace/collections/feature-visibility.ts
 web/src/app/workspace/collections/tools.ts
-web/src/components/chat/agent-turn-card.tsx
 web/src/components/chat/chat-input.tsx
-web/src/components/chat/chat-messages.tsx
-web/src/components/chat/message-feedback.tsx
-web/src/components/chat/message-part-ai.tsx
-web/src/components/chat/message-parts-ai.tsx
-web/src/components/chat/message-parts-user.tsx
-web/src/components/chat/message-reference.tsx
-web/src/components/chat/message-timestamp.tsx
 web/src/components/providers/app-provider.tsx
 web/src/components/user-avatar.tsx
 web/src/lib/api/client.ts

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -498,6 +498,19 @@ def test_evaluation_feature_uses_v2_typed_api_boundary():
 
 
 def test_bot_feature_uses_v2_typed_api_boundary():
+    """Bot feature adapter boundary — also covers the #4 Phase 1b batch 6
+    ("chat type shell") 8-file migration.
+
+    Batch 6 migrates eight `components/chat/*` type-only consumers off the
+    legacy `@/api` SDK onto `features/bot/types`. `chat-input.tsx` is
+    deferred (it has `apiClient.chatDocumentsApi.*` call-sites for chat-
+    document attachment, which crosses the chat↔document domain boundary
+    and is out of scope for a pure type-shell migration). `chat-messages.tsx`
+    uses a raw `fetch(` against the agent-runtime streaming/artifact
+    endpoints — that is an intentional non-SDK path, not a Phase 1b
+    regression, so this test does not forbid `fetch(` in the migrated
+    business code (only inside `features/bot/**`).
+    """
     checked_paths = [
         REPO_ROOT / "web/src/app/workspace/bots",
         REPO_ROOT / "web/src/app/workspace/layout.tsx",
@@ -547,6 +560,60 @@ def test_bot_feature_uses_v2_typed_api_boundary():
     # required keys should reappear.
     assert "max_length: input.max_length ?? null" not in bot_client_api
     assert "turns: input.turns ?? null" not in bot_client_api
+
+    # #4 Phase 1b batch 6 — chat type shell migration. The eight type-only
+    # consumers below must only reach `features/bot/types` for chat-domain
+    # types. The legacy `@/api` SDK and `FeedbackTag{Enum,TypeEnum}` enum
+    # classes are banned across this scope. The `chat-input.tsx` caller is
+    # **deliberately out of scope** (deferred to the chat/document boundary
+    # batch).
+    batch6_chat_paths = [
+        REPO_ROOT / "web/src/components/chat/agent-turn-card.tsx",
+        REPO_ROOT / "web/src/components/chat/chat-messages.tsx",
+        REPO_ROOT / "web/src/components/chat/message-feedback.tsx",
+        REPO_ROOT / "web/src/components/chat/message-part-ai.tsx",
+        REPO_ROOT / "web/src/components/chat/message-parts-ai.tsx",
+        REPO_ROOT / "web/src/components/chat/message-parts-user.tsx",
+        REPO_ROOT / "web/src/components/chat/message-reference.tsx",
+        REPO_ROOT / "web/src/components/chat/message-timestamp.tsx",
+    ]
+    batch6_sources = {path: path.read_text() for path in batch6_chat_paths}
+    batch6_joined = "\n".join(batch6_sources.values())
+
+    # Negative: the 8 migrated chat shell files must not reach the legacy
+    # SDK or the legacy enum classes. Note that `fetch(` is allowed here
+    # (chat-messages.tsx uses it for agent-runtime streaming, not for the
+    # legacy SDK).
+    assert "from '@/api'" not in batch6_joined
+    assert "FeedbackTagEnum" not in batch6_joined
+    assert "FeedbackTypeEnum" not in batch6_joined
+    assert "apiClient.defaultApi" not in batch6_joined
+    assert "serverApi.defaultApi" not in batch6_joined
+    assert "apiClient.chatDocumentsApi" not in batch6_joined
+    assert "getServerApi" not in batch6_joined
+
+    # Positive: every migrated chat-shell file now imports from
+    # `features/bot/types`; the feedback form uses the derived
+    # `FEEDBACK_TAGS` const + the `FeedbackType` alias instead of the old
+    # enum classes.
+    for source in batch6_sources.values():
+        assert "from '@/features/bot/types'" in source
+    message_feedback = batch6_sources[
+        REPO_ROOT / "web/src/components/chat/message-feedback.tsx"
+    ]
+    assert "FEEDBACK_TAGS" in message_feedback
+    assert "FeedbackType" in message_feedback
+
+    # Positive: features/bot/types exposes the schema-derived chat shell
+    # aliases + the runtime `FEEDBACK_TAGS` const (constrained by
+    # `satisfies readonly FeedbackTag[]`), matching the locked gate.
+    bot_types = (REPO_ROOT / "web/src/features/bot/types.ts").read_text()
+    assert "components['schemas']['ChatMessage']" in bot_types
+    assert "components['schemas']['Feedback']" in bot_types
+    assert "components['schemas']['Reference']" in bot_types
+    assert "NonNullable<Feedback['tag']>" in bot_types
+    assert "NonNullable<Feedback['type']>" in bot_types
+    assert "satisfies readonly FeedbackTag[]" in bot_types
 
 
 def test_collection_feature_uses_v2_typed_api_boundary():

--- a/web/src/components/chat/agent-turn-card.tsx
+++ b/web/src/components/chat/agent-turn-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Feedback, Reference } from '@/api';
+import type { Feedback, Reference } from '@/features/bot/types';
 import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { Markdown } from '@/components/markdown';
 import { Badge } from '@/components/ui/badge';

--- a/web/src/components/chat/chat-input.tsx
+++ b/web/src/components/chat/chat-input.tsx
@@ -1,8 +1,8 @@
 import {
-  ChatDetails,
   Collection,
   UploadDocumentResponseStatusEnum,
 } from '@/api';
+import type { ChatDetails } from '@/features/bot/types';
 import type { ModelSpec } from '@/features/providers/types';
 import { PageContent } from '@/components/page-container';
 import { useBotContext } from '@/components/providers/bot-provider';

--- a/web/src/components/chat/chat-messages.tsx
+++ b/web/src/components/chat/chat-messages.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChatDetails, ChatMessage, Feedback } from '@/api';
+import type { ChatDetails, ChatMessage, Feedback } from '@/features/bot/types';
 import { useBotContext } from '@/components/providers/bot-provider';
 import _ from 'lodash';
 import { useParams } from 'next/navigation';
@@ -160,7 +160,7 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
   }, [turnStates]);
 
   const activeTurnStorageKey = useMemo(
-    () => getActiveTurnStorageKey(chat.id),
+    () => getActiveTurnStorageKey(chat.id ?? undefined),
     [chat.id],
   );
 

--- a/web/src/components/chat/message-feedback.tsx
+++ b/web/src/components/chat/message-feedback.tsx
@@ -1,4 +1,8 @@
-import { Feedback, FeedbackTagEnum, FeedbackTypeEnum } from '@/api';
+import {
+  FEEDBACK_TAGS,
+  type Feedback,
+  type FeedbackType,
+} from '@/features/bot/types';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -19,7 +23,7 @@ import {
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Textarea } from '@/components/ui/textarea';
-import { cn, objectKeys } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ThumbsDown, ThumbsUp } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -28,7 +32,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 const feedbackSchema = z.object({
-  tag: z.enum(objectKeys(FeedbackTagEnum), {
+  tag: z.enum(FEEDBACK_TAGS, {
     error: 'You need to select a feedback type.',
   }),
   message: z.string().optional(),
@@ -51,11 +55,11 @@ export const MessageFeedback = ({
   const common_action = useTranslations('common.action');
 
   const handleVote = useCallback(
-    (type: FeedbackTypeEnum) => {
+    (type: FeedbackType) => {
       if (!turnId) return;
       if (type === feedback?.type) {
         onFeedback(turnId, {});
-      } else if (type === FeedbackTypeEnum.good) {
+      } else if (type === 'good') {
         onFeedback(turnId, { type });
       } else {
         setVisible(true);
@@ -68,7 +72,7 @@ export const MessageFeedback = ({
     (values: z.infer<typeof feedbackSchema>) => {
       if (!turnId) return;
       onFeedback(turnId, {
-        type: FeedbackTypeEnum.bad,
+        type: 'bad',
         tag: values.tag,
         message: values.message,
       });
@@ -102,7 +106,7 @@ export const MessageFeedback = ({
                           defaultValue={field.value}
                           className="flex flex-col gap-2"
                         >
-                          {objectKeys(FeedbackTagEnum).map((key) => {
+                          {FEEDBACK_TAGS.map((key) => {
                             return (
                               <Label key={key} className="block">
                                 <FormItem
@@ -176,11 +180,11 @@ export const MessageFeedback = ({
         disabled={!turnId}
         className={cn(
           'cursor-pointer',
-          feedback?.type === FeedbackTypeEnum.good
+          feedback?.type === 'good'
             ? 'text-green-500 hover:text-green-600'
             : 'text-muted-foreground',
         )}
-        onClick={() => handleVote(FeedbackTypeEnum.good)}
+        onClick={() => handleVote('good')}
       >
         <ThumbsUp />
       </Button>
@@ -190,11 +194,11 @@ export const MessageFeedback = ({
         disabled={!turnId}
         className={cn(
           'cursor-pointer',
-          feedback?.type === FeedbackTypeEnum.bad
+          feedback?.type === 'bad'
             ? 'text-rose-500 hover:text-rose-600'
             : 'text-muted-foreground',
         )}
-        onClick={() => handleVote(FeedbackTypeEnum.bad)}
+        onClick={() => handleVote('bad')}
       >
         <ThumbsDown />
       </Button>

--- a/web/src/components/chat/message-part-ai.tsx
+++ b/web/src/components/chat/message-part-ai.tsx
@@ -1,4 +1,4 @@
-import { ChatMessage } from '@/api';
+import type { ChatMessage } from '@/features/bot/types';
 import { Markdown } from '@/components/markdown';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import _ from 'lodash';
@@ -38,7 +38,7 @@ export const MessagePartAi = ({
     case 'thinking':
       return (
         <MessageCollapseContent title="Thinking" animate={loading}>
-          <Markdown>{part.data}</Markdown>
+          <Markdown>{part.data ?? ''}</Markdown>
         </MessageCollapseContent>
       );
     case 'tool_call_result':
@@ -49,7 +49,7 @@ export const MessagePartAi = ({
         </MessageCollapseContent>
       );
     case 'message':
-      return <Markdown>{part.data}</Markdown>;
+      return <Markdown>{part.data ?? ''}</Markdown>;
     case 'stop':
       return '';
     default:

--- a/web/src/components/chat/message-parts-ai.tsx
+++ b/web/src/components/chat/message-parts-ai.tsx
@@ -1,4 +1,4 @@
-import { ChatMessage, Feedback } from '@/api';
+import type { ChatMessage, Feedback } from '@/features/bot/types';
 import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { Card } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
@@ -29,7 +29,8 @@ export const MessagePartsAi = ({
     [parts],
   );
   const turnId = useMemo(
-    () => parts.find((part) => part.role === 'ai' && part.id)?.id,
+    () =>
+      parts.find((part) => part.role === 'ai' && part.id)?.id ?? undefined,
     [parts],
   );
   const copyText = useMemo(

--- a/web/src/components/chat/message-parts-user.tsx
+++ b/web/src/components/chat/message-parts-user.tsx
@@ -1,4 +1,4 @@
-import { ChatMessage } from '@/api';
+import type { ChatMessage } from '@/features/bot/types';
 import { Markdown } from '@/components/markdown';
 import { useBotContext } from '@/components/providers/bot-provider';
 import { UserRound } from 'lucide-react';

--- a/web/src/components/chat/message-reference.tsx
+++ b/web/src/components/chat/message-reference.tsx
@@ -1,4 +1,4 @@
-import { Reference } from '@/api';
+import type { Reference } from '@/features/bot/types';
 import { Markdown } from '@/components/markdown';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -39,6 +39,15 @@ export const MessageReference = ({
         </DrawerHeader>
         <div className="overflow-auto px-4 pb-4 select-text">
           {references?.map((reference: Reference, index) => {
+            const query =
+              typeof reference.metadata?.query === 'string'
+                ? reference.metadata.query
+                : undefined;
+            const type =
+              typeof reference.metadata?.type === 'string'
+                ? reference.metadata.type
+                : undefined;
+            const text = reference.text ?? '';
             return (
               <MessageCollapseContent
                 defaultOpen={index <= 2}
@@ -47,17 +56,16 @@ export const MessageReference = ({
                   <div className="flex flex-row justify-between">
                     <div>
                       {index + 1}.{' '}
-                      {reference.metadata?.query ||
-                        _.truncate(reference.text, { length: 30 })}
+                      {query || _.truncate(text, { length: 30 })}
                     </div>
                     <div className="text-muted-foreground ml-auto flex flex-row items-center gap-2 text-xs">
-                      <span>{_.startCase(reference.metadata?.type)}</span>
+                      <span>{_.startCase(type)}</span>
                       <span>{(reference.score || 0).toFixed(2)}</span>
                     </div>
                   </div>
                 }
               >
-                <Markdown>{reference.text}</Markdown>
+                <Markdown>{text}</Markdown>
               </MessageCollapseContent>
             );
           })}

--- a/web/src/components/chat/message-timestamp.tsx
+++ b/web/src/components/chat/message-timestamp.tsx
@@ -1,4 +1,4 @@
-import { ChatMessage } from '@/api';
+import type { ChatMessage } from '@/features/bot/types';
 import { cn } from '@/lib/utils';
 import { useFormatter } from 'next-intl';
 

--- a/web/src/features/bot/types.ts
+++ b/web/src/features/bot/types.ts
@@ -9,6 +9,21 @@ export type Chat = components['schemas']['Chat'];
 export type ChatList = components['schemas']['ChatList'];
 export type ChatDetails = components['schemas']['ChatDetails'];
 export type ChatUpdate = components['schemas']['ChatUpdate'];
+export type ChatMessage = components['schemas']['ChatMessage'];
+
+export type Feedback = components['schemas']['Feedback'];
+export type FeedbackTag = NonNullable<Feedback['tag']>;
+export type FeedbackType = NonNullable<Feedback['type']>;
+
+export const FEEDBACK_TAGS = [
+  'Harmful',
+  'Unsafe',
+  'Fake',
+  'Unhelpful',
+  'Other',
+] as const satisfies readonly FeedbackTag[];
+
+export type Reference = components['schemas']['Reference'];
 
 export type TitleGenerateRequest =
   components['schemas']['TitleGenerateRequest'];


### PR DESCRIPTION
## Summary

Phase 1b batch 6 — **chat type shell**. Migrates eight `components/chat/*` display-layer files off the legacy `@/api` SDK onto `features/bot/types`. These files are pure type consumers (no `apiClient` / `defaultApi` call sites).

**Scope locked by PM/Weston/dongdong/ApeRAG专家/符炫炜** (msg=6e6dfcbe / cd5c7b08 / e83f4510 / 9da54984 / 7175cfb9):

### 8 files migrated and dropped from legacy allowlist

| File | Legacy imports swapped | Notes |
| --- | --- | --- |
| `agent-turn-card.tsx` | `Feedback`, `Reference` | display-only |
| `chat-messages.tsx` | `ChatDetails`, `ChatMessage`, `Feedback` | raw `fetch(` to agent-runtime streaming endpoints is intentional, not Phase 1b legacy SDK |
| `message-feedback.tsx` | `Feedback`, `FeedbackTagEnum`, `FeedbackTypeEnum` | enum classes replaced with schema-derived string literal unions + `FEEDBACK_TAGS` const |
| `message-part-ai.tsx` | `ChatMessage` | display-only |
| `message-parts-ai.tsx` | `ChatMessage`, `Feedback` | display-only |
| `message-parts-user.tsx` | `ChatMessage` | display-only |
| `message-reference.tsx` | `Reference` | display-only |
| `message-timestamp.tsx` | `ChatMessage` | display-only |

### `features/bot/types.ts` additions (already on raw-schema allowlist, no new row)
- `ChatMessage`, `Feedback`, `Reference` — schema aliases
- `FeedbackTag = NonNullable<Feedback['tag']>` — schema-derived union
- `FeedbackType = NonNullable<Feedback['type']>` — schema-derived union
- `FEEDBACK_TAGS` — runtime const, constrained by `satisfies readonly FeedbackTag[]`

### Necessary type-propagation cascade (per rule, architect msg=9e4212ef)

- **`chat-input.tsx`** — swaps `ChatDetails` import source from `@/api` to `@/features/bot/types` so it remains compatible with the typed `chat-messages.tsx` consumer. Other legacy imports (`Collection`, `UploadDocumentResponseStatusEnum`, `apiClient.chatDocumentsApi`) stay untouched and chat-input.tsx **remains on the legacy allowlist**. This is the same cascade pattern used in batch 4 (bot-provider → chat-input `ModelSpec`).

### Null-narrow fixups at consumer sites (typed schema nullability)

Schema-derived types surface `| null` where legacy SDK had `undefined`. Minimal narrowing:
- `part.data ?? ''` (message-part-ai.tsx)
- `reference.text ?? ''`, `typeof reference.metadata?.query === 'string'` guard (message-reference.tsx)
- `parts.find(...)?.id ?? undefined` (message-parts-ai.tsx)
- `chat.id ?? undefined` at `getActiveTurnStorageKey` call-site (chat-messages.tsx)

## Deferred (locked)

- **`chat-input.tsx`** — chat-document attachment (`chatDocumentsApi`) is a cross-domain boundary (chat ↔ document). Deferred until chat/document adapter design.
- **document / admin / auth domains** — separate batches
- **`feature-visibility.ts` / `tools.ts`** — carry-over from batch 5 (indexing / retrieval / document domain enums)

## Fixture delta

| Fixture | Before | After |
| --- | --- | --- |
| `tests/boundaries/web_legacy_api_allowlist.txt` | 39 | **31** (drops 8 chat shell files) |
| `tests/boundaries/web_raw_schema_allowlist.txt` | 11 | 11 (unchanged) |
| `tests/boundaries/web_route_data_allowlist.txt` | 18 | 18 (unchanged — no `apiClient` / `defaultApi` direct usage in chat components) |

## Local verification

- `pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py` — **19 passed**
- `npm run lint` — clean
- `npx tsc --noEmit` — **28 errors (main baseline 29)**; one pre-existing `bots/[botId]/chats/[chatId]/page.tsx:54` error resolved as collateral of unifying `ChatDetails` type source; no new errors.

## Test plan

- [ ] GitHub `lint-and-unit` passes
- [ ] `e2e-http-smoke` passes
- [ ] Diff-scoped CR: 8 migrated files fully legacy-free + chat-input.tsx cascade limited to ChatDetails import swap; fixture delta strictly `39→31 / 11 / 18`; `test_bot_feature_uses_v2_typed_api_boundary` extended (not duplicated) with batch 6 scope; negative assertions do not scan chat-input.tsx and do not forbid raw `fetch(` outside `features/**`
- [ ] `mergeable=MERGEABLE`, admin squash merge after first no-blocker CR + lint-and-unit + smoke green (per Phase 1b precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)