### PR TITLE
ci(nebula): wait for storaged ONLINE after ADD HOSTS (#22)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -331,25 +331,57 @@ services:
       - sh
       - -c
       - |
+        # Phase 1 — register storaged with metad (ADD HOSTS).
+        # Returning OK here only means the host is now in metad's
+        # registry; metad still needs at least one successful heartbeat
+        # round before it marks the host ONLINE, and CREATE SPACE with
+        # replica_factor>=1 requires ONLINE hosts — so ADD-HOSTS-success
+        # alone is not a green light for callers. See Phase 2 below.
+        registered=0
         for i in `seq 1 $$ACTIVATOR_RETRY`; do
           output=$$(nebula-console -addr nebula-graphd -port 9669 -u root -p nebula -e 'ADD HOSTS "nebula-storaged":9779' 2>&1)
           if [ $$? -eq 0 ]; then
-            echo "Storage activated successfully."
-            exit 0
+            echo "Storage registered via ADD HOSTS."
+            registered=1
+            break
           fi
           if echo "$$output" | grep -q "Existed"; then
-            echo "Storage already activated."
-            exit 0
+            echo "Storage already registered (ADD HOSTS returned Existed)."
+            registered=1
+            break
           fi
           if [ $$i -lt $$ACTIVATOR_RETRY ]; then
-            echo "Attempt $$i/$$ACTIVATOR_RETRY activating storaged; retrying..."
+            echo "Attempt $$i/$$ACTIVATOR_RETRY registering storaged; retrying..."
             sleep 5
             continue
           fi
-          echo "Failed to activate storaged after $$ACTIVATOR_RETRY attempts."
+          echo "Failed to register storaged after $$ACTIVATOR_RETRY attempts."
           echo "$$output"
           exit 1
         done
+        if [ "$$registered" -ne 1 ]; then
+          echo "Storage never got registered; aborting."
+          exit 1
+        fi
+
+        # Phase 2 — wait until storaged is visible as ONLINE to metad
+        # via the usual heartbeat cycle. Without this poll, the
+        # activator can exit 0 while storaged is still OFFLINE, and any
+        # immediately-following `CREATE SPACE replica_factor=1` call
+        # fails with "Host not enough!" in metad's placement check.
+        # This is the Nebula race symptom tracked in task #22.
+        for i in `seq 1 $$ACTIVATOR_RETRY`; do
+          status=$$(nebula-console -addr nebula-graphd -port 9669 -u root -p nebula -e 'SHOW HOSTS' 2>&1)
+          if echo "$$status" | grep -q "ONLINE"; then
+            echo "Storaged is ONLINE."
+            exit 0
+          fi
+          echo "Storaged not ONLINE yet (attempt $$i/$$ACTIVATOR_RETRY); retrying..."
+          sleep 5
+        done
+        echo "Storaged failed to reach ONLINE status within $$ACTIVATOR_RETRY attempts."
+        echo "$$status"
+        exit 1
     depends_on:
       - nebula-graphd
     profiles: ["nebula"]


### PR DESCRIPTION
## Summary

Fixes the `Backend-Compat-Test / graph-compat (nebula)` flake that started showing up on any PR touching `aperag/graphindex/**` (most recently #1629 Step 3). Every Nebula backend test was failing with:

```
RuntimeError: Nebula query failed: Host not enough!
```

on `CREATE SPACE ... replica_factor=1`.

## Root cause

The `nebula-storage-activator` container was only waiting for `ADD HOSTS` to succeed before exiting. In Nebula:

- `ADD HOSTS` registers `nebula-storaged` in metad's hosts registry.
- The host is not marked `ONLINE` until metad receives at least one heartbeat from it (default ~10s cadence).
- `CREATE SPACE ... replica_factor>=1` consults metad's placement planner, which only counts `ONLINE` hosts, so it returns `Host not enough!` if no host has heartbeat yet.

Our `.github/workflows/compat-test.yml` waits for the activator to `exited 0` and then immediately runs pytest. That's exactly the window where storaged is registered-but-not-online, so the job fails deterministically in CI.

PostgreSQL/Neo4j backends don't share this registration layer — they stayed green throughout, confirming the failure is 100% backend-specific startup ordering, not a code regression.

## Fix

Split the activator into two phases:

1. **Register** — `ADD HOSTS "nebula-storaged":9779` until we either get OK or `"Existed"` (same semantics as before, just explicit).
2. **Wait for ONLINE** — new loop that runs `SHOW HOSTS` until the storaged row reports `ONLINE`, reusing the same `ACTIVATOR_RETRY` budget.

Only when both phases succeed does the container `exit 0`, so the workflow's `docker inspect ... exited 0` gate now really means "storaged is ready to serve CREATE SPACE".

Diff is scoped to `docker-compose.yml` only. No `aperag/**` business code, no test harness, no `#1629` interaction.

## Test plan

- [ ] `Backend-Compat-Test / graph-compat (nebula)` turns green on this PR
- [ ] `graph-compat (postgresql)` and `graph-compat (neo4j)` remain green (regression check)
- [ ] `vector-compat (qdrant)` / `vector-compat (pgvector)` unaffected
- [ ] `lint-and-unit` unaffected

**Note**: Local Docker is not available in this sandbox (per lesson 9a-sept / #1628 Path 2 pattern), so validation is CI-only. If the first run still flakes, I iterate the wait budget or command form in this same PR; the PM ruling (msg=f0f0c0d5) explicitly allows that.

## Lesson 9a-sept reference

This PR is the canonical example of "infra-dependent gate needs CI-level fix-forward", validated against #1628 Path 2 bootstrap precedent.

Fixes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)