### PR TITLE
docs(zh-CN): Bryce readthrough fix-forward — upgrade 3 stale indexing-retrieval-kg refs

### DIFF
--- a/docs/zh-CN/architecture/identity-governance-model-platform-marketplace.md
+++ b/docs/zh-CN/architecture/identity-governance-model-platform-marketplace.md
@@ -589,7 +589,7 @@ lesson 9a-quatuordec：PEP 563 延迟 annotation 求值会让 FastAPI `response_
   - [`architecture/overview.md`](./overview.md) — 入口
   - [`architecture/domains.md`](./domains.md) — 12 域通览
   - [`architecture/conversation-agent-evaluation.md`](./conversation-agent-evaluation.md) — Phase 5/6 三域架构
-  - `architecture/indexing-retrieval-kg.md` — Phase 3 四域架构（起稿中）
+  - [`architecture/indexing-retrieval-kg.md`](./indexing-retrieval-kg.md) — Phase 3 四域架构
   - [`architecture/web-access.md`](./web-access.md) — web_access 域
 
 - **历史 / 决策**：

--- a/docs/zh-CN/architecture/web-access.md
+++ b/docs/zh-CN/architecture/web-access.md
@@ -238,7 +238,7 @@ API key 按 user 粒度配置，单个用户 key 泄露只影响该用户的搜�
 
 - `docs/modularization/architecture.md` Section 2.12 — canonical SSoT 的 `web_access` domain 定义
 - [`architecture/domains.md`](./domains.md) — 12 domain 通览
-- `architecture/indexing-retrieval-kg.md` — knowledge_base URL 导入消费链路（起稿中）
+- [`architecture/indexing-retrieval-kg.md`](./indexing-retrieval-kg.md) — knowledge_base URL 导入消费链路
 - [`architecture/conversation-agent-evaluation.md`](./conversation-agent-evaluation.md) — Agent Runtime tool 层
 - [`integration/openai-compat.md`](../integration/openai-compat.md) — 相关集成接口
 - [`user-guide/content-import.md`](../user-guide/content-import.md) — URL 导入的用户面流程

--- a/docs/zh-CN/user-guide/collection-marketplace.md
+++ b/docs/zh-CN/user-guide/collection-marketplace.md
@@ -163,7 +163,7 @@ Authorization: Bearer sk-<your-key>
 
 ## 知识图谱（KG）视角
 
-如果 owner 在自己的 collection 里启用了 Knowledge Graph（详见 `architecture/indexing-retrieval-kg.md`），订阅者可以通过 `GET /api/v1/marketplace/collections/{id}/graph?label=*&max_nodes=1000&max_depth=3` 只读查询：
+如果 owner 在自己的 collection 里启用了 Knowledge Graph（详见 [`architecture/indexing-retrieval-kg.md`](../architecture/indexing-retrieval-kg.md)），订阅者可以通过 `GET /api/v1/marketplace/collections/{id}/graph?label=*&max_nodes=1000&max_depth=3` 只读查询：
 
 - `label`：过滤节点 label（`*` 表示全部）
 - `max_nodes`：返回节点数上限（默认 1000，上限 10000）


### PR DESCRIPTION
## Summary

Per PM msg=e589830b owner-readthrough directive + msg=a60845be fix-forward discipline. task #11 (PR #1644, `architecture/indexing-retrieval-kg.md`) has merged, so the 3 plain-text '（起稿中）' placeholders used at PR #1643 merge time are now stale and can be upgraded to live Markdown links.

## Scope (3 lines / 3 files)

- `architecture/identity-governance-model-platform-marketplace.md` related-docs list
- `architecture/web-access.md` related-docs list
- `user-guide/collection-marketplace.md` inline KG reference

## Discipline

- 0 factual drift / 0 broken links (Weston msg=79fc5e5d already confirmed main-wide missing=0)
- 0 scope expansion — strictly fix-forward per PM post-closure口径
- Other owners may have similar stale '起稿中' refs to the same target (flagged @huangheng domains.md + overview.md in thread); handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)