### PR TITLE
feat(fe-rewrite): uplift landing and auth surfaces

### DIFF
--- a/web/src/app/auth/callback/[provider]/page.tsx
+++ b/web/src/app/auth/callback/[provider]/page.tsx
@@ -24,7 +24,9 @@ export default function Page() {
     if (loading) {
       return (
         <>
-          <LoaderCircle className="size-12 animate-spin opacity-50" />
+          <div className="bg-accent-soft text-accent-ink grid size-12 place-items-center rounded-full">
+            <LoaderCircle className="size-6 animate-spin" />
+          </div>
           <div className="text-muted-foreground text-sm">
             {page_auth('processing_oauth_login')}
           </div>
@@ -34,14 +36,18 @@ export default function Page() {
     if (tips) {
       return (
         <>
-          <ShieldAlert className="size-12" />
+          <div className="bg-destructive/10 text-destructive grid size-12 place-items-center rounded-full">
+            <ShieldAlert className="size-6" />
+          </div>
           <div className="text-muted-foreground text-sm">{tips}</div>
         </>
       );
     }
     return (
       <>
-        <ShieldPlus className="size-12" />
+        <div className="bg-accent-soft text-accent-ink grid size-12 place-items-center rounded-full">
+          <ShieldPlus className="size-6" />
+        </div>
         <div className="text-muted-foreground text-sm">
           {page_auth('oauth_successful')}
         </div>
@@ -90,24 +96,33 @@ export default function Page() {
   }, [error, code, state]);
 
   return (
-    <Card className="bg-card/50">
-      <CardContent className="flex flex-col gap-12">
-        <div className="text-center text-xl font-bold">
-          {page_auth('authentication')}
+    <Card className="border-border/80 bg-card/95 shadow-sm">
+      <CardContent className="flex flex-col gap-9 px-6 py-7 md:px-7">
+        <div className="text-center">
+          <div className="text-primary font-mono text-xs tracking-[0.18em] uppercase">
+            {page_auth('oauth_eyebrow')}
+          </div>
+          <h1 className="mt-3 font-serif text-4xl leading-tight font-normal tracking-[-0.035em]">
+            {page_auth('authentication')}
+          </h1>
         </div>
 
-        <div className="flex flex-col items-center justify-center gap-2 text-center">
+        <div className="flex flex-col items-center justify-center gap-3 text-center">
           {content}
         </div>
 
-        <div className="flex items-center justify-center gap-x-6">
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
           <Link href="/">
-            <Button>{page_auth('go_back_home')}</Button>
+            <Button className="rounded-full">
+              {page_auth('go_back_home')}
+            </Button>
           </Link>
-          <Button variant="outline" onClick={() => signIn({ redirectTo: '/' })}>
-            <div className="grid flex-1 text-left text-sm leading-tight">
-              {page_auth('retry')}
-            </div>
+          <Button
+            variant="outline"
+            className="rounded-full"
+            onClick={() => signIn({ redirectTo: '/' })}
+          >
+            {page_auth('retry')}
           </Button>
         </div>
       </CardContent>

--- a/web/src/app/auth/layout.tsx
+++ b/web/src/app/auth/layout.tsx
@@ -1,44 +1,90 @@
 import { AppLogo } from '@/components/app-topbar';
+import { getTranslations } from 'next-intl/server';
 
 export default async function AuthLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const t = await getTranslations('page_auth');
+
   return (
-    <>
-      <div className="flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
-        <div
-          aria-hidden="true"
-          className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
-        >
-          <div
-            style={{
-              clipPath:
-                'polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)',
-            }}
-            className="relative left-[calc(50%-11rem)] aspect-1155/678 w-144.5 -translate-x-1/2 rotate-30 bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-30 sm:left-[calc(50%-30rem)] sm:w-288.75"
-          ></div>
-        </div>
-        <div className="flex w-full max-w-sm flex-col gap-6">
-          <div className="self-center">
-            <AppLogo />
+    <main className="bg-background text-foreground grid min-h-[100dvh] lg:grid-cols-[1.05fr_0.95fr]">
+      <section className="bg-secondary/65 relative hidden overflow-hidden border-r p-10 lg:flex lg:flex-col xl:p-14">
+        <AppLogo />
+        <div className="relative z-10 flex flex-1 flex-col justify-center">
+          <div className="max-w-xl">
+            <div className="text-primary font-mono text-xs tracking-[0.18em] uppercase">
+              {t('auth_hero_eyebrow')}
+            </div>
+            <blockquote className="mt-6 font-serif text-4xl leading-tight font-normal tracking-[-0.035em] text-balance">
+              {t('auth_hero_quote')}
+            </blockquote>
+            <p className="text-muted-foreground mt-6 max-w-md text-sm leading-7">
+              {t('auth_hero_description')}
+            </p>
           </div>
-          {children}
         </div>
+        <AuthGraphFlourish />
+      </section>
+
+      <section className="relative flex min-h-[100dvh] flex-col px-6 py-8 md:px-10 lg:px-14">
         <div
           aria-hidden="true"
-          className="absolute inset-x-0 -z-10 transform-gpu overflow-hidden blur-3xl"
-        >
-          <div
-            style={{
-              clipPath:
-                'polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)',
-            }}
-            className="relative left-[calc(50%+3rem)] aspect-1155/678 w-144.5 -translate-x-1/2 bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-30 sm:left-[calc(50%+36rem)] sm:w-288.75"
-          ></div>
+          className="pointer-events-none absolute inset-0 -z-10"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle at 85% 12%, color-mix(in oklab, var(--primary) 9%, transparent), transparent 24rem), radial-gradient(circle at 12% 85%, color-mix(in oklab, var(--accent-ink) 6%, transparent), transparent 22rem)',
+          }}
+        />
+        <div className="flex items-center justify-between lg:hidden">
+          <AppLogo />
         </div>
-      </div>
-    </>
+        <div className="flex flex-1 items-center justify-center py-12">
+          <div className="w-full max-w-md">{children}</div>
+        </div>
+        <p className="text-muted-foreground mx-auto max-w-md text-center text-xs leading-5">
+          {t('auth_footer')}
+        </p>
+      </section>
+    </main>
+  );
+}
+
+function AuthGraphFlourish() {
+  const nodes = [
+    ['50%', '50%', 'size-15 bg-primary'],
+    ['28%', '28%', 'size-8 bg-chart-2'],
+    ['75%', '30%', 'size-9 bg-chart-4'],
+    ['24%', '72%', 'size-7 bg-chart-5'],
+    ['78%', '70%', 'size-8 bg-chart-1'],
+    ['52%', '18%', 'size-6 bg-chart-3'],
+  ] as const;
+
+  return (
+    <div className="pointer-events-none absolute right-[-5rem] bottom-[-4rem] h-[24rem] w-[30rem] opacity-80">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 rounded-full"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle, color-mix(in oklab, var(--primary) 13%, transparent), transparent 60%)',
+        }}
+      />
+      <svg className="absolute inset-0 size-full" aria-hidden="true">
+        <line x1="50%" y1="50%" x2="28%" y2="28%" className="stroke-border" />
+        <line x1="50%" y1="50%" x2="75%" y2="30%" className="stroke-border" />
+        <line x1="50%" y1="50%" x2="24%" y2="72%" className="stroke-border" />
+        <line x1="50%" y1="50%" x2="78%" y2="70%" className="stroke-border" />
+        <line x1="50%" y1="50%" x2="52%" y2="18%" className="stroke-border" />
+      </svg>
+      {nodes.map(([left, top, className]) => (
+        <span
+          key={`${left}-${top}`}
+          className={`border-secondary absolute -translate-x-1/2 -translate-y-1/2 rounded-full border-4 ${className}`}
+          style={{ left, top }}
+        />
+      ))}
+    </div>
   );
 }

