### PR TITLE
refactor(modularization): Phase 1b batch 8 — document upload trio (3 files) (#4)

### DIFF
--- a/tests/boundaries/web_legacy_api_allowlist.txt
+++ b/tests/boundaries/web_legacy_api_allowlist.txt
@@ -6,8 +6,6 @@ web/src/app/admin/users/users-data-table.tsx
 web/src/app/workspace/audit-logs/audit-log-detail.tsx
 web/src/app/workspace/audit-logs/audit-log-table.tsx
 web/src/app/workspace/audit-logs/page.tsx
-web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
-web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx
 web/src/app/workspace/collections/[collectionId]/graph-showcase/collection-graph-showcase.tsx
 web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-detail.tsx
 web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-merge.tsx

--- a/tests/boundaries/web_route_data_allowlist.txt
+++ b/tests/boundaries/web_route_data_allowlist.txt
@@ -6,9 +6,6 @@ web/src/app/admin/users/page.tsx
 web/src/app/admin/users/user-quota-action.tsx
 web/src/app/auth/signin/page.tsx
 web/src/app/layout.tsx
-web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
-web/src/app/workspace/collections/[collectionId]/documents/upload/import/text-import.tsx
-web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx
 web/src/app/workspace/collections/[collectionId]/graph-showcase/collection-graph-showcase.tsx
 web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-merge.tsx
 web/src/app/workspace/collections/[collectionId]/graph/collection-graph.tsx

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -785,19 +785,27 @@ def test_document_feature_uses_v2_typed_api_boundary():
 
     joined = "\n".join(sources.values())
     feature_sources = "\n".join(text for path, text in sources.items() if "/web/src/features/document/" in str(path))
+    business_sources = "\n".join(
+        text for path, text in sources.items() if "/web/src/features/document/" not in str(path)
+    )
 
     # Business code under #28 scope must not reach the old generated document
-    # SDK calls or the v1 document routes directly.
+    # SDK calls or the v1 document routes directly. The `features/document`
+    # adapter itself is allowed to wrap still-v1 paths (upload flow is
+    # Phase 1b typed-wrap of `/api/v1/collections/.../documents/{staged,
+    # upload,confirm,fetch-url}` — #4 batch 8), so the v1-path ban here
+    # targets business code only, not the adapter.
     assert "defaultApi.collectionsCollectionIdDocumentsGet" not in joined
     assert "defaultApi.collectionsCollectionIdDocumentsDocumentIdGet" not in joined
     assert "defaultApi.collectionsCollectionIdDocumentsDocumentIdDelete" not in joined
     assert "defaultApi.collectionsCollectionIdDocumentsDocumentIdRebuildIndexesPost" not in joined
     assert "defaultApi.collectionsCollectionIdRebuildFailedIndexesPost" not in joined
     assert "serverApi.defaultApi.getDocumentPreview" not in joined
-    assert "/api/v1/collections/" not in joined
+    assert "/api/v1/collections/" not in business_sources
 
-    # features/document adapter must only reach v2 typed paths and not fall
-    # back to the old `@/api` generated SDK or raw fetch.
+    # features/document adapter must only reach v2 typed paths (or the
+    # still-v1 upload-flow paths wrapped by batch 8) and not fall back to
+    # the old `@/api` generated SDK or raw fetch.
     assert "from '@/api'" not in feature_sources
     assert "fetch(" not in feature_sources
     assert "/api/v2/collections/{collection_id}/documents" in feature_sources
@@ -868,6 +876,119 @@ def test_document_feature_uses_v2_typed_api_boundary():
     assert "NonNullable<Document['vector_index_status']>" in document_types
     assert "RebuildIndexesRequest['index_types'][number]" in document_types
     assert "satisfies readonly DocumentIndexType[]" in document_types
+
+    # #4 Phase 1b batch 8 — document upload trio. Three upload/import
+    # callers (`document-upload.tsx`, `url-import.tsx`, `text-import.tsx`)
+    # migrate off `apiClient.defaultApi.collectionsCollectionIdDocuments{
+    # StagedGet,UploadPost,ConfirmPost,FetchUrlPost}` onto new
+    # `features/document/client-api` methods (`listStagedDocuments`,
+    # `uploadDocument`, `confirmDocuments`, `fetchUrlDocuments`).
+    # `text-import.tsx` was only on the route-data allowlist (no `@/api`
+    # type imports) but still hits the upload endpoint directly; this
+    # batch removes its raw SDK call so it drops from route-data too.
+    batch8_upload_paths = [
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx",
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx",
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/upload/import/text-import.tsx",
+    ]
+    batch8_sources = {path: path.read_text() for path in batch8_upload_paths}
+    batch8_joined = "\n".join(batch8_sources.values())
+
+    # Negative: the three migrated callers must not reach the legacy SDK
+    # or the legacy enum classes that this batch replaces with
+    # schema-derived aliases.
+    assert "from '@/api'" not in batch8_joined
+    assert "apiClient.defaultApi" not in batch8_joined
+    assert "serverApi.defaultApi" not in batch8_joined
+    assert "UploadDocumentResponseStatusEnum" not in batch8_joined
+    assert "FetchUrlResultItemFetchStatusEnum" not in batch8_joined
+    assert (
+        "collectionsCollectionIdDocumentsStagedGet" not in batch8_joined
+    )
+    assert (
+        "collectionsCollectionIdDocumentsUploadPost" not in batch8_joined
+    )
+    assert (
+        "collectionsCollectionIdDocumentsConfirmPost" not in batch8_joined
+    )
+    assert (
+        "collectionsCollectionIdDocumentsFetchUrlPost" not in batch8_joined
+    )
+
+    # Positive: every migrated caller now imports from
+    # `features/document/client-api`; the `document-upload.tsx` caller
+    # additionally uses the `UploadDocumentStatus` type alias instead of
+    # the legacy enum class.
+    for source in batch8_sources.values():
+        assert "from '@/features/document/client-api'" in source
+    document_upload_tsx = batch8_sources[
+        REPO_ROOT
+        / "web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx"
+    ]
+    assert "UploadDocumentStatus" in document_upload_tsx
+
+    # Positive: `features/document/client-api.ts` exposes the four upload
+    # adapters with empty-body throw guards (lesson 9a: typed components
+    # with required fields must not accept `data ?? {}`). The multipart
+    # upload explicitly uses a `FormData` `bodySerializer` to get the
+    # right `Content-Type: multipart/form-data; boundary=...` header from
+    # `fetch`.
+    document_client_api = (
+        REPO_ROOT / "web/src/features/document/client-api.ts"
+    ).read_text()
+    assert "listStagedDocuments" in document_client_api
+    assert "uploadDocument" in document_client_api
+    assert "confirmDocuments" in document_client_api
+    assert "fetchUrlDocuments" in document_client_api
+    assert (
+        "listStagedDocuments: empty response body" in document_client_api
+    )
+    assert "uploadDocument: empty response body" in document_client_api
+    assert (
+        "confirmDocuments: empty response body" in document_client_api
+    )
+    assert (
+        "fetchUrlDocuments: empty response body" in document_client_api
+    )
+    assert "bodySerializer" in document_client_api
+    assert "new FormData()" in document_client_api
+    assert (
+        "'/api/v1/collections/{collection_id}/documents/staged'"
+        in document_client_api
+    )
+    assert (
+        "'/api/v1/collections/{collection_id}/documents/upload'"
+        in document_client_api
+    )
+    assert (
+        "'/api/v1/collections/{collection_id}/documents/confirm'"
+        in document_client_api
+    )
+    assert (
+        "'/api/v1/collections/{collection_id}/documents/fetch-url'"
+        in document_client_api
+    )
+
+    # Positive: `features/document/types.ts` exposes the upload schema
+    # aliases (required-shape components) + the schema-derived nullable
+    # status unions.
+    assert (
+        "components['schemas']['UploadDocumentResponse']" in document_types
+    )
+    assert (
+        "components['schemas']['StagedDocumentsResponse']" in document_types
+    )
+    assert (
+        "components['schemas']['ConfirmDocumentsRequest']" in document_types
+    )
+    assert (
+        "components['schemas']['FetchUrlResponse']" in document_types
+    )
+    assert "UploadDocumentResponse['status']" in document_types
+    assert "FetchUrlResultItem['fetch_status']" in document_types
 
 
 def test_documents_upload_regression_guards():

--- a/web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { UploadDocumentResponseStatusEnum } from '@/api';
+import {
+  confirmDocuments,
+  listStagedDocuments,
+  uploadDocument,
+} from '@/features/document/client-api';
+import type { UploadDocumentStatus } from '@/features/document/types';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Button } from '@/components/ui/button';
 import {
@@ -29,7 +34,6 @@ import {
   FileUploadTrigger,
 } from '@/components/ui/file-upload';
 import { Progress } from '@/components/ui/progress';
-import { apiClient } from '@/lib/api/client';
 import { cn } from '@/lib/utils';
 import {
   ColumnDef,
@@ -73,7 +77,7 @@ type DocumentsWithFile = {
   progress: number;
   progress_status: 'pending' | 'uploading' | 'success' | 'failed';
   document_id?: string;
-  status?: UploadDocumentResponseStatusEnum;
+  status?: UploadDocumentStatus;
 };
 
 type AsyncTask = (callback: (error?: Error | null) => void) => void;
@@ -106,15 +110,12 @@ export const DocumentUpload = () => {
   const refreshStaged = useCallback(async () => {
     if (!collection.id) return;
     try {
-      const res =
-        await apiClient.defaultApi.collectionsCollectionIdDocumentsStagedGet({
-          collectionId: collection.id,
-        });
-      const staged: DocumentsWithFile[] = res.data.documents.map((doc) => ({
+      const res = await listStagedDocuments(collection.id);
+      const staged: DocumentsWithFile[] = res.documents.map((doc) => ({
         filename: doc.filename,
         size: doc.size,
         document_id: doc.document_id,
-        status: doc.status as UploadDocumentResponseStatusEnum,
+        status: doc.status,
         progress: 100,
         progress_status: 'success' as const,
       }));
@@ -181,19 +182,12 @@ export const DocumentUpload = () => {
 
   const handleSaveToCollection = useCallback(async () => {
     if (!collection.id) return;
-    const res =
-      await apiClient.defaultApi.collectionsCollectionIdDocumentsConfirmPost({
-        collectionId: collection.id,
-        confirmDocumentsRequest: {
-          document_ids: documents
-            .map((doc) => doc.document_id || '')
-            .filter((id) => !_.isEmpty(id)),
-        },
-      });
-    if (res.status === 200) {
-      toast.success('Document added successfully');
-      router.push(`/workspace/collections/${collection.id}/documents`);
-    }
+    const documentIds = documents
+      .map((doc) => doc.document_id || '')
+      .filter((id) => !_.isEmpty(id));
+    await confirmDocuments(collection.id, documentIds);
+    toast.success('Document added successfully');
+    router.push(`/workspace/collections/${collection.id}/documents`);
   }, [collection.id, documents, router]);
 
   // ── Upload machinery ─────────────────────────────────────────────────────
@@ -273,17 +267,15 @@ export const DocumentUpload = () => {
         const progressTask = networkSimulation(progressController.signal);
 
         try {
-          const res =
-            await apiClient.defaultApi.collectionsCollectionIdDocumentsUploadPost(
-              { collectionId: collection.id, file },
-              { timeout: 1000 * 30, signal: controller.signal },
-            );
+          const res = await uploadDocument(collection.id, file, {
+            signal: controller.signal,
+          });
 
           setDocuments((docs) => {
             const doc = docs.find((d) => d.file && _.isEqual(d.file, file));
-            if (doc && res.data.document_id) {
+            if (doc && res.document_id) {
               Object.assign(doc, {
-                ...res.data,
+                ...res,
                 progress: 100,
                 progress_status: 'success',
               });

--- a/web/src/app/workspace/collections/[collectionId]/documents/upload/import/text-import.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/upload/import/text-import.tsx
@@ -1,11 +1,11 @@
 'use client';
 
+import { uploadDocument } from '@/features/document/client-api';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { apiClient } from '@/lib/api/client';
 import { LoaderCircle, Type } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useState } from 'react';
@@ -33,10 +33,7 @@ export const TextImport = ({ onSuccess }: Props) => {
       // Create a File object from the text — reuses the existing upload endpoint entirely
       const file = new File([content], filename, { type: 'text/plain' });
 
-      await apiClient.defaultApi.collectionsCollectionIdDocumentsUploadPost({
-        collectionId: collection.id,
-        file,
-      });
+      await uploadDocument(collection.id, file);
 
       onSuccess();
     } finally {

--- a/web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/upload/import/url-import.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import { FetchUrlResultItem, FetchUrlResultItemFetchStatusEnum } from '@/api';
+import { fetchUrlDocuments } from '@/features/document/client-api';
+import type { FetchUrlStatus } from '@/features/document/types';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { apiClient } from '@/lib/api/client';
+import { ApiClientError } from '@/lib/api/typed/errors';
 import { AlertCircle, CheckCircle2, Globe, LoaderCircle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useState } from 'react';
 
 type UrlImportResult = {
   url: string;
-  fetch_status: 'success' | 'error';
+  fetch_status: FetchUrlStatus;
   document_id?: string;
   filename?: string;
   size?: number;
@@ -102,28 +103,16 @@ export const UrlImport = ({ onSuccess }: Props) => {
     setResults(null);
 
     try {
-      const res = await apiClient.defaultApi.collectionsCollectionIdDocumentsFetchUrlPost(
-        {
-          collectionId: collection.id,
-          fetchUrlRequest: { urls },
-        },
-        { timeout: 1000 * 60 },
-      );
-
-      const fetchResults: UrlImportResult[] = (res.data.results as FetchUrlResultItem[]).map(
-        (item) => ({
-          url: item.url,
-          fetch_status:
-            item.fetch_status === FetchUrlResultItemFetchStatusEnum.success
-              ? ('success' as const)
-              : ('error' as const),
-          document_id: item.document_id ?? undefined,
-          filename: item.filename ?? undefined,
-          size: item.size ?? undefined,
-          status: item.status ?? undefined,
-          error: item.error ?? undefined,
-        }),
-      );
+      const res = await fetchUrlDocuments(collection.id, urls);
+      const fetchResults: UrlImportResult[] = res.results.map((item) => ({
+        url: item.url,
+        fetch_status: item.fetch_status,
+        document_id: item.document_id ?? undefined,
+        filename: item.filename ?? undefined,
+        size: item.size ?? undefined,
+        status: item.status ?? undefined,
+        error: item.error ?? undefined,
+      }));
       setResults(fetchResults);
 
       const succeeded = fetchResults.filter((r) => r.fetch_status === 'success');
@@ -132,12 +121,8 @@ export const UrlImport = ({ onSuccess }: Props) => {
       }
     } catch (error: unknown) {
       const detail =
-        typeof error === 'object' &&
-        error !== null &&
-        'response' in error &&
-        typeof (error as { response?: { data?: { detail?: unknown } } }).response?.data?.detail ===
-          'string'
-          ? (error as { response?: { data?: { detail?: string } } }).response?.data?.detail
+        error instanceof ApiClientError
+          ? error.message
           : error instanceof Error
             ? error.message
             : 'Request failed';

--- a/web/src/features/document/client-api.ts
+++ b/web/src/features/document/client-api.ts
@@ -3,13 +3,17 @@
 import { browserApiClient } from '@/lib/api/typed/browser';
 
 import type {
+  ConfirmDocumentsResponse,
   DeleteDocumentsRequest,
   DeleteDocumentsResponse,
   Document,
   DocumentList,
   DocumentPreview,
+  FetchUrlResponse,
   RebuildIndexesRequest,
   RebuildIndexesResponse,
+  StagedDocumentsResponse,
+  UploadDocumentResponse,
 } from './types';
 
 export type ListDocumentsOptions = {
@@ -126,6 +130,98 @@ export async function rebuildFailedDocumentIndexes(
       params: { path: { collection_id: collectionId } },
     },
   );
+  return data;
+}
+
+// Upload flow (staged list / upload / confirm / fetch-url). Phase 1b typed
+// wrap: these wrap the still-v1 endpoints without renaming the path. All
+// four returns are single-resource shapes with required fields, so an empty
+// body means the backend broke its contract — the adapter throws instead
+// of returning a typed-shape-missing `{}` (new server/client adapter gate,
+// lesson 9a).
+
+export async function listStagedDocuments(
+  collectionId: string,
+  signal?: AbortSignal,
+): Promise<StagedDocumentsResponse> {
+  const { data } = await browserApiClient.GET(
+    '/api/v1/collections/{collection_id}/documents/staged',
+    {
+      params: { path: { collection_id: collectionId } },
+      signal,
+    },
+  );
+  if (!data) {
+    throw new Error('listStagedDocuments: empty response body');
+  }
+  return data;
+}
+
+// `openapi-fetch` 0.17 does not auto-encode `body: { file }` as
+// `multipart/form-data`; we supply an explicit `bodySerializer` that builds
+// a `FormData` and lets `fetch` set the correct `Content-Type` boundary.
+// The body type literally matches the generated
+// `Body_documents_upload_document_view` (`{ file: string /* binary */ }`),
+// but at runtime we pass a real `File` under `file`; that's why we cast to
+// `unknown` to satisfy the typed contract and then read `body.file` as the
+// actual File inside the serializer.
+export async function uploadDocument(
+  collectionId: string,
+  file: File,
+  options?: { signal?: AbortSignal; timeout?: number },
+): Promise<UploadDocumentResponse> {
+  const { data } = await browserApiClient.POST(
+    '/api/v1/collections/{collection_id}/documents/upload',
+    {
+      params: { path: { collection_id: collectionId } },
+      body: { file: file as unknown as string },
+      bodySerializer: (body) => {
+        const fd = new FormData();
+        fd.append('file', (body as unknown as { file: File }).file);
+        return fd;
+      },
+      signal: options?.signal,
+    },
+  );
+  if (!data) {
+    throw new Error('uploadDocument: empty response body');
+  }
+  return data;
+}
+
+export async function confirmDocuments(
+  collectionId: string,
+  documentIds: string[],
+): Promise<ConfirmDocumentsResponse> {
+  const { data } = await browserApiClient.POST(
+    '/api/v1/collections/{collection_id}/documents/confirm',
+    {
+      params: { path: { collection_id: collectionId } },
+      body: { document_ids: documentIds },
+    },
+  );
+  if (!data) {
+    throw new Error('confirmDocuments: empty response body');
+  }
+  return data;
+}
+
+export async function fetchUrlDocuments(
+  collectionId: string,
+  urls: string[],
+  options?: { signal?: AbortSignal },
+): Promise<FetchUrlResponse> {
+  const { data } = await browserApiClient.POST(
+    '/api/v1/collections/{collection_id}/documents/fetch-url',
+    {
+      params: { path: { collection_id: collectionId } },
+      body: { urls },
+      signal: options?.signal,
+    },
+  );
+  if (!data) {
+    throw new Error('fetchUrlDocuments: empty response body');
+  }
   return data;
 }
 

--- a/web/src/features/document/types.ts
+++ b/web/src/features/document/types.ts
@@ -26,3 +26,20 @@ export type DeleteDocumentsRequest =
   components['schemas']['DeleteDocumentsRequest'];
 export type DeleteDocumentsResponse =
   components['schemas']['DeleteDocumentsResponse'];
+
+export type UploadDocumentResponse =
+  components['schemas']['UploadDocumentResponse'];
+export type UploadDocumentStatus = UploadDocumentResponse['status'];
+
+export type StagedDocumentsResponse =
+  components['schemas']['StagedDocumentsResponse'];
+
+export type ConfirmDocumentsRequest =
+  components['schemas']['ConfirmDocumentsRequest'];
+export type ConfirmDocumentsResponse =
+  components['schemas']['ConfirmDocumentsResponse'];
+
+export type FetchUrlRequest = components['schemas']['FetchUrlRequest'];
+export type FetchUrlResponse = components['schemas']['FetchUrlResponse'];
+export type FetchUrlResultItem = components['schemas']['FetchUrlResultItem'];
+export type FetchUrlStatus = FetchUrlResultItem['fetch_status'];


### PR DESCRIPTION
## Summary

Phase 1b batch 8 — **document upload trio**. Migrates three document upload/import callers off the legacy `@/api` SDK onto a new upload-flow surface inside `features/document/client-api`. Single-domain slice (document); no cross-domain, no new feature directory. Scope locked by architect msg=5e87234e.

## 3 migrated files (all allowlist exits)

| File | Legacy surface swapped |
| --- | --- |
| `workspace/.../documents/upload/document-upload.tsx` | `UploadDocumentResponseStatusEnum` → `UploadDocumentStatus`; `apiClient.defaultApi.{StagedGet,ConfirmPost,UploadPost}` → `listStagedDocuments` / `confirmDocuments` / `uploadDocument` |
| `workspace/.../documents/upload/import/url-import.tsx` | `FetchUrlResultItem` + `FetchUrlResultItemFetchStatusEnum` → typed alias + `FetchUrlStatus`; `apiClient.defaultApi.FetchUrlPost` → `fetchUrlDocuments`; legacy axios-shape `err.response.data.detail` handler replaced with `ApiClientError` from typed browser client |
| `workspace/.../documents/upload/import/text-import.tsx` | not on legacy allowlist (no `@/api`) but was on **route-data** allowlist via `collectionsCollectionIdDocumentsUploadPost`; swaps to `uploadDocument` |

## `features/document/client-api.ts` additions

Four new typed-wrap adapters (Phase 1b rule: wrap still-v1 paths without renaming):

- `listStagedDocuments(collectionId, signal?)` → `GET /api/v1/collections/{id}/documents/staged`
- `uploadDocument(collectionId, file, {signal?, timeout?})` → `POST /api/v1/collections/{id}/documents/upload`
- `confirmDocuments(collectionId, documentIds)` → `POST /api/v1/collections/{id}/documents/confirm`
- `fetchUrlDocuments(collectionId, urls, {signal?})` → `POST /api/v1/collections/{id}/documents/fetch-url`

All four **throw on empty response body** (lesson 9a — required-field schemas must not accept `data ?? {}`).

### Multipart typed-wrap verification (architect msg=b1d8c19c review gate)

`openapi-fetch` 0.17 does not auto-convert `body: { file }` to `multipart/form-data`. `uploadDocument` uses an explicit `bodySerializer` that builds a `FormData`; `fetch` then sets the correct `Content-Type: multipart/form-data; boundary=...` header automatically. No raw `fetch` fallback needed — the typed client still routes through the browser error middleware (toast + `ApiClientError`). The body-shape type-assertion (`file as unknown as string`) matches the generated `Body_documents_upload_document_view.file: string /* binary */` schema; the runtime value is a real `File` handed to the serializer.

## `features/document/types.ts` additions (already on raw-schema allowlist, no new row)

- `UploadDocumentResponse` (schema alias)
- `UploadDocumentStatus = UploadDocumentResponse['status']` (required-field union)
- `StagedDocumentsResponse`, `ConfirmDocumentsRequest`, `ConfirmDocumentsResponse`
- `FetchUrlRequest`, `FetchUrlResponse`, `FetchUrlResultItem`
- `FetchUrlStatus = FetchUrlResultItem['fetch_status']`

## Non-goals (locked, msg=5e87234e + msg=8b6f8e66)

- No auth / admin / audit / graph / search / `feature-visibility.ts` / `chat-input.tsx`.
- No `features/upload/` directory; upload stays inside the document feature (single-domain slice).
- No v1 → v2 path rename (Phase 1b rule — typed wrap only).

## Fixture delta

| Fixture | Before | After |
| --- | --- | --- |
| `tests/boundaries/web_legacy_api_allowlist.txt` | 24 | **22** |
| `tests/boundaries/web_raw_schema_allowlist.txt` | 11 | 11 (unchanged; `features/document/types.ts` already on allowlist) |
| `tests/boundaries/web_route_data_allowlist.txt` | 18 | **15** (drops `document-upload.tsx` + `url-import.tsx` + `text-import.tsx`) |

## Local verification

- `pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py` — **20 passed** (test_document_feature extended with batch 8 block).
- `npm run lint` — clean.
- `npx tsc --noEmit` — **21 errors (= main baseline)**; no new errors.

Contract test now includes:
- Negative scope on 3 migrated callers: no `@/api`, no `apiClient.defaultApi.*`, no legacy upload enum classes, no legacy upload method names.
- Positive scope on adapter: all four methods present with empty-body throw guards; `bodySerializer` + `new FormData()` used for multipart; all four typed v1 paths reachable.
- Existing `"/api/v1/collections/" not in joined` assertion narrowed from `joined` to `business_sources` (adapter itself is allowed to reference still-v1 upload paths per Phase 1b rule).

## Test plan

- [ ] GitHub `lint-and-unit` passes
- [ ] `e2e-http-smoke` passes (provider suite non-blocking per Phase 1b precedent + task #11 in progress)
- [ ] Diff-scoped CR: 3 migrated files fully legacy-free; multipart `bodySerializer` uses `FormData`; empty-body throw guards on all 4 adapters; fixture delta strictly `24→22 / 11 / 18→15`; contract test extended (not duplicated)
- [ ] `mergeable=MERGEABLE`, admin squash merge after first no-blocker CR + `lint-and-unit` + smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)