### PR TITLE
docs(zh-CN): task #8 — architecture/overview + domains + development-guide

### DIFF
--- a/docs/zh-CN/architecture/_category.yaml
+++ b/docs/zh-CN/architecture/_category.yaml
@@ -1,0 +1,2 @@
+title: 架构
+position: 5

--- a/docs/zh-CN/architecture/domains.md
+++ b/docs/zh-CN/architecture/domains.md
@@ -36,20 +36,22 @@ description: ApeRAG 后端 12 个业务 domain 的职责、目录契约、跨 do
 
 | Domain | DB 实体 / Enum | Service 模块 | 自持 Port（对外依赖声明） | 主 API 路由 | 细节文档 |
 | --- | --- | --- | --- | --- | --- |
-| **identity** | `Role` · `User` · `OAuthAccount` | `user_manager`、`identity_user_ops` | `AuthenticatedUser` · `BotInitOps` · `ChatInitOps` · `QuotaInitOps` | 走 `aperag/views/auth.py`（fastapi-users + OAuth） | [identity-governance-model-platform-marketplace.md](./identity-governance-model-platform-marketplace.md) |
+| **identity** | `Role` · `User` · `OAuthAccount` | `user_manager`、`identity_user_ops` | `AuthenticatedUser` · `BotInitOps` · `ChatInitOps` · `QuotaInitOps` | 走 `aperag/views/auth.py`（fastapi-users + OAuth） | `architecture/identity-governance-model-platform-marketplace.md`（起稿中） |
 | **governance** | `ApiKey` · `AuditLog`（+ `ApiKeyStatus` · `AuditResource`） | `api_key_service`、`audit_service` | `AuthenticatedUser` · `UserView` | `api/routes.py`（合并 api-key + audit-log） | 同上 |
 | **model_platform** | `LLMProvider` · `LLMProviderModel`（+ `APIType`） | `default_model_service`、`llm_available_model_service`、`llm_provider_service` | `AuthenticatedUser` | `api/llm_routes.py` + `api/providers_v2_routes.py`（2-router split，见下文） | 同上 |
 | **marketplace** | `CollectionMarketplace` · `UserCollectionSubscription`（+ `CollectionMarketplaceStatusEnum`） | `marketplace_service`、`marketplace_collection_service` | `AuthenticatedUser` | `api/routes.py` | 同上 |
-| **knowledge_base** | `Collection` · `CollectionSummary` · `Document`（4 个 Enum） | `collection_service`、`collection_summary_service`、`document_service` | `AuthenticatedUser` · `MarketplaceOps` · `MarketplaceCollectionOps` · `SearchPipelineOps` · `QuotaOps` | `api/routes.py` | [indexing-retrieval-kg.md](./indexing-retrieval-kg.md) |
+| **knowledge_base** | `Collection` · `CollectionSummary` · `Document`（4 个 Enum） | `collection_service`、`collection_summary_service`、`document_service` | `AuthenticatedUser` · `MarketplaceOps` · `MarketplaceCollectionOps` · `SearchPipelineOps` · `QuotaOps` | `api/routes.py` | `architecture/indexing-retrieval-kg.md`（起稿中） |
 | **indexing** | `DocumentIndex`（+ `DocumentIndexType` · `DocumentIndexStatus`） | `manager`、`document_parser`、`vector_index`、`fulltext_index`、`graph_index`、`summary_index`、`vision_index` 等功能模块 | `CollectionIndexingView` · `IndexingTrigger` | — | 同上 |
 | **retrieval** | `SearchHistory` | `service.py` + `pipeline.py` | `GraphQueryContext` · `GraphSearchContract` | `api/routes.py` | 同上 |
 | **knowledge_graph** | `GraphCurationRun` · `GraphCurationSuggestion`（+ 2 个 Enum） | `service.py` + `graphindex/` 11 个子模块 | `CollectionRow` | `api/routes.py`（加 `aperag/views/graph.py` 上的 410-Gone shim） | 同上 |
-| **conversation** | `Bot` · `Chat` · `TurnFeedback`（+ 5 个 Enum） | `bot_service`、`chat_service`、`chat_collection_service`、`chat_document_service`、`chat_title_service`、`turn_feedback_service` | `KnowledgeBaseCollectionView` · `AuthenticatedUser` · `QuotaOps` | `api/routes.py`（内部按前缀拆 `chat_router` + `bots_router`） | [conversation-agent-evaluation.md](./conversation-agent-evaluation.md) |
+| **conversation** | `Bot` · `Chat` · `TurnFeedback`（+ 5 个 Enum） | `bot_service`、`chat_service`、`chat_collection_service`、`chat_document_service`、`chat_title_service`、`turn_feedback_service` | `KnowledgeBaseCollectionView` · `AuthenticatedUser` · `QuotaOps` | `api/routes.py`（内部按前缀拆 `chat_router` + `bots_router`） | `architecture/conversation-agent-evaluation.md`（起稿中） |
 | **agent_runtime** | `AgentTurn` · `AgentTimelineEvent` · `AgentArtifact`（+ 3 个 Enum） | `runtime`、`services`、`storage` | `AuthenticatedUser` · `PromptTemplateOps` | `api/routes.py` | 同上 |
 | **evaluation** | `EvaluationDataset` · `EvaluationDatasetItem` · `EvaluationRun` · `EvaluationRunItem` · `EvaluationRunItemAttempt`（+ 5 个 Enum） | `services`、`worker`（`dispatch_fn` 测试注入 seam）、`tasks`、`judges`、`constants` + `db/repositories/evaluation_v2.py` | `AuthenticatedUser`；`ChatSessionOps` / `AgentTurnDispatchOps` 是 **dead Protocol 字面量**（零运行时调用，见 SSoT Section 2.1 脚注和 Section 8 F14） | `api/routes.py` | 同上 |
-| **web_access** | —（无实体） | — （功能子包：`reader/`、`search/`、`utils/`） | — | `api/routes.py` | [web-access.md](./web-access.md) |
+| **web_access** | —（无实体） | — （功能子包：`reader/`、`search/`、`utils/`） | — | `api/routes.py` | `architecture/web-access.md`（起稿中） |
 
 详细的实体 schema 数量、service 模块责任、每个 port 的方法签名都在 SSoT Section 2.1 以及每个 domain 对应的 consolidated 文档里；本表只做定位用。
+
+> 标注「起稿中」的 consolidated 架构文档正在其他 lane 并行起草，落 main 后本表与下文 §3 的「去哪读」会把 code path 升级为 Markdown 链接。
 
 ---
 
@@ -62,54 +64,54 @@ description: ApeRAG 后端 12 个业务 domain 的职责、目录契约、跨 do
 - **做什么**：用户账号、角色（`Role`）、OAuth 绑定、`fastapi-users` 接入。
 - **canonical 点**：它是整个系统里唯一能 `import User` / `import Role` 的地方（G15/G16 禁止其他 domain 这么做）。别的 domain 想读 user 只能通过 `AuthenticatedUser(Protocol)`；想写 user（目前只有 `conversation.chat_collection_service` 更新 `User.chat_collection_id`）必须走 `identity_user_ops.set_chat_collection` 这类 facade（lesson 9a-sexdec 三层优先级）。
 - **3 个 `*InitOps` adapter**：`BotInitOps` / `ChatInitOps` / `QuotaInitOps` 在 `aperag/app.py` 启动时注入，用于 `UserManager.on_after_register` —— 新用户注册时自动创建默认 Bot、默认 ChatCollection、默认配额。
-- **去哪读**：[`identity-governance-model-platform-marketplace.md`](./identity-governance-model-platform-marketplace.md)
+- **去哪读**：`architecture/identity-governance-model-platform-marketplace.md`（起稿中）
 
 ### 3.2 governance
 
 - **做什么**：API Key 管理 + 审计日志（`AuditLog` / `ApiKey`）。
 - **注意**：它**不**负责配额（`quota_service`）— 配额是 standalone-infra permanent seam，通过 `QuotaOps` Protocol 注入给 `knowledge_base` 和 `conversation` 两个消费方（SSoT Section 5.1）。
 - **路由**：`aperag/views/api_key.py` 和 `aperag/views/audit.py` 是 shim，真实 router 是 `aperag/domains/governance/api/routes.py`。
-- **去哪读**：[`identity-governance-model-platform-marketplace.md`](./identity-governance-model-platform-marketplace.md)
+- **去哪读**：`architecture/identity-governance-model-platform-marketplace.md`（起稿中）
 
 ### 3.3 model_platform
 
 - **做什么**：LLM provider / 模型配置 / 默认模型（`LLMProvider` · `LLMProviderModel`）。
 - **2-router split**：`/api/v1/llm_configurations` 在 `llm_routes.py`，`/api/v2/providers` 在 `providers_v2_routes.py`；两个 router 同时挂在 `aperag/app.py`，便于前端在 v1/v2 共存期平滑过渡（SSoT 8.2 F12 记录了未来合并候选）。
 - **跨 domain 消费**：`conversation.chat_title_service` 直接 import `default_model_service`；`conversation.chat_collection_service` 直接 import `llm_available_model_service`（都是 provider-in-domain 的直接 import）。
-- **去哪读**：[`identity-governance-model-platform-marketplace.md`](./identity-governance-model-platform-marketplace.md)
+- **去哪读**：`architecture/identity-governance-model-platform-marketplace.md`（起稿中）
 
 ### 3.4 marketplace
 
 - **做什么**：公开 collection 发布 / 订阅（`CollectionMarketplace` · `UserCollectionSubscription`）。
 - **与 KB 的关系**：`knowledge_base.collection_service` 通过自持的 `MarketplaceOps` / `MarketplaceCollectionOps` Protocol 消费；marketplace 结构性满足，不反向 import KB 的 `ports.py`（consumer-owned 原则）。
-- **用户操作面**：发布 / 订阅流程见 [`user-guide/collection-marketplace.md`](../user-guide/collection-marketplace.md)；架构内部细节在 Phase 4 consolidated doc。
+- **用户操作面**：发布 / 订阅流程见 `user-guide/collection-marketplace.md`（起稿中）；架构内部细节由 `architecture/identity-governance-model-platform-marketplace.md`（起稿中）覆盖。
 
 ### 3.5 knowledge_base
 
 - **做什么**：collection / document / collection-summary —— 知识库领域的主体。
 - **消费的 5 个 port**：`AuthenticatedUser` · `MarketplaceOps` · `MarketplaceCollectionOps` · `SearchPipelineOps` · `QuotaOps`。5 个里 1 个是 standalone-infra permanent（`_quota_ops`）、3 个 provider 已搬进 domain（走 `aperag/app.py` adapter）、1 个（`_search_pipeline_ops`）分类未定（SSoT 8.2 F15 记录）。
 - **schema**：跨 domain 共享的 `CollectionConfig` / `KnowledgeGraphConfig` / `IndexPrompts` / `Chunk` / `VisionChunk` 等 primitives 落在 `aperag/schema/common.py`（SSoT Section 2.3 严格准入规则）；KB 自己的 `Collection` / `Document` / `CollectionView` 等 Pydantic schema 在 `aperag/domains/knowledge_base/schemas.py`。
