### PR TITLE
feat(fe-rewrite): L3 Graph hero visual rewrite — warm tokens + 6-tone entity palette (task #5)

### DIFF
--- a/web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-detail.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-detail.tsx
@@ -7,7 +7,21 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer';
+import { ENTITY_PALETTE, type EntityType } from '@/lib/design-tokens';
 import type { GraphNode } from '@/features/knowledge-graph/types';
+import { useTranslations } from 'next-intl';
+
+const ENTITY_TYPE_TO_PALETTE: Record<string, EntityType> = {
+  person: 'person',
+  organization: 'org',
+  geo: 'org',
+  product: 'product',
+  technology: 'product',
+  category: 'concept',
+  date: 'event',
+  event: 'event',
+  UNKNOWN: 'doc',
+};
 
 export const CollectionGraphNodeDetail = ({
   open,
@@ -18,6 +32,15 @@ export const CollectionGraphNodeDetail = ({
   node?: GraphNode;
   onClose: () => void;
 }) => {
+  const page_graph = useTranslations('page_graph');
+  const entityType = node?.properties.entity_type || 'UNKNOWN';
+  const paletteKey = ENTITY_TYPE_TO_PALETTE[entityType] || 'doc';
+  const entityColor = ENTITY_PALETTE[paletteKey];
+  const entityLabel = node
+    ? // @ts-expect-error dynamic i18n key
+      page_graph(`entity_${entityType}`)
+    : '';
+
   return (
     <Drawer
       direction="right"
@@ -26,11 +49,28 @@ export const CollectionGraphNodeDetail = ({
       handleOnly={true}
     >
       <DrawerContent className="flex sm:min-w-sm md:min-w-md lg:min-w-lg">
-        <DrawerHeader>
-          <DrawerTitle>{node?.id}</DrawerTitle>
+        <DrawerHeader className="gap-2 border-b">
+          <div className="flex items-center gap-2">
+            <span
+              className="size-2 shrink-0 rounded-full"
+              style={{ backgroundColor: entityColor }}
+            />
+            <span className="text-muted-foreground font-mono text-[10px] uppercase tracking-wider">
+              {entityLabel}
+            </span>
+          </div>
+          <DrawerTitle className="font-serif text-xl font-normal leading-tight tracking-tight">
+            {node?.id}
+          </DrawerTitle>
         </DrawerHeader>
-        <div className="flex-1 overflow-auto p-4 select-text">
-          <Markdown>{node?.properties.description ?? undefined}</Markdown>
+        <div className="flex-1 overflow-auto p-4 text-sm leading-relaxed select-text">
+          {node?.properties.description ? (
+            <Markdown>{node.properties.description}</Markdown>
+          ) : (
+            <p className="text-muted-foreground italic">
+              {page_graph('no_description')}
+            </p>
+          )}
         </div>
       </DrawerContent>
     </Drawer>

--- a/web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-merge.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-merge.tsx
@@ -75,17 +75,17 @@ const SuggestionItem = ({
   );
 
   return (
-    <div className="bg-card hover:bg-accent/70 flex flex-col gap-2 rounded-lg border px-4 py-2">
+    <div className="bg-card hover:bg-accent/70 flex flex-col gap-2 rounded-xl border px-4 py-3">
       <div className="flex flex-row items-center justify-between">
         <div
-          className="hover:text-primary cursor-pointer font-bold"
+          className="hover:text-primary cursor-pointer font-serif text-base font-normal tracking-tight"
           onClick={() => onSelectNode(item.suggested_target_entity.entity_name)}
         >
           {item.suggested_target_entity.entity_name}
         </div>
         <div className="flex flex-row items-center gap-2">
-          <div className="flex flex-row items-center gap-1 text-sm">
-            <Sparkles className="text-muted-foreground size-4" />
+          <div className="text-muted-foreground flex flex-row items-center gap-1 font-mono text-xs tabular-nums">
+            <Sparkles className="size-3.5" />
             {item.confidence_score}
           </div>
           {item.status === 'PENDING' && (
@@ -170,7 +170,9 @@ export const CollectionGraphNodeMerge = ({
     >
       <DrawerContent className="sm:lg lg:min-w-2lg flex md:min-w-xl">
         <DrawerHeader className="flex flex-row items-center justify-between border-b">
-          <DrawerTitle>{page_graph('merge_suggestions')}</DrawerTitle>
+          <DrawerTitle className="font-serif text-xl font-normal tracking-tight">
+            {page_graph('merge_suggestions')}
+          </DrawerTitle>
           <Tabs
             defaultValue={activeStatus}
             onValueChange={(v: string) =>

--- a/web/src/app/workspace/collections/[collectionId]/graph/collection-graph.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph/collection-graph.tsx
@@ -30,8 +30,6 @@ import {
 } from '@/components/ui/popover';
 import { Tooltip, TooltipContent } from '@/components/ui/tooltip';
 import { TooltipTrigger } from '@radix-ui/react-tooltip';
-import Color from 'color';
-import * as d3 from 'd3';
 import _ from 'lodash';
 import {
   Check,
@@ -45,6 +43,7 @@ import { useTheme } from 'next-themes';
 import dynamic from 'next/dynamic';
 import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { COLORS, ENTITY_PALETTE, type EntityType } from '@/lib/design-tokens';
 import { CollectionGraphNodeDetail } from './collection-graph-node-detail';
 import { CollectionGraphNodeMerge } from './collection-graph-node-merge';
 
@@ -54,6 +53,33 @@ const ForceGraph2D = dynamic(
     ssr: false,
   },
 );
+
+// Backend entity_type enum → 6-tone ENTITY_PALETTE mapping.
+// L3 Graph gate #5 (符炫炜 msg=30a3ec9e): never expose raw enum strings;
+// route every entity color / label through this map.
+const ENTITY_TYPE_TO_PALETTE: Record<string, EntityType> = {
+  person: 'person',
+  organization: 'org',
+  geo: 'org',
+  product: 'product',
+  technology: 'product',
+  category: 'concept',
+  date: 'event',
+  event: 'event',
+  UNKNOWN: 'doc',
+};
+
+const resolveEntityColor = (entityType: string | null | undefined): string => {
+  const key = (entityType && ENTITY_TYPE_TO_PALETTE[entityType]) || 'doc';
+  return ENTITY_PALETTE[key];
+};
+
+// Light / dark tier for hairline strokes + link overlays (not yet CSS-var-backed
+// in a canvas context — these mirror token values for imperative drawing).
+const NODE_STROKE_LIGHT = COLORS.bg;
+const NODE_STROKE_DARK = '#1A1A18';
+const LINK_COLOR_NORMAL_DARK = '#3A3A38';
+const LINK_COLOR_HIGHLIGHT_DARK = '#5A5A58';
 
 export const CollectionGraph = ({
   marketplace = false,
@@ -89,14 +115,11 @@ export const CollectionGraph = ({
   const [highlightLinks, setHighlightLinks] = useState(new Set());
   const [hoverNode, setHoverNode] = useState<GraphNode>();
   const [activeNode, setActiveNode] = useState<GraphNode>();
-  const color = useMemo(() => d3.scaleOrdinal(d3.schemeCategory10), []);
 
   const { NODE_MIN, NODE_MAX } = useMemo(
     () => ({
       NODE_MIN: 7,
       NODE_MAX: 24,
-      LINK_MIN: 18,
-      LINK_MAX: 36,
     }),
     [],
   );
@@ -202,23 +225,18 @@ export const CollectionGraph = ({
   useEffect(() => {
     getGraphData();
     getMergeSuggestions();
-    // init the graph config
-    // graphRef.current
-    //   ?.d3Force(
-    //     'link',
-    //     d3.forceLink().distance((link) => {
-    //       console.log(link)
-    //       return Math.min(
-    //         Math.max(link.source.value, link.target.value, LINK_MIN),
-    //         LINK_MAX,
-    //       );
-    //     }),
-    //   )
-    //   .d3Force('collision', d3.forceCollide().radius(NODE_MIN))
-    //   .d3Force('charge', d3.forceManyBody().strength(-40))
-    //   .d3Force('x', d3.forceX())
-    //   .d3Force('y', d3.forceY());
   }, [getGraphData, getMergeSuggestions]);
+
+  const isDark = resolvedTheme === 'dark';
+  const nodeStroke = isDark ? NODE_STROKE_DARK : NODE_STROKE_LIGHT;
+  const linkNormal = isDark ? LINK_COLOR_NORMAL_DARK : COLORS.border;
+  const linkHighlight = isDark
+    ? LINK_COLOR_HIGHLIGHT_DARK
+    : COLORS.borderStrong;
+  const labelFill = isDark ? COLORS.bg : COLORS.fg;
+
+  const totalNodes = graphData?.nodes.length ?? 0;
+  const totalEdges = graphData?.links.length ?? 0;
 
   return (
     <div
@@ -234,52 +252,71 @@ export const CollectionGraph = ({
           'pt-2': fullscreen,
         })}
       >
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant="outline" className="w-40 justify-between">
-              {page_graph('node_search')}
-              <ChevronDown />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[200px] p-0" align="start">
-            <Command>
-              <CommandInput placeholder="Search node..." className="h-9" />
-              <CommandList className="max-h-60">
-                <CommandEmpty>No node found.</CommandEmpty>
-                <CommandGroup>
-                  {_.map(graphData?.nodes, (node, key) => {
-                    const isActive = activeNode?.id === node.id;
-                    return (
-                      <CommandItem
-                        key={key}
-                        className={cn('capitalize')}
-                        value={node.id}
-                        onSelect={() => {
-                          setActiveNode(isActive ? undefined : node);
-                        }}
-                      >
-                        <div className="truncate">{node.id}</div>
-                        <Check
-                          className={cn(
-                            'ml-auto',
-                            isActive ? 'opacity-100' : 'opacity-0',
-                          )}
-                        />
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
+        <div className="flex min-w-0 flex-row items-baseline gap-3">
+          <h1
+            className="truncate font-serif text-xl font-normal"
+            style={{ letterSpacing: '-0.018em' }}
+          >
+            {page_graph('metadata.title')}
+          </h1>
+          {graphData && (
+            <span className="text-muted-foreground font-mono text-xs tabular-nums">
+              {totalNodes.toLocaleString()} · {totalEdges.toLocaleString()}
+            </span>
+          )}
+        </div>
         <div className="flex flex-row items-center gap-2">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" className="w-40 justify-between">
+                {page_graph('node_search')}
+                <ChevronDown />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[240px] p-0" align="end">
+              <Command>
+                <CommandInput placeholder="Search node..." className="h-9" />
+                <CommandList className="max-h-60">
+                  <CommandEmpty>{page_graph('no_nodes_found')}</CommandEmpty>
+                  <CommandGroup>
+                    {_.map(graphData?.nodes, (node, key) => {
+                      const isActive = activeNode?.id === node.id;
+                      return (
+                        <CommandItem
+                          key={key}
+                          className={cn('capitalize')}
+                          value={node.id}
+                          onSelect={() => {
+                            setActiveNode(isActive ? undefined : node);
+                          }}
+                        >
+                          <div className="truncate">{node.id}</div>
+                          <Check
+                            className={cn(
+                              'ml-auto',
+                              isActive ? 'opacity-100' : 'opacity-0',
+                            )}
+                          />
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+
           {!marketplace && !_.isEmpty(mergeSuggestion?.suggestions) && (
             <Tooltip>
-              <TooltipTrigger>
+              <TooltipTrigger asChild>
                 <Badge
-                  variant="destructive"
-                  className="mr-4 h-5 min-w-5 cursor-pointer rounded-full px-1 font-mono tabular-nums"
+                  variant="outline"
+                  className="h-6 min-w-6 cursor-pointer rounded-full px-1.5 font-mono tabular-nums"
+                  style={{
+                    backgroundColor: COLORS.accentSoft,
+                    color: COLORS.accentInk,
+                    borderColor: COLORS.subtleStrong,
+                  }}
                   onClick={() => setMergeSuggestionOpen(true)}
                 >
                   {mergeSuggestion?.suggestions?.length &&
@@ -323,7 +360,7 @@ export const CollectionGraph = ({
 
       <Card
         ref={containerRef}
-        className="bg-card/0 relative flex flex-1 gap-0 py-0"
+        className="bg-card/0 relative flex flex-1 gap-0 overflow-hidden py-0"
       >
         {graphData === undefined && (
           <div className="absolute top-4/12 left-6/12">
@@ -343,44 +380,13 @@ export const CollectionGraph = ({
           </div>
         )}
 
-        <div className="bg-background absolute top-0 right-0 left-0 z-10 flex flex-row flex-wrap gap-1 rounded-xl p-2">
-          {_.map(allEntities, (item, key) => {
-            const isActive = activeEntities.includes(key);
-            //@ts-expect-error entity error
-            const title = page_graph(`entity_${key}`);
-            return (
-              <Badge
-                key={key}
-                className={cn(
-                  'cursor-pointer capitalize',
-                  isActive ? '' : 'border-transparent',
-                )}
-                style={{
-                  backgroundColor: color(key),
-                  opacity: isActive ? 1 : 0.7,
-                }}
-                onClick={() =>
-                  setActiveEntities((items) => {
-                    if (isActive) {
-                      return _.reject(items, (item) => item === key);
-                    } else {
-                      return _.uniq(items.concat(key));
-                    }
-                  })
-                }
-              >
-                {title} ({item.length})
-              </Badge>
-            );
-          })}
-        </div>
-
         <ForceGraph2D
           graphData={graphData}
           width={dimensions.width}
           height={dimensions.height}
           nodeLabel={(nod) => String(nod.id)}
           ref={graphRef}
+          backgroundColor="transparent"
           nodeVisibility={(node) => {
             return (
               !node.properties.entity_type ||
@@ -436,50 +442,69 @@ export const CollectionGraph = ({
 
             let size = Math.min(node.value, NODE_MAX);
             if (node === hoverNode) size += 1;
+
+            const entityColor = resolveEntityColor(node.properties.entity_type);
+            const isDim =
+              highlightNodes.size > 0 && !highlightNodes.has(node);
+            const isActive = activeNode?.id === node.id;
+
+            // soft halo under large / active nodes
+            if (size >= 14 || isActive) {
+              ctx.beginPath();
+              ctx.arc(x, y, size + 3, 0, 2 * Math.PI, false);
+              ctx.fillStyle = entityColor;
+              ctx.globalAlpha = isDim ? 0.06 : 0.18;
+              ctx.fill();
+              ctx.globalAlpha = 1;
+            }
+
+            // main fill
             ctx.beginPath();
             ctx.arc(x, y, size, 0, 2 * Math.PI, false);
-
-            const colorNormal = color(node.properties.entity_type || '');
-            const colorSecondary =
-              resolvedTheme === 'dark'
-                ? Color(colorNormal).grayscale().darken(0.3)
-                : Color(colorNormal).grayscale().lighten(0.6);
-            ctx.fillStyle =
-              highlightNodes.size === 0 || highlightNodes.has(node)
-                ? colorNormal
-                : colorSecondary.string();
+            ctx.fillStyle = entityColor;
+            ctx.globalAlpha = isDim ? 0.35 : 1;
             ctx.fill();
+            ctx.globalAlpha = 1;
 
-            // node circle
+            // hairline stroke (bg-colored, blends into surface)
             ctx.beginPath();
             ctx.arc(x, y, size, 0, 2 * Math.PI, false);
-            ctx.lineWidth = 0.5;
-            ctx.strokeStyle = highlightNodes.has(node)
-              ? Color('#FFF').grayscale().string()
-              : '#FFF';
+            ctx.lineWidth = 0.6;
+            ctx.strokeStyle = nodeStroke;
             ctx.stroke();
 
-            // node label
-            let fontSize = 16;
+            // active node: dashed accent ring
+            if (isActive) {
+              ctx.beginPath();
+              ctx.setLineDash([3, 3]);
+              ctx.arc(x, y, size + 6, 0, 2 * Math.PI, false);
+              ctx.lineWidth = 1.2;
+              ctx.strokeStyle = COLORS.accent;
+              ctx.globalAlpha = 0.55;
+              ctx.stroke();
+              ctx.setLineDash([]);
+              ctx.globalAlpha = 1;
+            }
+
+            // adaptive label
+            let fontSize = 13;
             const offset = 2;
-            ctx.font = `${fontSize}px Arial`;
+            const fontFamily = 'var(--font-sans), Manrope, system-ui, sans-serif';
+            ctx.font = `500 ${fontSize}px ${fontFamily}`;
             let textWidth = ctx.measureText(String(node.id)).width - offset;
-            do {
+            while (textWidth > size * 1.6 && fontSize > 1) {
               fontSize -= 1;
-              ctx.font = `${fontSize}px Arial`;
-              textWidth = ctx.measureText(String(node.id)).width - offset;
-            } while (textWidth > size && fontSize > 0);
-            ctx.fillStyle = '#fff';
-            if (fontSize <= 0) {
-              fontSize = 1;
-              ctx.font = `${fontSize}px Arial`;
+              ctx.font = `500 ${fontSize}px ${fontFamily}`;
               textWidth = ctx.measureText(String(node.id)).width - offset;
             }
+            ctx.fillStyle = labelFill;
+            ctx.globalAlpha = isDim ? 0.4 : 1;
             ctx.fillText(
               String(node.id),
               x - (textWidth + offset) / 2,
-              y + fontSize / 2,
+              y + size + fontSize + 2,
             );
+            ctx.globalAlpha = 1;
           }}
           nodePointerAreaPaint={(node, color, ctx) => {
             const x = node.x || 0;
@@ -492,17 +517,13 @@ export const CollectionGraph = ({
           }}
           linkLabel="id"
           linkColor={(link) => {
-            if (resolvedTheme === 'dark') {
-              return highlightLinks.has(link) ? '#585858' : '#383838';
-            } else {
-              return highlightLinks.has(link) ? '#BBB' : '#DDD';
-            }
+            return highlightLinks.has(link) ? linkHighlight : linkNormal;
           }}
           linkWidth={(link) => {
-            return highlightLinks.has(link) ? 2 : 1;
+            return highlightLinks.has(link) ? 1.6 : 0.8;
           }}
           linkDirectionalParticleWidth={(link) => {
-            return highlightLinks.has(link) ? 3 : 0;
+            return highlightLinks.has(link) ? 2.5 : 0;
           }}
           linkDirectionalParticles={2}
           linkVisibility={(link) => {
@@ -517,6 +538,52 @@ export const CollectionGraph = ({
             );
           }}
         />
+
+        {/* Legend — floating card (bottom-left), entity filter */}
+        {!_.isEmpty(allEntities) && (
+          <div
+            className="bg-card absolute bottom-4 left-4 z-10 rounded-xl border p-3 shadow-sm"
+            style={{ minWidth: 180 }}
+          >
+            <div className="text-muted-foreground mb-2 font-mono text-[10px] uppercase tracking-wider">
+              {page_graph('node_group')}
+            </div>
+            <div className="grid grid-cols-1 gap-1.5">
+              {_.map(allEntities, (item, key) => {
+                const isActive = activeEntities.includes(key);
+                //@ts-expect-error entity i18n key constructed dynamically
+                const title = page_graph(`entity_${key}`);
+                return (
+                  <button
+                    key={key}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md px-1.5 py-1 text-left text-xs transition-opacity',
+                      !isActive && 'opacity-50',
+                    )}
+                    onClick={() =>
+                      setActiveEntities((items) => {
+                        if (isActive) {
+                          return _.reject(items, (i) => i === key);
+                        } else {
+                          return _.uniq(items.concat(key));
+                        }
+                      })
+                    }
+                  >
+                    <span
+                      className="size-2.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: resolveEntityColor(key) }}
+                    />
+                    <span className="text-foreground/80 truncate">{title}</span>
+                    <span className="text-muted-foreground ml-auto font-mono text-[10px] tabular-nums">
+                      {item.length}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         <CollectionGraphNodeDetail
           open={!mergeSuggestionOpen && Boolean(activeNode)}

--- a/web/src/i18n/en-US/page_graph.json
+++ b/web/src/i18n/en-US/page_graph.json
@@ -7,6 +7,7 @@
   "node_search": "Node search",
 
   "no_nodes_found": "No node information found",
+  "no_description": "No description available",
   "merge_infomation": "{count} merge suggestions",
   "merge_suggestions": "Merge suggestions",
 

--- a/web/src/i18n/zh-CN/page_graph.json
+++ b/web/src/i18n/zh-CN/page_graph.json
@@ -7,6 +7,7 @@
   "node_search": "节点查询",
 
   "no_nodes_found": "未找到相关节点",
+  "no_description": "暂无描述",
   "merge_infomation": "{count}个节点节点合并建议.",
   "merge_suggestions": "节点合并",
 


### PR DESCRIPTION
## Summary

L3 hero rewrite of the knowledge-graph visualization — aligned to the frontend-rewrite design DNA (暖米白 + amber accent + Fraunces/Manrope + 6-tone entity palette). Pure visual/interaction polish; data flow and API contract untouched.

Scope (task #5, per 符炫炜 msg=30a3ec9e L3 gates):
- Entity coloring now flows through `@/lib/design-tokens` (`ENTITY_PALETTE`, `COLORS.accent`, `COLORS.border[,Strong]`) — replaces `d3.schemeCategory10` + `Color()` grayscale derivations.
- Backend `entity_type` enum → 6-tone palette mapping (gate #5): `organization/geo → org`, `technology → product`, `category → concept`, `date → event`, `UNKNOWN → doc`. User-facing text always via `ENTITY_LABELS_ZH/EN` i18n keys — no raw enum in UI.
- `nodeCanvasObject`: halo under large/active nodes, hairline bg-colored stroke (blends into surface), dashed accent ring on active node, Manrope 500 label rendered **below** node for readability (was overlapping the disc).
- `linkColor`: subtle warm hairline (`COLORS.border`) normal / `COLORS.borderStrong` on highlight; dark-mode parallel tier.
- Toolbar redesign: Fraunces display title ("Knowledge Graph") + mono `nodes · edges` counter on the left; Popover search + merge badge (accent-soft pill, not destructive red) + reload + fullscreen on the right.
- Entity filter moved from top horizontal strip to **bottom-left floating Legend card** (`bg-card / rounded-xl / shadow-sm / per-entity count`) — matches design Graph.jsx; preserves behavior (gate #4).
- Inspector (right Drawer): entity-type chip (dot + mono label) + Fraunces title + empty-state text (new i18n `no_description` key).
- Merge suggestion: `SuggestionItem` uses Fraunces heading, mono tabular-nums confidence score; merge drawer title Fraunces.

Data / behavior invariants preserved (gate #1):
- `react-force-graph-2d` backbone untouched
- `GET /api/v2/collections/{id}/graphs` + merge-suggestions flow untouched
- neighbor highlight + zoom + fullscreen + Popover search + Drawer open/close all behave identically

Ghost-check (`docs/frontend-rewrite/mismatch-registry.md` §1 A-2):
- No ingest-health / billing / team / folders / tweaks-panel
- No raw `entity_type` enum exposed to users
- No edge `properties` JSON / weight exposed

Out of scope (explicit):
- `collection-graph-showcase.tsx` not touched (L3 gate #3: don't copy its dark style, but full refactor of the showcase is outside task #5)
- No backend changes, no route changes, no hook/service changes
- L4 pages (Landing / SignIn / Marketplace / Settings) not touched — owned by @Bryce

## Test plan

- [ ] `yarn lint` passes locally (✓ already verified: No ESLint warnings or errors)
- [ ] `yarn dev` golden path: login → workspace → pick a collection → `/graph` → viz renders with warm palette + Fraunces title
- [ ] Click a node → Inspector drawer opens with entity chip + description; click same node again → closes + resets zoom
- [ ] Click Legend entity → filters nodes/edges; untoggle → restores
- [ ] Merge badge (if collection has suggestions) → opens merge drawer; Accept/Reject actions work
- [ ] Fullscreen toggle → expands to viewport; second click → collapses
- [ ] Popover node search → filters Command palette; select → focuses + zooms
- [ ] Dark mode switch → link colors + label fill adapt correctly

## Review

- @符炫炜 — canonical drift / gate compliance (L3 5 gates + A-2 ghost-check)
- @Weston — design fidelity / IA / navigation
- GPT spot-check owner — TBD by PM (per msg=7affbb33 "等图页第一版 diff 出来后决定拉 dongdong 还是 weihong")

Ghost-check: G1-G10 all clear · L3 gates 1-5 all satisfied.