### PR TITLE
test(e2e): capture provider-aware E2E diagnostics before compose teardown (#11)

### DIFF
--- a/.github/workflows/e2e-http-smoke.yml
+++ b/.github/workflows/e2e-http-smoke.yml
@@ -2,6 +2,12 @@ name: E2E HTTP
 
 on:
   workflow_call:
+  # ``workflow_dispatch`` lets a diagnostic task fire the full suite against
+  # the current ref without opening a dummy PR. See task #11: after Phase A
+  # (log preservation) merges, Phase B (causation verdict) may need to
+  # replay the provider-aware suite on demand rather than waiting for a
+  # natural PR failure.
+  workflow_dispatch:
 
 jobs:
   e2e-http-smoke:

--- a/.github/workflows/e2e-http-smoke.yml
+++ b/.github/workflows/e2e-http-smoke.yml
@@ -110,8 +110,29 @@ jobs:
           path: tests/e2e_http/bootstrap/.generated
           if-no-files-found: ignore
 
+      - name: Upload provider diagnostic bundle on failure
+        if: failure() && steps.provider-secrets.outputs.available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-http-provider-diagnostic-artifacts
+          path: tests/e2e_http/.diagnostic-artifacts
+          if-no-files-found: ignore
+
       - name: Dump Compose diagnostics on failure
         if: failure() && steps.provider-secrets.outputs.available == 'true'
+        env:
+          E2E_ALIBABACLOUD_API_KEY: ${{ secrets.E2E_ALIBABACLOUD_API_KEY }}
+          E2E_OPENROUTER_API_KEY: ${{ secrets.E2E_OPENROUTER_API_KEY }}
         run: |
+          # Re-run the diagnostic capture here as a safety net: if the
+          # in-script trap failed to execute ``provider_diagnostic.sh`` (e.g.
+          # because the failure happened before the trap was installed), this
+          # step still produces a bundle while the containers are around —
+          # assuming the compose stack has not already been torn down by the
+          # trap. No-op on an empty stack. See task #11.
           docker compose -f docker-compose.yml ps || true
-          docker compose -f docker-compose.yml logs --no-color api celeryworker celerybeat postgres redis qdrant es || true
+          if docker compose -f docker-compose.yml ps --quiet | grep -q .; then
+            ./tests/e2e_http/scripts/provider_diagnostic.sh || true
+          else
+            echo "No compose services left to diagnose; relying on in-script trap artifacts."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,9 @@ web/src/api/openapi.public.json
 cursorplans
 celerybeat-schedule.db
 frontend/node_modules/
+
+# E2E HTTP diagnostic bundle (written by tests/e2e_http/scripts/provider_diagnostic.sh
+# on provider-suite failure; uploaded as a GitHub Actions artifact but never
+# committed).
+tests/e2e_http/.diagnostic-artifacts/
+tests/e2e_http/bootstrap/.generated/

--- a/tests/e2e_http/scripts/provider_diagnostic.sh
+++ b/tests/e2e_http/scripts/provider_diagnostic.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Capture provider-aware E2E failure evidence before the compose teardown wipes
+# the containers. Called from ``run_compose_full.sh`` cleanup on non-zero exit,
+# and from the CI workflow "diagnose" step so we have a second chance to fetch
+# evidence even if the cleanup hook itself failed.
+#
+# Output bundle: ``tests/e2e_http/.diagnostic-artifacts/`` — uploaded by the
+# GitHub workflow as ``e2e-http-provider-diagnostic-artifacts`` on failure.
+#
+# Secrets: ``E2E_ALIBABACLOUD_API_KEY`` must not appear in the bundle. We rewrite
+# it to ``<REDACTED_ALIBABACLOUD_API_KEY>`` in every captured stream, and drop
+# any ``Authorization: Bearer ...`` / ``"api_key": "..."`` payloads. Additional
+# ``E2E_EXTRA_REDACT`` values (``:``-separated) can be passed in to scrub more
+# secrets without code changes.
+#
+# See ``#模块化重构`` task #11 for the causation checklist this script feeds.
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DIAG_DIR="${E2E_DIAG_DIR:-${ROOT_DIR}/tests/e2e_http/.diagnostic-artifacts}"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.yml"
+
+mkdir -p "${DIAG_DIR}"
+
+_redact() {
+  # Accepts stream on stdin, writes redacted stream on stdout.
+  local sed_args=()
+  if [[ -n "${E2E_ALIBABACLOUD_API_KEY:-}" ]]; then
+    sed_args+=(-e "s|${E2E_ALIBABACLOUD_API_KEY}|<REDACTED_ALIBABACLOUD_API_KEY>|g")
+  fi
+  if [[ -n "${E2E_OPENROUTER_API_KEY:-}" ]]; then
+    sed_args+=(-e "s|${E2E_OPENROUTER_API_KEY}|<REDACTED_OPENROUTER_API_KEY>|g")
+  fi
+  if [[ -n "${E2E_EXTRA_REDACT:-}" ]]; then
+    local IFS=":"
+    local extra
+    for extra in ${E2E_EXTRA_REDACT}; do
+      [[ -z "${extra}" ]] && continue
+      sed_args+=(-e "s|${extra}|<REDACTED>|g")
+    done
+  fi
+  sed_args+=(-e 's|\(Authorization:\s*Bearer \)[A-Za-z0-9._-]\{8,\}|\1<REDACTED>|g')
+  sed_args+=(-e 's|\("api_key"\s*:\s*"\)[^"]*|\1<REDACTED>|g')
+  sed_args+=(-e 's|\("apiKey"\s*:\s*"\)[^"]*|\1<REDACTED>|g')
+  sed "${sed_args[@]}"
+}
+
+echo "[provider_diagnostic] capturing to ${DIAG_DIR}"
+
+{
+  echo "=== docker compose ps ==="
+  docker compose -f "${COMPOSE_FILE}" ps
+  echo
+  echo "=== docker compose version ==="
+  docker compose version
+  echo
+  echo "=== uname + runner env ==="
+  uname -a
+  echo "GITHUB_RUN_ID=${GITHUB_RUN_ID:-<local>}"
+  echo "RUNNER_OS=${RUNNER_OS:-<local>}"
+} 2>&1 | _redact > "${DIAG_DIR}/compose-ps.txt" || true
+
+for svc in api celeryworker celerybeat postgres redis qdrant es; do
+  out="${DIAG_DIR}/compose-logs-${svc}.txt"
+  # --tail=4000 keeps the bundle small even for long-running workers while
+  # still covering the failing hurl request window (~1-2s).
+  docker compose -f "${COMPOSE_FILE}" logs --no-color --timestamps --tail=4000 "${svc}" 2>&1 \
+    | _redact > "${out}" || true
+done
+
+# Preserve the bootstrap env so reviewers can see base URL / run id / model
+# config without dumping live secrets. Bootstrap never writes the raw keys
+# into this file, but we redact defensively.
+BOOTSTRAP_ENV="${ROOT_DIR}/tests/e2e_http/bootstrap/.generated/e2e.env"
+if [[ -f "${BOOTSTRAP_ENV}" ]]; then
+  _redact < "${BOOTSTRAP_ENV}" > "${DIAG_DIR}/e2e.env.redacted" || true
+fi
+
+# Alibaba direct smoke: same Alibaba embedding model (``text-embedding-v3``),
+# same runner network, same secret. Failure → points at key / quota / service /
+# network. Success → points at ApeRAG/LiteLLM adaptation layer.
+ALIBABA_DIRECT_BASE="${E2E_ALIBABA_DIRECT_BASE:-https://dashscope.aliyuncs.com/compatible-mode/v1}"
+if [[ -n "${E2E_ALIBABACLOUD_API_KEY:-}" ]]; then
+  {
+    echo "=== Alibaba direct smoke ${ALIBABA_DIRECT_BASE}/embeddings (text-embedding-v3) ==="
+    curl --silent --show-error --include \
+      --max-time 20 \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${E2E_ALIBABACLOUD_API_KEY}" \
+      -X POST "${ALIBABA_DIRECT_BASE}/embeddings" \
+      -d '{"model":"text-embedding-v3","input":["ApeRAG is a retrieval augmented generation platform.","Embeddings convert text into vectors."]}' \
+      || echo "[provider_diagnostic] alibaba direct smoke curl exit=$?"
+  } 2>&1 | _redact > "${DIAG_DIR}/alibaba-direct-smoke.txt" || true
+else
+  echo "[provider_diagnostic] E2E_ALIBABACLOUD_API_KEY unset; skipping direct smoke" \
+    > "${DIAG_DIR}/alibaba-direct-smoke.txt"
+fi
+
+# Secret-leak self-check: fail loudly if the raw Alibaba key somehow survived
+# redaction in any captured file. Prevents CI from publishing a bundle that
+# contains the key.
+if [[ -n "${E2E_ALIBABACLOUD_API_KEY:-}" ]]; then
+  if grep --recursive --fixed-strings --silent -- "${E2E_ALIBABACLOUD_API_KEY}" "${DIAG_DIR}" 2>/dev/null; then
+    echo "[provider_diagnostic] ERROR: Alibaba API key leaked into diagnostic bundle; scrubbing and aborting" >&2
+    # Wipe the bundle rather than upload a leaky one.
+    rm -rf "${DIAG_DIR}"
+    mkdir -p "${DIAG_DIR}"
+    echo "Diagnostic bundle suppressed: raw API key leaked past redaction. Investigate sed rules in provider_diagnostic.sh." \
+      > "${DIAG_DIR}/REDACTION_FAILURE.txt"
+    exit 1
+  fi
+fi
+
+echo "[provider_diagnostic] bundle ready: $(ls -1 "${DIAG_DIR}" | tr '\n' ' ')"

--- a/tests/e2e_http/scripts/run_compose_full.sh
+++ b/tests/e2e_http/scripts/run_compose_full.sh
@@ -5,9 +5,20 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "${ROOT_DIR}"
 
 cleanup() {
+  # Capture diagnostics BEFORE ``down.sh`` wipes the containers. Without this
+  # order the ``if: failure()`` GitHub step that runs ``docker compose logs``
+  # finds no containers (because the trap already tore them down) and
+  # provider-aware failures — e.g. ``POST /api/v1/embeddings`` returning 500 —
+  # stay opaque. See ``#模块化重构`` task #11.
+  local exit_code=$?
+  if [[ "${exit_code}" -ne 0 && "${E2E_DIAGNOSTIC_ON_FAILURE:-1}" == "1" ]]; then
+    echo "[run_compose_full] capturing diagnostics (exit=${exit_code})"
+    "${ROOT_DIR}/tests/e2e_http/scripts/provider_diagnostic.sh" || true
+  fi
   if [[ "${E2E_KEEP_UP:-0}" != "1" ]]; then
     "${ROOT_DIR}/tests/e2e_http/runners/compose/down.sh"
   fi
+  return "${exit_code}"
 }
 
 trap cleanup EXIT

--- a/tests/e2e_http/scripts/run_full.sh
+++ b/tests/e2e_http/scripts/run_full.sh
@@ -31,7 +31,12 @@ FULL_DIR="${ROOT_DIR}/tests/e2e_http/hurl/full"
 
 for file in "${FULL_DIR}"/*.hurl; do
   echo "Running ${file}"
+  # ``--error-format long`` prints the HTTP response body when an assertion
+  # fails, so provider-aware failures like ``POST /api/v1/embeddings`` → 500
+  # surface their FastAPI ``detail`` / LiteLLM error in the job log instead
+  # of leaving reviewers with only the status code. See task #11.
   hurl --test \
+    --error-format long \
     --file-root "${ROOT_DIR}" \
     --variable base_url="${E2E_BASE_URL}" \
     --variable username="${E2E_USERNAME}" \


### PR DESCRIPTION
## Summary

**Phase A** of `#模块化重构` task #11. Adds observability so the next provider-aware E2E failure (the kind that made `10_provider_llm.hurl:138` / `POST /api/v1/embeddings` return 500 without any captured context on #1617/#1619) produces a usable evidence bundle. Pure CI + shell; no business code changes.

## Root cause the PR addresses

`tests/e2e_http/scripts/run_compose_full.sh` installs a `trap cleanup EXIT` that runs `down.sh` (`docker compose down -v`) whenever the script exits. By the time the workflow's `if: failure()` "Dump Compose diagnostics" step runs, the containers are already gone, so `docker compose logs api` prints nothing. Reviewers are left with just the hurl status line.

## Deliverables (fixed order per @架构师 msg=8f4d817c)

This PR lands **Deliverables 1 + 2** — the log preservation and response-body capture side of the fix. Deliverable 3 (Alibaba direct smoke) is actually also captured here because it fits in the same bundle. Deliverable 4 (causation verdict) comes after we get one real CI bundle and post findings in the #11 thread.

| # | Deliverable | Where |
|---|---|---|
| 1 | Preserve `api` / `celeryworker` / `celerybeat` + others on failure | `provider_diagnostic.sh` called **before** `down.sh` in `run_compose_full.sh` cleanup trap; artifact uploaded by workflow |
| 2 | Real `/api/v1/embeddings` response body / traceback | `run_full.sh` now passes `--error-format long` so hurl prints response body on assertion failure; combined with container logs in the bundle this gives the FastAPI `detail` / LiteLLM error |
| 3 | Same-key Alibaba direct smoke | `provider_diagnostic.sh` curls `dashscope.aliyuncs.com/compatible-mode/v1/embeddings` with **same `E2E_ALIBABACLOUD_API_KEY`, same runner network, same model, same input** per @Weston msg=5a3016b1 |
| 4 | Causation verdict | Follow-up thread reply after first bundle lands, per @架构师 msg=bb25ce26 "不在 #11 顺手修业务逻辑" |

## Files

- `tests/e2e_http/scripts/provider_diagnostic.sh` (new, executable): bundle writer
- `tests/e2e_http/scripts/run_compose_full.sh`: cleanup trap calls diagnostic on non-zero exit **before** teardown, preserves exit code
- `tests/e2e_http/scripts/run_full.sh`: hurl `--error-format long`
- `.github/workflows/e2e-http-smoke.yml`: new \`Upload provider diagnostic bundle on failure\` step; expanded \`Dump Compose diagnostics\` step re-runs the diagnostic as a safety net when containers are still alive
- `.gitignore`: excludes `tests/e2e_http/.diagnostic-artifacts/` and the pre-existing `tests/e2e_http/bootstrap/.generated/`

## Secret-safety (Weston msg=5a3016b1 guardrail)

- Every captured stream passes through `sed` redaction: literal key values, `Authorization: Bearer …`, `\"api_key\": \"…\"`, `\"apiKey\": \"…\"`.
- Trailing `grep --recursive --fixed-strings` self-check scans the bundle for the raw key. If any leaks past redaction, the bundle is wiped and replaced with a `REDACTION_FAILURE.txt` marker, rather than uploading leaky evidence.
- `E2E_EXTRA_REDACT` hook for adding more secrets without touching code.

## Explicit non-goals

- No change to `aperag/**`, provider selection, LiteLLM adaptation, `/api/v1/embeddings` handler.
- No widening of #1617/#1619 web_access scope.
- No move of the merge gate: \`lint-and-unit\` + \`e2e-http-smoke\` remains; provider-aware suite stays non-blocking.

## Local validation

- \`bash -n\` on all three scripts → OK
- Positive redaction run with a dummy key → bundle clean, no leak
- Negative redaction run with a pre-staged leaked file → guard triggers, bundle wiped, \`REDACTION_FAILURE.txt\` written
- Workflow YAML parsed by \`python3 -c 'import yaml; yaml.safe_load(...)'\` → valid

## Test plan

- [x] Local bash syntax + YAML parse
- [x] Local redaction smoke (positive + negative)
- [ ] GitHub \`lint-and-unit\` green
- [ ] First real run on provider-aware suite publishes \`e2e-http-provider-diagnostic-artifacts\`; then I post the Phase B causation verdict in the #11 thread

## Merge gate (per new口径)

- 1 家 no-blocker CR
- \`lint-and-unit\` SUCCESS
- \`mergeStateStatus=CLEAN\`
- Do not wait for e2e-http-provider (which is exactly what this PR is diagnosing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)