-- **去哪读**：[`indexing-retrieval-kg.md`](./indexing-retrieval-kg.md)（KB 与 indexing / retrieval / knowledge_graph 深度耦合，放在同一篇 consolidated doc 里）
+- **去哪读**：`architecture/indexing-retrieval-kg.md`（起稿中）（KB 与 indexing / retrieval / knowledge_graph 深度耦合，放在同一篇 consolidated doc 里）
 
 ### 3.6 indexing
 
 - **做什么**：索引 reconciler + 每种索引类型的 worker（vector / fulltext / graph / summary / vision）。
 - **谁驱动它**：`knowledge_base.collection_service` 通过自持的 `SearchPipelineOps`；indexing 对外暴露 `CollectionIndexingView` / `IndexingTrigger` 给 retrieval / KB 用。
 - **注意**：indexing 没有 `api/routes.py` —— 它是内部重建任务的后端，不对外提供 HTTP。
-- **去哪读**：[`indexing-retrieval-kg.md`](./indexing-retrieval-kg.md)
+- **去哪读**：`architecture/indexing-retrieval-kg.md`（起稿中）
 
 ### 3.7 retrieval
 
 - **做什么**：检索 pipeline 编排 + chunk 聚合 + reranking。
 - **与 knowledge_graph 的关系**：retrieval 自持 `GraphQueryContext` · `GraphSearchContract`，knowledge_graph 结构性满足 —— **单向** Protocol（lesson 9a-quad）。G10/G3 禁止 knowledge_graph 反向 import retrieval。
-- **去哪读**：[`indexing-retrieval-kg.md`](./indexing-retrieval-kg.md)
+- **去哪读**：`architecture/indexing-retrieval-kg.md`（起稿中）
 
 ### 3.8 knowledge_graph
 
 - **做什么**：实体 / 关系 ORM + Nebula Graph 客户端 + `graphindex` reconciler。
 - **自持 port**：`CollectionRow` —— 内部抽象，封装 `graphindex` 旧代码对 KB `Collection` 形状的依赖。
 - **路由**：`aperag/views/graph.py` 保留一条 410-Gone legacy route（`/collections/{id}/graphs/export/kg-eval`，Phase 2 hard-cut 的 tombstone），其他都在 `aperag/domains/knowledge_graph/api/routes.py`。
-- **去哪读**：[`indexing-retrieval-kg.md`](./indexing-retrieval-kg.md)
+- **去哪读**：`architecture/indexing-retrieval-kg.md`（起稿中）
 
 ### 3.9 conversation
 
@@ -122,14 +124,14 @@ description: ApeRAG 后端 12 个业务 domain 的职责、目录契约、跨 do
 - **消费的 port**：`KnowledgeBaseCollectionView` · `AuthenticatedUser` · `QuotaOps`（`_quota_ops` 是 standalone-infra permanent 的两条永久 seam 之一）。
 - **跨 domain 被谁消费**：`agent_runtime.runtime`（late-import `chat_document_service`）、`evaluation.worker`（late-import `chat_service_global`，在 `dispatch_fn` 内）。late-import 是故意的，为了避免 module-import-time 的 `evaluation → agent_runtime → conversation` 环。
 - **路由拆分**：`api/routes.py` 同时导出 `chat_router`（挂 `/chats`）和 `bots_router`（挂 `/bots`）两个 router，app.py 分开挂（前缀不同，便于 OpenAPI 聚合）。
-- **去哪读**：[`conversation-agent-evaluation.md`](./conversation-agent-evaluation.md)
+- **去哪读**：`architecture/conversation-agent-evaluation.md`（起稿中）
 
 ### 3.10 agent_runtime
 
 - **做什么**：agent turn 编排 / SSE 流式 / artifact 存储（`AgentTurn` · `AgentTimelineEvent` · `AgentArtifact`）。
 - **`PromptTemplateOps` seam**：`runtime._prompt_template_ops` 是第 2 条 standalone-infra permanent DI 槽（SSoT Section 5.1 的两条之一），provider 是 `aperag.service.prompt_template_service`（跨切面，跨 `agent_runtime` 执行 / `conversation` bot-config / indexing prompt / 用户面 `/prompts` CRUD 四个地方，无法归入某个 domain）。
 - **与 evaluation 的关系**：`evaluation.worker.dispatch_fn` late-import `agent_runtime.runtime` 和 `agent_runtime.services` 做 turn 分派。
-- **去哪读**：[`conversation-agent-evaluation.md`](./conversation-agent-evaluation.md)
+- **去哪读**：`architecture/conversation-agent-evaluation.md`（起稿中）
 
 ### 3.11 evaluation
 
@@ -137,13 +139,13 @@ description: ApeRAG 后端 12 个业务 domain 的职责、目录契约、跨 do
 - **重要细节**：`worker.dispatch_fn` 是 **测试注入用的模块级函数引用**，**不是** `Protocol + DI` 槽 —— 测试 monkeypatch 它来替换真实 turn 分派器。G18 alt 注册表不包括 `dispatch_fn`，因为默认实现是一个正常函数而不是 `None` 槽（SSoT Section 5.2 明确列出这个区别）。
 - **dead Protocol 字面量**：`ports.py` 里仍写着 `ChatSessionOps` / `AgentTurnDispatchOps` 两个 Protocol class，但零运行时调用（rebase 过程中被搁置，SSoT Section 2.1 脚注 + Section 8 F14 说明）。将来会机械删除，按 Phase 6 entry 4 删 `ChatDocumentOps` 的先例。
 - **terminal 状态判断**：`EvaluationRunStatus.is_terminal()` classmethod（Phase 6 从 `_TERMINAL_RUN_STATUSES` 常量升格），任何消费方都走这个 API。
-- **去哪读**：[`conversation-agent-evaluation.md`](./conversation-agent-evaluation.md)
+- **去哪读**：`architecture/conversation-agent-evaluation.md`（起稿中）
 
 ### 3.12 web_access
 
 - **做什么**：爬虫抓取 / 网络搜索 / URL 阅读 —— 提供给 `knowledge_base` 的 document ingestion 用。
 - **当前形态**：**没有实体**、没有 service，只有 schemas、路由、三个功能子包（`reader/` · `search/` · `utils/`）。SSoT 8.2 F11 把「是否给 web_access 补 entity + service」列为未来候选。
-- **去哪读**：[`web-access.md`](./web-access.md)
+- **去哪读**：`architecture/web-access.md`（起稿中）
 
 ---
 

