### PR TITLE
feat(fe-rewrite): L1 token SSoT follow-up — dark canvas + entityTypeToPaletteKey (#7)

### DIFF
--- a/web/src/lib/design-tokens.ts
+++ b/web/src/lib/design-tokens.ts
@@ -83,6 +83,59 @@ export const ENTITY_LABELS_EN: Record<EntityType, string> = {
 };
 
 /**
+ * Backend entity_type enum → canonical `EntityType` palette key.
+ *
+ * The backend emits a wider set of raw enum strings than the 6-tone
+ * design palette. This map collapses the wider set onto the 6 canonical
+ * keys so that callers never leak raw enum strings into the UI and
+ * never have to re-implement the mapping per lane.
+ *
+ * Unknown / missing types fall back to `doc` (neutral ink gray).
+ */
+const ENTITY_TYPE_TO_PALETTE: Record<string, EntityType> = {
+  person: 'person',
+  organization: 'org',
+  geo: 'org',
+  product: 'product',
+  technology: 'product',
+  category: 'concept',
+  date: 'event',
+  event: 'event',
+  UNKNOWN: 'doc',
+};
+
+/**
+ * Resolve a backend `entity_type` string to the canonical palette key.
+ * Safe for `null | undefined` input (returns `'doc'`).
+ *
+ * Usage:
+ *   const color = ENTITY_PALETTE[entityTypeToPaletteKey(node.entity_type)];
+ *   const label = ENTITY_LABELS_ZH[entityTypeToPaletteKey(node.entity_type)];
+ */
+export function entityTypeToPaletteKey(
+  rawType: string | null | undefined,
+): EntityType {
+  if (!rawType) return 'doc';
+  return ENTITY_TYPE_TO_PALETTE[rawType] ?? 'doc';
+}
+
+/**
+ * Dark-mode canvas overlays. These mirror token values for imperative
+ * drawing contexts (HTML canvas, inline SVG) where Tailwind classes
+ * and CSS vars aren't reachable.
+ *
+ * Pair with the light-mode equivalents from `COLORS`:
+ *   stroke: light → `COLORS.bg`     / dark → `CANVAS_DARK.nodeStroke`
+ *   link normal:    light → `COLORS.border`       / dark → `CANVAS_DARK.linkNormal`
+ *   link highlight: light → `COLORS.borderStrong` / dark → `CANVAS_DARK.linkHighlight`
+ */
+export const CANVAS_DARK = {
+  nodeStroke: '#1A1A18',
+  linkNormal: '#3A3A38',
+  linkHighlight: '#5A5A58',
+} as const;
+
+/**
  * Radius scale (px). Maps to the Tailwind `rounded-*` utilities via
  * the `--radius*` CSS vars in `globals.css`:
  *   rounded-sm → 6px / rounded-md → 8px / rounded-lg → 10px / rounded-xl → 14px


### PR DESCRIPTION
## Summary

Task #7 — additive L1 token / util patches extracted from L3 Graph hero rewrite (merged via #1652) so L2 Chat (`#4`) and L4 other screens (`#6`) can reuse them without re-implementing.

Closes: #7

## What changes

Single file: `web/src/lib/design-tokens.ts` (+53 LOC, additive only).

- **`entityTypeToPaletteKey(rawType)`** — collapses the wider backend `entity_type` enum (`person / organization / geo / product / technology / category / date / event / UNKNOWN`) onto the 6-tone canonical palette key. Handles `null | undefined`. Unknown / missing types fall back to `'doc'` (neutral ink gray). Promotes the inline `ENTITY_TYPE_TO_PALETTE` map currently living in `collection-graph.tsx` so Chat and L4 screens that color entity chips can import it directly.
- **`CANVAS_DARK`** — three dark-mode overlays (`nodeStroke`, `linkNormal`, `linkHighlight`) for imperative drawing contexts (HTML canvas, inline SVG) where Tailwind classes and CSS vars aren't reachable. Pairs with the light-mode equivalents already in `COLORS` (`bg`, `border`, `borderStrong`).

## Scope (A-2 ghost-feature self-check)

- [x] Additive only — no existing exports changed
- [x] No consumer-side call-site edits (L3 can refactor to `ENTITY_PALETTE[entityTypeToPaletteKey(x)]` in a separate 2-line follow-up at its own pace — non-blocking)
- [x] No UI changes, no new features, no backend contract touched
- [x] No tweaks panel / industry toggle / ingest-health / spend-budget / team / billing / folders

## Canonical alignment

Both additions were pre-blessed by @符炫炜 (canonical spot-check on #1652) and approved by @架构师 (msg=3b22786f) as L1 owner work rather than pushing onto L4 Bryce.

## Verified

- [x] `yarn lint` → No ESLint warnings or errors
- [x] TS surface: pure additive — no public signature changes, no breaking

## Review request

- @符炫炜 — canonical drift / L2 / L4 consumer path alignment
- @dongdong — GPT spot-check (TS types + drop-in import path)

Ghost-check: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)