### PR TITLE
refactor(modularization): Phase 6 (#20) cleanup — retire residual Protocol + promote is_terminal + identity facade

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -42,9 +42,6 @@ from aperag.domains.conversation.api.routes import (
     chat_router as chat_router,
 )
 from aperag.domains.conversation.service.bot_service import set_quota_ops as _conv_set_quota_ops
-from aperag.domains.conversation.service.chat_document_service import (
-    set_chat_collection_ops as _conv_set_chat_collection_ops,
-)
 from aperag.domains.evaluation.api.routes import router as evaluation_v2_router
 from aperag.domains.governance.api.routes import router as governance_router
 from aperag.domains.identity.service.user_manager import (
@@ -114,20 +111,6 @@ _kb_set_quota_ops(_legacy_quota_service)
 # instance is plugged in here — Phase 6 cleanup removes the wire-up
 # when quota_service finds its permanent home.
 _conv_set_quota_ops(_legacy_quota_service)
-
-# Wire the ``ChatCollectionServiceOps`` DI slot for ``chat_document_service``
-# (Phase 5 step 5-S4d). ``chat_document_service`` moved into the
-# conversation domain before ``chat_collection_service`` itself — the
-# sibling service still needs a Phase 4 identity-domain rebase for the
-# ``session.get(User, ...)`` rewrite. Until 5-S4f (after ``#1633``
-# merges), the legacy singleton fills the DI slot; it structurally
-# satisfies the Protocol verbatim.
-from aperag.service.chat_collection_service import (  # noqa: E402
-    chat_collection_service as _legacy_chat_collection_service,
-)
-
-_conv_set_chat_collection_ops(_legacy_chat_collection_service)
-
 
 # Wire the agent_runtime domain's consumer-owned PromptTemplateOps DI
 # slot (Phase 5 step 5-S5b). ``prompt_template_service`` stays as a

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -104,19 +104,19 @@ _kb_set_search_pipeline_ops(_legacy_search_pipeline_service)
 _kb_set_quota_ops(_legacy_quota_service)
 
 # Wire the conversation domain's consumer-owned QuotaOps DI slot for
-# ``bot_service`` (Phase 5 step 5-S4c, canonical msg=4a93c97e Q1 C).
-# The legacy quota_service structurally satisfies the narrower
-# conversation ``QuotaOps`` Protocol (``check_and_consume_quota`` +
-# ``release_quota``) via the same singleton, so the same legacy
-# instance is plugged in here — Phase 6 cleanup removes the wire-up
-# when quota_service finds its permanent home.
+# ``bot_service``. ``quota_service`` is a standalone-infrastructure
+# module with no natural domain home, so the Protocol + DI seam is
+# the permanent integration point. The singleton structurally
+# satisfies the narrower conversation ``QuotaOps`` Protocol
+# (``check_and_consume_quota`` + ``release_quota``) directly.
 _conv_set_quota_ops(_legacy_quota_service)
 
 # Wire the agent_runtime domain's consumer-owned PromptTemplateOps DI
-# slot (Phase 5 step 5-S5b). ``prompt_template_service`` stays as a
-# legacy provider through Phase 6 cleanup, so an adapter exposes the
-# three Protocol methods onto the legacy singleton + module-level
-# ``build_agent_query_prompt`` helper.
+# slot. ``prompt_template_service`` is a standalone-infrastructure
+# module (no natural domain home), so the Protocol + DI seam is the
+# permanent integration point — an adapter exposes the three Protocol
+# methods onto the singleton + module-level ``build_agent_query_prompt``
+# helper.
 from aperag.service.prompt_template_service import (  # noqa: E402
     build_agent_query_prompt as _legacy_build_agent_query_prompt,
 )

--- a/aperag/db/repositories/evaluation_v2.py
+++ b/aperag/db/repositories/evaluation_v2.py
@@ -16,10 +16,9 @@
 ``aperag.domains.evaluation.db.repositories.evaluation_v2`` after
 Phase 5 step 5-S6.
 
-``aperag.db.ops`` pulls in the repository mixin from here (plus the
-``_TERMINAL_RUN_STATUSES`` frozenset if any caller still wants the
-module-level alias), so the existing call sites keep working without
-a rename sweep. Phase 6 cleanup removes the shim.
+``aperag.db.ops`` pulls in the repository mixin from here so the
+existing call sites keep working without a rename sweep. Phase 6
+cleanup removes the shim.
 """
 
 from aperag.domains.evaluation.db.repositories.evaluation_v2 import (  # noqa: F401

--- a/aperag/domains/agent_runtime/ports.py
+++ b/aperag/domains/agent_runtime/ports.py
@@ -14,10 +14,13 @@
 
 """Cross-domain contracts owned by the ``agent_runtime`` domain.
 
-``PromptTemplateOps`` is the consumer-owned Protocol for the legacy
-``aperag.service.prompt_template_service`` provider, which stays in
-``aperag/service/`` so the agent_runtime domain cannot ``from
-aperag.service.*`` import it directly without tripping G1.
+``PromptTemplateOps`` is the consumer-owned Protocol seam for
+``aperag.service.prompt_template_service``. The service is a
+standalone-infrastructure module (cross-cutting across agent_runtime
+runtime calls, conversation bot-config resolution, indexing prompt
+resolution, and a user-facing ``/prompts`` REST surface) with no
+natural domain home — the Protocol + DI seam is its permanent
+integration point under G1.
 
 ``AuthenticatedUser`` stays per-domain (lesson 9a-ter); runtime
 handlers only need ``id`` for turn ownership / lease checks.
@@ -43,8 +46,7 @@ class AuthenticatedUser(Protocol):
 
 @runtime_checkable
 class PromptTemplateOps(Protocol):
-    """Consumer-owned view of the legacy
-    ``aperag.service.prompt_template_service``.
+    """Consumer-owned view of ``aperag.service.prompt_template_service``.
 
     Exposes the three surfaces ``runtime.py`` actually uses:
 
@@ -63,11 +65,6 @@ class PromptTemplateOps(Protocol):
     singleton plus the module-level ``build_agent_query_prompt``
     function, so ``aperag/app.py`` wires an adapter that fans out to
     both to satisfy the Protocol.
-
-    Phase 6 cleanup will either move ``prompt_template_service`` into
-    a canonical domain home (agent_runtime or model_platform candidate
-    per msg=65a3b27d) or retire the Protocol in favour of a direct
-    cross-domain import.
     """
 
     async def resolve_agent_system_prompt(self, *, bot: Any, user_id: str) -> str: ...

--- a/aperag/domains/agent_runtime/ports.py
+++ b/aperag/domains/agent_runtime/ports.py
@@ -14,20 +14,10 @@
 
 """Cross-domain contracts owned by the ``agent_runtime`` domain.
 
-Phase 5 step 5-S5b adds the ``PromptTemplateOps`` Protocol for the
-legacy ``aperag.service.prompt_template_service`` provider —
-``prompt_template_service`` stays in ``aperag/service/`` through
-Phase 6 cleanup, so the agent_runtime domain cannot ``from
+``PromptTemplateOps`` is the consumer-owned Protocol for the legacy
+``aperag.service.prompt_template_service`` provider, which stays in
+``aperag/service/`` so the agent_runtime domain cannot ``from
 aperag.service.*`` import it directly without tripping G1.
-
-The ``ChatDocumentOps`` Protocol originally seeded in Phase 5 step 1
-has been **retired** per msg=940bd884 simplification: after
-``chat_document_service`` physically moved into the conversation
-domain (Phase 5 step 5-S4d), ``runtime.py`` can reach it via a
-direct cross-domain import (domain→domain is allowed by G1). The
-Protocol is kept here only in archived form (below the ``__all__``
-for the live surface) so any in-flight branch still referencing it
-resolves the same shape; Phase 6 removes it outright.
 
 ``AuthenticatedUser`` stays per-domain (lesson 9a-ter); runtime
 handlers only need ``id`` for turn ownership / lease checks.
@@ -99,17 +89,3 @@ __all__ = [
     "AuthenticatedUser",
     "PromptTemplateOps",
 ]
-
-
-# ``ChatDocumentOps`` retained for any in-flight caller that still
-# imports it. Phase 5 step 5-S5b replaced the runtime's DI seam with a
-# direct cross-domain import of
-# ``aperag.domains.conversation.service.chat_document_service`` now
-# that the conversation domain is merged — the Protocol definition is
-# no longer wired at app startup and is scheduled for removal in
-# Phase 6.
-
-
-@runtime_checkable
-class ChatDocumentOps(Protocol):  # pragma: no cover - retired, Phase 6 deletion candidate
-    async def has_documents_in_chat(self, chat_id: str, user_id: str) -> bool: ...

--- a/aperag/domains/agent_runtime/runtime.py
+++ b/aperag/domains/agent_runtime/runtime.py
@@ -296,11 +296,6 @@ class PydanticAIRuntime(AgentRuntime):
             )
 
             history_context = await self.history_writer.build_history_context(user, chat.id)
-            # Direct cross-domain import of the sibling conversation service
-            # (Phase 5 step 5-S4d moved it into the conversation domain) —
-            # G1 allows domain→domain. msg=940bd884 simplification avoids a
-            # ``ChatDocumentOps`` Protocol seam now that the provider has
-            # moved out of the legacy ``aperag.service.*`` ban target.
             from aperag.domains.conversation.service.chat_document_service import chat_document_service
 
             has_chat_files = await chat_document_service.has_documents_in_chat(chat.id, user)

--- a/aperag/domains/conversation/ports.py
+++ b/aperag/domains/conversation/ports.py
@@ -115,34 +115,8 @@ class QuotaOps(Protocol):
     ) -> None: ...
 
 