--- a/docs/zh-CN/architecture/domains.md
+++ b/docs/zh-CN/architecture/domains.md
@@ -1,0 +1,241 @@
+---
+title: 12 Domain 通览
+description: ApeRAG 后端 12 个业务 domain 的职责、目录契约、跨 domain 关系一览
+---
+
+# 12 Domain 通览
+
+> 本文回答「后端每个 domain 负责什么、目录里有哪些文件、domain 之间怎么互相调」。结构性不变式（G1–G19、dual-hook、permanent seam、shim 清单）在 [`docs/modularization/architecture.md`](../../modularization/architecture.md)（canonical SSoT）里已经写死，本文不复述，只给中文读者一个落地的导读。
+
+---
+
+## 1. Domain 是什么
+
+`aperag/domains/<domain>/` 是一个业务 domain 的完整目录，默认包含这些槽位（每个 domain 不一定全用）：
+
+| 文件 / 目录 | 作用 |
+| --- | --- |
+| `db/models.py` | SQLAlchemy ORM 类 + 由本 domain 拥有的 Enum |
+| `schemas.py` | 本 domain 拥有的 Pydantic schema；通过 **dual-hook** 绑到 `aperag.schema.view_models`（见 SSoT Section 3.3） |
+| `ports.py` | **consumer-owned** `Protocol` — 本 domain 声明「我对别人的依赖长什么样」，provider 结构性满足，provider 永远不 import 本 domain 的 `ports.py` |
+| `service/` 或 `service.py` | 业务逻辑。只能直接 import 本 domain 自己的 `db/` / `schemas.py`，以及其他 domain 已经搬到 `aperag/domains/` 的部分 |
+| `api/routes.py`（或 `<feature>_routes.py`） | FastAPI 路由 module；router 变量名由 domain 决定；`aperag/views/*.py` 里的同名文件是 re-export shim |
+
+不是每个 domain 都塞满所有槽位 —— 例如 `web_access` 没有实体（DB 层为空），`indexing` 没有 API 路由。
+
+**Domain 之间如何互相访问** 在 SSoT Section 3.1 写死了两种形态：
+
+- **直接 import** — 当 provider 已经搬进 `aperag/domains/`（例：`from aperag.domains.knowledge_base.service.document_service import document_service`）。
+- **consumer-owned `Protocol` + DI 槽** — 当 provider 仍然在旧位置（`aperag/service/*.py`）。consumer 在自己的 `ports.py` 声明 `Protocol`，留一个 `_ops: Optional[XOps]` 槽 + `set_x_ops()` setter + `_get_x_ops()` accessor；`aperag/app.py` 在启动时把旧 provider（或一个 adapter）塞进槽里。
+
+> G1 禁止 `aperag/domains/**` 任何文件 import `aperag.service.*` / `aperag.schema.view_models` / `aperag.db.models`。sibling 同域 import 总是直接 import。
+
+---
+
+## 2. 12 Domain 速查表
+
+| Domain | DB 实体 / Enum | Service 模块 | 自持 Port（对外依赖声明） | 主 API 路由 | 细节文档 |
+| --- | --- | --- | --- | --- | --- |
+| **identity** | `Role` · `User` · `OAuthAccount` | `user_manager`、`identity_user_ops` | `AuthenticatedUser` · `BotInitOps` · `ChatInitOps` · `QuotaInitOps` | 走 `aperag/views/auth.py`（fastapi-users + OAuth） | [identity-governance-model-platform-marketplace.md](./identity-governance-model-platform-marketplace.md) |
+| **governance** | `ApiKey` · `AuditLog`（+ `ApiKeyStatus` · `AuditResource`） | `api_key_service`、`audit_service` | `AuthenticatedUser` · `UserView` | `api/routes.py`（合并 api-key + audit-log） | 同上 |
+| **model_platform** | `LLMProvider` · `LLMProviderModel`（+ `APIType`） | `default_model_service`、`llm_available_model_service`、`llm_provider_service` | `AuthenticatedUser` | `api/llm_routes.py` + `api/providers_v2_routes.py`（2-router split，见下文） | 同上 |
+| **marketplace** | `CollectionMarketplace` · `UserCollectionSubscription`（+ `CollectionMarketplaceStatusEnum`） | `marketplace_service`、`marketplace_collection_service` | `AuthenticatedUser` | `api/routes.py` | 同上 |
+| **knowledge_base** | `Collection` · `CollectionSummary` · `Document`（4 个 Enum） | `collection_service`、`collection_summary_service`、`document_service` | `AuthenticatedUser` · `MarketplaceOps` · `MarketplaceCollectionOps` · `SearchPipelineOps` · `QuotaOps` | `api/routes.py` | [indexing-retrieval-kg.md](./indexing-retrieval-kg.md) |
+| **indexing** | `DocumentIndex`（+ `DocumentIndexType` · `DocumentIndexStatus`） | `manager`、`document_parser`、`vector_index`、`fulltext_index`、`graph_index`、`summary_index`、`vision_index` 等功能模块 | `CollectionIndexingView` · `IndexingTrigger` | — | 同上 |
+| **retrieval** | `SearchHistory` | `service.py` + `pipeline.py` | `GraphQueryContext` · `GraphSearchContract` | `api/routes.py` | 同上 |
+| **knowledge_graph** | `GraphCurationRun` · `GraphCurationSuggestion`（+ 2 个 Enum） | `service.py` + `graphindex/` 11 个子模块 | `CollectionRow` | `api/routes.py`（加 `aperag/views/graph.py` 上的 410-Gone shim） | 同上 |
+| **conversation** | `Bot` · `Chat` · `TurnFeedback`（+ 5 个 Enum） | `bot_service`、`chat_service`、`chat_collection_service`、`chat_document_service`、`chat_title_service`、`turn_feedback_service` | `KnowledgeBaseCollectionView` · `AuthenticatedUser` · `QuotaOps` | `api/routes.py`（内部按前缀拆 `chat_router` + `bots_router`） | [conversation-agent-evaluation.md](./conversation-agent-evaluation.md) |
+| **agent_runtime** | `AgentTurn` · `AgentTimelineEvent` · `AgentArtifact`（+ 3 个 Enum） | `runtime`、`services`、`storage` | `AuthenticatedUser` · `PromptTemplateOps` | `api/routes.py` | 同上 |
+| **evaluation** | `EvaluationDataset` · `EvaluationDatasetItem` · `EvaluationRun` · `EvaluationRunItem` · `EvaluationRunItemAttempt`（+ 5 个 Enum） | `services`、`worker`（`dispatch_fn` 测试注入 seam）、`tasks`、`judges`、`constants` + `db/repositories/evaluation_v2.py` | `AuthenticatedUser`；`ChatSessionOps` / `AgentTurnDispatchOps` 是 **dead Protocol 字面量**（零运行时调用，见 SSoT Section 2.1 脚注和 Section 8 F14） | `api/routes.py` | 同上 |
+| **web_access** | —（无实体） | — （功能子包：`reader/`、`search/`、`utils/`） | — | `api/routes.py` | [web-access.md](./web-access.md) |
+
+详细的实体 schema 数量、service 模块责任、每个 port 的方法签名都在 SSoT Section 2.1 以及每个 domain 对应的 consolidated 文档里；本表只做定位用。
+
+---
+
+## 3. 每个 Domain 一段话定位
+
+下面每段只讲「这个 domain 负责什么、对谁重要、去哪读细节」。实现细节、canonical rule 都由 cross-ref 接管。
+
+### 3.1 identity
+
+- **做什么**：用户账号、角色（`Role`）、OAuth 绑定、`fastapi-users` 接入。
+- **canonical 点**：它是整个系统里唯一能 `import User` / `import Role` 的地方（G15/G16 禁止其他 domain 这么做）。别的 domain 想读 user 只能通过 `AuthenticatedUser(Protocol)`；想写 user（目前只有 `conversation.chat_collection_service` 更新 `User.chat_collection_id`）必须走 `identity_user_ops.set_chat_collection` 这类 facade（lesson 9a-sexdec 三层优先级）。
+- **3 个 `*InitOps` adapter**：`BotInitOps` / `ChatInitOps` / `QuotaInitOps` 在 `aperag/app.py` 启动时注入，用于 `UserManager.on_after_register` —— 新用户注册时自动创建默认 Bot、默认 ChatCollection、默认配额。
+- **去哪读**：[`identity-governance-model-platform-marketplace.md`](./identity-governance-model-platform-marketplace.md)
+
+### 3.2 governance
+
+- **做什么**：API Key 管理 + 审计日志（`AuditLog` / `ApiKey`）。
+- **注意**：它**不**负责配额（`quota_service`）— 配额是 standalone-infra permanent seam，通过 `QuotaOps` Protocol 注入给 `knowledge_base` 和 `conversation` 两个消费方（SSoT Section 5.1）。
+- **路由**：`aperag/views/api_key.py` 和 `aperag/views/audit.py` 是 shim，真实 router 是 `aperag/domains/governance/api/routes.py`。
+- **去哪读**：[`identity-governance-model-platform-marketplace.md`](./identity-governance-model-platform-marketplace.md)
+
+### 3.3 model_platform
+
+- **做什么**：LLM provider / 模型配置 / 默认模型（`LLMProvider` · `LLMProviderModel`）。
+- **2-router split**：`/api/v1/llm_configurations` 在 `llm_routes.py`，`/api/v2/providers` 在 `providers_v2_routes.py`；两个 router 同时挂在 `aperag/app.py`，便于前端在 v1/v2 共存期平滑过渡（SSoT 8.2 F12 记录了未来合并候选）。
+- **跨 domain 消费**：`conversation.chat_title_service` 直接 import `default_model_service`；`conversation.chat_collection_service` 直接 import `llm_available_model_service`（都是 provider-in-domain 的直接 import）。
+- **去哪读**：[`identity-governance-model-platform-marketplace.md`](./identity-governance-model-platform-marketplace.md)
+
+### 3.4 marketplace
+
+- **做什么**：公开 collection 发布 / 订阅（`CollectionMarketplace` · `UserCollectionSubscription`）。
+- **与 KB 的关系**：`knowledge_base.collection_service` 通过自持的 `MarketplaceOps` / `MarketplaceCollectionOps` Protocol 消费；marketplace 结构性满足，不反向 import KB 的 `ports.py`（consumer-owned 原则）。
+- **用户操作面**：发布 / 订阅流程见 [`user-guide/collection-marketplace.md`](../user-guide/collection-marketplace.md)；架构内部细节在 Phase 4 consolidated doc。
+
+### 3.5 knowledge_base
+
+- **做什么**：collection / document / collection-summary —— 知识库领域的主体。
+- **消费的 5 个 port**：`AuthenticatedUser` · `MarketplaceOps` · `MarketplaceCollectionOps` · `SearchPipelineOps` · `QuotaOps`。5 个里 1 个是 standalone-infra permanent（`_quota_ops`）、3 个 provider 已搬进 domain（走 `aperag/app.py` adapter）、1 个（`_search_pipeline_ops`）分类未定（SSoT 8.2 F15 记录）。
+- **schema**：跨 domain 共享的 `CollectionConfig` / `KnowledgeGraphConfig` / `IndexPrompts` / `Chunk` / `VisionChunk` 等 primitives 落在 `aperag/schema/common.py`（SSoT Section 2.3 严格准入规则）；KB 自己的 `Collection` / `Document` / `CollectionView` 等 Pydantic schema 在 `aperag/domains/knowledge_base/schemas.py`。
+- **去哪读**：[`indexing-retrieval-kg.md`](./indexing-retrieval-kg.md)（KB 与 indexing / retrieval / knowledge_graph 深度耦合，放在同一篇 consolidated doc 里）
+
+### 3.6 indexing
+
+- **做什么**：索引 reconciler + 每种索引类型的 worker（vector / fulltext / graph / summary / vision）。
+- **谁驱动它**：`knowledge_base.collection_service` 通过自持的 `SearchPipelineOps`；indexing 对外暴露 `CollectionIndexingView` / `IndexingTrigger` 给 retrieval / KB 用。
+- **注意**：indexing 没有 `api/routes.py` —— 它是内部重建任务的后端，不对外提供 HTTP。
+- **去哪读**：[`indexing-retrieval-kg.md`](./indexing-retrieval-kg.md)
+
+### 3.7 retrieval
+
+- **做什么**：检索 pipeline 编排 + chunk 聚合 + reranking。
+- **与 knowledge_graph 的关系**：retrieval 自持 `GraphQueryContext` · `GraphSearchContract`，knowledge_graph 结构性满足 —— **单向** Protocol（lesson 9a-quad）。G10/G3 禁止 knowledge_graph 反向 import retrieval。
+- **去哪读**：[`indexing-retrieval-kg.md`](./indexing-retrieval-kg.md)
+
+### 3.8 knowledge_graph
+
+- **做什么**：实体 / 关系 ORM + Nebula Graph 客户端 + `graphindex` reconciler。
+- **自持 port**：`CollectionRow` —— 内部抽象，封装 `graphindex` 旧代码对 KB `Collection` 形状的依赖。
+- **路由**：`aperag/views/graph.py` 保留一条 410-Gone legacy route（`/collections/{id}/graphs/export/kg-eval`，Phase 2 hard-cut 的 tombstone），其他都在 `aperag/domains/knowledge_graph/api/routes.py`。
+- **去哪读**：[`indexing-retrieval-kg.md`](./indexing-retrieval-kg.md)
+
+### 3.9 conversation
+
+- **做什么**：Bot / Chat / TurnFeedback + 聊天发起编排。内部 6 个 service（SSoT Section 2.5 详细拓扑）：
+  - `bot_service` · `turn_feedback_service` —— 叶子，不消费其他 conversation service。
+  - `chat_title_service` —— 读 `chat_service`，调 `model_platform.default_model_service`。
+  - `chat_collection_service` —— 调 `knowledge_base.collection_service`、`model_platform.llm_available_model_service`、`identity.identity_user_ops.set_chat_collection`（唯一一个跨 domain 写 `User` 的路径）。
+  - `chat_document_service` —— 消费 `chat_collection_service`（Phase 6 entry 2 退役了 `ChatCollectionServiceOps` seam，改走 sibling 直接 import）。
+  - `chat_service` —— CRUD 顶层 + 导出 `chat_service_global` 模块级单例 + `ChatRow` ORM 别名（让 ORM 行和 Pydantic `Chat` 响应 schema 在同一模块同名无冲突）。
+- **消费的 port**：`KnowledgeBaseCollectionView` · `AuthenticatedUser` · `QuotaOps`（`_quota_ops` 是 standalone-infra permanent 的两条永久 seam 之一）。
+- **跨 domain 被谁消费**：`agent_runtime.runtime`（late-import `chat_document_service`）、`evaluation.worker`（late-import `chat_service_global`，在 `dispatch_fn` 内）。late-import 是故意的，为了避免 module-import-time 的 `evaluation → agent_runtime → conversation` 环。
+- **路由拆分**：`api/routes.py` 同时导出 `chat_router`（挂 `/chats`）和 `bots_router`（挂 `/bots`）两个 router，app.py 分开挂（前缀不同，便于 OpenAPI 聚合）。
+- **去哪读**：[`conversation-agent-evaluation.md`](./conversation-agent-evaluation.md)
+
+### 3.10 agent_runtime
+
+- **做什么**：agent turn 编排 / SSE 流式 / artifact 存储（`AgentTurn` · `AgentTimelineEvent` · `AgentArtifact`）。
+- **`PromptTemplateOps` seam**：`runtime._prompt_template_ops` 是第 2 条 standalone-infra permanent DI 槽（SSoT Section 5.1 的两条之一），provider 是 `aperag.service.prompt_template_service`（跨切面，跨 `agent_runtime` 执行 / `conversation` bot-config / indexing prompt / 用户面 `/prompts` CRUD 四个地方，无法归入某个 domain）。
+- **与 evaluation 的关系**：`evaluation.worker.dispatch_fn` late-import `agent_runtime.runtime` 和 `agent_runtime.services` 做 turn 分派。
+- **去哪读**：[`conversation-agent-evaluation.md`](./conversation-agent-evaluation.md)
+
+### 3.11 evaluation
+
+- **做什么**：数据集 / 评估 run / judge。大量 ORM 行（10 个实体类 / 5 个 Enum）。
+- **重要细节**：`worker.dispatch_fn` 是 **测试注入用的模块级函数引用**，**不是** `Protocol + DI` 槽 —— 测试 monkeypatch 它来替换真实 turn 分派器。G18 alt 注册表不包括 `dispatch_fn`，因为默认实现是一个正常函数而不是 `None` 槽（SSoT Section 5.2 明确列出这个区别）。
+- **dead Protocol 字面量**：`ports.py` 里仍写着 `ChatSessionOps` / `AgentTurnDispatchOps` 两个 Protocol class，但零运行时调用（rebase 过程中被搁置，SSoT Section 2.1 脚注 + Section 8 F14 说明）。将来会机械删除，按 Phase 6 entry 4 删 `ChatDocumentOps` 的先例。
+- **terminal 状态判断**：`EvaluationRunStatus.is_terminal()` classmethod（Phase 6 从 `_TERMINAL_RUN_STATUSES` 常量升格），任何消费方都走这个 API。
+- **去哪读**：[`conversation-agent-evaluation.md`](./conversation-agent-evaluation.md)
+
+### 3.12 web_access
+
+- **做什么**：爬虫抓取 / 网络搜索 / URL 阅读 —— 提供给 `knowledge_base` 的 document ingestion 用。
+- **当前形态**：**没有实体**、没有 service，只有 schemas、路由、三个功能子包（`reader/` · `search/` · `utils/`）。SSoT 8.2 F11 把「是否给 web_access 补 entity + service」列为未来候选。
+- **去哪读**：[`web-access.md`](./web-access.md)
+
+---
+
+## 4. Domain 之间的依赖关系
+
+下图是稳态关系（边上的标签是「用什么机制」）：
+
+```
+identity      ←── AuthenticatedUser Protocol (read)   ← 所有其他 domain
+identity      ─── identity_user_ops facade (write)    → conversation.chat_collection_service
+
+governance    （无跨 domain 入边；被 admin UI 消费）
+quota_service（standalone-infra）─── QuotaOps Protocol → knowledge_base.collection_service, conversation.bot_service
+
+model_platform ─── default_model_service 直接 import  ← conversation.chat_title_service
+model_platform ─── llm_available_model_service 直接    ← conversation.chat_collection_service
+
+marketplace   ─── MarketplaceOps / MarketplaceCollectionOps（结构性满足）→ knowledge_base.collection_service
+
+knowledge_base ─── Collection / Document 直接 import  → conversation.chat_collection_service, retrieval.pipeline, agent_runtime.runtime, web_access routes
+
+indexing      ─── CollectionIndexingView / IndexingTrigger  ↔ knowledge_base / retrieval
+
+retrieval     ─── GraphSearchContract Protocol（单向）→ knowledge_graph
+knowledge_graph：禁止反向 import retrieval.ports / retrieval.service / retrieval.schemas（G10/G3）
+
+conversation.chat_service_global      ─── 直接 import ← evaluation.worker（late-import，破环）
+conversation.chat_document_service    ─── 直接 import ← agent_runtime.runtime（late-import）
+
+agent_runtime.runtime ─── _prompt_template_ops DI slot  ← standalone-infra: aperag.service.prompt_template_service
+
+evaluation    （无跨 domain provider 角色；被 admin UI 消费；worker 有测试注入 dispatch_fn seam）
+
+web_access    （无实体；消费 KB Collection 做带网页增强的检索）
+```
+
+要点：
+
+- **先看 provider 在哪**。如果 provider 已经在 `aperag/domains/<d>/`，consumer 直接 import。
+- **否则用 consumer-owned Protocol + DI 槽**。consumer 自持 `Protocol` 和槽，`aperag/app.py` 启动时注入（legacy provider 或 adapter）。
+- **standalone-infra permanent（类 B）** 只有两条：`QuotaOps` 和 `PromptTemplateOps` —— 它们不会搬进任何 domain，永久用 DI 注入（SSoT Section 3.2）。
+- **late-import** 只用在破 module-import 循环。目前唯一的活用法是 `evaluation.worker.dispatch_fn` 和 `agent_runtime.runtime` 对 `conversation` 服务的调用。
+
+---
+
+## 5. 不属于 domain 的共享基础设施
+
+下面这些 top-level 模块是 domain 共享基础设施，**不**归入任何一个 domain：
+
+| 模块 / 目录 | 作用 |
+| --- | --- |
+| `aperag/app.py` | FastAPI app factory；模块级 DI wire-up —— 7 个 Phase 3+4 槽 + 2 个 Phase 5/6 permanent 槽（SSoT Section 5） |
+| `aperag/config.py` | Settings / 环境变量 / 数据库 URL |
+| `aperag/openapi_spec.py` | OpenAPI 生成 + `HIDDEN_FROM_PUBLIC_PATH_PREFIXES` 注册表 |
+| `aperag/db/base.py` | SQLAlchemy declarative `Base`；所有 per-domain `db/models.py` 共用这一个 metadata 注册表（让 alembic autogenerate 能跨 domain 发现模型） |
+| `aperag/db/ops.py` | 异步 DB 查询 helper |
+| `aperag/db/models.py` | **re-export shim** — 把各 domain 的 ORM 重新导出给还没迁移的调用方 |
+| `aperag/db/repositories/*.py` | Repository 层（domain-owned + legacy 混杂） |
+| `aperag/schema/common.py` | **跨 domain 共享的原语 Pydantic 类型**，严格准入（SSoT Section 2.3） |
+| `aperag/schema/view_models.py` | **re-export shim + dual-hook** —— 给老调用方兜底（SSoT Section 3.3） |
+| `aperag/llm/` | LiteLLM 集成（completion / embedding / rerank / cache）—— 共享基础设施，不是 domain |
+| `aperag/utils/` | `audit_decorator`、常量、日期 / 分页 helper、spider、LLM response 处理等 |
+| `aperag/service/*.py` | **re-export shim** + 一小撮 legacy-only service（`chat_completion_service` / `evaluation_service` / `export_service` / `prompt_template_service` / `quota_service` / `search_pipeline_service` 等，SSoT Section 6.1） |
+| `aperag/views/*.py` | router re-export shim + 一小撮 legacy 非 domain view（`auth.py`、`config.py`、`main.py`、`openai.py`、`prompts.py` 等） |
+| `aperag/agent_runtime/`、`aperag/evaluation_v2/` | **legacy top-level package** —— 仅作 re-export shim，让旧 import 路径仍可用；真实实现在 `aperag/domains/agent_runtime/` / `aperag/domains/evaluation/` |
+
+所有 legacy shim 的退役计划都在 SSoT Section 6 + Section 8（F2 / F3 / F9 future candidates）记录，新代码**不要**走 shim 路径。
+
+---
+
+## 6. 新代码落位速决
+
+如果你要加新代码，先回答三个问题：
+
+1. **功能属于哪个 domain？**
+   - 找到对应 `aperag/domains/<d>/`，按目录契约放（`db/models.py` / `schemas.py` / `service/` / `api/routes.py`）。
+   - 不确定归哪个 domain，对照上面 §3 的一段话定位。
+2. **要用到的 primitive 是跨 domain 共用的吗？**
+   - 如果是 ≥2 个 domain 都会用、且是纯值对象（无 ORM 依赖 / 无 domain 特定语义），放 `aperag/schema/common.py`（准入严格，对照 SSoT Section 2.3）。
+   - 否则只放本 domain 的 `schemas.py`。
+3. **是真正的跨切面基础设施吗？**
+   - 共享的 LLM 封装 → `aperag/llm/`；OAuth / fastapi-users 集成仍留在 `aperag/views/auth.py`；DB session helper → `aperag/db/` 下。
+   - **不要**新建 `aperag/domains/infrastructure/` 之类的 —— domain 就是业务 domain，基础设施继续留 top-level。
+
+跨 domain 调用：
+
+- Provider 已经在 `aperag/domains/` → 直接 import（**不要**绕一层 `ports.py`）。
+- Provider 还没搬 → consumer 自持 `Protocol` + DI 槽，到 `aperag/app.py` 注入。
+- Provider 是永久跨切面基础设施（`QuotaOps` / `PromptTemplateOps`）→ 同样走 DI 槽，保持永久性（**不要**试图把它搬进 domain）。
+
+新代码上线前，`make test-unit` 会跑 `tests/unit_test/test_modularization_boundaries.py` 里的 20 条边界测试；G1-G19 定义见 SSoT Section 4 + [`development/development-guide.md`](../development/development-guide.md) 里的「Domain 边界门禁 G1–G19 速查」。
+
+---
+
+*本文档基线：`origin/main @ 10cabcf`（PR #1637 merged），与 canonical SSoT `docs/modularization/architecture.md` 同步。domain 清单 / cross-domain rule / permanent seam 任何变更先改 SSoT，再回头更新本表。*

