### PR TITLE
refactor(modularization): Phase 1b batch 7 — document type shell (7 files) (#4)

### DIFF
--- a/tests/boundaries/web_legacy_api_allowlist.txt
+++ b/tests/boundaries/web_legacy_api_allowlist.txt
@@ -3,15 +3,9 @@ web/src/app/admin/configuration/parser-settings.tsx
 web/src/app/admin/configuration/quota-settings.tsx
 web/src/app/admin/users/user-quota-action.tsx
 web/src/app/admin/users/users-data-table.tsx
-web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
-web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
-web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx
 web/src/app/workspace/audit-logs/audit-log-detail.tsx
 web/src/app/workspace/audit-logs/audit-log-table.tsx
 web/src/app/workspace/audit-logs/page.tsx
-web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
-web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx
-web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
 web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
 web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx
 web/src/app/workspace/collections/[collectionId]/graph-showcase/collection-graph-showcase.tsx
@@ -23,7 +17,6 @@ web/src/app/workspace/collections/[collectionId]/search/search-result-drawer.tsx
 web/src/app/workspace/collections/[collectionId]/search/search-table.tsx
 web/src/app/workspace/collections/[collectionId]/search/search-test.tsx
 web/src/app/workspace/collections/feature-visibility.ts
-web/src/app/workspace/collections/tools.ts
 web/src/components/chat/chat-input.tsx
 web/src/components/providers/app-provider.tsx
 web/src/components/user-avatar.tsx

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -807,6 +807,68 @@ def test_document_feature_uses_v2_typed_api_boundary():
     document_detail = (workspace_documents / "[documentId]/document-detail.tsx").read_text()
     assert "buildDocumentObjectUrl" in document_detail
 
+    # #4 Phase 1b batch 7 — document type shell migration. Seven type-only
+    # callers must drop `@/api` in favour of `features/document/types` (plus
+    # a `SharedCollection` type import from `features/marketplace/types` for
+    # the marketplace documents-table). The feature-visibility.ts carryover
+    # is **deliberately excluded** because it mixes indexing and retrieval
+    # enums and is deferred to the retrieval/search batch; the upload-flow
+    # trio (`document-upload.tsx`, `url-import.tsx`, `text-import.tsx`)
+    # remains with the future upload batch.
+    batch7_document_paths = [
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx",
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx",
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx",
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx",
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx",
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx",
+        REPO_ROOT / "web/src/app/workspace/collections/tools.ts",
+    ]
+    batch7_sources = {path: path.read_text() for path in batch7_document_paths}
+    batch7_joined = "\n".join(batch7_sources.values())
+
+    # Negative: the 7 migrated type-only files must not reach the legacy
+    # `@/api` SDK or the legacy enum classes that this batch replaces with
+    # schema-derived aliases. `apiClient`/`defaultApi`/`serverApi`/`fetch(`
+    # are already banned transitively via the #28 assertions above plus the
+    # file-level lint; this block is the scoped `@/api` + enum check.
+    assert "from '@/api'" not in batch7_joined
+    assert "DocumentStatusEnum" not in batch7_joined
+    assert "DocumentVectorIndexStatusEnum" not in batch7_joined
+    assert "RebuildIndexesRequestIndexTypesEnum" not in batch7_joined
+
+    # Positive: every migrated file now imports from `features/document/types`;
+    # the marketplace documents-table additionally pulls its SharedCollection
+    # type from `features/marketplace/types` instead of the legacy SDK.
+    for source in batch7_sources.values():
+        assert "from '@/features/document/types'" in source
+    marketplace_documents_table = batch7_sources[
+        REPO_ROOT
+        / "web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx"
+    ]
+    assert (
+        "from '@/features/marketplace/types'" in marketplace_documents_table
+    )
+
+    # Positive: `features/document/types.ts` exposes the schema-derived
+    # aliases + the runtime `DOCUMENT_INDEX_TYPES` const (constrained by
+    # `satisfies readonly DocumentIndexType[]`). This is the locked gate
+    # for batch 7; a regression here would mean a handwritten enum or
+    # union slipped back in.
+    document_types = (
+        REPO_ROOT / "web/src/features/document/types.ts"
+    ).read_text()
+    assert "NonNullable<Document['status']>" in document_types
+    assert "NonNullable<Document['vector_index_status']>" in document_types
+    assert "RebuildIndexesRequest['index_types'][number]" in document_types
+    assert "satisfies readonly DocumentIndexType[]" in document_types
+
 
 def test_documents_upload_regression_guards():
     """Regression guards for #前端 #16 document upload UX fixes.

--- a/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { DocumentPreview } from '@/api';
+import type { DocumentPreview } from '@/features/document/types';
 import { buildDocumentAssetUrl, Markdown } from '@/components/markdown';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';

--- a/web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
@@ -1,9 +1,12 @@
-import { Document, DocumentVectorIndexStatusEnum } from '@/api';
+import type {
+  Document,
+  DocumentIndexStatus as DocumentIndexStatusType,
+} from '@/features/document/types';
 import { cn } from '@/lib/utils';
 import _ from 'lodash';
 
-const getIndexStatusBg = (status?: DocumentVectorIndexStatusEnum) => {
-  const data = {
+const getIndexStatusBg = (status?: DocumentIndexStatusType | null) => {
+  const data: Record<DocumentIndexStatusType, string> = {
     ACTIVE: 'bg-green-500',
     CREATING: 'bg-sky-500',
     DELETING: 'bg-pink-500',

--- a/web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx
@@ -26,10 +26,10 @@ import * as React from 'react';
 import { defaultStyles, FileIcon } from 'react-file-icon';
 
 import {
-  Document,
-  RebuildIndexesRequestIndexTypesEnum,
-  SharedCollection,
-} from '@/api';
+  DOCUMENT_INDEX_TYPES,
+  type Document,
+} from '@/features/document/types';
+import type { SharedCollection } from '@/features/marketplace/types';
 
 import { DataGrid, DataGridPagination } from '@/components/data-grid';
 import { FormatDate } from '@/components/format-date';
@@ -98,7 +98,7 @@ export function DocumentsTable({
 
   const columns: ColumnDef<Document>[] = React.useMemo(() => {
     const indexCols: ColumnDef<Document>[] = [];
-    objectKeys(RebuildIndexesRequestIndexTypesEnum).map((key) => {
+    DOCUMENT_INDEX_TYPES.map((key) => {
       const accessorKey = key.toLowerCase() + '_index_status';
 
       indexCols.push({

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
@@ -1,9 +1,12 @@
-import { Document, DocumentVectorIndexStatusEnum } from '@/api';
+import type {
+  Document,
+  DocumentIndexStatus as DocumentIndexStatusType,
+} from '@/features/document/types';
 import { cn } from '@/lib/utils';
 import _ from 'lodash';
 
-const getIndexStatusBg = (status?: DocumentVectorIndexStatusEnum) => {
-  const data = {
+const getIndexStatusBg = (status?: DocumentIndexStatusType | null) => {
+  const data: Record<DocumentIndexStatusType, string> = {
     ACTIVE: 'bg-green-500',
     CREATING: 'bg-sky-500',
     DELETING: 'bg-pink-500',

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { RebuildIndexesRequestIndexTypesEnum } from '@/api';
+import { DOCUMENT_INDEX_TYPES } from '@/features/document/types';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -17,7 +17,7 @@ import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
 import { rebuildDocumentIndexes } from '@/features/document/client-api';
 import type { Document } from '@/features/document/types';
-import { cn, objectKeys } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Slot } from '@radix-ui/react-slot';
 import { useTranslations } from 'next-intl';
@@ -30,7 +30,7 @@ import { isVisibleDocumentIndexType } from '../../feature-visibility';
 import { DocumentIndexStatus } from './document-index-status';
 
 const documentReBuildSchema = z.object({
-  index_types: z.array(z.enum(objectKeys(RebuildIndexesRequestIndexTypesEnum))),
+  index_types: z.array(z.enum(DOCUMENT_INDEX_TYPES)),
 });
 
 type DocumentReBuildSchemaType = z.infer<typeof documentReBuildSchema>;
@@ -48,9 +48,9 @@ export const DocumentReBuildIndex = ({
   const common_action = useTranslations('common.action');
   const [visible, setVisible] = useState<boolean>(false);
   const router = useRouter();
-  const visibleIndexTypes = objectKeys(
-    RebuildIndexesRequestIndexTypesEnum,
-  ).filter(isVisibleDocumentIndexType);
+  const visibleIndexTypes = DOCUMENT_INDEX_TYPES.filter(
+    isVisibleDocumentIndexType,
+  );
   const form = useForm<DocumentReBuildSchemaType>({
     resolver: zodResolver(documentReBuildSchema),
     defaultValues: {

--- a/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
@@ -27,9 +27,10 @@ import {
 import * as React from 'react';
 import { defaultStyles, FileIcon } from 'react-file-icon';
 
-import { RebuildIndexesRequestIndexTypesEnum } from '@/api';
-
-import type { Document } from '@/features/document/types';
+import {
+  DOCUMENT_INDEX_TYPES,
+  type Document,
+} from '@/features/document/types';
 
 import { DataGrid, DataGridPagination } from '@/components/data-grid';
 import { FormatDate } from '@/components/format-date';
@@ -216,39 +217,37 @@ export function DocumentsTable({
 
   const columns: ColumnDef<Document>[] = React.useMemo(() => {
     const indexCols: ColumnDef<Document>[] = [];
-    objectKeys(RebuildIndexesRequestIndexTypesEnum)
-      .filter(isVisibleDocumentIndexType)
-      .map((key) => {
-        const accessorKey = key.toLowerCase() + '_index_status';
+    DOCUMENT_INDEX_TYPES.filter(isVisibleDocumentIndexType).map((key) => {
+      const accessorKey = key.toLowerCase() + '_index_status';
 
-        const config = collection.config;
-        let enabled: boolean | undefined;
-        switch (key) {
-          case 'FULLTEXT':
-            enabled = config?.enable_fulltext;
-            break;
-          case 'GRAPH':
-            enabled = config?.enable_knowledge_graph;
-            break;
-          case 'VECTOR':
-            enabled = config?.enable_vector;
-            break;
-          default:
-            enabled = false;
-        }
-        if (enabled) {
-          indexCols.push({
-            accessorKey,
-            header: page_collections(`index_type_${key}.title`),
-            cell: ({ row }) => (
-              <DocumentIndexStatus
-                document={row.original}
-                accessorKey={accessorKey}
-              />
-            ),
-          });
-        }
-      });
+      const config = collection.config;
+      let enabled: boolean | undefined;
+      switch (key) {
+        case 'FULLTEXT':
+          enabled = config?.enable_fulltext;
+          break;
+        case 'GRAPH':
+          enabled = config?.enable_knowledge_graph;
+          break;
+        case 'VECTOR':
+          enabled = config?.enable_vector;
+          break;
+        default:
+          enabled = false;
+      }
+      if (enabled) {
+        indexCols.push({
+          accessorKey,
+          header: page_collections(`index_type_${key}.title`),
+          cell: ({ row }) => (
+            <DocumentIndexStatus
+              document={row.original}
+              accessorKey={accessorKey}
+            />
+          ),
+        });
+      }
+    });
 
     const cols: ColumnDef<Document>[] = [
       {

--- a/web/src/app/workspace/collections/tools.ts
+++ b/web/src/app/workspace/collections/tools.ts
@@ -1,17 +1,15 @@
-import { DocumentStatusEnum } from '@/api';
+import type { DocumentStatus } from '@/features/document/types';
 
-export const getDocumentStatusColor = (status?: DocumentStatusEnum) => {
-  const data: {
-    [key in DocumentStatusEnum]: string;
-  } = {
-    [DocumentStatusEnum.PENDING]: 'text-muted-foreground',
-    [DocumentStatusEnum.RUNNING]: 'text-muted-foreground',
-    [DocumentStatusEnum.COMPLETE]: 'text-accent-foreground',
-    [DocumentStatusEnum.UPLOADED]: 'text-muted-foreground',
-    [DocumentStatusEnum.FAILED]: 'text-red-500',
-    [DocumentStatusEnum.EXPIRED]: 'text-muted-foreground line-through',
-    [DocumentStatusEnum.DELETED]: 'text-muted-foreground line-through',
-    [DocumentStatusEnum.DELETING]: 'text-muted-foreground line-through',
+export const getDocumentStatusColor = (status?: DocumentStatus | null) => {
+  const data: Record<DocumentStatus, string> = {
+    PENDING: 'text-muted-foreground',
+    RUNNING: 'text-muted-foreground',
+    COMPLETE: 'text-accent-foreground',
+    UPLOADED: 'text-muted-foreground',
+    FAILED: 'text-red-500',
+    EXPIRED: 'text-muted-foreground line-through',
+    DELETED: 'text-muted-foreground line-through',
+    DELETING: 'text-muted-foreground line-through',
   };
   return status ? data[status] : 'text-muted-foreground';
 };

--- a/web/src/features/document/types.ts
+++ b/web/src/features/document/types.ts
@@ -4,10 +4,23 @@ export type Document = components['schemas']['Document'];
 export type DocumentList = components['schemas']['DocumentList'];
 export type DocumentPreview = components['schemas']['DocumentPreview'];
 
+export type DocumentStatus = NonNullable<Document['status']>;
+export type DocumentIndexStatus = NonNullable<Document['vector_index_status']>;
+
 export type RebuildIndexesRequest =
   components['schemas']['RebuildIndexesRequest'];
 export type RebuildIndexesResponse =
   components['schemas']['RebuildIndexesResponse'];
+
+export type DocumentIndexType = RebuildIndexesRequest['index_types'][number];
+
+export const DOCUMENT_INDEX_TYPES = [
+  'VECTOR',
+  'FULLTEXT',
+  'GRAPH',
+  'SUMMARY',
+  'VISION',
+] as const satisfies readonly DocumentIndexType[];
 
 export type DeleteDocumentsRequest =
   components['schemas']['DeleteDocumentsRequest'];


### PR DESCRIPTION
## Summary

Phase 1b batch 7 — **document type shell**. Migrates seven document-domain type-only consumers off the legacy `@/api` SDK onto `features/document/types`. No client-api surface change; no upload/fetch-url call-site migration.

Scope locked by PM/Weston/dongdong/符炫炜/ApeRAG专家 (msg=33565f88 / bcdfa5b8 / 09e62ee1 / 6803ee4f / c4732e26).

## 7 files migrated and dropped from legacy allowlist

| File | Legacy imports swapped |
| --- | --- |
| `marketplace/.../document-detail.tsx` | `DocumentPreview` → `features/document/types` |
| `marketplace/.../document-index-status.tsx` | `Document`, `DocumentVectorIndexStatusEnum` → `features/document/types` (`Document`, `DocumentIndexStatus`) |
| `marketplace/.../documents-table.tsx` | `Document`, `RebuildIndexesRequestIndexTypesEnum` → `features/document/types`; `SharedCollection` → `features/marketplace/types` (cross-feature type boundary) |
| `workspace/.../document-index-status.tsx` | same as marketplace |
| `workspace/.../document-rebuild-index.tsx` | `RebuildIndexesRequestIndexTypesEnum` + `objectKeys(...)` → `DOCUMENT_INDEX_TYPES` const |
| `workspace/.../documents-table.tsx` | same |
| `workspace/collections/tools.ts` | `DocumentStatusEnum` → `DocumentStatus` |

## `features/document/types.ts` additions (already on raw-schema allowlist, no new row)

- `DocumentStatus = NonNullable<Document['status']>`
- `DocumentIndexStatus = NonNullable<Document['vector_index_status']>`
- `DocumentIndexType = RebuildIndexesRequest['index_types'][number]`
- `DOCUMENT_INDEX_TYPES` const — `satisfies readonly DocumentIndexType[]`

All legacy enum usages (`DocumentStatusEnum.PENDING`, `objectKeys(RebuildIndexesRequestIndexTypesEnum)`, `DocumentVectorIndexStatusEnum` record keys) replaced with string-literal map keys or the derived runtime const.

## Deferred (per PM msg=33565f88 + Weston msg=bcdfa5b8)

- **`feature-visibility.ts`** — mixes indexing (`RebuildIndexesRequestIndexTypesEnum`) and retrieval/search (`SearchResultItem`, `SearchResultItemRecallTypeEnum`) enums; deferred to the retrieval/search batch (no handwritten search types in document batch).
- **upload flow** — `document-upload.tsx` + `url-import.tsx` + `text-import.tsx` (note: `text-import.tsx` is not on the legacy allowlist but is on the route-data allowlist via `apiClient.defaultApi.collectionsCollectionIdDocumentsUploadPost`); needs `features/document/client-api` upload surface.
- **admin** (parser/quota/user-quota) — needs `features/admin` + quota client-api.
- **auth** (`app-provider.tsx`) — needs `features/auth`.
- **audit** (`workspace/audit-logs/**` + `admin/audit-logs/page.tsx`) — Phase 4 governance.

## Transitive residual

`document-rebuild-index.tsx` and `workspace/documents-table.tsx` continue to import `isVisibleDocumentIndexType` from `feature-visibility.ts`, which itself still has legacy imports. That file is deferred to the retrieval/search batch; this batch only makes the 7 migrated files **directly legacy-free**, not the whole document subtree.

## Fixture delta

| Fixture | Before | After |
| --- | --- | --- |
| `tests/boundaries/web_legacy_api_allowlist.txt` | 31 | **24** |
| `tests/boundaries/web_raw_schema_allowlist.txt` | 11 | 11 (unchanged) |
| `tests/boundaries/web_route_data_allowlist.txt` | 18 | 18 (unchanged) |

## Local verification

- `pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py` — **19 passed**
- `npm run lint` — clean
- `npx tsc --noEmit` — **21 errors (main baseline 29)**; eight pre-existing errors resolved as collateral of unifying `Document` / `DocumentPreview` / `SharedCollection` type sources across marketplace and workspace files; no new errors.

## Test plan

- [ ] GitHub `lint-and-unit` passes
- [ ] `e2e-http-smoke` passes (provider suite not blocking per Phase 1b precedent)
- [ ] Diff-scoped CR: 7 migrated files fully `@/api`-free; `feature-visibility.ts` / upload trio / admin / auth / audit stay deferred; `features/document/types.ts` uses only schema-derived aliases + `satisfies readonly DocumentIndexType[]`; contract test extended (not duplicated) with batch 7 scope limited to 7 files + `features/document/**`; fixture delta strictly `31→24 / 11 / 18`
- [ ] `mergeable=MERGEABLE`, admin squash merge after first no-blocker CR + `lint-and-unit` + smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)