-@runtime_checkable
-class ChatCollectionServiceOps(Protocol):
-    """``chat_document_service``'s view of ``chat_collection_service``.
-
-    Phase 5 step 5-S4d moves ``chat_document_service`` into the
-    conversation domain before ``chat_collection_service`` itself —
-    ``chat_collection_service.create_user_chat_collection`` reaches
-    ``session.get(User, ...)`` which requires the Phase 4 identity
-    domain merge before it can be rewritten without leaking a G1
-    legacy-aggregate ``User`` import into the domain module.
-
-    Until the sibling service follows (5-S4f after ``#1633`` merges,
-    per PM ``msg=0f9f10c4`` β ruling), the two surfaces
-    ``chat_document_service`` actually calls —
-    ``get_user_chat_collection`` and ``create_user_chat_collection``
-    — are exposed here as a consumer-owned Protocol. ``aperag/app.py``
-    wires the legacy singleton in at startup; the legacy instance
-    structurally satisfies the Protocol verbatim.
-    """
-
-    async def get_user_chat_collection(self, user_id: str) -> Any: ...
-
-    async def create_user_chat_collection(self, user_id: str) -> Any: ...
-
-
 __all__ = [
     "KnowledgeBaseCollectionView",
     "AuthenticatedUser",
     "QuotaOps",
-    "ChatCollectionServiceOps",
 ]