--- a/docs/zh-CN/architecture/overview.md
+++ b/docs/zh-CN/architecture/overview.md
@@ -1,0 +1,80 @@
+---
+title: 架构总览
+description: ApeRAG 后端架构入口 — 从哪开始读、去哪找什么
+---
+
+# 架构总览
+
+> ApeRAG 后端经过 Phase 0→6 模块化重构后，代码以 **12 个业务 domain** 的形式组织在 `aperag/domains/**`，跨 domain 调用通过 **boundary gates（G1–G19）** 与少量 **permanent DI seams** 约束。本文是整个 `architecture/` 目录的入口，不重复实现细节，只负责导航。
+
+---
+
+## 一句话定位
+
+- **代码按业务职责分 12 个 domain**：`identity` · `governance` · `model_platform` · `marketplace` · `knowledge_base` · `indexing` · `retrieval` · `knowledge_graph` · `conversation` · `agent_runtime` · `evaluation` · `web_access`。
+- **每个 domain 自成一格**：自己的 DB 模型 · 自己的 Pydantic schema · 自己的 service · 自己的 FastAPI 路由，都在 `aperag/domains/<domain>/` 下。
+- **跨 domain 依赖有明确规则**：provider 已搬进 `aperag/domains/` 的直接 import；没搬进的通过 consumer 自持 `Protocol` + module-level DI slot + `aperag/app.py` startup 注入。
+- **有测试守住边界**：`tests/unit_test/test_modularization_boundaries.py` 实现 G1–G19 共 20 条边界测试，跟 `make lint` / `make test-unit` 一起跑在 CI。
+- **HTTP API 全程字节稳定**：`scripts/export_openapi.py --check` 在整个重构过程每次 squash merge 都通过。
+
+详细的 phase 产出、domain 清单、gate 列表、permanent seam 定义见 [`docs/modularization/architecture.md`](../../modularization/architecture.md)（英文，canonical source-of-truth，本目录所有文档都以它为基准）。
+
+---
+
+## 我该从哪里开始读？
+
+下面按「你关心什么」给一个导航表：
+
+| 你想了解 | 去这里 |
+| --- | --- |
+| 12 个 domain 各自做什么？domain 之间什么关系？ | [`architecture/domains.md`](./domains.md) |
+| identity / governance / model_platform / marketplace 这 4 个 domain 的内部结构 | [`architecture/identity-governance-model-platform-marketplace.md`](./identity-governance-model-platform-marketplace.md) |
+| knowledge_base / indexing / retrieval / knowledge_graph 的内部结构与 ingestion / retrieval pipeline | [`architecture/indexing-retrieval-kg.md`](./indexing-retrieval-kg.md) |
+| conversation / agent_runtime / evaluation 与 prompt 架构 | [`architecture/conversation-agent-evaluation.md`](./conversation-agent-evaluation.md) |
+| 爬虫抓取 / URL 阅读相关的 `web_access` 子包 | [`architecture/web-access.md`](./web-access.md) |
+| 英文的 canonical 全景（20 个 boundary 测试、permanent seam、shim lifecycle、future 候选） | [`docs/modularization/architecture.md`](../../modularization/architecture.md) |
+| 我想在本地把 ApeRAG 跑起来 / 贡献代码 | [`development/development-guide.md`](../development/development-guide.md) |
+| 我想部署 ApeRAG / 配置 LLM provider | `deployment/` 目录 |
+| 我是终端用户，想知道怎么创建 collection / 对话 / 评估 | `user-guide/` 目录 |
+| 我是系统管理员，想配额 / 审计 / API Key / prompt 定制 | `admin-guide/` 目录 |
+| 我是第三方接入方（OpenAI 兼容 / MCP / Dify） | `integration/` 目录 |
+| API 测试手册、调试指令、示例配置 | `reference/` 目录 |
+
+---
+
+## 为什么要模块化？
+
+重构之前，所有业务代码散落在 `aperag/service/*.py`、`aperag/db/models.py`、`aperag/schema/view_models.py` 三个大聚合层里。随着业务膨胀：
+
+- 单个文件超过千行，新人找一个功能的调用链需要跨十几个文件。
+- 跨 domain 调用随手 import，导致 DB 迁移牵一发动全身。
+- 重构任何一处都要跑全量测试。
+
+Phase 0→6 的目标是把这些聚合层拆成 domain-local 的代码，并用 **强制可测的边界规则** 锁住再次聚合的趋势。重构的关键产出：
+
+- **12 个独立 domain**，各自拥有 `db/` · `schemas.py` · `ports.py` · `service/` · `api/routes.py`。
+- **20 条 boundary 测试**（G1–G19 + CRITICAL_WIRINGS），跑在 `make test-unit` 里，任何违反边界的 import 都会红。
+- **2 条永久 DI seam**（`QuotaOps` / `PromptTemplateOps`），用来接入跨切面的共享基础设施而不破坏 domain 独立性。
+- **HTTP API 零漂移**：重构全程 OpenAPI 字节级稳定，前端/下游无需适配。
+- **54 次 CR，零 blocker**：按 phase 分批合并（PR #1629 / #1633 / #1634 / #1635），每次 squash 都保持主干可运行。
+
+更详细的 phase 拆分、每个 phase 的 breaking-changes、lesson-learned，见 `docs/modularization/` 目录下的其他文件。
+
+---
+
+## 与其他文档的分工
+
+- `docs/modularization/architecture.md` — **英文 canonical SSoT**，描述「重构结束后的稳态」。所有结构性不变式（12 domain 清单 / G1-G19 定义 / dual-hook 模式 / permanent seam 清单 / legacy shim 清单 / 新代码落位规则）只在这里有一份，本目录的中文文档通过 cross-reference 引用，不复制粘贴，避免随时间漂移。
+- `docs/modularization/breaking-changes/phase*.md` — 分 phase 的变更说明（为什么这样拆、删了什么、加了什么），主要给「重构期间改动过老代码」的读者。
+- `docs/modularization/roadmap.md` / `target-domain-map.md` — 重构启动前的设计稿，**仅作历史参考**，不代表当前状态。
+- 本目录（`docs/zh-CN/architecture/`） — 用中文讲「每个 domain 内部怎么回事」，粒度比 canonical SSoT 细，给需要读具体实现的中文读者。
+
+## 读者原则
+
+- 需要搞清楚「当前主干到底是什么结构」—— 先读 canonical SSoT，再回到本目录找 domain 细节。
+- 需要「在某个 domain 上加新代码」—— 读 `domains.md` 定位 domain，再读该 domain 所在 consolidated doc 的章节，最后回 `development/development-guide.md` 找具体命令与门禁要求。
+- 需要「对外接入 / 部署 / 操作 / 使用」—— 本目录以外的 `integration/` · `deployment/` · `admin-guide/` · `user-guide/` 才是正确位置，本目录不承载这些内容。
+
+---
+
+*本文档基线：`origin/main @ 10cabcf`（PR #1637 merged）；canonical SSoT 基线 `origin/main @ 28a9f531`（PR #1635 Phase 6 merged）。本目录其他文档随 `docs/modularization/architecture.md` 更新而维护；结构性不变式若发生变更，先改 canonical SSoT，再回头更新本目录。*

