### PR TITLE
ci: opt upload-artifact into hidden-file uploads (#14)

### DIFF
--- a/.github/workflows/e2e-http-smoke.yml
+++ b/.github/workflows/e2e-http-smoke.yml
@@ -50,6 +50,10 @@ jobs:
           name: e2e-http-bootstrap-artifacts
           path: tests/e2e_http/bootstrap/.generated
           if-no-files-found: ignore
+          # The bootstrap directory name starts with "." — actions/upload-artifact@v4
+          # treats it as hidden and silently uploads 0 files unless we opt in.
+          # See task #14 (root-cause: task #11 Phase B).
+          include-hidden-files: true
 
       - name: Dump Compose diagnostics on failure
         if: failure()
@@ -115,6 +119,8 @@ jobs:
           name: e2e-http-provider-bootstrap-artifacts
           path: tests/e2e_http/bootstrap/.generated
           if-no-files-found: ignore
+          # ``.generated`` starts with a dot (hidden). v4 default skips it. See #14.
+          include-hidden-files: true
 
       - name: Upload provider diagnostic bundle on failure
         if: failure() && steps.provider-secrets.outputs.available == 'true'
@@ -123,6 +129,10 @@ jobs:
           name: e2e-http-provider-diagnostic-artifacts
           path: tests/e2e_http/.diagnostic-artifacts
           if-no-files-found: ignore
+          # ``.diagnostic-artifacts`` starts with a dot (hidden). v4 default skips
+          # it. The entire bundle produced by ``provider_diagnostic.sh`` ends up
+          # unuploaded without this opt-in. See #14 (root-cause: #11 Phase B).
+          include-hidden-files: true
 
       - name: Dump Compose diagnostics on failure
         if: failure() && steps.provider-secrets.outputs.available == 'true'


### PR DESCRIPTION
## Summary

Closes #11 Phase B follow-up #14. Fixes the artifact bundle produced by \`provider_diagnostic.sh\` (landed in #1620) never actually arriving at the Actions artifact surface.

## Root cause from #11 Phase B run 24845074156

- Script log: \`[provider_diagnostic] bundle ready: alibaba-direct-smoke.txt compose-logs-api.txt ...\` (10 files written)
- Upload step log: \`No files were found with the provided path: tests/e2e_http/.diagnostic-artifacts\` → 0 artifacts
- Same failure mode on \`tests/e2e_http/bootstrap/.generated\` (bootstrap step)

The common factor: both paths start with a leading dot. \`actions/upload-artifact@v4\` defaults \`include-hidden-files\` to \`false\`, so hidden directories are walked and yield zero files before upload.

## Change

Three upload steps in \`.github/workflows/e2e-http-smoke.yml\` now set \`include-hidden-files: true\`:

1. \`Upload bootstrap artifacts on failure\` — smoke job (path \`.generated\`)
2. \`Upload bootstrap artifacts on failure\` — provider job (same path)
3. \`Upload provider diagnostic bundle on failure\` — provider job (path \`.diagnostic-artifacts\`)

Each has a one-line comment pointing back at #14/#11 so future editors don't strip it.

## Redaction regression check (guardrail for #14)

\`provider_diagnostic.sh\` already runs \`grep --recursive --fixed-strings\` on the bundle for the raw API key values and, on any hit, wipes the bundle and writes \`REDACTION_FAILURE.txt\`. Turning on hidden uploads does not weaken redaction — the leak check runs before upload, and its file sits in the same leading-dot directory so the workflow would then publish the redaction-failure marker instead of the leaky bundle.

## Evidence requirement per #14 opener

@架构师 msg=9afb01c1 asks for "一次真实 provider run 里 artifact 可下载的证据". That requires a provider failure to occur. Since #15 (Alibaba \`encoding_format\`) is still open, the very next provider run will naturally fail at \`10_provider_llm.hurl:138\` and the fixed upload steps will publish the bundle. I will add the artifact download receipt to the #14 thread after the first post-merge provider run produces one.

## Test plan

- [x] \`python3 -c 'import yaml; yaml.safe_load(...)'\` parses
- [x] \`git diff --check\` clean
- [ ] GitHub \`lint-and-unit\` green
- [ ] First post-merge provider run's \`e2e-http-provider-diagnostic-artifacts\` is non-empty on \`gh run download\`

## Merge gate

Per new口径: 1 家 no-blocker CR + \`lint-and-unit\` SUCCESS + CLEAN → admin merge, not waiting on \`e2e-http-provider\`. I will self-merge (per @earayu2 msg=abf9a919) once gate met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)