### PR TITLE
fix(evaluation_v2): guard terminal→running in update_run_status (#23)

### DIFF
--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -40,6 +40,14 @@ from aperag.db.models import (
 from aperag.db.repositories.base import AsyncRepositoryProtocol
 from aperag.utils.utils import utc_now
 
+_TERMINAL_RUN_STATUSES = frozenset(
+    {
+        EvaluationRunStatus.COMPLETED,
+        EvaluationRunStatus.FAILED,
+        EvaluationRunStatus.CANCELLED,
+    }
+)
+
 
 class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
     """Read/write helpers for evaluation resources."""
@@ -114,11 +122,31 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
         error_message: Optional[str] = None,
         summary: Optional[dict] = None,
     ) -> Optional[EvaluationRun]:
+        """Update a run's status with a terminal → running guard.
+
+        If the persisted run is already in a terminal status
+        (COMPLETED / FAILED / CANCELLED) and the requested transition
+        is to ``RUNNING``, this is a no-op and returns the existing
+        row unchanged — preventing a late worker
+        ``update_run_status(RUNNING)`` from overwriting a cancel that
+        raced in between ``get_run_for_worker`` and this call. That
+        race produced the symptom tracked in task #23 where
+        ``gmt_finished`` ended up earlier than ``gmt_started`` and the
+        run flipped back to ``running`` right after cancel returned
+        ``cancelled``. Explicit terminal → QUEUED transitions (the
+        ``service.retry_run_item`` re-queue flow) are still allowed,
+        so retries continue to work.
+        """
         async def _operation(session: AsyncSession):
             stmt = select(EvaluationRun).where(EvaluationRun.id == run_id)
             run = (await session.execute(stmt)).scalars().first()
             if not run:
                 return None
+            if (
+                run.status in _TERMINAL_RUN_STATUSES
+                and status == EvaluationRunStatus.RUNNING
+            ):
+                return run
             now = utc_now()
             run.status = status
             if error_message is not None:
@@ -127,11 +155,7 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
                 run.summary = summary
             if status == EvaluationRunStatus.RUNNING and run.gmt_started is None:
                 run.gmt_started = now
-            if status in (
-                EvaluationRunStatus.COMPLETED,
-                EvaluationRunStatus.FAILED,
-                EvaluationRunStatus.CANCELLED,
-            ):
+            if status in _TERMINAL_RUN_STATUSES:
                 run.gmt_finished = now
             else:
                 run.gmt_finished = None

--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -137,15 +137,13 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
         ``service.retry_run_item`` re-queue flow) are still allowed,
         so retries continue to work.
         """
+
         async def _operation(session: AsyncSession):
             stmt = select(EvaluationRun).where(EvaluationRun.id == run_id)
             run = (await session.execute(stmt)).scalars().first()
             if not run:
                 return None
-            if (
-                run.status in _TERMINAL_RUN_STATUSES
-                and status == EvaluationRunStatus.RUNNING
-            ):
+            if run.status in _TERMINAL_RUN_STATUSES and status == EvaluationRunStatus.RUNNING:
                 return run
             now = utc_now()
             run.status = status


### PR DESCRIPTION
## Summary

Fixes the `16_evaluation_v2.hurl:269` flake tracked in #23: `cancel` returns `status=cancelled`, but the immediately-following GET sees `status=running`, and the response has `gmt_finished < gmt_started` — a physically impossible timestamp ordering that pinpointed the race.

## Root cause (TOCTOU in update_run_status)

Worker's pre-check is not atomic with its status write:

1. worker: `get_run_for_worker(run_id)` → sees QUEUED
2. worker: `run.status in _TERMINAL_RUN_STATUSES` → False, proceed
3. **cancel endpoint interleaves**: `update_run_status(CANCELLED)` → row becomes `status=CANCELLED`, `gmt_finished=T1`
4. worker resumes: `update_run_status(RUNNING)` → overwrites to `status=RUNNING`, `gmt_started=T1+dt`, (previously) `gmt_finished=None`
5. hurl sees `status=running`; the inverted `gmt_finished < gmt_started` timestamp is the fingerprint of step 3/4 commit ordering.

## Fix

Narrow the mutator itself. `aperag/db/repositories/evaluation_v2.py::update_run_status` now:

- Reads the persisted run first (already did).
- If the persisted status is terminal (COMPLETED / FAILED / CANCELLED) **and** the caller is asking for RUNNING, returns the existing row unchanged. This is the only illegal transition the worker race produces.
- Terminal → QUEUED is still allowed so `service.retry_run_item` keeps working.
- Terminal → same-terminal or non-terminal non-RUNNING (theoretical) still passes through; not a concern in practice.

Also extracts `_TERMINAL_RUN_STATUSES` to a module-level `frozenset` so the repo layer has a single canonical reference. The worker module keeps its own copy to avoid a cross-module coupling just for a readability win.

## Test plan

- [x] `uv run pytest tests/unit_test/` → 667 passed, 29 skipped
- [x] `uv run ruff check aperag/db/repositories/evaluation_v2.py` → clean
- [ ] CI: `16_evaluation_v2.hurl:269` (both cancel-first and worker-first orderings) go green deterministically
- [ ] CI: no regression in `e2e-http-smoke` evaluation_v2 suite
- [ ] CI: `lint-and-unit` (including `make db-check`) green

## Lesson 9a-dec reference

This PR is the concrete follow-up mandated by @符炫炜 msg=1087db7f (lesson 9a-dec), which allowed #1629 Step 4a to pass the smoke gate conditionally while the pre-existing race was tracked here. Once #1630 (#22 Nebula) and this PR both merge, the two external-cause exceptions logged against recent #1629 checkpoints are fully retired.

Fixes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)