--- a/docs/zh-CN/architecture/overview.md
+++ b/docs/zh-CN/architecture/overview.md
@@ -28,10 +28,10 @@ description: ApeRAG 后端架构入口 — 从哪开始读、去哪找什么
 | 你想了解 | 去这里 |
 | --- | --- |
 | 12 个 domain 各自做什么？domain 之间什么关系？ | [`architecture/domains.md`](./domains.md) |
-| identity / governance / model_platform / marketplace 这 4 个 domain 的内部结构 | [`architecture/identity-governance-model-platform-marketplace.md`](./identity-governance-model-platform-marketplace.md) |
-| knowledge_base / indexing / retrieval / knowledge_graph 的内部结构与 ingestion / retrieval pipeline | [`architecture/indexing-retrieval-kg.md`](./indexing-retrieval-kg.md) |
-| conversation / agent_runtime / evaluation 与 prompt 架构 | [`architecture/conversation-agent-evaluation.md`](./conversation-agent-evaluation.md) |
-| 爬虫抓取 / URL 阅读相关的 `web_access` 子包 | [`architecture/web-access.md`](./web-access.md) |
+| identity / governance / model_platform / marketplace 这 4 个 domain 的内部结构 | `architecture/identity-governance-model-platform-marketplace.md`（起稿中） |
+| knowledge_base / indexing / retrieval / knowledge_graph 的内部结构与 ingestion / retrieval pipeline | `architecture/indexing-retrieval-kg.md`（起稿中） |
+| conversation / agent_runtime / evaluation 与 prompt 架构 | `architecture/conversation-agent-evaluation.md`（起稿中） |
+| 爬虫抓取 / URL 阅读相关的 `web_access` 子包 | `architecture/web-access.md`（起稿中） |
 | 英文的 canonical 全景（20 个 boundary 测试、permanent seam、shim lifecycle、future 候选） | [`docs/modularization/architecture.md`](../../modularization/architecture.md) |
 | 我想在本地把 ApeRAG 跑起来 / 贡献代码 | [`development/development-guide.md`](../development/development-guide.md) |
 | 我想部署 ApeRAG / 配置 LLM provider | `deployment/` 目录 |
@@ -40,33 +40,31 @@ description: ApeRAG 后端架构入口 — 从哪开始读、去哪找什么
 | 我是第三方接入方（OpenAI 兼容 / MCP / Dify） | `integration/` 目录 |
 | API 测试手册、调试指令、示例配置 | `reference/` 目录 |
 
+> 标注「起稿中」的 consolidated 架构文档正在并行起草，落 main 后本表会把 code path 升级为 Markdown 链接。
+
 ---
 
-## 为什么要模块化？
+## 当前架构为什么这样组织
 
-重构之前，所有业务代码散落在 `aperag/service/*.py`、`aperag/db/models.py`、`aperag/schema/view_models.py` 三个大聚合层里。随着业务膨胀：
+三条约束决定了现在的布局：
 
-- 单个文件超过千行，新人找一个功能的调用链需要跨十几个文件。
-- 跨 domain 调用随手 import，导致 DB 迁移牵一发动全身。
-- 重构任何一处都要跑全量测试。
+- **业务职责清晰可定位**：把代码按业务 domain 聚类（`aperag/domains/<d>/`），而不是按层（`service/` / `models/` / `views/`）。新人看到一个 endpoint 能在一个目录里找齐 DB / schema / 业务 / 路由。
+- **跨 domain 依赖显式且可测**：`aperag/domains/**` 内禁止 import 旧聚合层（G1）；跨 domain 访问只有两种形态——provider-in-domain 直接 import、或 consumer-owned Protocol + DI 槽。`tests/unit_test/test_modularization_boundaries.py` 里 20 条 pytest 锁住全部边界规则（G1–G19 + CRITICAL_WIRINGS），跟 `make test-unit` 一起跑，违反 import 会红在 CI。
+- **永久性的跨切面基础设施有独立接入点**：跨 domain 的基础设施（配额、prompt template）不塞进某个 domain，也不偷偷下沉到共享层，而是用 **permanent DI seam**（`QuotaOps` / `PromptTemplateOps`）显式注入。两条 seam 的启动时 wiring 由 `aperag/app.py` 负责、同样受 boundary 测试保护。
 
-Phase 0→6 的目标是把这些聚合层拆成 domain-local 的代码，并用 **强制可测的边界规则** 锁住再次聚合的趋势。重构的关键产出：
+外部契约零漂移是硬要求：HTTP API（OpenAPI）、前端 typed client、数据库迁移历史在整个重构过程保持字节级稳定。
 
-- **12 个独立 domain**，各自拥有 `db/` · `schemas.py` · `ports.py` · `service/` · `api/routes.py`。
-- **20 条 boundary 测试**（G1–G19 + CRITICAL_WIRINGS），跑在 `make test-unit` 里，任何违反边界的 import 都会红。
-- **2 条永久 DI seam**（`QuotaOps` / `PromptTemplateOps`），用来接入跨切面的共享基础设施而不破坏 domain 独立性。
-- **HTTP API 零漂移**：重构全程 OpenAPI 字节级稳定，前端/下游无需适配。
-- **54 次 CR，零 blocker**：按 phase 分批合并（PR #1629 / #1633 / #1634 / #1635），每次 squash 都保持主干可运行。
+历史过程（分 phase 的变更、每一步为什么这样拆、lesson-learned）都在 [`docs/modularization/`](../../modularization/) 目录：
 
-更详细的 phase 拆分、每个 phase 的 breaking-changes、lesson-learned，见 `docs/modularization/` 目录下的其他文件。
+- `docs/modularization/architecture.md` — 当前稳态的 canonical 文档（英文）。
+- `docs/modularization/breaking-changes/phase*.md` — 每个 phase 的变更说明，改老代码前可读。
+- `docs/modularization/roadmap.md` / `target-domain-map.md` / `README.md` — 重构启动前的设计稿，仅历史参考。
 
 ---
 
 ## 与其他文档的分工
 
-- `docs/modularization/architecture.md` — **英文 canonical SSoT**，描述「重构结束后的稳态」。所有结构性不变式（12 domain 清单 / G1-G19 定义 / dual-hook 模式 / permanent seam 清单 / legacy shim 清单 / 新代码落位规则）只在这里有一份，本目录的中文文档通过 cross-reference 引用，不复制粘贴，避免随时间漂移。
-- `docs/modularization/breaking-changes/phase*.md` — 分 phase 的变更说明（为什么这样拆、删了什么、加了什么），主要给「重构期间改动过老代码」的读者。
-- `docs/modularization/roadmap.md` / `target-domain-map.md` — 重构启动前的设计稿，**仅作历史参考**，不代表当前状态。
+- [`docs/modularization/architecture.md`](../../modularization/architecture.md) — **英文 canonical SSoT**，描述「当前稳态」。所有结构性不变式（12 domain 清单 / G1-G19 定义 / dual-hook 模式 / permanent seam 清单 / legacy shim 清单 / 新代码落位规则）只在这里有一份，本目录的中文文档通过 cross-reference 引用，不复制粘贴，避免随时间漂移。
 - 本目录（`docs/zh-CN/architecture/`） — 用中文讲「每个 domain 内部怎么回事」，粒度比 canonical SSoT 细，给需要读具体实现的中文读者。
 
 ## 读者原则

--- a/docs/zh-CN/development/development-guide.md
+++ b/docs/zh-CN/development/development-guide.md
@@ -1,19 +1,25 @@
 ---
 title: 开发指南
-description: ApeRAG 开发环境设置和工作流程
+description: ApeRAG 开发环境设置、工作流程、模块化后代码落位 + 边界门禁
 ---
 
 # 🛠️ 开发指南
 
