### PR TITLE
feat(fe-rewrite): L1 design system baseline — warm editorial tokens (#3)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -6,8 +6,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-sans);
+  --font-serif: var(--font-serif);
+  --font-mono: var(--font-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -27,6 +28,8 @@
   --color-destructive: var(--destructive);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-ink: var(--accent-ink);
   --color-muted-foreground: var(--muted-foreground);
   --color-muted: var(--muted);
   --color-secondary-foreground: var(--secondary-foreground);
@@ -44,77 +47,103 @@
 }
 
 :root {
-  /* --radius: 0.625rem; */
-  --radius: 0.5rem;
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  /* --primary: oklch(0.205 0 0); */
-  --primary: #0165ca;
-  /* --primary-foreground: oklch(0.985 0 0); */
-  --primary-foreground: #fff;
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  /* Radius — base 10px; Tailwind calc: sm=6 / md=8 / lg=10 / xl=14 (cards). */
+  --radius: 0.625rem;
+
+  /* Surfaces — warm off-white editorial, per design DNA. */
+  --background: #fcfbf8;
+  --foreground: #0a0a0a;
+  --card: #ffffff;
+  --card-foreground: #0a0a0a;
+  --popover: #ffffff;
+  --popover-foreground: #0a0a0a;
+
+  /* Subtle / hover / chip surfaces. */
+  --secondary: #f5f3ee;
+  --secondary-foreground: #0a0a0a;
+  --muted: #f5f3ee;
+  --muted-foreground: #6b6a65;
+
+  /* shadcn `accent` — reserved for subtle hover surfaces (preserves upstream semantics).
+     Brand amber lives in `--primary` + `--accent-soft` / `--accent-ink` (see below). */
+  --accent: #f0ede5;
+  --accent-foreground: #0a0a0a;
+
+  /* Brand amber — the single warm accent used for CTAs, focus rings, NextTopLoader,
+     inline chips (via `--accent-soft` / `--accent-ink`). No gradients, no second hue. */
+  --primary: #c96442;
+  --primary-foreground: #ffffff;
+  --accent-soft: #fbede4;
+  --accent-ink: #7a3320;
+
+  --destructive: #a83530;
+
+  /* Bone hairline borders, warm. */
+  --border: #edeae2;
+  --input: #edeae2;
+  --ring: #c96442;
+
+  /* Graph entity palette — muted, not saturated. */
+  --chart-1: #8c5a3d; /* person - warm brown */
+  --chart-2: #3f5e4f; /* org - deep sage */
+  --chart-3: #5a4f7a; /* concept - muted violet */
+  --chart-4: #8b5a1e; /* product - ochre */
+  --chart-5: #7a3320; /* event - rust */
+
+  /* Sidebar — same warm surface as page, subtle border. */
+  --sidebar: #fcfbf8;
+  --sidebar-foreground: #0a0a0a;
+  --sidebar-primary: #c96442;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f5f3ee;
+  --sidebar-accent-foreground: #0a0a0a;
+  --sidebar-border: #edeae2;
+  --sidebar-ring: #c96442;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  /* --primary: oklch(0.922 0 0); */
-  --primary: #026ad4;
-  /* --primary-foreground: oklch(0.205 0 0); */
-  --primary-foreground: #fff;
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: #1a1916;
+  --foreground: #f2efe9;
+  --card: #23211d;
+  --card-foreground: #f2efe9;
+  --popover: #23211d;
+  --popover-foreground: #f2efe9;
+
+  --secondary: #2e2c26;
+  --secondary-foreground: #f2efe9;
+  --muted: #2e2c26;
+  --muted-foreground: #b8b6b0;
+
+  /* Dark subtle hover surface (preserves upstream `hover:bg-accent` semantics). */
+  --accent: #2e2c26;
+  --accent-foreground: #f2efe9;
+
+  /* Brand amber in dark — brightened slightly for contrast. */
+  --primary: #d97757;
+  --primary-foreground: #ffffff;
+  --accent-soft: #3a2a22;
+  --accent-ink: #fbede4;
+
+  --destructive: #c96452;
+
+  --border: #35322c;
+  --input: #35322c;
+  --ring: #d97757;
+
+  --chart-1: #b78360;
+  --chart-2: #7aa28e;
+  --chart-3: #9186b8;
+  --chart-4: #b68845;
+  --chart-5: #c96452;
+
+  --sidebar: #23211d;
+  --sidebar-foreground: #f2efe9;
+  --sidebar-primary: #d97757;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #2e2c26;
+  --sidebar-accent-foreground: #f2efe9;
+  --sidebar-border: #35322c;
+  --sidebar-ring: #d97757;
 }
 
 @layer base {
@@ -123,5 +152,15 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-feature-settings:
+      'cv11',
+      'ss01',
+      'ss03';
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  ::selection {
+    background-color: var(--accent-soft);
+    color: var(--accent-ink);
   }
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import { Toaster } from '@/components/ui/sonner';
 import { getCurrentUser } from '@/features/auth/server-api';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Fraunces, JetBrains_Mono, Manrope } from 'next/font/google';
 import NextTopLoader from 'nextjs-toploader';
 
 import { AppProvider } from '@/components/providers/app-provider';
@@ -12,14 +12,26 @@ import './globals.css';
 
 import { getTranslations } from 'next-intl/server';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const fontSans = Manrope({
+  variable: '--font-sans',
   subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
 });
 
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
+const fontSerif = Fraunces({
+  variable: '--font-serif',
   subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  axes: ['opsz'],
+  display: 'swap',
+});
+
+const fontMono = JetBrains_Mono({
+  variable: '--font-mono',
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  display: 'swap',
 });
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -49,7 +61,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${fontSans.variable} ${fontSerif.variable} ${fontMono.variable} font-sans antialiased`}
       >
         <NextTopLoader
           // color="color-mix(in oklab, var(--primary), transparent)"
@@ -60,7 +72,7 @@ export default async function RootLayout({
         <NextIntlClientProvider>
           <ThemeProvider
             attribute="class"
-            defaultTheme={process.env.NEXT_PUBLIC_DEFAULT_THEME || 'system'}
+            defaultTheme={process.env.NEXT_PUBLIC_DEFAULT_THEME || 'light'}
             enableSystem
             disableTransitionOnChange
           >

--- a/web/src/components/app-topbar.tsx
+++ b/web/src/components/app-topbar.tsx
@@ -32,7 +32,6 @@ import { cn } from '@/lib/utils';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { setLocale } from '@/services/cookies';
 import { useLocale, useTranslations } from 'next-intl';
-import { FaGithub } from 'react-icons/fa6';
 import { NavigationMenu, NavigationMenuList } from './ui/navigation-menu';
 import { UserAvatar, UserAvatarProfile } from './user-avatar';
 
@@ -224,15 +223,6 @@ export const AppDocs = () => (
   </Button>
 );
 
-export const AppGithub = () => (
-  <Button variant="ghost" size="icon" asChild>
-    <Link target="_blank" href="https://github.com/apecloud/ApeRAG">
-      <FaGithub />
-      <span className="sr-only">Github</span>
-    </Link>
-  </Button>
-);
-
 export const AppTopbar = ({ className }: React.ComponentProps<'div'>) => {
   return (
     <>
@@ -255,7 +245,6 @@ export const AppTopbar = ({ className }: React.ComponentProps<'div'>) => {
           </NavigationMenu>
         </div>
         <div className="flex flex-row items-center gap-2">
-          <AppGithub />
           <AppDocs />
           <AppThemeDropdownMenu />
           <AppUserDropdownMenu />

--- a/web/src/components/chart-mermaid.tsx
+++ b/web/src/components/chart-mermaid.tsx
@@ -29,8 +29,6 @@ export const ChartMermaid = ({ children }: { children: string }) => {
         theme: isDark ? 'dark' : 'neutral',
         securityLevel: 'loose',
         themeVariables: {
-          // primaryColor: '#0165ca',
-          // primaryTextColor: '#fff',
           fontSize: 'inherit',
           labelBkg: 'transparent',
           lineColor: 'var(--input)',

--- a/web/src/components/page-container.tsx
+++ b/web/src/components/page-container.tsx
@@ -12,7 +12,6 @@ import Link from 'next/link';
 import React, { useMemo } from 'react';
 import {
   AppDocs,
-  AppGithub,
   AppLocaleDropdownMenu,
   AppThemeDropdownMenu,
 } from './app-topbar';
@@ -85,7 +84,6 @@ export const PageHeader = ({
             extra
           ) : (
             <>
-              <AppGithub />
               <AppDocs />
               <AppLocaleDropdownMenu />
               <AppThemeDropdownMenu />

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -11,6 +11,7 @@ const buttonVariants = cva(
       variant: {
         default:
           'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        ink: 'bg-foreground text-background shadow-xs hover:bg-foreground/90',
         destructive:
           'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -27,8 +27,8 @@ import { cn } from '@/lib/utils';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = '16rem';
-const SIDEBAR_WIDTH_MOBILE = '18rem';
+const SIDEBAR_WIDTH = '14.5rem';
+const SIDEBAR_WIDTH_MOBILE = '17rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 

--- a/web/src/lib/design-tokens.ts
+++ b/web/src/lib/design-tokens.ts
@@ -1,0 +1,130 @@
+/**
+ * Design tokens — TS SSoT mirror of `src/app/globals.css`.
+ *
+ * Derived from the frontend-rewrite design bundle at
+ * `/Users/earayu/Downloads/aperag/project/src/tokens.jsx` (SSoT).
+ * Source of truth for design values consumed from TypeScript
+ * (e.g. Graph entity palette, Chat trace inline styles, SVG theming).
+ *
+ * Do NOT duplicate these values inline inside feature components —
+ * import from this module so L2 (Chat) and L3 (Graph) stay canonical.
+ */
+
+/**
+ * Surface + ink palette. Prefer Tailwind utilities backed by CSS vars
+ * (`bg-background`, `text-foreground`, `bg-card`, etc.) whenever possible.
+ * Use this TS mirror only when Tailwind classes aren't reachable
+ * (SVG fill, inline style, canvas drawing).
+ */
+export const COLORS = {
+  bg: '#FCFBF8',
+  card: '#FFFFFF',
+  subtle: '#F5F3EE',
+  subtleStrong: '#EDEAE2',
+
+  fg: '#0A0A0A',
+  fgSecondary: '#3A3A38',
+  muted: '#6B6A65',
+  mutedSoft: '#9A9893',
+  placeholder: '#B8B6B0',
+
+  border: '#EDEAE2',
+  borderStrong: '#DDD9CF',
+
+  accent: '#C96442',
+  accentSoft: '#FBEDE4',
+  accentInk: '#7A3320',
+
+  ok: '#3F7D4A',
+  okSoft: '#EAF2E8',
+  warn: '#8B6A1A',
+  warnSoft: '#F5EED7',
+  danger: '#A83530',
+  dangerSoft: '#F5E4E2',
+  info: '#3A5A8C',
+} as const;
+
+/**
+ * Knowledge-graph entity palette — muted, not saturated.
+ * Consumed by L3 Graph (`collection-graph.tsx`), Inspector, Legend, and
+ * any other place that needs to color an entity by its type.
+ */
+export const ENTITY_PALETTE = {
+  person: '#8C5A3D',
+  org: '#3F5E4F',
+  concept: '#5A4F7A',
+  doc: '#6B6A65',
+  product: '#8B5A1E',
+  event: '#7A3320',
+} as const;
+
+export type EntityType = keyof typeof ENTITY_PALETTE;
+
+/**
+ * Human-readable labels for entity types (zh-CN).
+ * L3 Graph Legend + Inspector header use these instead of raw enum strings.
+ */
+export const ENTITY_LABELS_ZH: Record<EntityType, string> = {
+  person: '人员',
+  org: '组织',
+  concept: '概念',
+  doc: '文档',
+  product: '设备',
+  event: '事件',
+};
+
+export const ENTITY_LABELS_EN: Record<EntityType, string> = {
+  person: 'Person',
+  org: 'Organization',
+  concept: 'Concept',
+  doc: 'Document',
+  product: 'Product',
+  event: 'Event',
+};
+
+/**
+ * Radius scale (px). Maps to the Tailwind `rounded-*` utilities via
+ * the `--radius*` CSS vars in `globals.css`:
+ *   rounded-sm → 6px / rounded-md → 8px / rounded-lg → 10px / rounded-xl → 14px
+ * Use these values only for inline SVG / canvas / non-Tailwind callsites.
+ */
+export const RADIUS = {
+  xs: 6,
+  sm: 8,
+  md: 10,
+  lg: 14,
+  xl: 20,
+  pill: 9999,
+} as const;
+
+/**
+ * Elevation shadows — three restrained tiers.
+ * Card shadow-sm is enough for most surfaces; larger tiers reserved
+ * for floating inspectors and popovers.
+ */
+export const SHADOW = {
+  xs: '0 1px 2px rgba(10,10,10,0.04), 0 0 0 1px rgba(10,10,10,0.04)',
+  sm: '0 2px 6px rgba(10,10,10,0.05), 0 0 0 1px rgba(10,10,10,0.05)',
+  md: '0 8px 28px rgba(10,10,10,0.08), 0 0 0 1px rgba(10,10,10,0.05)',
+} as const;
+
+/**
+ * Font stacks. Must match `next/font/google` wiring in `src/app/layout.tsx`.
+ * Prefer Tailwind `font-sans / font-serif / font-mono` utilities over
+ * inlining these strings.
+ */
+export const FONTS = {
+  sans: 'var(--font-sans), "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "HarmonyOS Sans SC", "Microsoft YaHei", system-ui, sans-serif',
+  serif:
+    'var(--font-serif), "Noto Serif SC", "PingFang SC", Georgia, serif',
+  mono: 'var(--font-mono), ui-monospace, "SF Mono", Menlo, monospace',
+} as const;
+
+/**
+ * Layout constants.
+ */
+export const LAYOUT = {
+  sidebarWidth: 232,
+  chatCenterMaxWidth: 720,
+  chatRightRailWidth: 300,
+} as const;


### PR DESCRIPTION
## Summary

L1 / task #3 — unblocks L2 (Chat) and L3 (Graph) re-implementation by shipping the shared brand layer.

Replaces the legacy `#0165ca` enterprise-blue with the design bundle's warm-amber editorial system and introduces a TS SSoT mirror of the design source (`/Users/earayu/Downloads/aperag/project/src/tokens.jsx`).

## What changes

- **CSS tokens** (`globals.css`) — warm off-white surfaces + near-black ink + bone hairline borders + single `#C96442` amber brand. Preserves `--accent` as the subtle hover surface so the 9 existing `hover:bg-accent` call sites stay semantically correct; brand amber lives in `--primary` + `--accent-soft` / `--accent-ink` chip variables. Chart-1..5 remapped to the muted 5-tone entity palette. Default theme flipped from `system` → `light`. Dark variant rebuilt on warm deep-gray surfaces.
- **Typography** (`layout.tsx`) — `Geist` / `Geist_Mono` → `Manrope` (sans) + `Fraunces` (serif, `opsz` axis) + `JetBrains_Mono` (mono). Font CSS vars renamed to canonical `--font-sans` / `--font-serif` / `--font-mono` and registered in `@theme inline`.
- **TS SSoT** (`web/src/lib/design-tokens.ts`, new) — `COLORS`, `ENTITY_PALETTE`, `ENTITY_LABELS_ZH` / `_EN` (so L3 Graph doesn't leak raw enum strings), `RADIUS`, `SHADOW`, `FONTS`, `LAYOUT` (`sidebarWidth: 232` etc.). Canonical import entry for L2 / L3.
- **shadcn Button** — add `ink` variant (near-black filled, for the design bundle's `primary` tier). `default` continues to use `bg-primary` which now resolves to warm amber — intentional brand shift.
- **App shell** — narrow `Sidebar` from `16rem` → `14.5rem` (232px). Remove `AppGithub` + `react-icons/fa6` import per designer's explicit direction ("去掉 header 中的 github logo"). Drop dead `#0165ca` comment in `chart-mermaid.tsx`.

## Scope (A-2 ghost-feature self-check)

- [x] No chat / graph page changes (L2 / L3 territory)
- [x] No backend API bindings touched
- [x] No tweaks panel, no industry runtime toggle
- [x] No ingest-health / spend-budget / team / billing / folders

## Verified

- [x] yarn lint → No ESLint warnings or errors
- [x] grep '#0165ca|#026ad4' on web/src/ → zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)