--- a/aperag/domains/conversation/service/chat_collection_service.py
+++ b/aperag/domains/conversation/service/chat_collection_service.py
@@ -12,41 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Chat-collection management service moved to the conversation domain
-in Phase 5 step 5-S4f.
+"""Chat-collection management service in the conversation domain.
 
-Phase 4 ``#1633`` + Phase 3 ``#1629`` are merged on main, so the
-cross-domain ORM imports take the β canonical path from
-``msg=4ed698d8`` — direct domain-to-domain imports of ``User`` /
-``Collection`` + sibling domain services, no stopgap Protocol + DI
-wrapper:
+Cross-domain dependencies are direct imports:
 
-* ``aperag.db.models.User`` → ``aperag.domains.identity.db.models.User``
-* ``aperag.db.models.Collection`` →
-  ``aperag.domains.knowledge_base.db.models.Collection``
-* ``aperag.schema.view_models.CollectionConfig / ModelSpec /
-  TagFilterCondition / TagFilterRequest`` → ``aperag.schema.common``
-  for the first two and
-  ``aperag.domains.model_platform.schemas`` for the tag filters.
-* ``aperag.service.collection_service`` →
-  ``aperag.domains.knowledge_base.service.collection_service``
-* ``aperag.service.llm_available_model_service`` →
-  ``aperag.domains.model_platform.service.llm_available_model_service``
+* ``aperag.domains.identity.db.models.User`` is **not** imported here —
+  ``User.chat_collection_id`` writes travel through the identity-owned
+  ``set_chat_collection`` facade (lesson 9a-sexdec hierarchy-1) so G16
+  stays green without the conversation domain leaking the ``User`` ORM.
+* ``aperag.domains.knowledge_base.db.models.Collection`` is imported
+  directly (domain→domain is legal under G1).
+* ``aperag.domains.knowledge_base.service.collection_service`` + the
+  ``model_platform`` availability service similarly sibling-import.
 
-The pre-move ``KnowledgeBaseCollectionView`` return type (from
-``aperag.domains.conversation.ports``) is kept — the Protocol was
-established in Phase 3 Step 5c for exactly this module, and there is
-no benefit in swapping it for the concrete ``Collection`` class here.
-
-The ``_mark_as_chat_collection`` transaction closure uses
-``session.get(Collection, ...)`` — Collection is now imported from the
-knowledge_base domain, which G1 permits. The ``User.chat_collection_id``
-update is issued via ``sqlalchemy.text`` rather than ``session.get(User,
-...)`` + attribute assignment so the conversation domain does not have
-to import the identity-owned ``User`` ORM class (G16 canonical per
-``msg=6d2ae86a`` forbids ``User`` imports outside the identity domain).
-The raw UPDATE hits the same ``users`` table that the ORM mapper binds
-to, so the transaction semantics are identical.
+The pre-move ``KnowledgeBaseCollectionView`` return type is kept —
+the Protocol was established in Phase 3 Step 5c for exactly this
+module, and there is no benefit in swapping it for the concrete
+``Collection`` class here.
 """
 
 from __future__ import annotations
@@ -54,10 +36,9 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from sqlalchemy import text
-
 from aperag.db.ops import async_db_ops
 from aperag.domains.conversation.ports import KnowledgeBaseCollectionView
+from aperag.domains.identity.service.identity_user_ops import set_chat_collection as identity_set_chat_collection
 from aperag.domains.knowledge_base.db.models import Collection
 from aperag.domains.knowledge_base.schemas import CollectionCreate
 from aperag.domains.knowledge_base.service.collection_service import collection_service
@@ -172,13 +153,7 @@ class ChatCollectionService:
                 session.add(collection_obj)
                 await session.flush()
 
-            # Update User.chat_collection_id via raw SQL so this module
-            # does not have to import the identity-owned ``User`` ORM
-            # class (G16 canonical).
-            await session.execute(
-                text("UPDATE users SET chat_collection_id = :cid WHERE id = :uid"),
-                {"cid": collection_response.id, "uid": user_id},
-            )
+            await identity_set_chat_collection(session, user_id, collection_response.id)
             await session.flush()
 
         await self.db_ops.execute_with_transaction(_mark_as_chat_collection)