-本指南重点介绍如何为 ApeRAG 设置开发环境和开发工作流程。这是为希望为 ApeRAG 做贡献或在本地运行它进行开发的开发人员设计的。
+本指南面向想从源代码跑 ApeRAG 或贡献代码的开发者，讲三件事：
 
-## 🚀 开发环境设置
+1. **开发环境怎么搭**（§1）
+2. **模块化之后新代码写在哪、边界怎么守**（§2、§3 —— Phase 0→6 重构的核心结果）
+3. **常见开发任务怎么做**（§4）
 
-按照以下步骤从源代码设置 ApeRAG 进行开发：
+如果你只是想快速跑起来，直接看 §1。如果你要给某个 domain 加功能，**先读 §2 再动手**，否则很容易撞 boundary gate 失败。
 
-### 1. 📂 克隆仓库并设置环境
+---
 
-首先，获取源代码并配置环境变量：
+## 1. 🚀 开发环境设置
+
+按顺序执行，每一步都会验证上一步。
+
+### 1.1 📂 克隆仓库并配置环境变量
 
 ```bash
 git clone https://github.com/apecloud/ApeRAG.git
@@ -21,358 +27,487 @@ cd ApeRAG
 cp envs/env.template .env
 ```
 
-如果需要，编辑 `.env` 文件以配置您的 AI 服务设置。默认设置适用于下一步启动的本地数据库服务。
+`.env` 默认值和下一步 `make infra-up` 起的本地数据库匹配，一般无需改。接入真实 LLM provider 时再改 `OPENAI_API_KEY` 之类的。
 
-### 2. 📋 系统前提条件
+### 1.2 📋 系统前提
 
