### PR TITLE
docs(zh-CN): task #17 — integration/mcp + dify + deployment/build-docker-image (3 docs)

### DIFF
--- a/docs/zh-CN/deployment/build-docker-image.md
+++ b/docs/zh-CN/deployment/build-docker-image.md
@@ -1,50 +1,204 @@
 ---
 title: 构建 Docker 镜像
-description: 如何构建 ApeRAG 容器镜像
+description: 构建 ApeRAG 后端与前端容器镜像、本地调试与多平台发布的完整指南
+position: 1
 ---
 
-# 构建指南
+# 构建 Docker 镜像
 
-本节介绍如何构建 ApeRAG 容器镜像。这主要适用于需要创建自己的构建或部署到"快速开始"中未涵盖的环境的用户。
+本文覆盖从本地单平台构建到多平台发布的完整流程。适合两类读者：
 
-## 构建容器镜像
+- 想把改动后的代码打进自己镜像，在 Docker Compose 或 Kubernetes 上自验的开发者
+- 准备把 ApeRAG 集成到自己 CI 流水线里，做内部发布的运维/平台团队
 
-项目使用 Docker 和 `make` 命令来构建容器镜像。
+如果你只想跑起 ApeRAG 而不改代码，直接用官方镜像 + 根目录的 [`docker-compose.yml`](https://github.com/apecloud/ApeRAG/blob/main/docker-compose.yml)（见 [快速开始](../getting-started/quickstart.md)），不需要本文。
 
-*   **本地平台构建**：
-    这些命令为您当前机器的架构构建镜像。
-    ```bash
-    # 为本地平台构建所有必要的镜像
-    make build-local
+## 镜像构成
 
-    # 仅为本地平台构建后端镜像
-    make build-aperag-local
+ApeRAG 由两个独立镜像组成，`docker-compose.yml` 里分别对应 `api` / `celeryworker` / `celerybeat` / `flower`（共用后端镜像）和 `frontend`：
 
-    # 仅为本地平台构建前端镜像
-    make build-aperag-frontend-local
-    ```
+| 镜像 | 用途 | Dockerfile | 基础镜像 |
+|------|------|-----------|---------|
+| `apecloud/aperag` | FastAPI 主进程 + Celery worker/beat/flower | [`Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/Dockerfile) | `python:3.11.13-slim`（多阶段 + uv） |
+| `apecloud/aperag-frontend` | Next.js standalone 构建产物 + PM2 runtime | [`web/Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/web/Dockerfile) | `node:20.18.0-alpine` |
 
-*   **多平台构建**：
-    这些命令为多种架构（例如 amd64、arm64）构建镜像。这需要设置和配置 Docker Buildx。
-    ```bash
-    # 为多个平台构建所有必要的镜像
-    make build
+默认镜像仓库是 `apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com`（阿里云张家口）；`docker-compose.yml` 在本机使用时会回退到 Docker Hub（`${REGISTRY:-docker.io}`）。
 
-    # 仅为多个平台构建后端镜像
-    make build-aperag
+## 前置条件
 
-    # 仅为多个平台构建前端镜像
-    make build-aperag-frontend
-    ```
-    您可以使用 `PLATFORMS` 变量指定目标平台，例如：
-    ```bash
-    make build PLATFORMS=linux/amd64,linux/arm64
-    ```
+- Docker 20.10 或更新（需要 `docker buildx` 子命令）
+- 前端构建需要 **Node.js 20+** 和 **Yarn classic** — 这是为了在宿主机先生成 `web/build/` 输出后再打包进镜像
+- 多平台构建需要可用的 QEMU（macOS Docker Desktop 默认自带；Linux 需先 `docker run --privileged --rm tonistiigi/binfmt --install all`）
+- 可选：`make`（所有命令都有对应 Makefile target，推荐用 Makefile）
 
-## 部署
+本地构建不需要在宿主机安装 Python/uv — 这些都在镜像构建阶段的容器里完成。
 
-有关常见的部署方法，请参考主 README 中的"快速开始"部分：
-*   [Kubernetes 快速开始](../README-zh.md#kubernetes-部署推荐生产环境)
-*   [Docker Compose 快速开始](../README-zh.md#快速开始)
+## 本地单平台构建
 
-对于自定义部署，您需要调整这些方法或使用构建的容器镜像与您选择的编排平台配合使用。确保所有必需的服务（数据库、后端、前端、Celery worker）都正确配置并能够相互通信。 
+开发自验推荐走本地构建，只构建当前机器架构、不推送仓库。镜像直接 `--load` 到本机 Docker daemon。
+
+```bash
+# 同时构建后端 + 前端
+make build-local
+
+# 只构建后端
+make build-aperag-local
+
+# 只构建前端
+make build-aperag-frontend-local
+```
+
+默认版本标签是 `nightly`（见 Makefile 顶部 `VERSION ?= nightly`），想覆盖传 `VERSION` 即可：
+
+```bash
+make build-local VERSION=v1.0.0-dev
+```
+
+构建完成后本地 Docker 里就会出现 `apecloud/aperag:v1.0.0-dev` 和 `apecloud/aperag-frontend:v1.0.0-dev`，可以直接用在 `docker-compose.yml` 里：
+
+```bash
+REGISTRY='' VERSION=v1.0.0-dev docker compose up -d
+```
+
+（`REGISTRY=''` 让 compose 用无前缀的镜像名，匹配本机打好的 tag。）
+
+## 多平台构建
+
+发布到仓库时要同时产出 `linux/amd64` 和 `linux/arm64`。多平台构建走 `docker buildx`，并且**必须携带 `--push`**（`docker buildx build` 不支持把多平台 manifest `--load` 到本机）。
+
+Makefile 已经包装好了：
+
+```bash
+# 构建并推送后端 + 前端到 ${REGISTRY}
+make build VERSION=v1.2.3 REGISTRY=docker.io
+
+# 只发后端
+make build-aperag VERSION=v1.2.3 REGISTRY=docker.io
+
+# 只发前端
+make build-aperag-frontend VERSION=v1.2.3 REGISTRY=docker.io
+```
+
+默认目标架构是 `linux/amd64,linux/arm64`，可通过 `BUILDX_PLATFORM` 覆盖：
+
+```bash
+make build VERSION=v1.2.3 BUILDX_PLATFORM=linux/amd64
+```
+
+首次运行时会自动创建名为 `multi-platform` 的 buildx builder（`make setup-builder`）；排查 builder 本身的问题可以 `make clean-builder` 后重跑。
+
+## 版本与镜像标签
+
+构建时参与的 Make 变量：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `VERSION` | `nightly` | 镜像 tag；发版时建议传 Git tag（如 `v1.2.3`） |
+| `REGISTRY` | `apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com` | 推送目标仓库 |
+| `APERAG_IMAGE` | `apecloud/aperag` | 后端镜像仓库名 |
+| `APERAG_FRONTEND_IMG` | `apecloud/aperag-frontend` | 前端镜像仓库名 |
+| `BUILDX_PLATFORM` | `linux/amd64,linux/arm64` | 多平台目标 |
+| `BUILDX_ARGS` | `--sbom=false --provenance=false` | 额外 buildx 参数 |
+
+镜像内部会烧入一份 `aperag/version/__init__.py`（由 `release-version` 目标在每次 build 前重新生成），包含 `VERSION` 字符串和当前 `HEAD` 的 7 位短 commit hash，便于线上反查当前运行的代码版本。
+
+## 后端镜像细节
+
+[`Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/Dockerfile) 采用 2-stage 构建：
+
+1. **Builder 阶段**：基于 `python:3.11.13-slim`，安装 `uv` 并 `uv sync --active` 把所有依赖安装进 `/opt/venv`。
+2. **Final 阶段**：全新的 `python:3.11.13-slim`，只从 builder 拷贝 `/opt/venv`，再 `COPY . /app` 并 `pip install --no-deps -e .`，把项目代码以可编辑模式挂上。
+
+这种结构的好处：
+
+- Runtime 镜像里不保留 `build-essential` / `git` / `uv` 等构建工具，面向最终用户的镜像保持较小体积
+- 依赖层 (`uv sync`) 与代码层 (`COPY . /app`) 分离，只改业务代码不会使依赖缓存失效
+
+Entrypoint 是 [`scripts/entrypoint.sh`](https://github.com/apecloud/ApeRAG/blob/main/scripts/entrypoint.sh)，会先等 PostgreSQL 起来、确保 `pgvector` 扩展存在，再 `exec` 真正的启动命令（`scripts/start-api.sh` / `scripts/start-celery-worker.sh` 等）。
+
+## 前端镜像细节
+
+[`web/Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/web/Dockerfile) 是一个 runtime-only 的镜像：它假设 `web/build/` 已经在宿主机上构建好，直接把它拷进容器，再装 PM2、用 `pm2-runtime start server.js` 启动。
+
+所以完整的前端构建流程是两步：
+
+1. `make build-aperag-frontend-assets` 在宿主机上跑 `yarn install && yarn build`，产出 `web/build/`（Next.js standalone 输出）
+2. `docker buildx build` 打包成镜像
+
+`make build-aperag-frontend[-local]` 已经把这两步串起来了，手工调试时也可以单独跑 step 1 观察前端构建日志。
+
+镜像暴露端口 3000，环境变量 `PORT=3000`、`HOSTNAME=0.0.0.0`；Docker Compose 里前端通过 `API_SERVER_ENDPOINT=http://api:8000` 反向代理到后端。
+
+## Docker Compose
+
+打完镜像后，根目录的 [`docker-compose.yml`](https://github.com/apecloud/ApeRAG/blob/main/docker-compose.yml) 是最常用的 orchestration 入口。除了 `api` / `celeryworker` / `celerybeat` / `flower` / `frontend`，还包含所有必需的基础设施服务：`postgres`（含 pgvector）、`redis`、`qdrant`、`es`（Elasticsearch 带 IK 分词器）。
+
+三个可选服务通过 Docker Compose profile 控制，默认不启动：
+
+- `--profile jaeger`：启动 Jaeger all-in-one 用于分布式追踪
+- `--profile neo4j`：启动 Neo4j 5.26 enterprise 作为 Graph 后端（可选，默认用 PostgreSQL 存储图数据）
+- `--profile nebula`：启动 Nebula Graph 3.8 作为 Graph 后端（与 `neo4j` profile 互斥）
+
+常用命令：
+
+```bash
+# 只启动默认服务（不带 profile）
+docker compose up -d
+
+# 带 Neo4j 图库
+docker compose --profile neo4j up -d
+
+# 关掉并清卷（危险：会删除 PostgreSQL / Qdrant / ES 数据）
+docker compose down -v
+```
+
+## Kubernetes 部署入口
+
+Helm chart 位于 [`deploy/aperag/`](https://github.com/apecloud/ApeRAG/tree/main/deploy/aperag)，`values.yaml` 里的 image 相关字段直接对应本文档的构建产物：
+
+- `image.repository`（默认 `docker.io/apecloud/aperag`）
+- `image.tag`（默认 `v0.0.0-nightly`）
+- 前端字段同理（`frontend.image.repository` / `frontend.image.tag`）
+
+如果要在本地 KinD / minikube 里用刚 build 好的本地镜像，可以跳过推送直接 side-load：
+
+```bash
+# minikube
+make load-images-to-minikube VERSION=v1.0.0-dev
+
+# KinD
+make load-images-to-kind VERSION=v1.0.0-dev KIND_CLUSTER_NAME=aperag
+```
+
+## CI 发布流程
+
+仓库里用 [`.github/workflows/release-image.yml`](https://github.com/apecloud/ApeRAG/blob/main/.github/workflows/release-image.yml) 自动发布镜像。两种触发方式：
+
+- **GitHub Release published**：自动用 release tag 作为镜像 tag，同时发布后端与前端两个镜像，成功后触发 E2E workflow
+- **Workflow dispatch**：手动触发，支持只发某一个镜像（`image_name` 下拉），tag 来自 `image_tag` 输入
+
+工作流本身不直接写 `docker buildx`，而是复用 `apecloud/apecloud-cd/.github/workflows/release-image-cache-sync.yml` 做多平台构建 + 仓库缓存同步；具体镜像名称、Dockerfile 路径、pre-build 钩子（`MAKE_OPS_PRE: build-aperag-frontend-assets`）都通过 inputs 传入。
+
+## 常见问题
+
+**Q：只改了后端代码，前端不想重新 build？**
+只跑 `make build-aperag-local`。前端镜像可以继续用上次的；`docker-compose.yml` 里两个镜像的 tag 是各自独立的环境变量控制。
+
+**Q：`yarn build` 报错 `ENOMEM`？**
+前端 standalone build 会占用比较多内存（~2GB）。在 CI 或小内存容器里构建时，通过 `NODE_OPTIONS=--max-old-space-size=4096 yarn build` 提高 heap 限制。
+
+**Q：构建多平台镜像时报 `no match for platform in manifest`？**
+一般是基础镜像在该 registry mirror 下没有 arm64 manifest。尝试 `docker pull` 基础镜像时带 `--platform=linux/arm64` 确认可用；不行就切换回 Docker Hub。
+
+**Q：可不可以只发后端不发前端？**
+可以。`make build-aperag VERSION=... REGISTRY=...` 只发后端；前端可以继续用官方镜像或者上次发的版本。`docker-compose.yml` 里两个 tag 独立，拆版发布不会冲突。
+
+**Q：`Dockerfile` 里为什么要 `pip install --no-deps -e .`？**
+`uv sync` 已经把所有依赖装进 `/opt/venv`，这一步只负责把 `aperag/` 包以 editable 模式挂到 venv 里（主要是为了让 `importlib.metadata` 能正确返回包信息），不再安装依赖。
+
+## 相关链接
+
+- [`docker-compose.yml`](https://github.com/apecloud/ApeRAG/blob/main/docker-compose.yml) — 单机编排入口
+- [`deploy/aperag/`](https://github.com/apecloud/ApeRAG/tree/main/deploy/aperag) — Helm chart
+- [快速开始](../getting-started/quickstart.md) — 仅使用官方镜像的最短路径
+- [如何调试](../reference/how-to-debug.md) — 启动失败 / 日志排查

--- a/docs/zh-CN/integration/dify.md
+++ b/docs/zh-CN/integration/dify.md
@@ -179,5 +179,5 @@ Dify 会自动拉取 ApeRAG MCP Server 暴露的工具清单。配置成功后�
 
 - [MCP 集成指南](./mcp.md) — ApeRAG MCP Server 架构、认证和通用客户端接入
 - [MCP API 参考](./mcp-api.md) — 5 个工具的完整参数/返回 schema
-- `docs/zh-CN/integration/openai-compat.md` — 另一条可用于 Dify 自定义模型接入的路径（Bryce lane 起草中，merge 后即为站内链接）
+- [OpenAI 兼容 API](./openai-compat.md) — 另一条可用于 Dify 自定义模型接入的路径
 - **GitHub**：[apecloud/ApeRAG](https://github.com/apecloud/ApeRAG)

--- a/docs/zh-CN/integration/dify.md
+++ b/docs/zh-CN/integration/dify.md
@@ -1,6 +1,7 @@
 ---
 title: Dify 集成 ApeRAG
-description: 通过 MCP 协议快速集成 ApeRAG 的 Graph RAG 能力
+description: 通过 MCP 协议在 Dify Agent 中调用 ApeRAG 的混合检索与 Graph-RAG 能力
+position: 2
 keywords: Dify, ApeRAG, MCP, Graph RAG
 ---
 
@@ -12,6 +13,12 @@ ApeRAG 是一款具备多模态索引、AI 智能体、MCP 支持及可扩展 K8
 - 不同于"标准" RAG，ApeRAG 实现了 **Graph-RAG**，通过构建知识图谱理解数据要素之间的深层关系
 - 集成了 **MinerU**，专为复杂文档、科学论文和财务报告设计，可以准确提取表格、公式和工程图表
 - 全面支持 Kubernetes，提供内置的**高可用性**、**可扩展性**和**企业级管理能力**
+
+## 集成原理
+
+ApeRAG 侧没有 Dify 专属的适配代码，整条链路完全基于标准的 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)：Dify 的 Agent 节点支持把任意 MCP Server 挂成工具集，ApeRAG 启动时就内置了一个 MCP Server（路径 `/mcp/`，与 REST API 共生于 8000 端口）。Dify Agent 通过 HTTP + `Authorization: Bearer <ApeRAG API Key>` 直接调用 ApeRAG 的 5 个工具：知识库检索、聊天文件检索、网页搜索、网页抓取、知识库列表。
+
+如果想先了解 ApeRAG MCP 的架构细节与客户端配置通用说明，参见 [MCP 集成指南](./mcp.md)；每个工具的完整参数与返回 schema 见 [MCP API 参考](./mcp-api.md)。
 
 ## 视频演示
 
@@ -29,19 +36,19 @@ ApeRAG 是一款具备多模态索引、AI 智能体、MCP 支持及可扩展 K8
   </iframe>
 </div>
 
-## Step 1: 准备知识库
+## Step 1：准备知识库
 
-打开 ApeRAG Web 界面（见[快速开始](../../../README-zh.md#快速开始)；Docker Compose 启动时一般为 http://localhost:3000/web/）。登录后选择或导入知识库。下文以「三国演义」知识库为例，点击订阅。
+打开 ApeRAG Web 界面（Docker Compose 启动时一般为 `http://localhost:3000/web/`；部署细节参考 [构建 Docker 镜像](../deployment/build-docker-image.md) 和 README-zh）。登录后选择或导入一个知识库。下文以「三国演义」知识库为例，点击订阅。
 
 <div align="center">
   <img src="/images/zh-CN/dify/step1-subscribe-collection.png" alt="订阅知识库" width="800" />
 </div>
 
-## Step 2: 配置 MCP Server
+## Step 2：配置 MCP Server
 
 ### 2.1 添加 MCP Server
 
-来到 Dify - 工具 - MCP，点击添加 MCP Server。
+进入 Dify → 工具 → MCP，点击添加 MCP Server。
 
 <div align="center">
   <img src="/images/zh-CN/dify/step2-add-mcp.png" alt="添加 MCP Server" width="800" />
@@ -49,7 +56,9 @@ ApeRAG 是一款具备多模态索引、AI 智能体、MCP 支持及可扩展 K8
 
 ### 2.2 填写配置信息
 
-填写 Server URL：`http://localhost:8000/mcp/`（若非本机部署，请改为实际 API 地址，例如 `https://<你的域名>/mcp/`），并粘贴从 ApeRAG 复制的 API Key，点击确定。
+**Server URL**：`http://localhost:8000/mcp/`（非本机部署时改成实际 API 地址，如 `https://<你的域名>/mcp/`）。
+
+**API Key**：从 ApeRAG Web 控制台复制，作为 `Bearer` token 填入。
 
 <div align="center">
   <img src="/images/zh-CN/dify/step2-configure-mcp.png" alt="配置 MCP" width="700" />
@@ -61,17 +70,17 @@ ApeRAG 是一款具备多模态索引、AI 智能体、MCP 支持及可扩展 K8
 
 ### 2.3 配置成功
 
-MCP Server 添加成功。
+Dify 会自动拉取 ApeRAG MCP Server 暴露的工具清单。配置成功后应能看到 `list_collections`、`search_collection`、`search_chat_files`、`web_search`、`web_read` 五个工具。
 
 <div align="center">
   <img src="/images/zh-CN/dify/step2-mcp-success.png" alt="MCP 配置成功" width="800" />
 </div>
 
-## Step 3: 创建 Agent 应用
+## Step 3：创建 Agent 应用
 
 ### 3.1 创建应用
 
-来到 Dify - Studio，点击创建应用。
+进入 Dify → Studio，点击创建应用。
 
 <div align="center">
   <img src="/images/zh-CN/dify/step3-create-app.png" alt="创建应用" width="800" />
@@ -79,15 +88,15 @@ MCP Server 添加成功。
 
 ### 3.2 选择类型
 
-点击更多基础应用类型，选择 **Agent** 类型，命名后点击创建。
+点击更多基础应用类型，选择 **Agent**，命名后创建。
 
 <div align="center">
   <img src="/images/zh-CN/dify/step3-select-agent.png" alt="选择 Agent 类型" width="700" />
 </div>
 
-## Step 4: 配置 Agent
+## Step 4：配置 Agent
 
-点击 Agent，输入 Prompt，在工具里添加创建好的 ApeRAG MCP，右上角选择驱动 Agent 的大语言模型，点击发布运行即可使用。
+点击 Agent，输入 Prompt，在工具里添加配置好的 ApeRAG MCP Server，右上角选择驱动 Agent 的大语言模型，点击发布运行即可。
 
 <div align="center">
   <img src="/images/zh-CN/dify/step4-configure-agent.png" alt="配置 Agent" width="800" />
@@ -98,6 +107,8 @@ MCP Server 添加成功。
 </div>
 
 ### Prompt 参考
+
+下列 Prompt 针对 ApeRAG 现有的 5 个 MCP 工具（`list_collections` / `search_collection` / `search_chat_files` / `web_search` / `web_read`）编写，可直接贴到 Dify Agent 的系统提示词位置：
 
 ```markdown
 # ApeRAG 智能助手
@@ -110,33 +121,29 @@ MCP Server 添加成功。
 
 **语言智能**：始终用用户提问的语言回应。用户用中文提问时，无论源语言如何都用中文回应。
 
-**可视化思维**：**[关键]** 您是一个偏好视觉解释的助手。凡是涉及实体关系、流程或结构的信息，您必须优先考虑将其可视化。
-
 **完整解决**：从多角度探索，交叉验证来源，确保全面覆盖后再回应。
 
 ## 搜索策略
 
 ### 优先级系统
 1. **用户指定知识库**（通过"@"提及）：严格限制仅搜索指定库
-2. **未指定知识库**：自主发现并搜索相关库
-3. **网络搜索**（如启用）：补充信息
+2. **未指定知识库**：先用 `list_collections` 自主发现，再选择相关库搜索
+3. **网络搜索**（如启用）：补充时效性信息
 4. **清晰归属**：始终标注来源
 
 ### 搜索执行
-- **知识库搜索**：默认使用向量+图搜索
+- **知识库搜索**：默认同时开启向量、全文、图谱、摘要、视觉五种检索方式
 - **结果处理逻辑**：
   1. 执行搜索
-  2. **检测图数据**：检查搜索结果是否包含 `entities` (实体) 和 `relationships` (关系)
-  3. **强制可视化**：如果搜索结果包含非空的实体或关系数据，**您必须**调用 `create_diagram` 工具
-  4. **内容甄别**：忽略不相关结果
+  2. 如结果包含实体 / 关系数据（`recall_type == "graph_search"`），在回复正文中显式说明涉及的实体与关系
+  3. 忽略不相关结果
 
 ## 可用工具
 
 ### 知识管理
 - `list_collections()`：发现可用知识源
-- `search_collection(collection_id, query, ...)`: **[主要工具]** 在持久化知识库中进行混合搜索
-- `search_chat_files(chat_id, query, ...)`: **[仅限聊天]** 仅搜索用户在本次聊天会话中临时上传的文件
-- `create_diagram(content)`：**[强制工具]** 当搜索结果包含结构化信息（实体/关系）时，必须调用此工具生成 Mermaid 图表
+- `search_collection(collection_id, query, ...)`：**[主要工具]** 在持久化知识库中进行混合搜索
+- `search_chat_files(chat_id, query, ...)`：**[仅限聊天]** 仅搜索用户在本次聊天会话中临时上传的文件
 
 ### 网络智能
 - `web_search(query, ...)`：多引擎网络搜索
@@ -150,10 +157,6 @@ MCP Server 添加成功。
 ### 全面分析
 [包含上下文和见解的详细解释]
 
-### 知识图谱可视化
-[此处展示工具生成的图表]
-*（仅在成功调用 create_diagram 后显示。该图表展示了基于搜索结果的实体关系。）*
-
 ### 支持证据
 - [知识库名称]：[关键发现]
 
@@ -161,8 +164,20 @@ MCP Server 添加成功。
 - [标题]（[域名]）- [要点]
 ```
 
----
+## 常见问题
 
-ApeRAG + Dify 的集成非常简单，集成后不仅可以体验 Dify 的平台功能，还可以享受到 **ApeRAG 强大的 Graph-RAG 能力**，感兴趣的小伙伴快去试试吧！
+**Q：Dify 能把 ApeRAG 当成"外部知识库"（External Knowledge Base）连接吗？**
+不行。ApeRAG 当前没有实现 Dify External KB 的专属 HTTP 契约。Dify 侧的集成路径只有两条：本文介绍的 MCP 工具调用，以及直接把 ApeRAG 的 OpenAI 兼容端点（`POST /v1/chat/completions`，见代码路径 `aperag/views/openai.py`）当成自定义模型接入。
 
-**GitHub**: https://github.com/apecloud/ApeRAG
+**Q：Agent 没看到我的知识库？**
+先在 ApeRAG Web 控制台确认当前 API Key 对应的用户能在知识库列表里看到目标 collection。`list_collections` 返回的范围就是 Key 对应用户的可见范围。
+
+**Q：工具调用失败返回 401 / 403？**
+检查 Dify 填写的 API Key 是否与 ApeRAG Web 控制台完全一致；Bearer token 前缀由 Dify 自动加上，不需要在 Key 里再带 `Bearer`。
+
+## 相关链接
+
+- [MCP 集成指南](./mcp.md) — ApeRAG MCP Server 架构、认证和通用客户端接入
+- [MCP API 参考](./mcp-api.md) — 5 个工具的完整参数/返回 schema
+- `docs/zh-CN/integration/openai-compat.md` — 另一条可用于 Dify 自定义模型接入的路径（Bryce lane 起草中，merge 后即为站内链接）
+- **GitHub**：[apecloud/ApeRAG](https://github.com/apecloud/ApeRAG)

--- a/docs/zh-CN/integration/mcp.md
+++ b/docs/zh-CN/integration/mcp.md
@@ -1,0 +1,111 @@
+---
+title: MCP 集成指南
+description: ApeRAG 内置 MCP Server，用于让 Claude Desktop、Cursor、Dify 等 AI 客户端直接调用知识库检索与网页抓取能力
+position: 1
+---
+
+# MCP 集成指南
+
+ApeRAG 内置了一个 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) Server，与主 API 进程共生，不需要额外部署。任何支持 MCP 协议的客户端（Claude Desktop、Cursor、Dify、Pydantic AI Agent 等）都可以通过 HTTP 直接调用 ApeRAG 的 5 个工具：知识库检索、聊天临时文件检索、网页搜索、网页内容抓取、知识库列表。
+
+本文只描述「怎么接入 ApeRAG MCP」和「底层是怎么跑起来的」。每个工具的完整参数、返回 schema 和调优建议，见 [MCP API 参考](./mcp-api.md)。
+
+## 架构一览
+
+- **进程模型**：MCP Server 是 FastAPI 主进程的子挂载，路径为 `/mcp/`；它通过 [FastMCP](https://github.com/jlowin/fastmcp) 框架实现，运行在 stateless HTTP 模式（与 SSE 兼容），复用同一个 `uvicorn` 进程、同一份 8000 端口。
+- **业务边界**：MCP Server 自己不持有数据层，所有工具都是通过 `httpx` 回调 ApeRAG 自身的 `/api/v1/...` 和 `/api/v2/...` 路由，最终走到 `retrieval` / `knowledge_base` / `web_access` 等 domain；这样客户端走 MCP 和走 REST API 看到的语义一致。
+- **共享基础设施**：`aperag/mcp/` 在后端模块化划分里属于 "shared infrastructure"，不是独立 domain。详见 [`docs/modularization/architecture.md`](../../modularization/architecture.md) 第 F10 条「跨域共享基础设施」相关条目。
+- **内部复用**：ApeRAG 的 Agent Runtime V3 自身也会把同一 MCP Server 当作 toolset 注入到 Agent Turn 里，启动时通过环境变量 `APERAG_MCP_URL`（默认 `http://localhost:8000/mcp/`）引用。
+
+## 开箱即用
+
+默认部署无需额外配置即可启用 MCP：
+
+- **Docker Compose**：`docker-compose up -d` 即可，`api` 服务的 `8000:8000` 端口同时暴露 REST API 和 MCP Server。
+- **健康检查**：`curl http://localhost:8000/health` 正常即说明主进程和 MCP 子挂载都已启动。
+- **关闭 MCP**：目前没有提供关闭开关；MCP Server 与主进程共生。
+
+可选环境变量：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `APERAG_API_KEY` | — | MCP 认证备用凭证；仅当客户端没带 `Authorization` 头时才会读到 |
+| `OTEL_MCP_ENABLED` | `true` | 是否为 MCP 开启 OpenTelemetry 追踪；排查性能问题时可关掉 |
+| `APERAG_MCP_URL` | `http://localhost:8000/mcp/` | Agent Runtime 内部回连 MCP 的地址，仅当你把 MCP 反向代理到非默认路径时才需要改 |
+
+## 认证
+
+MCP Server 有两条认证通道，按优先级读取：
+
+1. **HTTP Authorization 头（推荐，生产环境唯一可用方式）**：客户端在每次请求里带 `Authorization: Bearer <api-key>`。API Key 在 ApeRAG Web 控制台创建。
+2. **环境变量 `APERAG_API_KEY`（备用，单租户场景）**：当 Authorization 头缺失时才回退到这个。多用户同时使用时会导致互相串号，不要在生产环境启用。
+
+两种方式都没命中时，MCP Server 会直接报错拒绝请求。
+
+## 客户端接入
+
+### Claude Desktop
+
+修改 Claude Desktop 的 `claude_desktop_config.json`：
+
+```json
+{
+  "mcpServers": {
+    "aperag": {
+      "url": "http://localhost:8000/mcp/",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+远程部署时把 `http://localhost:8000/mcp/` 替换成你的实际地址（`https://<你的域名>/mcp/`）。保存后重启 Claude Desktop 即可在对话中看到 `list_collections`、`search_collection` 等工具。
+
+### Cursor
+
+在 `~/.cursor/mcp.json` 或项目级 `.cursor/mcp.json` 里加入与 Claude Desktop 一致的 `mcpServers` 段即可。Cursor 会在 Agent / Composer 模式下自动调用。
+
+### Dify
+
+Dify 的工作流 Agent 节点支持 "MCP Server" 工具类型。配置方法详见 [Dify 集成](./dify.md) — 核心步骤是在 Dify 工具面板里填写 `http://<ApeRAG 地址>/mcp/` 和 API Key，然后把对应 Agent 挂上即可。
+
+### 其他 MCP 客户端
+
+所有遵循 MCP HTTP 传输规范的客户端都可以直接对接：只需要提供一个支持 `Bearer` 认证头的 HTTP client 端即可。如果客户端只支持 stdio 传输，需要在本地起一个 MCP HTTP-to-stdio 代理把 `/mcp/` 桥接过去（这部分由客户端侧完成，不需要 ApeRAG 做改造）。
+
+## 可用工具速览
+
+完整参数与返回 schema 见 [MCP API 参考](./mcp-api.md)。概览如下：
+
+| 工具 | 作用 | 典型场景 |
+|------|------|---------|
+| `list_collections` | 列出当前 API Key 可访问的知识库 | 让 Agent 在多个知识库之间自动选择 |
+| `search_collection` | 在指定知识库中做混合检索（向量 / 全文 / 图谱 / 摘要 / 视觉） | 主流 RAG 问答 |
+| `search_chat_files` | 在一次对话中临时上传的文件里检索 | 即时分析用户上传的简历、论文等 |
+| `web_search` | 互联网搜索（JINA / DuckDuckGo） | 补充时效性信息 |
+| `web_read` | 抓取给定 URL 列表并返回正文 | 读取引用链接的原文 |
+
+附带一项 MCP Resource `aperag://usage-guide` 提供给客户端作为 Agent 使用的提示词素材；以及一项 MCP Prompt `search_assistant`，供客户端复用。
+
+## 常见问题
+
+**Q：MCP 可以独立部署吗？**
+不行。MCP Server 与 ApeRAG 主进程绑定在同一个 FastAPI 应用上，所有工具都通过内部回调走 REST API，拆出来反而需要额外的服务发现。
+
+**Q：启动时没看到 MCP Server 挂上？**
+启动日志里会打印 FastMCP 的初始化信息；如果只看到 uvicorn 启动但没有 FastMCP 输出，检查是否能访问 `http://localhost:8000/mcp/`（正常会返回 MCP 协议响应，不是 404）。
+
+**Q：我希望只允许部分工具？**
+目前没有基于工具粒度的开关；授权粒度走 API Key，所有调用会落到这个 Key 对应的用户身份，用户看不到的知识库不会出现在 `list_collections` 里。
+
+**Q：搜到图片时 URL 以 `asset://` 开头怎么办？**
+这是 ApeRAG 自定义协议，客户端需要再请求 `GET /api/v1/assets/...` 换成真实 HTTP URL。`asset_url` 的构造见 [MCP API 参考](./mcp-api.md) 的 "图片处理" 小节。
+
+## 相关链接
+
+- [MCP 协议规范](https://modelcontextprotocol.io/)
+- [MCP API 参考](./mcp-api.md) — 5 个工具的完整参数/返回 schema
+- [Dify 集成](./dify.md) — 在 Dify Agent 里接入 ApeRAG MCP
+- [`docs/modularization/architecture.md`](../../modularization/architecture.md) — 后端模块化边界（MCP 归属「共享基础设施」）


### PR DESCRIPTION
## Summary

task #17 交付：3 篇 integration / deployment 正文，按 PM msg=878f5e2e factual-baseline + cross-ref discipline 编写，baseline `origin/main @ c75a739b` (含 task #18 Phase 1 delete)。

- **`docs/zh-CN/integration/mcp.md`** (NEW, 111 LOC) — ApeRAG MCP Server 集成指南：架构、启用、认证、客户端接入（Claude Desktop / Cursor / Dify / Pydantic AI）、5 工具速览。cross-ref `./mcp-api.md` (API 参考) 与 `docs/modularization/architecture.md`。
- **`docs/zh-CN/integration/dify.md`** (rewritten, 168 → 183 LOC) — 修正不存在的 `create_diagram` 工具引用；Prompt 模板改为真实 5 工具；新增「集成原理」section 明确 ApeRAG 没有 Dify-native 代码，完全基于 MCP 协议。保留原 workflow 截图 + 视频演示。
- **`docs/zh-CN/deployment/build-docker-image.md`** (rewritten, 49 → 204 LOC) — 从 skeleton 扩展到完整构建指南：镜像构成（2 image 独立）、前置条件、本地单平台、多平台 buildx、版本与 tag、Dockerfile 多阶段细节、前端独立构建流程、Docker Compose profile、K8s Helm 入口、CI `release-image.yml` workflow、常见问题。

## Cross-ref discipline

所有 Markdown link 指向 **已落 main 的文件** 或 **同 PR 内文件**，无 forward broken link：
- `./mcp-api.md` ✓ 已在 main
- `./mcp.md` ↔ `./dify.md` ✓ 同 PR
- `../../modularization/architecture.md` ✓ 已在 main（post-Phase-6 SSoT）
- `../getting-started/quickstart.md` ✓ 已在 main（Weston task #16）
- `../reference/how-to-debug.md` ✓ 已在 main（Weston task #16）
- `../deployment/build-docker-image.md` ✓ 同 PR
- **`openai-compat.md`** 按 Weston Option A 降级成 plain code path + 起稿提示（Bryce PR #1643 起草中）

## Factual baseline

- MCP server: `aperag/mcp/server.py` (848 LOC FastMCP) mount 在 `/mcp/`，5 tools，auth 两通道（Authorization header / `APERAG_API_KEY` env）
- Dify 集成: 本质走 MCP；ApeRAG 无 Dify-native code（grep 过 repo 只有 docs sync 脚本）
- Docker: 2 Dockerfile（`Dockerfile` python:3.11.13-slim 2-stage uv + `web/Dockerfile` node:20.18-alpine + PM2）；Makefile 完整 target 集；`.github/workflows/release-image.yml` 复用 apecloud-cd 做多平台发布

## Test plan

- [x] 本地 draft 完成，3 篇 doc 自洽互链
- [x] 所有 Markdown link 的目标文件在 main 已存在或同 PR 内
- [x] 前置 Explore baseline survey 完成（3 parallel agents）
- [ ] （不等 CI per earayu2 msg=f6370851）最小 review spot-check 通过后直接 merge

## Task 状态

task #17 → in_review 即可（assignee 自己点 merge 后收 Done）。按 earayu2 msg=f6370851 最小 review + 不等 CI 口径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)