### PR TITLE
test(e2e): fix evaluation-v2 hurl default-bot resolver collision (#18)

### DIFF
--- a/tests/e2e_http/hurl/full/16_evaluation_v2.hurl
+++ b/tests/e2e_http/hurl/full/16_evaluation_v2.hurl
@@ -28,10 +28,14 @@ collection_id: jsonpath "$.id"
 jsonpath "$.id" == "{{collection_id}}"
 jsonpath "$.config.source" == "system"
 
+# Title must NOT be the literal "Default Agent Bot" — auth.py:84 already
+# auto-creates a bot with that exact title on user registration, and the
+# default-bot resolver picks the oldest title match, which would be the
+# auto-created bot, not this one.
 POST {{base_url}}/api/v2/bots
 Content-Type: application/json
 {
-  "title": "Default Agent Bot",
+  "title": "Eval Agent Bot {{run_id}}",
   "description": "HTTP evaluation v3 run coverage",
   "type": "agent"
 }
@@ -182,6 +186,10 @@ jsonpath "$.summary.total" == 3
 jsonpath "$.summary.pending" == 3
 jsonpath "$.summary.completed" == 0
 
+# POST without bot_id exercises the default-bot resolver; the resolved
+# bot_id is NOT {{bot_id}} (that one is titled "Eval Agent Bot ..."),
+# it's the registration-auto bot titled "Default Agent Bot". Capture
+# and verify the title instead of comparing ids.
 POST {{base_url}}/api/v2/evaluation-runs
 Content-Type: application/json
 {
@@ -191,12 +199,18 @@ Content-Type: application/json
 HTTP 200
 [Captures]
 run_id_default_bot: jsonpath "$.id"
+default_resolved_bot_id: jsonpath "$.bot_id"
 [Asserts]
 jsonpath "$.id" == "{{run_id_default_bot}}"
-jsonpath "$.bot_id" == "{{bot_id}}"
 jsonpath "$.dataset_id" == "{{dataset_id}}"
 jsonpath "$.collection_id" == "{{collection_id}}"
 jsonpath "$.status" == "queued"
+
+GET {{base_url}}/api/v2/bots/{{default_resolved_bot_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{default_resolved_bot_id}}"
+jsonpath "$.title" == "Default Agent Bot"
 
 GET {{base_url}}/api/v2/evaluation-runs?bot_id={{bot_id}}&page=1&page_size=20
 HTTP 200


### PR DESCRIPTION
## Summary

Closes #18. Fixes the `16_evaluation_v2.hurl:196` `bot_id` assertion drift that was keeping the provider-aware E2E job red after #14/#15 landed.

## Root cause (internal fixture drift, not external)

`16_evaluation_v2.hurl` (introduced by #20 PR-2 / #1595 `22ed079a` on 2026-04-23) creates a bot with the literal title `\"Default Agent Bot\"` and then posts an evaluation-run without `bot_id` to exercise the default-resolver, asserting that `$.bot_id == {{bot_id}}`.

Two facts collide:

1. `aperag/views/auth.py:84` auto-creates a bot with the exact title `\"Default Agent Bot\"` on every user registration — pre-existing behaviour.
2. `aperag/db/repositories/evaluation_v2.py::resolve_default_evaluation_bot` picks `Bot.title == default_title` ordered by `gmt_created ASC LIMIT 1`.

So the registration-auto bot (older) always wins the tie-break and the resolver returns that bot's id, not the hurl-created one. The assertion was broken from birth.

The failure stayed hidden until #15 fixed the earlier `10_provider_llm.hurl` `encoding_format` 500 that was aborting the suite before reaching `16_evaluation_v2.hurl`.

## Evidence

Observed on provider run [24847696429](https://github.com/apecloud/ApeRAG/actions/runs/24847696429/job/72739820028) (main @ `92828e9b`, post-#14/#15 merge):

```
error: Assert failure
   --> tests/e2e_http/hurl/full/16_evaluation_v2.hurl:196:0
    |
196 | jsonpath \"$.bot_id\" == \"{{bot_id}}\"
    |   actual:   string <botffc8f082ac50944b>
    |   expected: string <botf4b51da819423319>
```

## Fix (hurl-only, backend untouched)

1. Rename the hurl-created bot to `\"Eval Agent Bot {{run_id}}\"` so it no longer collides with the auto-created default bot.
2. Drop the incorrect `$.bot_id == {{bot_id}}` assertion on the default-resolver POST. Capture the resolved id + GET the bot and assert `$.title == \"Default Agent Bot\"` — this pins the resolver's actual contract rather than a hurl-local bot_id that couldn't match anyway.

## Why not touch the resolver

Title-match + oldest-wins is a known fragile pattern (@符炫炜 msg=4912a494 flagged it as a Phase 5 evaluation-domain refactor candidate — `is_system_default` boolean or per-user ownership scoping). That rework is out of scope for a CI unblocking fix; this PR is the minimal correction so the provider E2E gate stops masking other failures.

## Tests

- `uv run --extra test pytest tests/unit_test/ -q` not affected — no Python code touched.
- Provider-aware gate will validate on PR CI (`e2e-http-provider` job running the full suite). Per new merge口径 (@earayu2 msg=f5b13976 / PM msg=5d3d2f7b) I will wait for `e2e-http-provider` green before self-merge.

## Merge gate per new policy

- `lint-and-unit` green
- `e2e-http-smoke` green
- `e2e-http-provider` green (including `16_evaluation_v2.hurl` now passing)
- 1 reviewer no-blocker CR

## Out of scope

- Resolver strategy change (Phase 5 candidate, per @符炫炜 msg=4912a494).
- Any other hurl file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)