-在开始之前，请确保您的系统具备：
+- **Node.js** ≥ 20（前端开发要；仅后端开发可以不装）— [下载](https://nodejs.org/)
+- **Docker + Docker Compose**（本地数据库服务要）— [下载](https://docs.docker.com/get-docker/)
+- **Python 3.11** —— 不用手动装，下一步的 `uv` 会自动拉起来
 
-*   **Node.js**：推荐版本 20 或更高版本用于前端开发。[下载 Node.js](https://nodejs.org/)
-*   **Docker & Docker Compose**：本地运行数据库服务所需。[下载 Docker](https://docs.docker.com/get-docker/)
-
-**注意**：需要 Python 3.11，但将在下一步中通过 `uv` 自动管理。
-
-### 3. 🗄️ 启动数据库服务
-
-使用 Docker Compose 启动必要的数据库服务：
+### 1.3 🗄️ 启动数据库服务
 
 ```bash
-# 启动核心数据库：PostgreSQL、Redis、Qdrant、Elasticsearch
+# PostgreSQL + Redis + Qdrant + Elasticsearch
 make infra-up
 ```
 
-这将在后台启动所有必需的数据库服务。您的 `.env` 文件中的默认连接设置已预配置为与这些服务一起工作。
+后台启动所有必须的数据库。`.env` 默认连接字符串已经指向它们。
 
 <details>
 <summary><strong>高级数据库选项</strong></summary>
 
 ```bash
-# 使用 Neo4j 而不是 PostgreSQL 进行图存储
+# 用 Neo4j 代替 PostgreSQL 作图存储
 make infra-up WITH_NEO4J=1
 ```
 
 </details>
 
-### 4. ⚙️ 设置开发环境
-
-创建 Python 虚拟环境并设置开发工具：
+### 1.4 ⚙️ 设置 Python 开发环境
 
 ```bash
 make env-dev
 ```
 
-此命令将：
-*   如果尚未可用，则安装 `uv`
-*   创建 Python 3.11 虚拟环境（位于 `.venv/` 中）
-*   安装后端依赖和仓库 git hooks
-*   为代码质量安装 pre-commit hooks
-*   安装 addlicense 工具进行许可证管理
+这一步会：
 
-**激活虚拟环境：**
+- 如果还没装，下载 `uv`
+- 创建 Python 3.11 虚拟环境（位置 `.venv/`）
+- 安装后端依赖 + repo git hooks
+- 安装 pre-commit hooks（lint / format 自动跑）
+- 安装 `addlicense` 工具（license 管理）
+
+**激活虚拟环境**：
+
 ```bash
 source .venv/bin/activate
 ```
 
-当您在终端提示符中看到 `(.venv)` 时，您就知道它是活动的。
+终端提示符里出现 `(.venv)` 代表激活成功。
 
-### 5. 📦 安装依赖项
-
-安装所有后端和前端依赖项：
+### 1.5 📦 安装依赖
 
 ```bash
 make env-install
 ```
 
-此命令将：
-*   将 `pyproject.toml` 中的所有 Python 后端依赖项安装到虚拟环境中
-*   使用 `yarn` 安装前端 Node.js 依赖项
+一次性装齐：`pyproject.toml` 里所有 Python 依赖 + `web/` 前端的 `yarn install`。
 
-### 6. 🔄 应用数据库迁移
-
-设置数据库架构：
+### 1.6 🔄 应用数据库迁移
 
 ```bash
 make db-migrate
 ```
 
-### 7. ▶️ 启动开发服务
+Alembic 会按 `aperag/migration/versions/` 的顺序把 schema 推到最新。
 
-现在您可以启动开发服务。为每个服务打开单独的终端窗口/选项卡：
+### 1.7 ▶️ 启动开发服务
 
-**终端 1 - 后端 API 服务器：**
+在不同终端窗口跑：
+
+| 终端 | 命令 | 做什么 |
+| --- | --- | --- |
+| 1 | `make serve-api` | FastAPI 后端，`http://localhost:8000`，代码改动自动 reload |
+| 2 | `make serve-worker` | Celery worker，处理异步后台任务 |
+| 3（可选） | `make serve-web` | 前端 dev server，`http://localhost:3000`，hot reload |
+
+### 1.8 🌐 访问入口
+
+- 前端 UI：<http://localhost:3000>（启动了 web 才有）
+- 后端 API：<http://localhost:8000>
+- API 文档：<http://localhost:8000/docs>
+
+### 1.9 ⏹️ 停止服务
+
 ```bash
-make serve-api
-```
-这将在 `http://localhost:8000` 启动 FastAPI 开发服务器，代码更改时自动重新加载。
-
-**终端 2 - Celery Worker：**
-```bash
-make serve-worker
-```
-这将启动 Celery worker 以处理异步后台任务。
-
-**终端 3 - 前端（可选）：**
-```bash
-make serve-web
-```
-这将在 `http://localhost:3000` 启动前端开发服务器，支持热重载。
-
-### 8. 🌐 访问 ApeRAG
-
-服务运行后，您可以访问：
-*   **前端 UI**：http://localhost:3000 (如果已启动)
-*   **后端 API**：http://localhost:8000
-*   **API 文档**：http://localhost:8000/docs
-
-### 9. ⏹️ 停止服务
-
-要停止开发环境：
-
-**停止数据库服务：**
-```bash
-# 停止数据库服务（保留数据）
+# 停数据库服务，保留数据
 make stack-down
 
-# 停止服务并移除所有数据卷
+# 停数据库服务并删除所有 data volumes（⚠️ 永久删数据）
 make stack-down REMOVE_VOLUMES=1
 ```
 
-**停止开发服务：**
-- 后端 API 服务器：在运行 `make serve-api` 的终端中按 `Ctrl+C`
-- Celery Worker：在运行 `make serve-worker` 的终端中按 `Ctrl+C`
-- 前端服务器：在运行 `make serve-web` 的终端中按 `Ctrl+C`
+开发服务（`make serve-api` / `serve-worker` / `serve-web`）在各自终端 `Ctrl+C`。
 
-**数据管理：**
-- `make stack-down` - 停止服务但保留所有数据（PostgreSQL、Redis、Qdrant 等）
-- `make stack-down REMOVE_VOLUMES=1` - 停止服务并**⚠️ 永久删除所有数据**
-- 即使已经运行过 `make stack-down`，您也可以运行 `make stack-down REMOVE_VOLUMES=1`
+**验证数据是否被清掉**：
 
-**验证数据移除：**
 ```bash
-# 检查卷是否仍然存在
 docker volume ls | grep aperag
-
-# REMOVE_VOLUMES=1 后应该不返回结果
+# REMOVE_VOLUMES=1 后这里应该什么都不返回
 ```
 
-现在您已经从源代码本地运行 ApeRAG，准备好进行开发！🎉
+现在本地环境跑起来了 🎉，继续往下读之前，**请先读 §2**。
 
-## ❓ 常见开发任务
+---
+
+## 2. 📦 模块化后的代码布局
+
+Phase 0→6 重构把后端从「所有业务堆在 `aperag/service/*` + `aperag/db/models.py` + `aperag/schema/view_models.py` 三个大聚合层」拆成了 **12 个业务 domain**，新代码几乎都该落在 `aperag/domains/<domain>/` 下。
+
+### 2.1 12 Domain 清单
+
+| Domain | 做什么 |
+| --- | --- |
+| `identity` | 用户账号 / Role / OAuth / fastapi-users |
+| `governance` | API Key 管理 + 审计日志 |
+| `model_platform` | LLM provider / 模型配置 / 默认模型（v1 + v2 两个 router） |
+| `marketplace` | 公开 collection 发布 / 订阅 |
+| `knowledge_base` | Collection / Document / CollectionSummary（主领域） |
+| `indexing` | 索引 reconciler + 各类 worker（vector / fulltext / graph / summary / vision） |
+| `retrieval` | 检索 pipeline 编排 + chunk 聚合 + reranking |
+| `knowledge_graph` | 实体 / 关系 ORM + Nebula + `graphindex` reconciler |
+| `conversation` | Bot / Chat / TurnFeedback + 聊天发起编排 |
+| `agent_runtime` | Agent turn / SSE / artifact 存储 |
+| `evaluation` | 数据集 / 评估 run / judge |
+| `web_access` | 爬虫 / URL 阅读 / 网络搜索 |
+
+一段话定位 + cross-ref 到各 domain 细节见 [`docs/zh-CN/architecture/domains.md`](../architecture/domains.md)，完整英文 canonical source-of-truth 在 [`docs/modularization/architecture.md`](../../modularization/architecture.md)。
+
+### 2.2 Per-domain 目录契约
+
+```
+aperag/domains/<domain>/
+├── db/
+│   └── models.py        # SQLAlchemy ORM + 本 domain 拥有的 Enum
+├── schemas.py           # 本 domain 的 Pydantic schema（走 dual-hook 绑回 view_models）
+├── ports.py             # consumer-owned Protocol（对别人的依赖声明）
+├── service/             # 业务逻辑；或直接 service.py
+├── api/
+│   └── routes.py        # FastAPI 路由；或按前缀切成 <feature>_routes.py
+└── __init__.py
+```
+
+不是每个 domain 都有全套（比如 `web_access` 没有 DB，`indexing` 没有 API 路由）。
+
+### 2.3 新代码落位决策树
+
+```
+要加的功能归属哪个业务 domain？
+├─ 归属明确 → aperag/domains/<domain>/ 对应槽位
+│                 ├─ 要加 ORM → db/models.py
+│                 ├─ 要加 Pydantic → schemas.py（注意 dual-hook）
+│                 ├─ 要加业务逻辑 → service/
+│                 └─ 要加 HTTP endpoint → api/routes.py（或 <feature>_routes.py）
+├─ 归属模糊 → 读 docs/zh-CN/architecture/domains.md §3，对照 12 domain 一段话定位
+└─ 不属于任何业务 domain（跨切面基础设施） → 保留在 top-level:
+     ├─ LLM 封装 → aperag/llm/
+     ├─ DB session helper → aperag/db/base.py
+     ├─ 工具 / 常量 → aperag/utils/
+     └─ （legacy）aperag/service/*.py 下的 shim + 3 条 legacy-only 服务（quota_service / prompt_template_service / search_pipeline_service 等），不要新增
+```
+
+**不要**在 `aperag/domains/` 下造新的 "shared" 子目录（例如 `aperag/domains/common/`）。跨 domain 共享的 Pydantic 原语走 `aperag/schema/common.py`（准入标准严格：≥2 domain 都用 + 纯值对象，见 canonical SSoT Section 2.3）。
+
+### 2.4 Pydantic schema 放哪
+
+- 只有本 domain 用 → `aperag/domains/<d>/schemas.py`，通过 **dual-hook Scenario A**（canonical SSoT Section 3.3）绑回 `aperag.schema.view_models`，老调用方仍能 `from aperag.schema.view_models import X` 导入。
+- ≥2 domain 都用 + 纯值对象（无 ORM 依赖 / 无 domain 特定语义） → `aperag/schema/common.py`，准入由 CR 人审（没有 AST 自动检查 —— 故意的，避免规则退化成 catch-all）。
+
+dual-hook 在域文件尾部已有 `_bind_view_models_reexports()` 模板，在新 schema 加完后记得把类名加进 `__all__`。
+
+### 2.5 跨 domain 调用的两种形态
+
+1. **Provider 已搬进 `aperag/domains/`** → 直接 import：
+
+   ```python
+   from aperag.domains.knowledge_base.service.document_service import document_service
+   await document_service.get_by_id(session, doc_id)
+   ```
+
+2. **Provider 还在 `aperag/service/*.py`**（或永久 standalone-infra） → **consumer-owned Protocol + DI 槽**：
+
+   - consumer 在自己的 `ports.py` 写 `Protocol`
+   - consumer 在 service 模块级留 `_ops: Optional[XOps]` + `set_x_ops()` + `_get_x_ops()`
+   - `aperag/app.py` 启动时把 provider（或 adapter）注入槽
+   - **provider 不能 import consumer 的 `ports.py`** —— Protocol 由 consumer 拥有，lesson 9a-quad
+
+   今天 legacy 未搬 provider 还剩一些（如 `search_pipeline_service` 待分类），两条永久 standalone-infra seam：`QuotaOps`（provider = `aperag.service.quota_service`）、`PromptTemplateOps`（provider = `aperag.service.prompt_template_service`）。
+
+更细节的 Protocol + DI pattern、两个子类（A 过渡 / B 永久）、`sys.modules.get(...)` 绕 G1 AST 扫描的技巧，都写在 canonical SSoT Section 3。
+
+---
+
+## 3. 🛡️ Domain 边界门禁 G1–G19 速查
+
+所有边界规则都写成了 `tests/unit_test/test_modularization_boundaries.py` 里的 pytest 测试，跑 `make test-unit` 会全部检查。下面是速查表，详细原因和 AST 扫描实现细节见 canonical SSoT Section 4。
+
+| Gate | 禁 / 要求 | 关键触发点 |
+| --- | --- | --- |
+| **G1** | `aperag/domains/**` 禁 import `aperag.service.*` / `aperag.schema.view_models` / `aperag.db.models` | 任何你 "偷懒" 从旧聚合路径拿东西 |
+| **G4** | domain API handler 的 `required_user` / `current_user` 参数必须有 `Protocol` 类型注解（不允许 `Any`） | 写 route 时类型漏了 |
+| **G10 / G3** | `retrieval ↔ knowledge_graph` 单向 —— retrieval 走 `graphindex.integration` 窄口；knowledge_graph 禁反向 import retrieval | KG 代码里不小心 import 了 retrieval |
+| **G14** | Phase 2 之后 `aperag/views/collections.py` / `aperag/views/graph.py` 里不能有 retrieval / KG 的 route 装饰器（除一条 410-Gone tombstone） | 老 route 漏删 |
+| **KB consumer-owned** | `marketplace_service` / `marketplace_collection_service` / `search_pipeline_service` / `quota_service` 等 legacy provider 禁 import `aperag.domains.knowledge_base.ports` | provider 反向 import consumer 的 Protocol |
+| **KB DI smoke** | `import aperag.app` 后 KB 4 个 `_*_ops` 槽必须 non-`None` | 启动 wire-up 漏了一条 |
+| **G15** | 非 identity domain 禁 import `Role` | 别处用 `Role.ADMIN`；改成字符串比较 `user.role == "admin"` |
+| **G16** | 非 identity domain 禁 import `User` ORM | 读走 `AuthenticatedUser(Protocol)` / `UserView`；写走 `identity_user_ops.*` facade（lesson 9a-sexdec 三层优先级） |
+| **G17** | `import aperag.app` 后 7 个 Phase 3+4 槽必须 non-`None`（4 KB + 3 identity `*InitOps`） | startup wire-up 顺序或缺项 |
+| **G18 alt** | `import aperag.app` 后 2 个 Phase 5/6 permanent 槽必须 non-`None`（`bot_service._quota_ops` / `runtime._prompt_template_ops`） | 上面两条永久 seam 漏了 |
+| **G19** | `aperag/domains/**/api/routes.py` 禁 `from __future__ import annotations` | PEP 563 + FastAPI 204 组合失败，lesson 9a-quatuordec |
+
+实战经验：
+
+- **G1 最容易撞**。写新 domain 时顺手写 `from aperag.db.models import ...` 就红。改成 `from aperag.domains.<d>.db.models import ...`。
+- **G15 / G16 撞上来就是改成 Protocol**。别 import `User` / `Role` 本身，读字段走 `Protocol` 声明的窄口。
+- **G17 / G18 alt 红意味着启动 wire-up 漏了一条** —— `aperag/app.py` 里对应 `set_x_ops(...)` 那行没跑到，通常是 `import` 顺序问题。
+- **G19 撞上来改成普通注解**（去掉文件头 `from __future__ import annotations`）。
+
+---
+
+## 4. ❓ 常见开发任务
 
 ### Q: 🔧 如何添加或修改 REST API 端点？
 
-**完整工作流程：**
-1. 使用 Python / Pydantic 定义 request / response model。
-2. 实现后端视图：`aperag/views/[module].py`
-3. 导出 code-first OpenAPI specs：
+**完整流程**：
+
+1. 定位 domain —— 按 §2.1 / §2.3 决定这个 endpoint 归哪个 domain。
+2. 请求 / 响应 schema 在 `aperag/domains/<d>/schemas.py` 加（或如果是共享原语，`aperag/schema/common.py`）。
+3. 业务逻辑在 `aperag/domains/<d>/service/` 里加方法。
+4. 在 `aperag/domains/<d>/api/routes.py` 加 `@router.post(...)` / `@router.get(...)`。注意：
+   - 路由参数用 `Annotated[AuthenticatedUser, Depends(required_user)]`，**不要** 用 `User`（会撞 G16）。
+   - **不要** 在 route module 顶部加 `from __future__ import annotations`（G19）。
+5. 导出 OpenAPI + 前端 typed client 更新：
+
    ```bash
-   make openapi-generate  # 写入 openapi.full.json 和 openapi.public.json
+   make openapi-generate   # 写 openapi.full.json + openapi.public.json
+   make openapi-check      # 验证导出链路干净
    ```
-4. 验证导出链路：
+
+6. 跑测试：
+
    ```bash
-   make openapi-check
+   make test-unit       # 包含 boundary tests（G1-G19）
+   make test-http-smoke # HTTP 黑盒 smoke，验证 endpoint 回正常
    ```
-5. 前端 typed client 更新统一通过 FE v2 adapter 层推进。
-6. 测试 API：
+
+### Q: 🗃️ 如何修改数据库模型 / schema？
+
+**迁移工作流程**：
+
+1. 定位 domain —— 实体属于哪个 domain。
+2. 改 `aperag/domains/<d>/db/models.py` 里的 SQLAlchemy 类。
+3. 生成 migration（Alembic autogenerate 能跨 domain 识别，是因为所有 `db/models.py` 共用 `aperag/db/base.py::Base`）：
+
+   ```bash
+   make db-revision  # 在 migration/versions/ 创建新 migration 文件
+   ```
+
+4. 人工检查生成的 migration；autogenerate 对 index/constraint rename 和某些复合变更可能出错，必要时手动修正。
+5. 应用：
+
+   ```bash
+   make db-migrate
+   ```
+
+6. 更新 `aperag/domains/<d>/service/` 里相关服务（**不要** 走 `aperag/service/*` shim 加业务逻辑）。
+7. 验证：
+
    ```bash
    make test-all
-   # ✅ 检查实时文档：http://localhost:8000/docs
    ```
 
-### Q: 🗃️ 如何修改数据库模型/架构？
+> 老 `aperag/db/models.py` 只是 re-export shim（把各 domain 的 ORM 重新导出，让旧 import 路径仍可用）。**不要**在 `aperag/db/models.py` 里加新 class —— 会绕开 domain ownership。
 
-**数据库迁移工作流程：**
-1. 编辑 `aperag/db/models.py` 中的 SQLModel 类
-2. 生成迁移文件：
+### Q: ⚡ 如何添加带后台处理的新功能？
+
+**流程**：
+
+1. 后端逻辑 → `aperag/domains/<d>/service/`
+2. Celery 任务 → `aperag/tasks/`（tasks 文件顺序按旧习惯保留在 top-level，不是 domain-owned；它们 import domain service 执行）
+3. 数据库模型 → `aperag/domains/<d>/db/models.py`
+4. 生成迁移 + 验证 API 契约：
+
    ```bash
-   make db-revision  # 在 migration/versions/ 中创建新迁移
-   ```
-3. 将迁移应用到数据库：
-   ```bash
-   make db-migrate  # 更新数据库架构
-   ```
-4. 更新相关代码（`aperag/db/repositories/` 中的仓库，`aperag/service/` 中的服务）
-5. 验证更改：
-   ```bash
-   make test-all  # ✅ 确保一切正常工作
+   make db-revision
+   make db-migrate
+   make openapi-check
    ```
 
-### Q: ⚡ 如何添加具有后台处理的新功能？
+5. 质量：
 
-**功能实现工作流程：**
-1. 实现功能组件：
-   - 后端逻辑：`aperag/[module]/`
-   - 异步任务：`aperag/tasks/`
-   - 数据库模型：`aperag/db/models.py`
-2. 更新 API 并验证 code-first contract：
-   ```bash
-   make db-revision      # 生成迁移文件
-   make db-migrate           # 应用数据库更改
-   make openapi-check         # 验证 FastAPI/Pydantic OpenAPI 导出
-   ```
-3. 质量保证：
    ```bash
    make format && make lint && make test-all
    ```
 
+如果你发现 `aperag/tasks/<x>.py` 里要调 `evaluation` 或 `agent_runtime` 而又想避免 import 循环，参考 `aperag/domains/evaluation/worker.py::dispatch_fn` 的 late-import 模式（canonical SSoT Section 2.5）。
+
 ### Q: 🧪 如何运行单元测试和 e2e 测试？
 
-**单元测试（快速，无外部依赖）：**
+**单元测试**（快，无外部依赖；包含 G1-G19 边界测试）：
+
 ```bash
-# 运行所有单元测试
+# 跑全部
 make test-unit
 
-# 运行特定测试文件
+# 跑单个文件
 uv run pytest tests/unit_test/test_model_service.py -v
 
-# 运行特定测试类或函数
+# 跑单个测试函数
 uv run pytest tests/unit_test/test_model_service.py::TestModelService::test_get_models -v
 
-# 运行带覆盖率的测试
-make test-unit
+# 只跑边界测试（G1-G19）
+uv run pytest tests/unit_test/test_modularization_boundaries.py -v
 ```
 
-**E2E 测试（需要运行服务）：**
-```bash
-# 设置：首先启动所需服务
-make infra-up      # 🗄️ 启动数据库
-make serve-api       # 🚀 启动 API 服务器（单独终端）
+**E2E 测试**（需要服务运行）：
 
-# 运行剩余的 pytest 版产品级 e2e
+```bash
+# 准备：先起数据库 + API
+make infra-up
+make serve-api                 # 单独终端
+
+# pytest e2e
 make test-e2e
 
-# 对运行中的服务执行 HTTP 黑盒 smoke
+# HTTP 黑盒 smoke
 make test-http-smoke
 
-# 运行后端集成测试
+# 集成测试
 make test-integration
 
-# 运行特定 pytest e2e 模块
+# 跑单个 e2e 文件
 uv run pytest tests/e2e_pytest/test_chat.py -v
 
-# 运行特定集成测试模块
-uv run pytest tests/integration/graphstorage/ -v
-
-# 运行带详细输出且不捕获的测试
+# 带 -s 看实时 print
 uv run pytest tests/e2e_pytest/test_chat.py -v -s
 
-# 性能基准测试（带计时）
+# 性能基准
 make test-e2e-perf
 ```
 
-**完整测试套件：**
+**全跑**：
+
 ```bash
-# 运行所有内容（单元 + e2e）
+# 单元 + e2e
 make test-all
 
-# 使用不同配置进行测试
-make infra-up WITH_NEO4J=1  # 使用 Neo4j 而不是 PostgreSQL 进行测试
+# 用不同后端配置跑
+make infra-up WITH_NEO4J=1
 make test-all
 ```
 
 ### Q: 🐛 如何调试失败的测试？
 
-**调试工作流程：**
-1. 单独运行失败的测试：
+1. 单独重跑并打开详细输出：
+
    ```bash
-   # 带完整输出的单个测试
    uv run pytest tests/unit_test/test_failing.py::test_specific_function -v -s
-   
-   # 在第一次失败时停止
+
+   # 第一次失败就停
    uv run pytest tests/unit_test/ -x --tb=short
    ```
-2. 对于 e2e 测试失败，确保服务正在运行：
+
+2. e2e 测试失败通常是服务没起全：
+
    ```bash
-   make infra-up       # 数据库服务
-   make serve-api         # API 服务器
-   make serve-worker         # 后台 workers（如果测试异步任务）
+   make infra-up
+   make serve-api
+   make serve-worker   # 如果测异步任务
    ```
-3. 使用调试工具：
+
+3. 调试工具：
+
    ```bash
-   # 使用 pdb 调试器运行
+   # pdb 断点
    uv run pytest tests/unit_test/test_failing.py --pdb
-   
-   # 在测试期间捕获日志
+
+   # 捕获日志
    uv run pytest tests/e2e_pytest/test_chat.py --log-cli-level=DEBUG
    ```
-4. 修复并重新测试：
+
+4. 修完再验证：
+
    ```bash
-   make format              # 自动修复样式问题
-   make lint               # 检查剩余问题
-   uv run pytest tests/path/to/fixed_test.py -v  # 验证修复
+   make format   # 自动修样式
+   make lint
+   uv run pytest tests/path/to/fixed_test.py -v
    ```
 
-### Q: 📦 如何安全地更新依赖项？
+### Q: 📦 如何安全地更新依赖？
 
-**Python 依赖项：**
-1. 编辑 `pyproject.toml`（添加/更新包）
-2. 更新虚拟环境：
+**Python**：
+
+1. 改 `pyproject.toml`
+2. `make env-install` 同步所有 group + extras
+3. `make test-all` 验证兼容
+
+**前端**：
+
+1. 改 `web/package.json`
+2. `cd web && yarn install`
+3. `make serve-web` 或 `yarn build` 检查编译
+
+### Q: 🚀 如何准备代码上生产？
+
+发布前清单：
+
+1. 代码质量：
+
    ```bash
-   make env-install            # 使用 uv 同步所有组和额外内容
-   make test-all              # 验证兼容性
+   make format        # 自动修
+   make lint          # 无 style 违规
+   make static-check  # mypy 类型检查
    ```
 
-**前端依赖项：**
-1. 编辑 `frontend/package.json`
-2. 更新并测试：
-   ```bash
-   cd frontend && yarn install
-   make serve-web      # 测试前端编译
-   ```
-
-### Q: 🚀 如何准备代码进行生产部署？
-
-**部署前检查清单：**
-1. 代码质量验证：
-   ```bash
-   make format            # 自动修复所有样式问题
-   make lint             # 验证无样式违规
-   make static-check     # MyPy 类型检查
-   ```
 2. 全面测试：
+
    ```bash
-   make test-all             # 所有单元 + e2e 测试
-   make test-e2e-perf  # 性能基准测试
+   make test-all
+   make test-e2e-perf
    ```
+
 3. API 一致性：
+
    ```bash
-   make openapi-check       # 确保 code-first OpenAPI 可以导出
+   make openapi-check
    ```
+
 4. 数据库迁移：
+
    ```bash
-   make db-revision    # 生成任何待处理的迁移
+   make db-revision
    ```
-5. 全栈集成测试：
+
+5. 类生产栈集成验证：
+
    ```bash
-   make stack-up WITH_NEO4J=1 WITH_DOCRAY=1  # 类似生产的设置
-   # 在 http://localhost:3000/web/ 手动测试
+   make stack-up WITH_NEO4J=1 WITH_DOCRAY=1
+   # 手动在 http://localhost:3000/web/ 测
    make stack-down
    ```
 
-### Q: 🔄 如何完全重置我的开发环境？
+### Q: 🔄 如何完全重置开发环境？
 
-**核选项重置（销毁所有数据）：**
+**核选项**（会清数据）：
+
 ```bash
-make stack-down REMOVE_VOLUMES=1  # ⚠️ 停止服务 + 删除所有数据
-make env-clean                         # 🧹 清理临时文件
+make stack-down REMOVE_VOLUMES=1
+make env-clean
 
-# 重新开始
-make infra-up                 # 🗄️ 新的数据库
-make db-migrate                      # 🔄 应用所有迁移
-make serve-api                  # 🚀 启动 API 服务器
-make serve-worker                   # ⚡ 启动后台 workers
+# 从头
+make infra-up
+make db-migrate
+make serve-api
+make serve-worker
 ```
 
-**软重置（保留数据）：**
+**软重置**（保留数据）：
+
 ```bash
-make stack-down                 # ⏹️ 停止服务，保留数据
-make infra-up               # 🗄️ 重启数据库
-make db-migrate                    # 🔄 应用任何新迁移
+make stack-down
+make infra-up
+make db-migrate
 ```
 
-**仅重置 Python 环境：**
+**只重置 Python 环境**：
+
 ```bash
-rm -rf .venv/                   # 🗑️ 移除虚拟环境
-make env-dev                       # ⚙️ 重新创建所有内容
-source .venv/bin/activate      # ✅ 重新激活
-``` 
+rm -rf .venv/
+make env-dev
+source .venv/bin/activate
+```
+
+---
+
+## 5. 📚 拓展阅读
+
+- [`docs/modularization/architecture.md`](../../modularization/architecture.md) — canonical 英文 SSoT，所有边界 / permanent seam / shim 清单的权威版本
+- [`docs/zh-CN/architecture/overview.md`](../architecture/overview.md) — 架构入口（中文）
+- [`docs/zh-CN/architecture/domains.md`](../architecture/domains.md) — 12 domain 通览（中文）
+- [`docs/modularization/breaking-changes/`](../../modularization/breaking-changes/) — 各 phase 的变更说明，改老代码前可读
+- [`tests/unit_test/test_modularization_boundaries.py`](../../../tests/unit_test/test_modularization_boundaries.py) — 20 条边界测试实现，是理解 G1–G19 最硬的权威
+
+---
+
+*文档基线：`origin/main @ 10cabcf`（PR #1637 merged）。Module-owner / G-gate 定义若发生变化，先改 canonical SSoT，再回头更新本文。*


### PR DESCRIPTION
## Summary

task #8 正文 rewrite PR cluster（per PM msg=a7d9f216 "1 task = 1 PR cluster" lock，blueprint PR #1637 Section 5 owner map）。

3 个文件，3 commits by doc：

- `docs/zh-CN/architecture/overview.md`（+80 LOC，new）— 架构入口短文；short entry + navigation，不重复 canonical invariants，cross-ref 到 `docs/modularization/architecture.md`
- `docs/zh-CN/architecture/domains.md`（+241 LOC，new）— 12 domain 通览；per-domain directory contract + 一段话定位 + cross-domain dependency 图 + shared-infra catalog + 新代码落位决策树
- `docs/zh-CN/development/development-guide.md`（+338 / -203，KEEP+UPDATE from 378→513 LOC）— 原 env setup Q&A 保留；**新增** §2 post-modularization 代码布局 + §3 G1-G19 gate 速查 + §4 重写 Q&A 把 import path 指向 `aperag/domains/<d>/...` canonical

## Scope discipline

按 PM + architect locks：
- **Current-state only**；不写历史 / roadmap（与 canonical SSoT 同规则）
- **不复述 canonical invariants**（12 domain 清单 / G1-G19 定义 / dual-hook / permanent seam）— cross-ref 即可
- **入口向 / 索引向**；不 deep-dive domain internals（由其他 lane 的 consolidated doc cover）
- Baseline: `origin/main @ 10cabcf`（PR #1637 merged）

## Cross-reference 目标

- 所有 architecture invariants → [`docs/modularization/architecture.md`](../docs/modularization/architecture.md)
- Phase-specific 变更 → `docs/modularization/breaking-changes/phase*.md`
- 后续 consolidated docs（其他 lane 在写）：
  - `docs/zh-CN/architecture/identity-governance-model-platform-marketplace.md`（@Bryce task #10）
  - `docs/zh-CN/architecture/indexing-retrieval-kg.md`（@Bryce task #11 + @cuiwenbo contributor）
  - `docs/zh-CN/architecture/conversation-agent-evaluation.md`（@chenyexuan task #9）
  - `docs/zh-CN/architecture/web-access.md`（@Bryce task #12）

## Review routing 建议

- **@Weston**：new IA consistency（overview.md navigation map + domains.md cross-ref 是否对齐 new 8-category IA）
- **@符炫炜**：canonical consistency（overview.md / domains.md 对 `docs/modularization/architecture.md` invariants 的引用是否准确无歧义）
- **@chenyexuan / @cuiwenbo / @Bryce**：各自 domain 一段话定位（§3.1–§3.12）是否精确
- PM 按 blueprint 决定 merge 时机

## Test plan

- [x] 3 commits 独立，每个可独立 review
- [x] Markdown 语法手动 verify（表格 / 代码块 / 链接）
- [x] 文档 repo links 相对路径 verify（无绝对路径 / external-only link hardcode）
- [ ] reviewer consistency check on domain 一段话定位
- [ ] merge 后加 cross-link 到 other lane consolidated docs（当 Bryce / chenyexuan / cuiwenbo 的 doc 落地时）

🤖 Generated with [Claude Code](https://claude.com/claude-code)