--- a/web/src/app/auth/signin/signin-form.tsx
+++ b/web/src/app/auth/signin/signin-form.tsx
@@ -12,6 +12,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
@@ -68,20 +69,28 @@ export function SignInForm({
 
   return (
     <div className={cn('flex flex-col gap-6', className)} {...props}>
-      <Card className="bg-card/50">
-        <CardContent>
-          <div className="mb-8 text-center text-xl font-bold">
-            {page_auth('welcome_back')}
+      <Card className="border-border/80 bg-card/95 shadow-sm">
+        <CardContent className="px-6 py-7 md:px-7">
+          <div className="mb-7">
+            <div className="text-primary font-mono text-xs tracking-[0.18em] uppercase">
+              {page_auth('signin_eyebrow')}
+            </div>
+            <h1 className="mt-3 font-serif text-4xl leading-tight font-normal tracking-[-0.035em]">
+              {page_auth('welcome_back')}
+            </h1>
+            <p className="text-muted-foreground mt-2 text-sm leading-6">
+              {page_auth('signin_description')}
+            </p>
           </div>
           {hasSocialLogin && (
-            <div className="mb-4 grid gap-4">
+            <div className="mb-6 grid gap-3">
               <div className="text-muted-foreground text-center text-sm">
                 {page_auth('login_in_with_a_third_party_account')}
               </div>
               {hasSocialGithubLogin && (
                 <Button
                   variant="outline"
-                  className="w-full"
+                  className="h-10 w-full rounded-lg active:scale-[0.98]"
                   onClick={() => signIn({ type: 'github', redirectTo })}
                 >
                   <FaGithub />
@@ -91,7 +100,7 @@ export function SignInForm({
               {hasSocialGoogleLogin && (
                 <Button
                   variant="outline"
-                  className="w-full"
+                  className="h-10 w-full rounded-lg active:scale-[0.98]"
                   onClick={() => signIn({ type: 'google', redirectTo })}
                 >
                   <FaGoogle />
@@ -100,7 +109,7 @@ export function SignInForm({
               )}
 
               <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
-                <span className="bg-card text-muted-foreground relative z-10 px-2">
+                <span className="bg-card text-muted-foreground relative z-10 px-3 font-mono text-[11px] tracking-[0.12em] uppercase">
                   {page_auth('or_continue_with')}
                 </span>
               </div>
@@ -109,20 +118,24 @@ export function SignInForm({
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(handleSignInLocal)}
-              className="grid gap-6"
+              className="grid gap-5"
             >
               <FormField
                 control={form.control}
                 name="username"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{page_auth('username')}</FormLabel>
+                    <FormLabel className="text-foreground text-xs font-medium">
+                      {page_auth('username')}
+                    </FormLabel>
                     <FormControl>
                       <Input
                         {...field}
+                        className="bg-background h-11 rounded-lg"
                         placeholder={page_auth('username_placeholder')}
                       />
                     </FormControl>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
@@ -132,7 +145,9 @@ export function SignInForm({
                 render={({ field }) => (
                   <FormItem>
                     <div className="flex justify-between">
-                      <FormLabel>{page_auth('password')}</FormLabel>
+                      <FormLabel className="text-foreground text-xs font-medium">
+                        {page_auth('password')}
+                      </FormLabel>
                       <Link
                         href="#"
                         className="text-muted-foreground hover:text-primary text-xs underline-offset-4 hover:underline"
@@ -144,22 +159,27 @@ export function SignInForm({
                       <Input
                         type="password"
                         {...field}
+                        className="bg-background h-11 rounded-lg"
                         placeholder={page_auth('password_placeholder')}
                       />
                     </FormControl>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
 
-              <Button type="submit" className="w-full">
+              <Button
+                type="submit"
+                className="h-11 w-full rounded-full active:scale-[0.98]"
+              >
                 {page_auth('signin')}
               </Button>
 
-              <div className="text-center text-sm">
+              <div className="text-muted-foreground text-center text-sm">
                 {page_auth('do_not_have_an_account')}
                 <Link
-                  href={`/auth/signup?callbaclUrl=${encodeURIComponent(redirectTo)}`}
-                  className="underline underline-offset-4"
+                  href={`/auth/signup?callbackUrl=${encodeURIComponent(redirectTo)}`}
+                  className="text-primary font-medium underline-offset-4 hover:underline"
                 >
                   {page_auth('signup')}
                 </Link>

--- a/web/src/app/auth/signup/signup-form.tsx
+++ b/web/src/app/auth/signup/signup-form.tsx
@@ -12,6 +12,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 
@@ -50,28 +51,40 @@ export function SignUpForm() {
 
   return (
     <div className="flex flex-col gap-6">
-      <Card className="bg-card/50">
-        <CardContent>
-          <div className="mb-8 text-center text-xl font-bold">
-            {page_auth('register_an_account')}
+      <Card className="border-border/80 bg-card/95 shadow-sm">
+        <CardContent className="px-6 py-7 md:px-7">
+          <div className="mb-7">
+            <div className="text-primary font-mono text-xs tracking-[0.18em] uppercase">
+              {page_auth('signup_eyebrow')}
+            </div>
+            <h1 className="mt-3 font-serif text-4xl leading-tight font-normal tracking-[-0.035em]">
+              {page_auth('register_an_account')}
+            </h1>
+            <p className="text-muted-foreground mt-2 text-sm leading-6">
+              {page_auth('signup_description')}
+            </p>
           </div>
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(handleSignUpLocal)}
-              className="grid gap-6"
+              className="grid gap-5"
             >
               <FormField
                 control={form.control}
                 name="username"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{page_auth('username')}</FormLabel>
+                    <FormLabel className="text-foreground text-xs font-medium">
+                      {page_auth('username')}
+                    </FormLabel>
                     <FormControl>
                       <Input
                         {...field}
+                        className="bg-background h-11 rounded-lg"
                         placeholder={page_auth('username_placeholder')}
                       />
                     </FormControl>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
@@ -80,13 +93,17 @@ export function SignUpForm() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{page_auth('email')}</FormLabel>
+                    <FormLabel className="text-foreground text-xs font-medium">
+                      {page_auth('email')}
+                    </FormLabel>
                     <FormControl>
                       <Input
                         {...field}
+                        className="bg-background h-11 rounded-lg"
                         placeholder={page_auth('email_placeholder')}
                       />
                     </FormControl>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
@@ -95,27 +112,34 @@ export function SignUpForm() {
                 name="password"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{page_auth('password')}</FormLabel>
+                    <FormLabel className="text-foreground text-xs font-medium">
+                      {page_auth('password')}
+                    </FormLabel>
                     <FormControl>
                       <Input
                         type="password"
                         {...field}
+                        className="bg-background h-11 rounded-lg"
                         placeholder={page_auth('password_placeholder')}
                       />
                     </FormControl>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
 
-              <Button type="submit" className="w-full">
+              <Button
+                type="submit"
+                className="h-11 w-full rounded-full active:scale-[0.98]"
+              >
                 {page_auth('signup')}
               </Button>
 
-              <div className="text-center text-sm">
+              <div className="text-muted-foreground text-center text-sm">
                 {page_auth('already_hava_an_account')}
                 <Link
                   href={`/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`}
-                  className="underline underline-offset-4"
+                  className="text-primary font-medium underline-offset-4 hover:underline"
                 >
                   {page_auth('signin')}
                 </Link>

--- a/web/src/app/auth/verify-request/page.tsx
+++ b/web/src/app/auth/verify-request/page.tsx
@@ -2,39 +2,41 @@
 
 import { useAppContext } from '@/components/providers/app-provider';
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 
+import { MailCheck } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 
 export default function Page() {
   const { signIn } = useAppContext();
+  const page_auth = useTranslations('page_auth');
+
   return (
     <div className="flex flex-col gap-6">
-      <Card className="bg-card/50">
-        <CardHeader className="text-center">
-          <CardTitle className="text-xl">Check your email</CardTitle>
-          <CardDescription>
-            A sign in link has been sent to your email address.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="mt-10 flex items-center justify-center gap-x-6">
+      <Card className="border-border/80 bg-card/95 shadow-sm">
+        <CardContent className="px-6 py-7 text-center md:px-7">
+          <div className="bg-accent-soft text-accent-ink mx-auto grid size-12 place-items-center rounded-full">
+            <MailCheck className="size-6" />
+          </div>
+          <h1 className="mt-5 font-serif text-4xl leading-tight font-normal tracking-[-0.035em]">
+            {page_auth('check_email_title')}
+          </h1>
+          <p className="text-muted-foreground mt-3 text-sm leading-6">
+            {page_auth('check_email_description')}
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Link href="/">
-              <Button>Go back home</Button>
+              <Button className="rounded-full">
+                {page_auth('go_back_home')}
+              </Button>
             </Link>
             <Button
               variant="outline"
+              className="rounded-full"
               onClick={() => signIn({ redirectTo: '/' })}
             >
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                Sign in again
-              </div>
+              {page_auth('signin_again')}
             </Button>
           </div>
         </CardContent>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,130 +1,507 @@
-import { AppTopbar } from '@/components/app-topbar';
-import { PageContainer, PageContent } from '@/components/page-container';
+import { AppLogo } from '@/components/app-topbar';
 import { Button } from '@/components/ui/button';
-import { ArrowRight, Mail } from 'lucide-react';
+import {
+  ArrowRight,
+  BookOpenText,
+  Boxes,
+  Check,
+  DatabaseZap,
+  GitBranch,
+  Mail,
+  Network,
+  ShieldCheck,
+  Sparkles,
+} from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
 
-const features = [
-  {
-    title: 'Hybrid Retrieval Engine',
-    description:
-      'Combines Graph RAG, vector search, and full-text search for comprehensive document understanding and retrieval.',
-  },
-  {
-    title: 'Graph RAG with LightRAG',
-    description:
-      'Enhanced version of LightRAG for advanced graph-based knowledge extraction, enabling deep relational and contextual queries.',
-  },
-  {
-    title: 'MinerU Integration',
-    description:
-      'Advanced document parsing service providing superior parsing for complex documents, tables, formulas, and scientific content with optional GPU acceleration.',
-  },
-  {
-    title: 'Production-Grade Deployment',
-    description:
-      'Full Kubernetes support with Helm charts and KubeBlocks integration for simplified deployment of production-grade databases.',
-  },
-  {
-    title: 'Multimodal Processing',
-    description:
-      'Supports various document formats (PDF, DOCX, etc.) with intelligent content extraction and structure recognition.',
-  },
-  {
-    title: 'Enterprise Management',
-    description:
-      'Built-in audit logging, LLM model management, graph visualization, and comprehensive document management interface.',
-  },
-];
+const navLinks = [
+  { href: '#agent', key: 'nav.agent' },
+  { href: '#graph', key: 'nav.graph' },
+  { href: '#deployment', key: 'nav.deployment' },
+  { href: '/docs', key: 'nav.docs' },
+] as const;
 
-export default function Home() {
+const capabilityKeys = ['hybrid', 'graph', 'agent', 'deployment'] as const;
+const traceSteps = [
+  'question',
+  'graph',
+  'manual',
+  'compare',
+  'answer',
+] as const;
+const agentFeatureKeys = ['runtime', 'mcp', 'audit'] as const;
+const deploymentFeatureKeys = ['private', 'models', 'management'] as const;
+
+type LandingTranslations = Awaited<ReturnType<typeof getTranslations>>;
+
+export default async function Home() {
+  const t = await getTranslations('page_landing');
+
   return (
-    <>
-      <AppTopbar />
-      <PageContainer className="relative px-6">
+    <main className="bg-background text-foreground min-h-[100dvh] overflow-hidden">
+      <LandingNav t={t} />
+      <section className="relative mx-auto grid max-w-7xl gap-12 px-6 pt-28 pb-20 md:grid-cols-[1.02fr_0.98fr] md:px-10 md:pt-36 lg:gap-16">
         <div
           aria-hidden="true"
-          className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
-        >
-          <div
-            style={{
-              clipPath:
-                'polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)',
-            }}
-            className="relative left-[calc(50%-11rem)] aspect-1155/678 w-144.5 -translate-x-1/2 rotate-30 bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-30 sm:left-[calc(50%-30rem)] sm:w-288.75"
-          ></div>
-        </div>
-        <PageContent className="mx-auto max-w-300 py-48">
-          <div className="hidden sm:mb-8 sm:flex sm:justify-center">
-            <div className="flex flex-row items-center gap-2 rounded-full border px-4 py-1 text-sm/6">
-              <Mail className="size-4" />
-              For technical questions, contact us by
-              <a href="mailto:sailwebs@apecloud.com" className="underline">
-                Email <span aria-hidden="true">&rarr;</span>
-              </a>
-            </div>
+          className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[44rem] opacity-90"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle at 76% 18%, color-mix(in oklab, var(--primary) 14%, transparent), transparent 32rem), radial-gradient(circle at 12% 32%, color-mix(in oklab, var(--accent-ink) 8%, transparent), transparent 26rem)',
+          }}
+        />
+        <div className="flex flex-col justify-center">
+          <div className="bg-card text-muted-foreground mb-7 inline-flex w-fit items-center gap-2 rounded-full border px-2 py-1 pr-3 text-xs shadow-xs">
+            <span className="bg-primary text-primary-foreground rounded-full px-2 py-0.5 font-mono text-[10px] tracking-[0.16em] uppercase">
+              {t('hero.badge')}
+            </span>
+            <span>{t('hero.badge_text')}</span>
           </div>
-          <div className="text-center">
-            <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
-              Production-Ready RAG Platform with Graph, Vector & Full-Text
-              Search
-            </h1>
-            <p className="text-muted-foreground mt-8 text-lg">
-              ApeRAG is a production-ready RAG (Retrieval-Augmented Generation)
-              platform that combines Graph RAG, vector search, and full-text
-              search. Build sophisticated AI applications with hybrid retrieval,
-              multimodal document processing, and enterprise-grade management
-              features.
-            </p>
-            <div className="mt-10 flex items-center justify-center gap-x-6">
-              <Button asChild>
-                <Link href="/workspace/collections">Get started</Link>
-              </Button>
-              <Button asChild variant="outline">
-                <Link href="/marketplace">
-                  Marketplace <ArrowRight />
-                </Link>
-              </Button>
-            </div>
+          <h1 className="max-w-3xl font-serif text-5xl leading-[1.02] font-normal tracking-[-0.045em] text-balance md:text-6xl lg:text-7xl">
+            {t('hero.title')}{' '}
+            <span className="text-primary">{t('hero.title_accent')}</span>
+          </h1>
+          <p className="text-muted-foreground mt-7 max-w-xl text-base leading-8 md:text-lg">
+            {t('hero.description')}
+          </p>
+          <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+            <Button
+              asChild
+              size="lg"
+              className="h-11 rounded-full px-6 active:scale-[0.98]"
+            >
+              <Link href="/workspace/collections">
+                {t('hero.primary_cta')}
+                <ArrowRight className="size-4" />
+              </Link>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
+              className="h-11 rounded-full px-6 active:scale-[0.98]"
+            >
+              <Link href="/marketplace">{t('hero.secondary_cta')}</Link>
+            </Button>
           </div>
-        </PageContent>
-        <div
-          aria-hidden="true"
-          className="absolute inset-x-0 top-[calc(100%-30rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-40rem)]"
-        >
-          <div
-            style={{
-              clipPath:
-                'polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)',
-            }}
-            className="relative left-[calc(50%+3rem)] aspect-1155/678 w-144.5 -translate-x-1/2 bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-30 sm:left-[calc(50%+36rem)] sm:w-288.75"
-          ></div>
+          <div className="text-muted-foreground mt-9 grid gap-3 text-sm sm:grid-cols-3">
+            {['private', 'models', 'license'].map((key) => (
+              <div key={key} className="flex items-center gap-2">
+                <span className="bg-accent-soft text-accent-ink grid size-5 place-items-center rounded-full">
+                  <Check className="size-3" />
+                </span>
+                {t(`hero.points.${key}`)}
+              </div>
+            ))}
+          </div>
         </div>
+        <HeroAgentTrace t={t} />
+      </section>
 
-        <PageContent className="">
-          <div className="mb-12 text-center text-5xl font-bold">
-            Key Features
-          </div>
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2">
-            {features.map((feature, index) => {
-              return (
-                <div
-                  key={index}
-                  className="relative overflow-hidden bg-gray-950/[4%] bg-[image:radial-gradient(var(--pattern-fg)_1px,_transparent_0)] bg-[size:10px_10px] bg-fixed [--pattern-fg:var(--color-gray-950)]/5 after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:inset-ring after:inset-ring-gray-950/5 dark:[--pattern-fg:var(--color-white)]/10 dark:after:inset-ring-white/10"
-                >
-                  <div className="p-8">
-                    <h3 className="mb-4 text-2xl">{feature.title}</h3>
-                    <div className="text-muted-foreground">
-                      {feature.description}
-                    </div>
-                  </div>
+      <section className="mx-auto max-w-7xl px-6 pb-20 md:px-10">
+        <div className="bg-card grid overflow-hidden rounded-xl border shadow-sm md:grid-cols-4">
+          {capabilityKeys.map((key, index) => (
+            <div
+              key={key}
+              className="border-b p-6 last:border-b-0 md:border-r md:border-b-0 last:md:border-r-0"
+            >
+              <div className="text-primary font-mono text-[11px] tracking-[0.16em] uppercase">
+                0{index + 1}
+              </div>
+              <div className="mt-5 text-lg font-medium tracking-tight">
+                {t(`capabilities.${key}.title`)}
+              </div>
+              <p className="text-muted-foreground mt-2 text-sm leading-6">
+                {t(`capabilities.${key}.description`)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
+        id="agent"
+        className="mx-auto grid max-w-7xl gap-12 px-6 py-20 md:grid-cols-[0.88fr_1.12fr] md:px-10 lg:gap-20"
+      >
+        <SectionIntro
+          eyebrow={t('agent.eyebrow')}
+          title={t('agent.title')}
+          description={t('agent.description')}
+        />
+        <div className="grid gap-4 md:grid-cols-2">
+          {agentFeatureKeys.map((key, index) => (
+            <FeaturePanel
+              key={key}
+              index={index + 1}
+              title={t(`agent.features.${key}.title`)}
+              description={t(`agent.features.${key}.description`)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section
+        id="graph"
+        className="mx-auto grid max-w-7xl gap-12 px-6 py-20 md:grid-cols-[1.12fr_0.88fr] md:px-10 lg:gap-20"
+      >
+        <GraphVisual t={t} />
+        <SectionIntro
+          eyebrow={t('graph.eyebrow')}
+          title={t('graph.title')}
+          description={t('graph.description')}
+          align="right"
+        />
+      </section>
+
+      <section
+        id="deployment"
+        className="mx-auto max-w-7xl px-6 py-20 md:px-10"
+      >
+        <div className="bg-card grid gap-8 rounded-xl border p-6 shadow-sm md:grid-cols-[0.9fr_1.1fr] md:p-10">
+          <SectionIntro
+            eyebrow={t('deployment.eyebrow')}
+            title={t('deployment.title')}
+            description={t('deployment.description')}
+          />
+          <div className="grid gap-4 sm:grid-cols-3">
+            {deploymentFeatureKeys.map((key) => (
+              <div key={key} className="bg-background rounded-xl border p-5">
+                <div className="bg-accent-soft text-accent-ink mb-6 grid size-10 place-items-center rounded-full">
+                  {key === 'private' ? (
+                    <ShieldCheck className="size-5" />
+                  ) : key === 'models' ? (
+                    <DatabaseZap className="size-5" />
+                  ) : (
+                    <Boxes className="size-5" />
+                  )}
                 </div>
-              );
-            })}
+                <div className="font-medium tracking-tight">
+                  {t(`deployment.features.${key}.title`)}
+                </div>
+                <p className="text-muted-foreground mt-2 text-sm leading-6">
+                  {t(`deployment.features.${key}.description`)}
+                </p>
+              </div>
+            ))}
           </div>
-        </PageContent>
-        <PageContent className="py-12"></PageContent>
-      </PageContainer>
-    </>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-20 md:px-10">
+        <div className="bg-foreground text-background relative overflow-hidden rounded-xl border p-8 shadow-sm md:p-12">
+          <div className="max-w-2xl">
+            <div className="text-background/60 font-mono text-xs tracking-[0.18em] uppercase">
+              {t('cta.eyebrow')}
+            </div>
+            <h2 className="mt-5 font-serif text-4xl leading-tight font-normal tracking-[-0.035em] md:text-5xl">
+              {t('cta.title')}
+            </h2>
+            <p className="text-background/70 mt-5 text-base leading-7">
+              {t('cta.description')}
+            </p>
+          </div>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button
+              asChild
+              size="lg"
+              className="bg-background text-foreground hover:bg-background/90 h-11 rounded-full px-6 active:scale-[0.98]"
+            >
+              <Link href="/workspace/collections">{t('cta.primary_cta')}</Link>
+            </Button>
+            <Button
+              asChild
+              size="lg"
+              variant="outline"
+              className="border-background/20 text-background hover:bg-background/10 hover:text-background h-11 rounded-full bg-transparent px-6 active:scale-[0.98]"
+            >
+              <a href="mailto:sailwebs@apecloud.com">
+                <Mail className="size-4" />
+                {t('cta.secondary_cta')}
+              </a>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function LandingNav({ t }: { t: LandingTranslations }) {
+  return (
+    <header className="bg-background/85 fixed inset-x-0 top-0 z-40 border-b backdrop-blur-xl">
+      <div className="mx-auto flex h-16 max-w-7xl items-center gap-8 px-6 md:px-10">
+        <AppLogo />
+        <nav className="text-muted-foreground hidden items-center gap-7 text-sm md:flex">
+          {navLinks.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="hover:text-foreground transition-colors"
+            >
+              {t(item.key)}
+            </Link>
+          ))}
+        </nav>
+        <div className="ml-auto flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm" className="rounded-full">
+            <Link href="/auth/signin">{t('nav.signin')}</Link>
+          </Button>
+          <Button asChild size="sm" className="rounded-full">
+            <Link href="/workspace/collections">{t('nav.start')}</Link>
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function HeroAgentTrace({ t }: { t: LandingTranslations }) {
+  return (
+    <div className="relative self-center">
+      <div
+        aria-hidden="true"
+        className="absolute -inset-8 -z-10 rounded-[2rem] opacity-80"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle at 30% 20%, color-mix(in oklab, var(--primary) 12%, transparent), transparent 22rem), radial-gradient(circle at 82% 82%, color-mix(in oklab, var(--accent-ink) 8%, transparent), transparent 18rem)',
+        }}
+      />
+      <div className="bg-card overflow-hidden rounded-xl border shadow-sm">
+        <div className="flex items-center gap-3 border-b px-5 py-4">
+          <div className="flex gap-1.5" aria-hidden="true">
+            <span className="bg-accent-soft size-2.5 rounded-full" />
+            <span className="bg-secondary size-2.5 rounded-full" />
+            <span className="bg-muted size-2.5 rounded-full" />
+          </div>
+          <span className="text-muted-foreground font-mono text-xs">
+            agent · collections/smt-manuals
+          </span>
+          <span className="text-primary ml-auto inline-flex items-center gap-2 font-mono text-[11px] uppercase">
+            <span className="bg-primary size-1.5 rounded-full" />
+            {t('hero_trace.status')}
+          </span>
+        </div>
+        <div className="px-6 py-5">
+          <div className="text-muted-foreground font-mono text-[11px] tracking-[0.14em] uppercase">
+            {t('hero_trace.user')}
+          </div>
+          <p className="mt-2 text-sm leading-6">{t('hero_trace.prompt')}</p>
+        </div>
+        <div className="bg-secondary/55 border-t px-6 py-5">
+          <div className="mb-4 flex items-center gap-2">
+            <Sparkles className="text-primary size-4" />
+            <span className="text-muted-foreground font-mono text-[11px] tracking-[0.16em] uppercase">
+              {t('hero_trace.title')}
+            </span>
+            <span className="text-muted-foreground ml-auto font-mono text-[11px]">
+              {t('hero_trace.meta')}
+            </span>
+          </div>
+          <div className="space-y-4">
+            {traceSteps.map((key, index) => (
+              <div key={key} className="grid grid-cols-[1.5rem_1fr] gap-3">
+                <div className="bg-card text-primary mt-1 grid size-6 place-items-center rounded-full shadow-xs">
+                  {index === 0 ? (
+                    <Sparkles className="size-3.5" />
+                  ) : index === 1 ? (
+                    <Network className="size-3.5" />
+                  ) : index === 2 ? (
+                    <BookOpenText className="size-3.5" />
+                  ) : index === 3 ? (
+                    <GitBranch className="size-3.5" />
+                  ) : (
+                    <Check className="size-3.5" />
+                  )}
+                </div>
+                <div>
+                  <div className="text-muted-foreground font-mono text-[10px] tracking-[0.14em] uppercase">
+                    {t(`hero_trace.steps.${key}.label`)}
+                  </div>
+                  <p className="text-foreground/85 mt-1 text-sm leading-6">
+                    {t(`hero_trace.steps.${key}.text`)}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionIntro({
+  eyebrow,
+  title,
+  description,
+  align = 'left',
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  align?: 'left' | 'right';
+}) {
+  return (
+    <div className={align === 'right' ? 'md:pl-8' : ''}>
+      <div className="text-primary font-mono text-xs tracking-[0.18em] uppercase">
+        {eyebrow}
+      </div>
+      <h2 className="mt-5 max-w-xl font-serif text-4xl leading-[1.08] font-normal tracking-[-0.035em] md:text-5xl">
+        {title}
+      </h2>
+      <p className="text-muted-foreground mt-6 max-w-xl text-base leading-7">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+function FeaturePanel({
+  index,
+  title,
+  description,
+}: {
+  index: number;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div
+      className={
+        index === 1
+          ? 'bg-card rounded-xl border p-6 shadow-sm md:col-span-2'
+          : 'bg-card rounded-xl border p-6 shadow-sm'
+      }
+    >
+      <div className="text-primary font-mono text-[11px] tracking-[0.16em] uppercase">
+        0{index}
+      </div>
+      <div className="mt-8 text-lg font-medium tracking-tight">{title}</div>
+      <p className="text-muted-foreground mt-2 max-w-xl text-sm leading-6">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+function GraphVisual({ t }: { t: LandingTranslations }) {
+  const nodes = [
+    [
+      '50%',
+      '48%',
+      'h-18 w-18 bg-primary text-primary-foreground',
+      t('graph.nodes.center'),
+    ],
+    ['24%', '22%', 'h-8 w-8 bg-chart-2 text-background', t('graph.nodes.org')],
+    [
+      '76%',
+      '25%',
+      'h-10 w-10 bg-chart-4 text-background',
+      t('graph.nodes.product'),
+    ],
+    [
+      '20%',
+      '72%',
+      'h-9 w-9 bg-chart-5 text-background',
+      t('graph.nodes.event'),
+    ],
+    [
+      '76%',
+      '76%',
+      'h-8 w-8 bg-chart-1 text-background',
+      t('graph.nodes.person'),
+    ],
+    [
+      '48%',
+      '16%',
+      'h-7 w-7 bg-chart-3 text-background',
+      t('graph.nodes.concept'),
+    ],
+  ] as const;
+
+  return (
+    <div className="bg-card relative min-h-[25rem] rounded-xl border p-5 shadow-sm">
+      <svg
+        className="absolute inset-5 h-[calc(100%-2.5rem)] w-[calc(100%-2.5rem)]"
+        aria-hidden="true"
+      >
+        <line
+          x1="50%"
+          y1="48%"
+          x2="24%"
+          y2="22%"
+          className="stroke-border"
+          strokeWidth="1"
+        />
+        <line
+          x1="50%"
+          y1="48%"
+          x2="76%"
+          y2="25%"
+          className="stroke-border"
+          strokeWidth="1"
+        />
+        <line
+          x1="50%"
+          y1="48%"
+          x2="20%"
+          y2="72%"
+          className="stroke-border"
+          strokeWidth="1"
+        />
+        <line
+          x1="50%"
+          y1="48%"
+          x2="76%"
+          y2="76%"
+          className="stroke-border"
+          strokeWidth="1"
+        />
+        <line
+          x1="50%"
+          y1="48%"
+          x2="48%"
+          y2="16%"
+          className="stroke-border"
+          strokeWidth="1"
+        />
+      </svg>
+      {nodes.map(([left, top, className, label]) => (
+        <div
+          key={label}
+          className="absolute -translate-x-1/2 -translate-y-1/2"
+          style={{ left, top }}
+        >
+          <div
+            className={`${className} border-card grid place-items-center rounded-full border-4 font-mono text-[10px] shadow-sm`}
+          >
+            {label}
+          </div>
+        </div>
+      ))}
+      <div className="bg-background/90 absolute bottom-5 left-5 rounded-xl border p-4 shadow-sm backdrop-blur">
+        <div className="text-muted-foreground font-mono text-[11px] tracking-[0.16em] uppercase">
+          {t('graph.legend')}
+        </div>
+        <div className="text-muted-foreground mt-3 grid grid-cols-2 gap-x-5 gap-y-2 text-xs">
+          {['Person', 'Org', 'Product', 'Event'].map((item, index) => (
+            <div key={item} className="flex items-center gap-2">
+              <span
+                className={`size-2 rounded-full ${
+                  index === 0
+                    ? 'bg-chart-1'
+                    : index === 1
+                      ? 'bg-chart-2'
+                      : index === 2
+                        ? 'bg-chart-4'
+                        : 'bg-chart-5'
+                }`}
+              />
+              {item}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -184,6 +184,8 @@
     "email": "邮箱",
     "email_placeholder": "邮箱",
     "signin": "Sign In",
+    "signin_eyebrow": "Secure workspace",
+    "signin_description": "Sign in to review collections, trace agent work, and manage your ApeRAG workspace.",
     "login_in_with_a_third_party_account": "Login with a third-party account",
     "login_with_google": "Login with Google",
     "login_with_github": "Login with GitHub",
@@ -192,9 +194,19 @@
     "forgot_your_password": "Forgot your password",
     "do_not_have_an_account": "Don't have an account? ",
     "signup": "Sign Up",
+    "signup_eyebrow": "Create workspace access",
+    "signup_description": "Create an account for your ApeRAG workspace. Existing backend registration rules stay unchanged.",
     "register_an_account": "Register an account",
     "already_hava_an_account": "Already have an account? ",
     "signout": "Sign Out",
+    "auth_hero_eyebrow": "ApeRAG",
+    "auth_hero_quote": "Ten years of operational documents become an assistant that can explain its path.",
+    "auth_hero_description": "The login surface is quiet by design: one warm brand system, existing authentication methods, and no extra product promises.",
+    "auth_footer": "Access is controlled by your configured ApeRAG authentication methods.",
+    "check_email_title": "Check your email",
+    "check_email_description": "A sign in link has been sent to your email address.",
+    "signin_again": "Sign in again",
+    "oauth_eyebrow": "OAuth callback",
     "processing_oauth_login": "Processing OAuth login...",
     "oauth_successful": "OAuth successful",
     "the_system_will_automatically_redirect": "the system will automatically redirect",
@@ -666,6 +678,7 @@
     "node_group": "Node Group",
     "node_search": "Node search",
     "no_nodes_found": "No node information found",
+    "no_description": "No description available",
     "merge_infomation": "{count} merge suggestions",
     "merge_suggestions": "Merge suggestions",
     "merge_accept": "Accept",
@@ -682,6 +695,136 @@
     "entity_geo": "GEO",
     "entity_event": "Event",
     "entity_UNKNOWN": "UNKNOWN"
+  },
+  "page_landing": {
+    "nav": {
+      "agent": "Agent",
+      "graph": "Graph",
+      "deployment": "Deployment",
+      "docs": "Docs",
+      "signin": "Sign in",
+      "start": "Open workspace"
+    },
+    "hero": {
+      "badge": "v2",
+      "badge_text": "GraphRAG x Agent runtime · private deployment",
+      "title": "Turn enterprise knowledge into",
+      "title_accent": "traceable answers.",
+      "description": "ApeRAG combines hybrid retrieval, knowledge graphs, and observable agent execution so operators can ask operational questions without losing provenance.",
+      "primary_cta": "Open workspace",
+      "secondary_cta": "Browse marketplace",
+      "points": {
+        "private": "Private deployment",
+        "models": "Works with mainstream models",
+        "license": "Apache 2.0"
+      }
+    },
+    "hero_trace": {
+      "status": "running",
+      "user": "Operator",
+      "prompt": "SMT-03 on line 3 reported E-047 this morning. Help me narrow down the likely cause.",
+      "title": "Agent trace",
+      "meta": "sources tracked",
+      "steps": {
+        "question": {
+          "label": "Understand",
+          "text": "Clarifies the equipment, error code, and time window before touching tools."
+        },
+        "graph": {
+          "label": "Graph",
+          "text": "Searches the knowledge graph for SMT-03 and related failure events."
+        },
+        "manual": {
+          "label": "Documents",
+          "text": "Reads maintenance notes and the E-047 troubleshooting section."
+        },
+        "compare": {
+          "label": "Compare",
+          "text": "Matches the recent incidents with historical feeder tension symptoms."
+        },
+        "answer": {
+          "label": "Answer",
+          "text": "Returns a concise diagnosis with citations and the next inspection steps."
+        }
+      }
+    },
+    "capabilities": {
+      "hybrid": {
+        "title": "Hybrid retrieval",
+        "description": "Vector, full-text, graph, and document evidence stay available in one query path."
+      },
+      "graph": {
+        "title": "Knowledge graph",
+        "description": "Entities, incidents, documents, and relationships become inspectable instead of hidden in chunks."
+      },
+      "agent": {
+        "title": "Observable agents",
+        "description": "Reasoning steps, searches, readings, and final answers are separated for review."
+      },
+      "deployment": {
+        "title": "Production controls",
+        "description": "Authentication, model providers, quota, API keys, audit logs, and admin controls remain part of the product."
+      }
+    },
+    "agent": {
+      "eyebrow": "01 — Agent",
+      "title": "The answer is only useful when the path is visible.",
+      "description": "ApeRAG keeps the agent trace readable by default: what it tried, what it read, what it compared, and which sources support the final answer.",
+      "features": {
+        "runtime": {
+          "title": "Replayable runtime",
+          "description": "Streaming events are preserved as a clear action timeline rather than raw tool payloads."
+        },
+        "mcp": {
+          "title": "MCP-ready tools",
+          "description": "Internal systems can be exposed as controlled tools without changing the user-facing conversation model."
+        },
+        "audit": {
+          "title": "Reviewable execution",
+          "description": "Citations, feedback, and trace details stay available without cluttering the primary reading path."
+        }
+      }
+    },
+    "graph": {
+      "eyebrow": "02 — Graph",
+      "title": "Dense relationships, rendered with restraint.",
+      "description": "The graph view keeps entity types, neighbors, search, and merge suggestions available while using a quieter warm palette for daily work.",
+      "legend": "Entity types",
+      "nodes": {
+        "center": "SMT",
+        "org": "ORG",
+        "product": "EQP",
+        "event": "EVT",
+        "person": "OPS",
+        "concept": "RAG"
+      }
+    },
+    "deployment": {
+      "eyebrow": "03 — Deployment",
+      "title": "Built for controlled enterprise environments.",
+      "description": "The design upgrade does not remove operational surfaces. Existing configuration, document management, quota, providers, and admin paths continue under the same visual system.",
+      "features": {
+        "private": {
+          "title": "Private runtime",
+          "description": "Deploy ApeRAG in your own environment and keep data controls explicit."
+        },
+        "models": {
+          "title": "Model platform",
+          "description": "Provider and model configuration remains first-class, not hidden behind a demo shell."
+        },
+        "management": {
+          "title": "Admin surfaces",
+          "description": "API keys, quota, audit logs, and system configuration will use the same brand layer."
+        }
+      }
+    },
+    "cta": {
+      "eyebrow": "Start with existing data",
+      "title": "Open a collection, ask a question, inspect the path.",
+      "description": "The new interface focuses on the workflows ApeRAG already supports: collections, documents, graph visualization, agent chat, marketplace publishing, and operational controls.",
+      "primary_cta": "Open workspace",
+      "secondary_cta": "Contact ApeCloud"
+    }
   },
   "page_marketplace": {
     "metadata": {

--- a/web/src/i18n/en-US/page_auth.json
+++ b/web/src/i18n/en-US/page_auth.json
@@ -11,6 +11,8 @@
   "email_placeholder": "邮箱",
 
   "signin": "Sign In",
+  "signin_eyebrow": "Secure workspace",
+  "signin_description": "Sign in to review collections, trace agent work, and manage your ApeRAG workspace.",
   "login_in_with_a_third_party_account": "Login with a third-party account",
   "login_with_google": "Login with Google",
   "login_with_github": "Login with GitHub",
@@ -20,10 +22,20 @@
   "do_not_have_an_account": "Don't have an account? ",
 
   "signup": "Sign Up",
+  "signup_eyebrow": "Create workspace access",
+  "signup_description": "Create an account for your ApeRAG workspace. Existing backend registration rules stay unchanged.",
   "register_an_account": "Register an account",
   "already_hava_an_account": "Already have an account? ",
 
   "signout": "Sign Out",
+  "auth_hero_eyebrow": "ApeRAG",
+  "auth_hero_quote": "Ten years of operational documents become an assistant that can explain its path.",
+  "auth_hero_description": "The login surface is quiet by design: one warm brand system, existing authentication methods, and no extra product promises.",
+  "auth_footer": "Access is controlled by your configured ApeRAG authentication methods.",
+  "check_email_title": "Check your email",
+  "check_email_description": "A sign in link has been sent to your email address.",
+  "signin_again": "Sign in again",
+  "oauth_eyebrow": "OAuth callback",
 
   "processing_oauth_login": "Processing OAuth login...",
   "oauth_successful": "OAuth successful",

--- a/web/src/i18n/en-US/page_landing.json
+++ b/web/src/i18n/en-US/page_landing.json
@@ -1,0 +1,130 @@
+{
+  "nav": {
+    "agent": "Agent",
+    "graph": "Graph",
+    "deployment": "Deployment",
+    "docs": "Docs",
+    "signin": "Sign in",
+    "start": "Open workspace"
+  },
+  "hero": {
+    "badge": "v2",
+    "badge_text": "GraphRAG x Agent runtime · private deployment",
+    "title": "Turn enterprise knowledge into",
+    "title_accent": "traceable answers.",
+    "description": "ApeRAG combines hybrid retrieval, knowledge graphs, and observable agent execution so operators can ask operational questions without losing provenance.",
+    "primary_cta": "Open workspace",
+    "secondary_cta": "Browse marketplace",
+    "points": {
+      "private": "Private deployment",
+      "models": "Works with mainstream models",
+      "license": "Apache 2.0"
+    }
+  },
+  "hero_trace": {
+    "status": "running",
+    "user": "Operator",
+    "prompt": "SMT-03 on line 3 reported E-047 this morning. Help me narrow down the likely cause.",
+    "title": "Agent trace",
+    "meta": "sources tracked",
+    "steps": {
+      "question": {
+        "label": "Understand",
+        "text": "Clarifies the equipment, error code, and time window before touching tools."
+      },
+      "graph": {
+        "label": "Graph",
+        "text": "Searches the knowledge graph for SMT-03 and related failure events."
+      },
+      "manual": {
+        "label": "Documents",
+        "text": "Reads maintenance notes and the E-047 troubleshooting section."
+      },
+      "compare": {
+        "label": "Compare",
+        "text": "Matches the recent incidents with historical feeder tension symptoms."
+      },
+      "answer": {
+        "label": "Answer",
+        "text": "Returns a concise diagnosis with citations and the next inspection steps."
+      }
+    }
+  },
+  "capabilities": {
+    "hybrid": {
+      "title": "Hybrid retrieval",
+      "description": "Vector, full-text, graph, and document evidence stay available in one query path."
+    },
+    "graph": {
+      "title": "Knowledge graph",
+      "description": "Entities, incidents, documents, and relationships become inspectable instead of hidden in chunks."
+    },
+    "agent": {
+      "title": "Observable agents",
+      "description": "Reasoning steps, searches, readings, and final answers are separated for review."
+    },
+    "deployment": {
+      "title": "Production controls",
+      "description": "Authentication, model providers, quota, API keys, audit logs, and admin controls remain part of the product."
+    }
+  },
+  "agent": {
+    "eyebrow": "01 — Agent",
+    "title": "The answer is only useful when the path is visible.",
+    "description": "ApeRAG keeps the agent trace readable by default: what it tried, what it read, what it compared, and which sources support the final answer.",
+    "features": {
+      "runtime": {
+        "title": "Replayable runtime",
+        "description": "Streaming events are preserved as a clear action timeline rather than raw tool payloads."
+      },
+      "mcp": {
+        "title": "MCP-ready tools",
+        "description": "Internal systems can be exposed as controlled tools without changing the user-facing conversation model."
+      },
+      "audit": {
+        "title": "Reviewable execution",
+        "description": "Citations, feedback, and trace details stay available without cluttering the primary reading path."
+      }
+    }
+  },
+  "graph": {
+    "eyebrow": "02 — Graph",
+    "title": "Dense relationships, rendered with restraint.",
+    "description": "The graph view keeps entity types, neighbors, search, and merge suggestions available while using a quieter warm palette for daily work.",
+    "legend": "Entity types",
+    "nodes": {
+      "center": "SMT",
+      "org": "ORG",
+      "product": "EQP",
+      "event": "EVT",
+      "person": "OPS",
+      "concept": "RAG"
+    }
+  },
+  "deployment": {
+    "eyebrow": "03 — Deployment",
+    "title": "Built for controlled enterprise environments.",
+    "description": "The design upgrade does not remove operational surfaces. Existing configuration, document management, quota, providers, and admin paths continue under the same visual system.",
+    "features": {
+      "private": {
+        "title": "Private runtime",
+        "description": "Deploy ApeRAG in your own environment and keep data controls explicit."
+      },
+      "models": {
+        "title": "Model platform",
+        "description": "Provider and model configuration remains first-class, not hidden behind a demo shell."
+      },
+      "management": {
+        "title": "Admin surfaces",
+        "description": "API keys, quota, audit logs, and system configuration will use the same brand layer."
+      }
+    }
+  },
+  "cta": {
+    "eyebrow": "Start with existing data",
+    "title": "Open a collection, ask a question, inspect the path.",
+    "description": "The new interface focuses on the workflows ApeRAG already supports: collections, documents, graph visualization, agent chat, marketplace publishing, and operational controls.",
+    "primary_cta": "Open workspace",
+    "secondary_cta": "Contact ApeCloud"
+  }
+}

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -184,6 +184,8 @@
     "email": "邮箱",
     "email_placeholder": "邮箱",
     "signin": "登录",
+    "signin_eyebrow": "安全工作区",
+    "signin_description": "登录后可以查看 Collection、追踪 Agent 执行，并管理你的 ApeRAG 工作区。",
     "login_in_with_a_third_party_account": "使用第三方账号登录",
     "login_with_google": "Google账号",
     "login_with_github": "GitHub账号",
@@ -192,9 +194,19 @@
     "forgot_your_password": "忘记密码",
     "do_not_have_an_account": "没有账号？ ",
     "signup": "注册",
+    "signup_eyebrow": "创建工作区访问",
+    "signup_description": "创建 ApeRAG 工作区账号，注册规则仍沿用当前后端能力。",
     "register_an_account": "注册账号",
     "already_hava_an_account": "已有账号？ ",
     "signout": "退出",
+    "auth_hero_eyebrow": "ApeRAG",
+    "auth_hero_quote": "十年的工艺文档，变成一个能说明答案路径的助手。",
+    "auth_hero_description": "登录页面保持克制：使用统一暖色品牌层、沿用现有认证方式，不额外承诺未接入的产品能力。",
+    "auth_footer": "访问权限由当前 ApeRAG 已配置的认证方式控制。",
+    "check_email_title": "检查你的邮箱",
+    "check_email_description": "登录链接已经发送到你的邮箱地址。",
+    "signin_again": "重新登录",
+    "oauth_eyebrow": "OAuth 回调",
     "processing_oauth_login": "处理OAuth登录中...",
     "oauth_successful": "OAuth认证成功",
     "the_system_will_automatically_redirect": "系统将自动跳转，请稍后...",
@@ -669,6 +681,7 @@
     "node_group": "节点分组",
     "node_search": "节点查询",
     "no_nodes_found": "未找到相关节点",
+    "no_description": "暂无描述",
     "merge_infomation": "{count}个节点节点合并建议.",
     "merge_suggestions": "节点合并",
     "merge_accept": "接受",
@@ -685,6 +698,136 @@
     "entity_geo": "位置",
     "entity_event": "事件",
     "entity_UNKNOWN": "未知"
+  },
+  "page_landing": {
+    "nav": {
+      "agent": "Agent",
+      "graph": "图谱",
+      "deployment": "部署",
+      "docs": "文档",
+      "signin": "登录",
+      "start": "进入工作区"
+    },
+    "hero": {
+      "badge": "v2",
+      "badge_text": "GraphRAG × Agent 运行时 · 私有化部署",
+      "title": "让企业知识变成",
+      "title_accent": "可追溯的答案。",
+      "description": "ApeRAG 把混合检索、知识图谱和可观测 Agent 执行放在同一条工作流里，让团队能问业务问题，也能看到答案从哪里来。",
+      "primary_cta": "进入工作区",
+      "secondary_cta": "浏览市场",
+      "points": {
+        "private": "私有化部署",
+        "models": "兼容主流模型",
+        "license": "Apache 2.0"
+      }
+    },
+    "hero_trace": {
+      "status": "运行中",
+      "user": "操作员",
+      "prompt": "3 号线 SMT-03 今早报 E-047，帮我判断最可能的原因。",
+      "title": "Agent 轨迹",
+      "meta": "来源已记录",
+      "steps": {
+        "question": {
+          "label": "理解",
+          "text": "先确认设备、错误码和时间范围，再决定要查哪些资料。"
+        },
+        "graph": {
+          "label": "图谱",
+          "text": "搜索知识图谱，找到 SMT-03 和关联故障事件。"
+        },
+        "manual": {
+          "label": "文档",
+          "text": "阅读维修记录和 E-047 排障章节。"
+        },
+        "compare": {
+          "label": "比对",
+          "text": "把近期故障和历史送料器张力问题做对照。"
+        },
+        "answer": {
+          "label": "回答",
+          "text": "输出带引用的诊断结论，并给出下一步检查建议。"
+        }
+      }
+    },
+    "capabilities": {
+      "hybrid": {
+        "title": "混合检索",
+        "description": "向量、全文、图谱和文档证据在同一条查询路径里协同工作。"
+      },
+      "graph": {
+        "title": "知识图谱",
+        "description": "实体、故障、文档和关系可以被查看，而不是被隐藏在切片里。"
+      },
+      "agent": {
+        "title": "可观测 Agent",
+        "description": "思考、检索、阅读、比对和最终回答被清晰分层，便于复盘。"
+      },
+      "deployment": {
+        "title": "生产控制面",
+        "description": "认证、模型供应商、配额、API Key、审计日志和管理员控制都保留在产品里。"
+      }
+    },
+    "agent": {
+      "eyebrow": "01 — Agent",
+      "title": "答案有用，前提是路径可见。",
+      "description": "ApeRAG 默认把 Agent 轨迹做成人能读懂的动作链：它试了什么、读了什么、比较了什么、最终答案由哪些来源支撑。",
+      "features": {
+        "runtime": {
+          "title": "可回放运行时",
+          "description": "流式事件保留为清晰的动作时间线，而不是把原始工具参数暴露给用户。"
+        },
+        "mcp": {
+          "title": "MCP 工具接入",
+          "description": "内部系统可以被封装成受控工具，同时不改变用户侧的对话体验。"
+        },
+        "audit": {
+          "title": "可审阅执行",
+          "description": "引用、反馈和轨迹详情仍然可见，但不会挤占主阅读路径。"
+        }
+      }
+    },
+    "graph": {
+      "eyebrow": "02 — 图谱",
+      "title": "复杂关系，也要克制呈现。",
+      "description": "图谱页保留实体类型、邻居高亮、搜索和合并建议，同时用更安静的暖色体系服务日常使用。",
+      "legend": "实体类型",
+      "nodes": {
+        "center": "SMT",
+        "org": "组织",
+        "product": "设备",
+        "event": "事件",
+        "person": "人员",
+        "concept": "概念"
+      }
+    },
+    "deployment": {
+      "eyebrow": "03 — 部署",
+      "title": "面向可控的企业环境。",
+      "description": "这次视觉升级不会移除运营控制面。现有配置、文档管理、配额、模型供应商和管理员路径会继续纳入同一套设计系统。",
+      "features": {
+        "private": {
+          "title": "私有运行时",
+          "description": "在自己的环境里部署 ApeRAG，数据边界和控制权保持明确。"
+        },
+        "models": {
+          "title": "模型平台",
+          "description": "供应商和模型配置仍是一级能力，不被藏在演示外壳后面。"
+        },
+        "management": {
+          "title": "管理页面",
+          "description": "API Key、配额、审计日志和系统配置都会使用同一套品牌层。"
+        }
+      }
+    },
+    "cta": {
+      "eyebrow": "从现有数据开始",
+      "title": "打开 Collection，问一个问题，再检查答案路径。",
+      "description": "新界面围绕 ApeRAG 已经支持的工作流展开：Collection、文档、图谱可视化、Agent Chat、市场发布和运营控制。",
+      "primary_cta": "进入工作区",
+      "secondary_cta": "联系 ApeCloud"
+    }
   },
   "page_marketplace": {
     "metadata": {

--- a/web/src/i18n/zh-CN/page_auth.json
+++ b/web/src/i18n/zh-CN/page_auth.json
@@ -11,6 +11,8 @@
   "email_placeholder": "邮箱",
 
   "signin": "登录",
+  "signin_eyebrow": "安全工作区",
+  "signin_description": "登录后可以查看 Collection、追踪 Agent 执行，并管理你的 ApeRAG 工作区。",
   "login_in_with_a_third_party_account": "使用第三方账号登录",
   "login_with_google": "Google账号",
   "login_with_github": "GitHub账号",
@@ -20,10 +22,20 @@
   "do_not_have_an_account": "没有账号？ ",
 
   "signup": "注册",
+  "signup_eyebrow": "创建工作区访问",
+  "signup_description": "创建 ApeRAG 工作区账号，注册规则仍沿用当前后端能力。",
   "register_an_account": "注册账号",
   "already_hava_an_account": "已有账号？ ",
 
   "signout": "退出",
+  "auth_hero_eyebrow": "ApeRAG",
+  "auth_hero_quote": "十年的工艺文档，变成一个能说明答案路径的助手。",
+  "auth_hero_description": "登录页面保持克制：使用统一暖色品牌层、沿用现有认证方式，不额外承诺未接入的产品能力。",
+  "auth_footer": "访问权限由当前 ApeRAG 已配置的认证方式控制。",
+  "check_email_title": "检查你的邮箱",
+  "check_email_description": "登录链接已经发送到你的邮箱地址。",
+  "signin_again": "重新登录",
+  "oauth_eyebrow": "OAuth 回调",
 
   "processing_oauth_login": "处理OAuth登录中...",
   "oauth_successful": "OAuth认证成功",

--- a/web/src/i18n/zh-CN/page_landing.json
+++ b/web/src/i18n/zh-CN/page_landing.json
@@ -1,0 +1,130 @@
+{
+  "nav": {
+    "agent": "Agent",
+    "graph": "图谱",
+    "deployment": "部署",
+    "docs": "文档",
+    "signin": "登录",
+    "start": "进入工作区"
+  },
+  "hero": {
+    "badge": "v2",
+    "badge_text": "GraphRAG × Agent 运行时 · 私有化部署",
+    "title": "让企业知识变成",
+    "title_accent": "可追溯的答案。",
+    "description": "ApeRAG 把混合检索、知识图谱和可观测 Agent 执行放在同一条工作流里，让团队能问业务问题，也能看到答案从哪里来。",
+    "primary_cta": "进入工作区",
+    "secondary_cta": "浏览市场",
+    "points": {
+      "private": "私有化部署",
+      "models": "兼容主流模型",
+      "license": "Apache 2.0"
+    }
+  },
+  "hero_trace": {
+    "status": "运行中",
+    "user": "操作员",
+    "prompt": "3 号线 SMT-03 今早报 E-047，帮我判断最可能的原因。",
+    "title": "Agent 轨迹",
+    "meta": "来源已记录",
+    "steps": {
+      "question": {
+        "label": "理解",
+        "text": "先确认设备、错误码和时间范围，再决定要查哪些资料。"
+      },
+      "graph": {
+        "label": "图谱",
+        "text": "搜索知识图谱，找到 SMT-03 和关联故障事件。"
+      },
+      "manual": {
+        "label": "文档",
+        "text": "阅读维修记录和 E-047 排障章节。"
+      },
+      "compare": {
+        "label": "比对",
+        "text": "把近期故障和历史送料器张力问题做对照。"
+      },
+      "answer": {
+        "label": "回答",
+        "text": "输出带引用的诊断结论，并给出下一步检查建议。"
+      }
+    }
+  },
+  "capabilities": {
+    "hybrid": {
+      "title": "混合检索",
+      "description": "向量、全文、图谱和文档证据在同一条查询路径里协同工作。"
+    },
+    "graph": {
+      "title": "知识图谱",
+      "description": "实体、故障、文档和关系可以被查看，而不是被隐藏在切片里。"
+    },
+    "agent": {
+      "title": "可观测 Agent",
+      "description": "思考、检索、阅读、比对和最终回答被清晰分层，便于复盘。"
+    },
+    "deployment": {
+      "title": "生产控制面",
+      "description": "认证、模型供应商、配额、API Key、审计日志和管理员控制都保留在产品里。"
+    }
+  },
+  "agent": {
+    "eyebrow": "01 — Agent",
+    "title": "答案有用，前提是路径可见。",
+    "description": "ApeRAG 默认把 Agent 轨迹做成人能读懂的动作链：它试了什么、读了什么、比较了什么、最终答案由哪些来源支撑。",
+    "features": {
+      "runtime": {
+        "title": "可回放运行时",
+        "description": "流式事件保留为清晰的动作时间线，而不是把原始工具参数暴露给用户。"
+      },
+      "mcp": {
+        "title": "MCP 工具接入",
+        "description": "内部系统可以被封装成受控工具，同时不改变用户侧的对话体验。"
+      },
+      "audit": {
+        "title": "可审阅执行",
+        "description": "引用、反馈和轨迹详情仍然可见，但不会挤占主阅读路径。"
+      }
+    }
+  },
+  "graph": {
+    "eyebrow": "02 — 图谱",
+    "title": "复杂关系，也要克制呈现。",
+    "description": "图谱页保留实体类型、邻居高亮、搜索和合并建议，同时用更安静的暖色体系服务日常使用。",
+    "legend": "实体类型",
+    "nodes": {
+      "center": "SMT",
+      "org": "组织",
+      "product": "设备",
+      "event": "事件",
+      "person": "人员",
+      "concept": "概念"
+    }
+  },
+  "deployment": {
+    "eyebrow": "03 — 部署",
+    "title": "面向可控的企业环境。",
+    "description": "这次视觉升级不会移除运营控制面。现有配置、文档管理、配额、模型供应商和管理员路径会继续纳入同一套设计系统。",
+    "features": {
+      "private": {
+        "title": "私有运行时",
+        "description": "在自己的环境里部署 ApeRAG，数据边界和控制权保持明确。"
+      },
+      "models": {
+        "title": "模型平台",
+        "description": "供应商和模型配置仍是一级能力，不被藏在演示外壳后面。"
+      },
+      "management": {
+        "title": "管理页面",
+        "description": "API Key、配额、审计日志和系统配置都会使用同一套品牌层。"
+      }
+    }
+  },
+  "cta": {
+    "eyebrow": "从现有数据开始",
+    "title": "打开 Collection，问一个问题，再检查答案路径。",
+    "description": "新界面围绕 ApeRAG 已经支持的工作流展开：Collection、文档、图谱可视化、Agent Chat、市场发布和运营控制。",
+    "primary_cta": "进入工作区",
+    "secondary_cta": "联系 ApeCloud"
+  }
+}


### PR DESCRIPTION
## Scope
- Rewrite the public Landing page with the warm editorial L1 design language and real product CTAs.
- Uplift auth layout plus signin/signup/verify-request/OAuth callback surfaces.
- Add `page_landing` i18n namespace and new auth copy in en-US / zh-CN.

## Gates
- L1 tokens only: warm off-white, amber CTA, Fraunces/Manrope/JetBrains Mono classes.
- No backend/auth contract changes; existing local/GitHub/Google auth methods remain dynamic.
- Ghost-check clear: no billing, folders, team collaboration, runtime tweaker, industry toggle, or unsupported SSO surface.
- Old blue/purple landing/auth gradients removed.

## Verification
- `yarn i18n:sync`
- `yarn lint`
- `git diff --check`
- grep old colors / ghost terms in #8 touched surface -> no blocker