--- a/aperag/domains/conversation/service/chat_document_service.py
+++ b/aperag/domains/conversation/service/chat_document_service.py
@@ -12,30 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Chat-document service moved to the ``conversation`` domain in
-Phase 5 step 5-S4d.
+"""Chat-document service for the ``conversation`` domain.
 
-Two cross-service hookups were rewritten for the move:
+Cross-service hookups are direct sibling / cross-domain imports:
 
-* ``aperag.service.chat_collection_service`` (G1 banned) is reached
-  via the new consumer-owned ``ChatCollectionServiceOps`` Protocol
-  (see ``aperag.domains.conversation.ports``). The legacy singleton
-  is wired in by ``aperag/app.py`` at startup; the Protocol only
-  surfaces the two methods this module actually calls
-  (``get_user_chat_collection`` / ``create_user_chat_collection``),
-  matching the narrower-than-upstream pattern Phase 3 established
-  for ``QuotaOps``.
-* ``aperag.service.document_service`` (G1 banned) is replaced with a
-  direct cross-domain import of
-  ``aperag.domains.knowledge_base.service.document_service`` (Phase
-  3 merged). Cross-domain direct imports are legal under G1 — the
-  strict ban only covers the three legacy aggregate modules.
+* ``chat_collection_service`` is a sibling inside this domain
+  (Phase 5 step 5-S4f moved it here) — direct import, no Protocol seam.
+* ``aperag.domains.knowledge_base.service.document_service`` is a
+  cross-domain direct import (legal under G1 — the strict ban only
+  covers the three legacy aggregate modules).
 
-``aperag.schema.view_models.Document`` is reached via
-``aperag.domains.knowledge_base.schemas.Document`` (the canonical
-location after Phase 3 step 5b3). Keeping the type annotation on
-``upload_chat_document`` means the OpenAPI response_model stays
-byte-stable when 5-S4g eventually merges the chat routes.
+``aperag.domains.knowledge_base.schemas.Document`` is the canonical
+response type after Phase 3 step 5b3; keeping the annotation on
+``upload_chat_document`` preserves the OpenAPI response_model.
 """
 
 from __future__ import annotations
@@ -47,37 +36,12 @@ from typing import Any, Dict, List, Optional
 from fastapi import HTTPException, UploadFile
 
 from aperag.db.ops import async_db_ops
-from aperag.domains.conversation.ports import ChatCollectionServiceOps
+from aperag.domains.conversation.service.chat_collection_service import chat_collection_service
 from aperag.domains.knowledge_base.schemas import Document
 from aperag.domains.knowledge_base.service.document_service import document_service
 from aperag.utils.utils import utc_now
 
 logger = logging.getLogger(__name__)
-
-_chat_collection_ops: Optional[ChatCollectionServiceOps] = None
-
-
-def set_chat_collection_ops(ops: ChatCollectionServiceOps) -> None:
-    """Wire the ``ChatCollectionServiceOps`` singleton at app startup.
-
-    ``aperag/app.py`` calls this once with the legacy
-    ``aperag.service.chat_collection_service.chat_collection_service``
-    instance (structurally satisfies the Protocol) until 5-S4f moves
-    ``chat_collection_service`` into the conversation domain and the
-    adapter is dropped.
-    """
-    global _chat_collection_ops
-    _chat_collection_ops = ops
-
-
-def _get_chat_collection_ops() -> ChatCollectionServiceOps:
-    if _chat_collection_ops is None:
-        raise RuntimeError(
-            "ChatCollectionServiceOps not wired — call aperag.domains.conversation.service."
-            "chat_document_service.set_chat_collection_ops() in aperag/app.py startup before"
-            " serving requests."
-        )
-    return _chat_collection_ops
 
 
 class ChatDocumentService:
@@ -90,11 +54,10 @@ class ChatDocumentService:
 
     async def upload_chat_document(self, chat_id: str, user_id: str, file: UploadFile) -> Document:
         """Upload chat document to user's chat collection"""
-        ops = _get_chat_collection_ops()
-        collection = await ops.get_user_chat_collection(user_id)
+        collection = await chat_collection_service.get_user_chat_collection(user_id)
         if not collection:
             # Create if missing (fallback)
-            collection = await ops.create_user_chat_collection(user_id)
+            collection = await chat_collection_service.create_user_chat_collection(user_id)
 
         # Prepare document metadata (without message_id initially)
         doc_metadata = {
@@ -113,7 +76,7 @@ class ChatDocumentService:
 
     async def get_chat_document_by_id(self, chat_id: str, document_id: str, user_id: str) -> Optional[Document]:
         """Get chat document by ID with chat ownership validation"""
-        collection = await _get_chat_collection_ops().get_user_chat_collection(user_id)
+        collection = await chat_collection_service.get_user_chat_collection(user_id)
         if not collection:
             return None
 
@@ -128,7 +91,7 @@ class ChatDocumentService:
         if not document_ids:
             return []
 
-        collection = await _get_chat_collection_ops().get_user_chat_collection(user_id)
+        collection = await chat_collection_service.get_user_chat_collection(user_id)
         if not collection:
             return []
 
@@ -158,7 +121,7 @@ class ChatDocumentService:
 
     async def has_documents_in_chat(self, chat_id: str, user_id: str) -> bool:
         """Return whether the current chat already has searchable uploaded files."""
-        collection = await _get_chat_collection_ops().get_user_chat_collection(user_id)
+        collection = await chat_collection_service.get_user_chat_collection(user_id)
         if not collection:
             return False
 
@@ -198,7 +161,7 @@ class ChatDocumentService:
         self, chat_id: str, message_id: str, document_ids: List[str], user_id: str
     ) -> None:
         """Associate uploaded documents with a message when user sends the message"""
-        collection = await _get_chat_collection_ops().get_user_chat_collection(user_id)
+        collection = await chat_collection_service.get_user_chat_collection(user_id)
         if not collection:
             return
 

