### PR TITLE
ci(nebula): extend schema visibility retry window (task #24)

### DIFF
--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'aperag/graphindex/**'
+      - 'aperag/domains/knowledge_graph/graphindex/**'
       - 'aperag/vectorstore/**'
       - 'tests/integration/compat/**'
       - '.github/workflows/compat-test.yml'

--- a/aperag/domains/knowledge_graph/graphindex/storage/nebula.py
+++ b/aperag/domains/knowledge_graph/graphindex/storage/nebula.py
@@ -62,7 +62,15 @@ _ENTITY_TAG = "entity"
 _CHUNK_TAG = "chunk"
 _EDGE_TYPE = "relates_to"
 _SCHEMA_VISIBILITY_ERROR = "No schema found for"
-_SCHEMA_VISIBILITY_RETRIES = 10
+# Nebula metad accepts ``CREATE SPACE`` before the schema finishes
+# propagating to every storaged node, so a follow-up ``USE <space>``
+# (or a tag/edge ``CREATE`` inside the new space) can briefly raise
+# ``SpaceNotFound`` / ``No schema found for`` while the heartbeat
+# catches up. Nebula's default ``heartbeat_interval_secs`` is 10s and
+# storaged typically picks up changes within 2× that window, so 30
+# retries at 1s is intentionally comfortable for a shared CI runner.
+# The happy path short-circuits well before the budget.
+_SCHEMA_VISIBILITY_RETRIES = 30
 _SCHEMA_VISIBILITY_DELAY_SECONDS = 1.0
 
 


### PR DESCRIPTION
## Summary

- Widen ``_SCHEMA_VISIBILITY_RETRIES`` in ``aperag/domains/knowledge_graph/graphindex/storage/nebula.py`` from 10 to 30 (delay per attempt unchanged at 1.0 s).
- Distinct from the ``Host not enough!`` startup race already fixed by #22 — this one is the ``CREATE SPACE`` → ``USE <space>`` meta-to-storaged propagation window that surfaced on PR #1629 ``1151e779`` as ``SpaceNotFound: SpaceName compat_test_compat_test_84b3fc83`` in ``test_list_labels[nebula]`` (7 / 8 Nebula subtests passed).
- Nebula's default ``heartbeat_interval_secs`` is 10 s and storaged typically picks up schema changes within 2× that, so a 30 s budget covers the worst case we have seen on the shared GitHub Actions runner. The happy path still short-circuits on the first successful ``USE``.

Canonical lineage: task #22 ``docker-compose.yml`` activator covered Race A (storaged not registered); this PR covers Race B (schema not yet propagated).

## Test plan

- [x] Local ``ruff check`` + ``ruff format --check`` clean
- [ ] CI ``graph-compat (nebula, nebula)`` green on this branch
- [ ] ``graph-compat`` on ``postgresql`` and ``neo4j`` stays green (regression guard)
- [ ] No change to Nebula runtime behaviour outside ``_ensure_space`` retry budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)