--- a/aperag/domains/evaluation/db/models.py
+++ b/aperag/domains/evaluation/db/models.py
@@ -26,11 +26,10 @@ Semantics worth knowing while editing:
   mutate historical run data, so the item rows carry value-copied
   ``input_message`` / ``expected_answer`` columns rather than joining
   back to the mutable dataset rows.
-* ``EvaluationRunStatus.is_terminal()`` (classmethod) was teased apart
-  in task #23 to close the cancel→running TOCTOU race; Phase 5 step
-  5-S6 will promote the ``_TERMINAL_RUN_STATUSES`` module-level
-  frozenset in ``aperag.db.repositories.evaluation_v2`` into a
-  classmethod on the enum so the check travels with the type.
+* ``EvaluationRunStatus.is_terminal()`` is the canonical terminal-
+  status predicate — task #23 used a module-level ``_TERMINAL_RUN_STATUSES``
+  frozenset to close the cancel→running TOCTOU race; Phase 6 promoted
+  it onto the enum so the check travels with the type.
 
 Legacy v1 tables (``Evaluation`` / ``EvaluationItem`` / ``QuestionSet`` /
 ``Question``) are **not** moved here — they belong to an older
@@ -99,6 +98,14 @@ class EvaluationRunStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
+
+    @classmethod
+    def is_terminal(cls, status) -> bool:
+        # ``EvaluationRun.status`` is persisted as a plain ``String`` column
+        # (see ``_enum_column``) so at read time ``status`` may be either an
+        # enum member or its raw string value — both compare equal to the
+        # enum members because ``EvaluationRunStatus`` inherits from ``str``.
+        return status in (cls.COMPLETED, cls.FAILED, cls.CANCELLED)
 
 
 class EvaluationRunItemStatus(str, Enum):

--- a/aperag/domains/evaluation/db/repositories/evaluation_v2.py
+++ b/aperag/domains/evaluation/db/repositories/evaluation_v2.py
@@ -39,14 +39,6 @@ from aperag.domains.evaluation.db.models import (
 )
 from aperag.utils.utils import utc_now
 
-_TERMINAL_RUN_STATUSES = frozenset(
-    {
-        EvaluationRunStatus.COMPLETED,
-        EvaluationRunStatus.FAILED,
-        EvaluationRunStatus.CANCELLED,
-    }
-)
-
 
 class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
     """Read/write helpers for evaluation resources."""
@@ -142,7 +134,7 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
             run = (await session.execute(stmt)).scalars().first()
             if not run:
                 return None
-            if run.status in _TERMINAL_RUN_STATUSES and status == EvaluationRunStatus.RUNNING:
+            if EvaluationRunStatus.is_terminal(run.status) and status == EvaluationRunStatus.RUNNING:
                 return run
             now = utc_now()
             run.status = status
@@ -152,7 +144,7 @@ class AsyncEvaluationV2RepositoryMixin(AsyncRepositoryProtocol):
                 run.summary = summary
             if status == EvaluationRunStatus.RUNNING and run.gmt_started is None:
                 run.gmt_started = now
-            if status in _TERMINAL_RUN_STATUSES:
+            if EvaluationRunStatus.is_terminal(status):
                 run.gmt_finished = now
             else:
                 run.gmt_finished = None

--- a/aperag/domains/evaluation/worker.py
+++ b/aperag/domains/evaluation/worker.py
@@ -227,12 +227,6 @@ _ITEM_STATUS_BY_ATTEMPT: dict[EvaluationRunItemAttemptStatus, EvaluationRunItemS
     EvaluationRunItemAttemptStatus.CANCELLED: EvaluationRunItemStatus.CANCELLED,
 }
 
-_TERMINAL_RUN_STATUSES = {
-    EvaluationRunStatus.COMPLETED,
-    EvaluationRunStatus.FAILED,
-    EvaluationRunStatus.CANCELLED,
-}
-
 
 async def execute_evaluation_run(
     run_id: str,
@@ -266,7 +260,7 @@ async def execute_evaluation_run(
         logger.warning("evaluation run %s vanished before worker could pick it up", run_id)
         return EvaluationRunStatus.FAILED
 
-    if run.status in _TERMINAL_RUN_STATUSES:
+    if EvaluationRunStatus.is_terminal(run.status):
         logger.info(
             "evaluation run %s already in terminal status %s; worker skipping",
             run_id,
@@ -290,7 +284,7 @@ async def execute_evaluation_run(
         if current_run is None:
             logger.warning("evaluation run %s vanished while worker was processing items", run_id)
             return EvaluationRunStatus.FAILED
-        if current_run.status in _TERMINAL_RUN_STATUSES:
+        if EvaluationRunStatus.is_terminal(current_run.status):
             logger.info(
                 "evaluation run %s moved to terminal status %s; worker stops dispatching remaining items",
                 run_id,
@@ -312,7 +306,7 @@ async def execute_evaluation_run(
     latest_run = await ops.get_run_for_worker(run_id)
     final_status = (
         latest_run.status
-        if latest_run is not None and latest_run.status in _TERMINAL_RUN_STATUSES
+        if latest_run is not None and EvaluationRunStatus.is_terminal(latest_run.status)
         else _final_run_status(summary)
     )
     await ops.update_run_status(run_id, final_status, summary=summary.model_dump())

--- a/aperag/domains/identity/service/identity_user_ops.py
+++ b/aperag/domains/identity/service/identity_user_ops.py
@@ -1,0 +1,38 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Identity-owned write facades for ``User`` fields that other domains
+need to mutate.
+
+G16 forbids consumer domains from importing the ``User`` ORM directly —
+this module is the single narrow entry point identity-owned writes
+travel through. Each facade is a thin wrapper over
+``session.get(User, …)`` + attribute assignment so transaction semantics
+stay aligned with the rest of the domain service layer (lesson 9a-sexdec
+hierarchy-1 terminal state).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aperag.domains.identity.db.models import User
+
+
+async def set_chat_collection(session: AsyncSession, user_id: str, collection_id: str) -> None:
+    user = await session.get(User, user_id)
+    if user is None:
+        return
+    user.chat_collection_id = collection_id
+    session.add(user)

--- a/aperag/service/chat_document_service.py
+++ b/aperag/service/chat_document_service.py
@@ -12,26 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Legacy shim for ``chat_document_service`` after Phase 5 step 5-S4d.
+"""Legacy shim — canonical home is
+``aperag.domains.conversation.service.chat_document_service``.
 
-The canonical home is
-``aperag.domains.conversation.service.chat_document_service``; this
-module re-exports the ``ChatDocumentService`` class, the
-``chat_document_service`` singleton, and the ``set_chat_collection_ops``
-DI setter so pre-migration callers (``views/chat.py``,
-``agent_runtime/runtime.py`` lazy import) keep resolving the same
-class objects without a rename sweep. Phase 6 cleanup removes the
-shim after every caller has migrated.
+Re-exports the ``ChatDocumentService`` class and
+``chat_document_service`` singleton so pre-migration callers keep
+resolving the same class objects. Phase 6 cleanup drops this shim
+after every caller has migrated.
 """
 
 from aperag.domains.conversation.service.chat_document_service import (  # noqa: F401
     ChatDocumentService,
     chat_document_service,
-    set_chat_collection_ops,
 )
 
 __all__ = [
     "ChatDocumentService",
     "chat_document_service",
-    "set_chat_collection_ops",
 ]

--- a/docs/modularization/breaking-changes/phase5-conversation-agent-eval.md
+++ b/docs/modularization/breaking-changes/phase5-conversation-agent-eval.md
@@ -25,8 +25,16 @@ required.
   one in the agent_runtime domain (`PromptTemplateOps`). The
   `ChatDocumentOps` Protocol seeded in 5-S1 was retired in 5-S5b
   (direct cross-domain import after the conversation domain landed).
+  Phase 6 subsequently retired `ChatCollectionServiceOps` as well
+  — `chat_document_service` now sibling-imports
+  `chat_collection_service` directly (both live in the conversation
+  domain after 5-S4f).
 - One new runtime smoke test: `test_phase5_di_critical_wirings_at_app_startup`
-  (G18 alt) assert three DI slots are non-`None` after `import aperag.app`.
+  (G18 alt) asserts the consumer-owned Protocol DI slots are
+  non-`None` after `import aperag.app`. Phase 6 shrunk the
+  registry from three slots to two once `ChatCollectionServiceOps`
+  was retired; the two remaining entries are
+  `conversation._quota_ops` and `agent_runtime._prompt_template_ops`.
 - Lesson 9a-quatuordec codified as a gate:
   `test_phase5_domain_routes_never_use_pep_563_future_annotations`
   enforces that no `aperag/domains/**/api/routes.py` file declares
@@ -99,7 +107,7 @@ required.
 | `AuthenticatedUser` | conversation / agent_runtime / evaluation (three separate per-domain copies) | implicit (FastAPI `Depends(required_user)`) — identity `User` row satisfies each Protocol structurally | — |
 | `KnowledgeBaseCollectionView` | conversation | structural — KB `Collection` ORM satisfies it | Phase 3 knowledge_base.db.models.Collection |
 | `QuotaOps` | conversation | `aperag/app.py` `_conv_set_quota_ops(_legacy_quota_service)` | `aperag.service.quota_service` (legacy, Phase 6 candidate) |
-| `ChatCollectionServiceOps` | conversation | `aperag/app.py` `_conv_set_chat_collection_ops(_legacy_chat_collection_service)` | `aperag.service.chat_collection_service` (shim — canonical domain home is live; Phase 6 simplifies) |
+| `ChatCollectionServiceOps` (**retired** in Phase 6) | conversation | — | replaced by sibling direct import (same domain) |
 | `PromptTemplateOps` | agent_runtime | `aperag/app.py` `_ar_set_prompt_template_ops(_PromptTemplateOpsAdapter())` | `aperag.service.prompt_template_service` (legacy, Phase 6 candidate) |
 | `ChatDocumentOps` (**retired** in 5-S5b) | agent_runtime | — | replaced by direct cross-domain import |
 

--- a/docs/modularization/breaking-changes/phase5-conversation-agent-eval.md
+++ b/docs/modularization/breaking-changes/phase5-conversation-agent-eval.md
@@ -106,9 +106,9 @@ required.
 |---|---|---|---|
 | `AuthenticatedUser` | conversation / agent_runtime / evaluation (three separate per-domain copies) | implicit (FastAPI `Depends(required_user)`) — identity `User` row satisfies each Protocol structurally | — |
 | `KnowledgeBaseCollectionView` | conversation | structural — KB `Collection` ORM satisfies it | Phase 3 knowledge_base.db.models.Collection |
-| `QuotaOps` | conversation | `aperag/app.py` `_conv_set_quota_ops(_legacy_quota_service)` | `aperag.service.quota_service` (legacy, Phase 6 candidate) |
+| `QuotaOps` | conversation | `aperag/app.py` `_conv_set_quota_ops(_legacy_quota_service)` | `aperag.service.quota_service` (standalone-infra, permanent seam) |
 | `ChatCollectionServiceOps` (**retired** in Phase 6) | conversation | — | replaced by sibling direct import (same domain) |
-| `PromptTemplateOps` | agent_runtime | `aperag/app.py` `_ar_set_prompt_template_ops(_PromptTemplateOpsAdapter())` | `aperag.service.prompt_template_service` (legacy, Phase 6 candidate) |
+| `PromptTemplateOps` | agent_runtime | `aperag/app.py` `_ar_set_prompt_template_ops(_PromptTemplateOpsAdapter())` | `aperag.service.prompt_template_service` (standalone-infra, permanent seam) |
 | `ChatDocumentOps` (**retired** in 5-S5b) | agent_runtime | — | replaced by direct cross-domain import |
 
 ## Lesson 9a-quatuordec (codified as a gate)
@@ -133,20 +133,25 @@ the move is pure file relocation. Promotion to
 `EvaluationRunStatus.is_terminal()` classmethod was deferred — Phase 6
 cleanup will evaluate whether to retire the module-level alias.
 
-## Phase 6 cleanup candidates
+## Phase 6 cleanup outcome
 
-1. `identity_user_ops.set_chat_collection` facade to retire the 5-S4f
-   `text("UPDATE users SET …")` pragma in
-   `aperag.domains.conversation.service.chat_collection_service`.
-2. `ChatCollectionServiceOps` Protocol seam simplification —
-   `chat_document_service` can direct-import the sibling service now
-   that 5-S4f moved it into the conversation domain.
-3. `PromptTemplateOps` Protocol seam evaluation —
-   `prompt_template_service` either moves into a canonical domain
-   home (agent_runtime or model_platform candidate) or the Protocol
-   is retired in favour of a direct cross-domain import.
-4. `_TERMINAL_RUN_STATUSES` module-level alias retirement /
-   `EvaluationRunStatus.is_terminal()` classmethod promotion.
-5. Legacy shim package deletion (the shim layer has no runtime value
-   once every caller has migrated to the canonical per-domain
-   imports).
+1. **Done** — `identity_user_ops.set_chat_collection` facade replaced
+   the 5-S4f raw `UPDATE users …` in
+   `aperag.domains.conversation.service.chat_collection_service`
+   (9a-sexdec hierarchy-1 terminal state).
+2. **Done** — `ChatCollectionServiceOps` Protocol seam retired;
+   `chat_document_service` now sibling-imports
+   `chat_collection_service` directly.
+3. **Resolved as no-op** — `PromptTemplateOps` is the permanent seam
+   for `aperag.service.prompt_template_service`. The service is a
+   standalone-infrastructure module (cross-cutting across runtime
+   execution, conversation bot-config resolution, indexing, and a
+   user-facing `/prompts` REST surface) with no natural domain home;
+   the Protocol + DI seam is its canonical long-term integration
+   point.
+4. **Done** — `_TERMINAL_RUN_STATUSES` promoted to
+   `EvaluationRunStatus.is_terminal()` classmethod; the #23 race-fix
+   guard is byte-identical with PR #1631 `54cd86b`.
+5. **Out of scope for this PR** — blanket legacy shim package
+   deletion is a separate initiative and was deliberately not
+   combined with the 5-entry cleanup sweep.

--- a/tests/unit_test/test_modularization_boundaries.py
+++ b/tests/unit_test/test_modularization_boundaries.py
@@ -716,15 +716,15 @@ def test_phase4_di_critical_wirings_at_app_startup():
 
 
 def test_phase5_di_critical_wirings_at_app_startup():
-    """G18 alt: runtime smoke for the remaining Phase 5 consumer-owned
-    Protocol DI slots — after ``import aperag.app`` the listed
-    ``_<name>_ops`` slots must resolve to non-``None`` instances.
+    """G18 alt: runtime smoke for the permanent consumer-owned Protocol
+    DI slots — after ``import aperag.app`` the listed ``_<name>_ops``
+    slots must resolve to non-``None`` instances.
 
-    The registry carries exactly the DI slots whose providers still
-    live in ``aperag/service/*`` (legacy-not-moved-yet). Every other
-    cross-domain collaborator uses a direct sibling / cross-domain
-    import per the canonical rule ``direct import = domain-moved
-    provider``.
+    The registry carries exactly the DI slots whose providers are
+    standalone-infrastructure modules with no natural domain home
+    (``quota_service``, ``prompt_template_service``). Every
+    domain-moved provider is reached via a direct sibling /
+    cross-domain import.
 
     ``dispatch_fn`` in ``aperag.domains.evaluation.worker`` is
     intentionally **not** listed — it is a module-level test-injection
@@ -735,12 +735,10 @@ def test_phase5_di_critical_wirings_at_app_startup():
     from aperag.domains.conversation.service import bot_service as conversation_bot_service
 
     PHASE5_CRITICAL_WIRINGS = [
-        # Phase 5 conversation DI slot — bot_service ↔ legacy quota_service
-        # (msg=4a93c97e Q1 C; legacy provider stays through Phase 6).
+        # bot_service ↔ quota_service (standalone-infra, permanent seam).
         (conversation_bot_service, "_quota_ops"),
-        # Phase 5 agent_runtime DI slot — runtime.py ↔ legacy
-        # prompt_template_service (msg=65a3b27d / 3578aa59; legacy
-        # provider stays through Phase 6).
+        # runtime.py ↔ prompt_template_service (standalone-infra,
+        # permanent seam).
         (agent_runtime_runtime, "_prompt_template_ops"),
     ]
     missing = [

--- a/tests/unit_test/test_modularization_boundaries.py
+++ b/tests/unit_test/test_modularization_boundaries.py
@@ -716,31 +716,28 @@ def test_phase4_di_critical_wirings_at_app_startup():
 
 
 def test_phase5_di_critical_wirings_at_app_startup():
-    """G18 alt: Phase 5 extension of G17. ``CRITICAL_WIRINGS`` registry
-    for the three Phase 5 domains — conversation / agent_runtime /
-    evaluation — after ``import aperag.app`` the listed
+    """G18 alt: runtime smoke for the remaining Phase 5 consumer-owned
+    Protocol DI slots — after ``import aperag.app`` the listed
     ``_<name>_ops`` slots must resolve to non-``None`` instances.
 
-    Canonical msg=cc04fa86 (living registry) + msg=6fbf875c (final 3
-    entries locked after direct-import simplifications in 5-S4b /
-    5-S4e / 5-S5b / 5-S6). The ``dispatch_fn`` module-level alias in
-    ``aperag.domains.evaluation.worker`` is intentionally **not**
-    listed: it is a test-injection seam, not a Protocol+DI slot.
+    The registry carries exactly the DI slots whose providers still
+    live in ``aperag/service/*`` (legacy-not-moved-yet). Every other
+    cross-domain collaborator uses a direct sibling / cross-domain
+    import per the canonical rule ``direct import = domain-moved
+    provider``.
+
+    ``dispatch_fn`` in ``aperag.domains.evaluation.worker`` is
+    intentionally **not** listed — it is a module-level test-injection
+    seam, not a Protocol+DI slot.
     """
     import aperag.app  # noqa: F401 — triggers module-scope wire-up
     from aperag.domains.agent_runtime import runtime as agent_runtime_runtime
     from aperag.domains.conversation.service import bot_service as conversation_bot_service
-    from aperag.domains.conversation.service import chat_document_service as conversation_chat_document_service
 
     PHASE5_CRITICAL_WIRINGS = [
         # Phase 5 conversation DI slot — bot_service ↔ legacy quota_service
         # (msg=4a93c97e Q1 C; legacy provider stays through Phase 6).
         (conversation_bot_service, "_quota_ops"),
-        # Phase 5 conversation DI slot — chat_document_service ↔
-        # chat_collection_service. The sibling is now in the conversation
-        # domain (5-S4f) so this seam is a Phase 6 simplification
-        # candidate; keep the wire-up until the Protocol is retired.
-        (conversation_chat_document_service, "_chat_collection_ops"),
         # Phase 5 agent_runtime DI slot — runtime.py ↔ legacy
         # prompt_template_service (msg=65a3b27d / 3578aa59; legacy
         # provider stays through Phase 6).


### PR DESCRIPTION
## Phase 6 / task #20 cleanup — residual Protocol + enum promotion + identity facade

Closes the canonical Phase 6 cleanup log registered during Phase 5 close-out (msg=da408d0f, 5 entries). PM msg=09e6753c / msg=95b584b0 lock scope **strictly** to these 5 entries — no Phase 3/4/5 large-scale shim sweep, no new-phase re-migration.

### Entry checklist

- [x] **Entry 4** — retire `ChatDocumentOps` dead Protocol class literal. Commit `1e80679`.
- [x] **Entry 5** — promote `_TERMINAL_RUN_STATUSES` → `EvaluationRunStatus.is_terminal()` classmethod. task #23 race-fix guard byte-identical semantics preserved. Commit `68ef567`.
- [ ] **Entry 2** — `ChatCollectionServiceOps` seam simplification (chat_document_service → sibling direct import) + `CRITICAL_WIRINGS` registry 3→2 propagated to test + breaking-changes doc.
- [ ] **Entry 1** — `identity_user_ops.set_chat_collection` facade replaces 5-S4f text SQL (9a-sexdec hierarchy-1 terminal state).
- [ ] **Entry 3** — `PromptTemplateOps` seam ownership evaluation (minimum-cost close-out).

### Scope guardrails (PM msg=92bbdadb + 95b584b0)

- No new phase, no generic shim removal sweep.
- `aperag.db.models` / `view_models` / `aperag.service.*` / `aperag.views.*` re-export removal **only** when locally unlocked by one of the 5 entries.
- Any entry that pulls in a new domain-move → report as blocker, do not silently expand scope.

### CR lane

@huangheng incremental review per Phase 4/5 cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)