### PR TITLE
feat(fe-rewrite): uplift collection detail pages

### DIFF
--- a/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
@@ -1,5 +1,4 @@
 'use client';
-import type { CollectionStatus } from '@/features/collection/types';
 import { FormatDate } from '@/components/format-date';
 import { PageContent } from '@/components/page-container';
 import { Button } from '@/components/ui/button';
@@ -17,9 +16,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import type { CollectionStatus } from '@/features/collection/types';
 import { cn } from '@/lib/utils';
 import _ from 'lodash';
 
+import { CollectionExport } from '@/components/collections/export-dialog';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
@@ -27,13 +28,14 @@ import {
   publishCollectionSharing,
   unpublishCollectionSharing,
 } from '@/features/collection/client-api';
-import { CollectionExport } from '@/components/collections/export-dialog';
 import {
   Calendar,
+  Database,
   Download,
   EllipsisVertical,
   Files,
   FlaskConical,
+  FolderSearch,
   Settings,
   Trash,
   VectorSquare,
@@ -46,10 +48,10 @@ import { toast } from 'sonner';
 import { CollectionDelete } from './collection-delete';
 
 export const CollectionHeader = ({ className }: { className?: string }) => {
-  const badgeColor: Record<CollectionStatus, string> = {
-    ACTIVE: 'bg-green-700',
-    INACTIVE: 'bg-red-500',
-    DELETED: 'bg-gray-500',
+  const statusClassName: Record<CollectionStatus, string> = {
+    ACTIVE: 'bg-accent-soft text-accent-ink border-accent-soft',
+    INACTIVE: 'bg-secondary text-muted-foreground border-transparent',
+    DELETED: 'bg-secondary text-muted-foreground border-transparent',
   };
   const { collection, share, loadShare } = useCollectionContext();
   const pathname = usePathname();
@@ -57,6 +59,7 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
   const page_evaluations = useTranslations('page_collection_evaluations');
   const page_documents = useTranslations('page_documents');
   const page_graph = useTranslations('page_graph');
+  const page_search = useTranslations('page_search');
 
   const urls = useMemo(() => {
     return {
@@ -85,37 +88,112 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
     [collection?.id, loadShare, page_collections],
   );
 
+  const navItems = useMemo(
+    () =>
+      [
+        {
+          href: urls.documents,
+          active: Boolean(pathname.match(urls.documents)),
+          icon: Files,
+          label: page_documents('metadata.title'),
+        },
+        {
+          href: urls.evaluations,
+          active: Boolean(pathname.match(urls.evaluations)),
+          icon: FlaskConical,
+          label: page_evaluations('metadata.title'),
+        },
+        collection.config?.enable_knowledge_graph
+          ? {
+              href: urls.graph,
+              active: Boolean(pathname.match(urls.graph)),
+              icon: VectorSquare,
+              label: page_graph('metadata.title'),
+            }
+          : null,
+        {
+          href: urls.search,
+          active: Boolean(pathname.match(urls.search)),
+          icon: FolderSearch,
+          label: page_search('metadata.title'),
+        },
+        {
+          href: urls.settings,
+          active: Boolean(pathname.match(urls.settings)),
+          icon: Settings,
+          label: page_collections('settings'),
+        },
+      ].filter(Boolean),
+    [
+      collection.config?.enable_knowledge_graph,
+      page_collections,
+      page_documents,
+      page_evaluations,
+      page_graph,
+      page_search,
+      pathname,
+      urls.documents,
+      urls.evaluations,
+      urls.graph,
+      urls.search,
+      urls.settings,
+    ],
+  );
+
   return (
     <PageContent className={cn('flex flex-col gap-4 pb-0', className)}>
-      <Card className="gap-0 p-0">
-        <CardHeader className="p-4">
-          <CardTitle className="text-2xl">{collection.title}</CardTitle>
-          <CardDescription className="flex flex-row items-center gap-6">
-            <div>
+      <Card className="border-border/70 gap-0 overflow-hidden rounded-xl py-0 shadow-sm">
+        <CardHeader className="gap-4 p-5 lg:grid-cols-[1fr_auto]">
+          <div className="flex min-w-0 gap-4">
+            <div className="bg-accent-soft text-accent-ink flex size-11 shrink-0 items-center justify-center rounded-xl">
+              <Database className="size-5" />
+            </div>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <CardTitle className="truncate text-2xl leading-8 font-medium">
+                  {collection.title}
+                </CardTitle>
+                {collection.status && (
+                  <Badge
+                    className={cn(
+                      'rounded-sm border',
+                      statusClassName[collection.status],
+                    )}
+                    variant="outline"
+                  >
+                    {_.upperFirst(_.lowerCase(collection.status))}
+                  </Badge>
+                )}
+              </div>
+              <CardDescription className="mt-2 max-w-3xl leading-6">
+                {_.truncate(
+                  collection.description ||
+                    page_collections('no_description_available'),
+                  {
+                    length: 220,
+                  },
+                )}
+              </CardDescription>
               {collection.created && (
-                <div className="text-muted-foreground flex items-center gap-1 text-sm">
-                  <Calendar className="size-3" />
+                <div className="text-muted-foreground mt-3 flex items-center gap-1.5 text-xs">
+                  <Calendar className="size-3.5" />
                   <FormatDate datetime={new Date(collection.created)} />
                 </div>
               )}
             </div>
-            <div className="flex items-center gap-2">
-              <div
-                className={cn(
-                  'size-2 rounded-2xl',
-                  collection.status
-                    ? badgeColor[collection.status]
-                    : 'bg-gray-500',
-                )}
-              />
-              <div className="text-muted-foreground text-sm">
-                {_.upperFirst(_.lowerCase(collection.status))}
-              </div>
-            </div>
-          </CardDescription>
-          <CardAction className="flex flex-row items-center gap-4">
+          </div>
+
+          <CardAction className="flex flex-row items-center gap-2">
             {share && (
-              <Badge variant={share.is_published ? 'default' : 'secondary'}>
+              <Badge
+                className={cn(
+                  'rounded-sm',
+                  share.is_published
+                    ? 'bg-accent-soft text-accent-ink border-accent-soft border'
+                    : '',
+                )}
+                variant={share.is_published ? 'outline' : 'secondary'}
+              >
                 {share.is_published
                   ? page_collections('public')
                   : page_collections('private')}
@@ -176,88 +254,26 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
             </DropdownMenu>
           </CardAction>
         </CardHeader>
-        <CardDescription className="mb-4 px-4">
-          {_.truncate(
-            collection.description ||
-              page_collections('no_description_available'),
-            {
-              length: 180,
-            },
-          )}
-        </CardDescription>
         <Separator />
-        <div className="bg-accent/50 flex flex-row gap-2 rounded-b-xl px-4">
-          <Button
-            asChild
-            data-active={Boolean(pathname.match(urls.documents))}
-            className="hover:border-b-primary data-[active=true]:border-b-primary h-10 rounded-none border-y-2 border-y-transparent px-1 has-[>svg]:px-2"
-            variant="ghost"
-          >
-            <Link href={urls.documents}>
-              <Files />
-              <span className="hidden sm:inline">
-                {page_documents('metadata.title')}
-              </span>
-            </Link>
-          </Button>
-
-          <Button
-            asChild
-            data-active={Boolean(pathname.match(urls.evaluations))}
-            className="hover:border-b-primary data-[active=true]:border-b-primary h-10 rounded-none border-y-2 border-y-transparent px-1 has-[>svg]:px-2"
-            variant="ghost"
-          >
-            <Link href={urls.evaluations}>
-              <FlaskConical />
-              <span className="hidden sm:inline">
-                {page_evaluations('metadata.title')}
-              </span>
-            </Link>
-          </Button>
-
-          {collection.config?.enable_knowledge_graph && (
-            <Button
-              asChild
-              data-active={Boolean(pathname.match(urls.graph))}
-              className="hover:border-b-primary data-[active=true]:border-b-primary h-10 rounded-none border-y-2 border-y-transparent px-1 has-[>svg]:px-2"
-              variant="ghost"
-            >
-              <Link href={urls.graph}>
-                <VectorSquare />
-                <span className="hidden sm:inline">
-                  {page_graph('metadata.title')}
-                </span>
-              </Link>
-            </Button>
-          )}
-
-          {/* <Button
-            asChild
-            data-active={Boolean(pathname.match(urls.search))}
-            className="hover:border-b-primary data-[active=true]:border-b-primary h-10 rounded-none border-y-2 border-y-transparent px-1 has-[>svg]:px-2"
-            variant="ghost"
-          >
-            <Link href={urls.search}>
-              <FolderSearch />
-              <span className="hidden sm:inline">
-                {page_search('metadata.title')}
-              </span>
-            </Link>
-          </Button> */}
-
-          <Button
-            asChild
-            data-active={Boolean(pathname.match(urls.settings))}
-            className="hover:border-b-primary data-[active=true]:border-b-primary h-10 rounded-none border-y-2 border-y-transparent px-1 has-[>svg]:px-2"
-            variant="ghost"
-          >
-            <Link href={urls.settings}>
-              <Settings />{' '}
-              <span className="hidden sm:inline">
-                {page_collections('settings')}
-              </span>
-            </Link>
-          </Button>
+        <div className="bg-muted/50 flex gap-1 overflow-x-auto px-3 py-2">
+          {navItems.map((item) => {
+            if (!item) return null;
+            const Icon = item.icon;
+            return (
+              <Button
+                key={item.href}
+                asChild
+                data-active={item.active}
+                className="data-[active=true]:bg-card data-[active=true]:text-foreground text-muted-foreground h-9 shrink-0 rounded-lg px-3 data-[active=true]:shadow-xs"
+                variant="ghost"
+              >
+                <Link href={item.href}>
+                  <Icon className="size-4" />
+                  <span>{item.label}</span>
+                </Link>
+              </Button>
+            );
+          })}
         </div>
       </Card>
     </PageContent>

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -2,16 +2,17 @@
 import { getDocumentStatusColor } from '@/app/workspace/collections/tools';
 import { FormatDate } from '@/components/format-date';
 import { buildDocumentAssetUrl, Markdown } from '@/components/markdown';
-import { buildDocumentObjectUrl } from '@/features/document/client-api';
-import type { Document, DocumentPreview } from '@/features/document/types';
 import { useCollectionContext } from '@/components/providers/collection-provider';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { buildDocumentObjectUrl } from '@/features/document/client-api';
+import type { Document, DocumentPreview } from '@/features/document/types';
 import { cn } from '@/lib/utils';
 import _ from 'lodash';
-import { ArrowLeft, LoaderCircle } from 'lucide-react';
+import { ArrowLeft, FileText, ImageIcon, LoaderCircle } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
@@ -24,6 +25,12 @@ const PDFDocument = dynamic(() => import('react-pdf').then((r) => r.Document), {
 const PDFPage = dynamic(() => import('react-pdf').then((r) => r.Page), {
   ssr: false,
 });
+
+const formatFileSize = (size?: number | null) => {
+  const kb = Number(size || 0) / 1000;
+  if (kb < 1000) return `${kb.toFixed(2)} KB`;
+  return `${(kb / 1000).toFixed(2)} MB`;
+};
 
 export const DocumentDetail = ({
   document,
@@ -61,58 +68,72 @@ export const DocumentDetail = ({
 
   return (
     <>
-      <Tabs defaultValue={defaultTab} className="gap-4">
-        <div className="flex flex-row items-center justify-between gap-2">
-          <div className="flex flex-row items-center gap-4">
-            <Button asChild variant="ghost" size="icon">
+      <Tabs
+        defaultValue={defaultTab}
+        className="border-border/70 bg-card gap-0 overflow-hidden rounded-xl border shadow-sm"
+      >
+        <div className="grid gap-4 border-b p-4 lg:grid-cols-[1fr_auto] lg:items-center">
+          <div className="flex min-w-0 flex-row items-start gap-3">
+            <Button asChild variant="outline" size="icon" className="shrink-0">
               <Link href={`/workspace/collections/${collection.id}/documents`}>
-                <ArrowLeft />
+                <ArrowLeft className="size-4" />
               </Link>
             </Button>
-            <div className={cn('max-w-80 truncate')}>
-              {documentPreview.doc_filename}
-            </div>
-          </div>
-
-          <div className="flex flex-row gap-6">
-            <div className="text-muted-foreground flex flex-row items-center gap-4 text-sm">
-              <div>{(Number(document.size || 0) / 1000).toFixed(2)} KB</div>
-              <Separator
-                orientation="vertical"
-                className="data-[orientation=vertical]:h-6"
-              />
-              {document.updated ? (
-                <>
-                  <div>
+            <div className="min-w-0">
+              <div className={cn('truncate text-base font-medium')}>
+                {documentPreview.doc_filename}
+              </div>
+              <div className="text-muted-foreground mt-2 flex flex-wrap items-center gap-2 text-xs">
+                <span className="font-mono tabular-nums">
+                  {formatFileSize(document.size)}
+                </span>
+                {document.updated ? (
+                  <>
+                    <Separator
+                      orientation="vertical"
+                      className="data-[orientation=vertical]:h-3"
+                    />
                     <FormatDate datetime={new Date(document.updated)} />
-                  </div>
-                  <Separator
-                    orientation="vertical"
-                    className="data-[orientation=vertical]:h-6"
-                  />
-                </>
-              ) : null}
-              <div className={getDocumentStatusColor(document.status)}>
-                {_.capitalize(document.status)}
+                  </>
+                ) : null}
+                {document.status ? (
+                  <>
+                    <Separator
+                      orientation="vertical"
+                      className="data-[orientation=vertical]:h-3"
+                    />
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        'bg-secondary rounded-sm border-transparent font-mono text-[10px] uppercase',
+                        getDocumentStatusColor(document.status),
+                      )}
+                    >
+                      {_.capitalize(document.status)}
+                    </Badge>
+                  </>
+                ) : null}
               </div>
             </div>
-            <TabsList>
-              {hasPdfPreview && <TabsTrigger value="pdf">PDF</TabsTrigger>}
-              {hasVisionPreview && (
-                <TabsTrigger value="vision">Images</TabsTrigger>
-              )}
-              <TabsTrigger value="markdown">Markdown</TabsTrigger>
-            </TabsList>
           </div>
+
+          <TabsList className="w-fit justify-start">
+            {hasPdfPreview && <TabsTrigger value="pdf">PDF</TabsTrigger>}
+            {hasVisionPreview && (
+              <TabsTrigger value="vision">Images</TabsTrigger>
+            )}
+            <TabsTrigger value="markdown">Markdown</TabsTrigger>
+          </TabsList>
         </div>
 
-        <TabsContent value="markdown">
-          <Card>
-            <CardContent>
+        <TabsContent value="markdown" className="bg-background/50 m-0 p-4">
+          <Card className="border-border/70 py-0 shadow-sm">
+            <CardContent className="p-5">
               {documentPreview.markdown_content?.trim() ? (
                 <Markdown>{documentPreview.markdown_content}</Markdown>
               ) : (
-                <div className="text-muted-foreground py-6 text-sm">
+                <div className="text-muted-foreground flex min-h-56 flex-col items-center justify-center gap-3 py-6 text-center text-sm">
+                  <FileText className="size-8" />
                   Markdown preview is unavailable for this document.
                 </div>
               )}
@@ -121,15 +142,15 @@ export const DocumentDetail = ({
         </TabsContent>
 
         {hasVisionPreview && (
-          <TabsContent value="vision">
+          <TabsContent value="vision" className="bg-background/50 m-0 p-4">
             <div className="grid gap-4 lg:grid-cols-2">
               {visionChunks.map((chunk, index) => {
                 const imageUrl = chunk.asset_id
                   ? buildDocumentAssetUrl(
                       `asset://${chunk.asset_id}?collection_id=${collection.id}&document_id=${document.id}`,
                       {
-                        collectionId: collection.id,
-                        documentId: document.id,
+                        collectionId: collection.id ?? '',
+                        documentId: document.id ?? '',
                         mode: 'workspace',
                       },
                     )
@@ -142,21 +163,29 @@ export const DocumentDetail = ({
                     : undefined;
 
                 return (
-                  <Card key={chunk.id || chunk.asset_id || index}>
-                    <CardContent className="space-y-4">
+                  <Card
+                    key={chunk.id || chunk.asset_id || index}
+                    className="border-border/70 gap-0 overflow-hidden py-0 shadow-sm"
+                  >
+                    <CardContent className="space-y-4 p-4">
                       {imageUrl ? (
                         <img
                           src={imageUrl}
                           alt={`Document image ${index + 1}`}
-                          className="w-full rounded-md border"
+                          className="border-border/70 bg-background w-full rounded-lg border"
                         />
-                      ) : null}
+                      ) : (
+                        <div className="text-muted-foreground bg-muted flex min-h-48 items-center justify-center rounded-lg">
+                          <ImageIcon className="size-8" />
+                        </div>
+                      )}
                       <div className="space-y-2">
                         <div className="text-sm font-medium">
                           {pageIdx ? `Page ${pageIdx}` : `Image ${index + 1}`}
                         </div>
-                        <div className="text-muted-foreground whitespace-pre-wrap text-sm">
-                          {chunk.text || 'No extracted image summary available.'}
+                        <div className="text-muted-foreground text-sm whitespace-pre-wrap">
+                          {chunk.text ||
+                            'No extracted image summary available.'}
                         </div>
                       </div>
                     </CardContent>
@@ -168,7 +197,7 @@ export const DocumentDetail = ({
         )}
 
         {hasPdfPreview && (
-          <TabsContent value="pdf">
+          <TabsContent value="pdf" className="bg-background/50 m-0 p-4">
             <PDFDocument
               file={buildDocumentObjectUrl(
                 collection.id ?? '',
@@ -179,7 +208,7 @@ export const DocumentDetail = ({
                 setNumPages(numPages);
               }}
               loading={
-                <div className="flex flex-col py-8">
+                <div className="flex flex-col py-12">
                   <LoaderCircle className="size-10 animate-spin self-center opacity-50" />
                 </div>
               }
@@ -188,8 +217,8 @@ export const DocumentDetail = ({
               {_.times(numPages).map((index) => {
                 return (
                   <div key={index} className="text-center">
-                    <Card className="inline-block overflow-hidden p-0">
-                      <PDFPage pageNumber={index + 1} className="bg-accent" />
+                    <Card className="border-border/70 inline-block overflow-hidden p-0 shadow-sm">
+                      <PDFPage pageNumber={index + 1} className="bg-muted" />
                     </Card>
                   </div>
                 );

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/features/document/server-api';
 import { toJson } from '@/lib/utils';
 import _ from 'lodash';
+import { notFound } from 'next/navigation';
 import { CollectionHeader } from '../../collection-header';
 import { DocumentDetail } from './document-detail';
 
@@ -23,6 +24,10 @@ export default async function Page({
     getDocument(collectionId, documentId),
     getDocumentPreview(collectionId, documentId),
   ]);
+
+  if (!document || !documentPreview) {
+    notFound();
+  }
 
   return (
     <PageContainer>
@@ -42,7 +47,7 @@ export default async function Page({
         ]}
       />
       <CollectionHeader />
-      <PageContent className="h-[100%]">
+      <PageContent className="h-[100%] pt-4">
         <DocumentDetail
           document={toJson(document)}
           documentPreview={toJson(documentPreview)}

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-rebuild-index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { DOCUMENT_INDEX_TYPES } from '@/features/document/types';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -17,6 +16,7 @@ import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
 import { rebuildDocumentIndexes } from '@/features/document/client-api';
 import type { Document } from '@/features/document/types';
+import { DOCUMENT_INDEX_TYPES } from '@/features/document/types';
 import { cn } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Slot } from '@radix-ui/react-slot';
@@ -117,13 +117,13 @@ export const DocumentReBuildIndex = ({
                 let enabled: boolean | undefined;
                 switch (key) {
                   case 'FULLTEXT':
-                    enabled = config?.enable_fulltext;
+                    enabled = Boolean(config?.enable_fulltext);
                     break;
                   case 'GRAPH':
-                    enabled = config?.enable_knowledge_graph;
+                    enabled = Boolean(config?.enable_knowledge_graph);
                     break;
                   case 'VECTOR':
-                    enabled = config?.enable_vector;
+                    enabled = Boolean(config?.enable_vector);
                     break;
                   default:
                     enabled = false;

--- a/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
@@ -27,13 +27,11 @@ import {
 import * as React from 'react';
 import { defaultStyles, FileIcon } from 'react-file-icon';
 
-import {
-  DOCUMENT_INDEX_TYPES,
-  type Document,
-} from '@/features/document/types';
+import { DOCUMENT_INDEX_TYPES, type Document } from '@/features/document/types';
 
 import { DataGrid, DataGridPagination } from '@/components/data-grid';
 import { FormatDate } from '@/components/format-date';
+import { Badge } from '@/components/ui/badge';
 import { cn, objectKeys, parsePageParams } from '@/lib/utils';
 import _ from 'lodash';
 import {
@@ -42,6 +40,7 @@ import {
   EllipsisVertical,
   FolderSync,
   Plus,
+  Search,
   Trash,
 } from 'lucide-react';
 
@@ -75,11 +74,47 @@ const NON_TERMINAL_INDEX_STATUSES = new Set([
   'DELETION_IN_PROGRESS',
 ]);
 
-const getEnabledIndexStatusKeys = (config?: {
-  enable_fulltext?: boolean;
-  enable_knowledge_graph?: boolean;
-  enable_vector?: boolean;
-}) => {
+const DOCUMENT_STATUS_CLASS: Record<string, string> = {
+  COMPLETE: 'bg-accent-soft text-accent-ink border-accent-soft',
+  RUNNING: 'bg-secondary text-foreground border-transparent',
+  PENDING: 'bg-secondary text-muted-foreground border-transparent',
+  UPLOADED: 'bg-secondary text-muted-foreground border-transparent',
+  FAILED: 'bg-destructive/10 text-destructive border-destructive/20',
+  EXPIRED: 'bg-secondary text-muted-foreground border-transparent line-through',
+  DELETED: 'bg-secondary text-muted-foreground border-transparent line-through',
+  DELETING:
+    'bg-secondary text-muted-foreground border-transparent line-through',
+};
+
+const formatFileSize = (size?: number | null) => {
+  const kb = Number(size || 0) / 1000;
+  if (kb < 1000) return `${kb.toFixed(2)} KB`;
+  return `${(kb / 1000).toFixed(2)} MB`;
+};
+
+const DocumentStatusBadge = ({ status }: { status?: string | null }) => {
+  if (!status) return null;
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'rounded-sm border font-mono text-[10px] tracking-normal uppercase',
+        DOCUMENT_STATUS_CLASS[status] ||
+          'bg-secondary text-muted-foreground border-transparent',
+      )}
+    >
+      {_.capitalize(status)}
+    </Badge>
+  );
+};
+
+const getEnabledIndexStatusKeys = (
+  config?: {
+    enable_fulltext?: boolean | null;
+    enable_knowledge_graph?: boolean | null;
+    enable_vector?: boolean | null;
+  } | null,
+) => {
   const keys: Array<keyof Document> = [];
   if (config?.enable_fulltext) keys.push('fulltext_index_status');
   if (config?.enable_knowledge_graph) keys.push('graph_index_status');
@@ -91,10 +126,7 @@ const hasNonTerminalDocumentState = (
   document: Document,
   enabledIndexStatusKeys: Array<keyof Document>,
 ) => {
-  if (
-    document.status &&
-    NON_TERMINAL_DOCUMENT_STATUSES.has(document.status)
-  ) {
+  if (document.status && NON_TERMINAL_DOCUMENT_STATUSES.has(document.status)) {
     return true;
   }
 
@@ -129,8 +161,7 @@ export function DocumentsTable({
   const router = useRouter();
   const [isPageVisible, setIsPageVisible] = React.useState(
     () =>
-      typeof document === 'undefined' ||
-      document.visibilityState === 'visible',
+      typeof document === 'undefined' || document.visibilityState === 'visible',
   );
 
   const query = React.useMemo(() => {
@@ -198,7 +229,9 @@ export function DocumentsTable({
         : FAST_BACKGROUND_POLL_INTERVAL_MS;
     }
 
-    return isPageVisible ? SLOW_POLL_INTERVAL_MS : SLOW_BACKGROUND_POLL_INTERVAL_MS;
+    return isPageVisible
+      ? SLOW_POLL_INTERVAL_MS
+      : SLOW_BACKGROUND_POLL_INTERVAL_MS;
   }, [hasDirtySearchInput, hasNonTerminalRows, isPageVisible]);
 
   React.useEffect(() => {
@@ -224,13 +257,13 @@ export function DocumentsTable({
       let enabled: boolean | undefined;
       switch (key) {
         case 'FULLTEXT':
-          enabled = config?.enable_fulltext;
+          enabled = Boolean(config?.enable_fulltext);
           break;
         case 'GRAPH':
-          enabled = config?.enable_knowledge_graph;
+          enabled = Boolean(config?.enable_knowledge_graph);
           break;
         case 'VECTOR':
-          enabled = config?.enable_vector;
+          enabled = Boolean(config?.enable_vector);
           break;
         default:
           enabled = false;
@@ -292,14 +325,16 @@ export function DocumentsTable({
             />
           );
           return (
-            <div className="flex flex-row items-center gap-2">
-              <div className="h-8 w-6">{icon}</div>
-              <div>
-                <div className="max-w-60 truncate">
+            <div className="flex min-w-0 flex-row items-center gap-3">
+              <div className="bg-muted flex h-10 w-9 shrink-0 items-center justify-center rounded-lg p-1.5">
+                {icon}
+              </div>
+              <div className="min-w-0">
+                <div className="max-w-80 truncate text-sm font-medium">
                   {row.original.vector_index_status === 'ACTIVE' ? (
                     <Link
                       href={`/workspace/collections/${collection.id}/documents/${row.original.id}`}
-                      className={cn('hover:text-primary')}
+                      className={cn('hover:text-primary transition-colors')}
                     >
                       {row.original.name}
                     </Link>
@@ -312,12 +347,17 @@ export function DocumentsTable({
                   )}
                 </div>
                 <div className="text-muted-foreground text-xs">
-                  {(Number(row.original.size || 0) / 1000).toFixed(2)} KB
+                  {formatFileSize(row.original.size)}
                 </div>
               </div>
             </div>
           );
         },
+      },
+      {
+        accessorKey: 'status',
+        header: page_documents('upload_progress'),
+        cell: ({ row }) => <DocumentStatusBadge status={row.original.status} />,
       },
       ...indexCols,
       {
@@ -325,7 +365,9 @@ export function DocumentsTable({
         header: page_documents('last_updated'),
         cell: ({ row }) => {
           return row.original.updated ? (
-            <FormatDate datetime={new Date(row.original.updated)} />
+            <span className="text-muted-foreground text-xs">
+              <FormatDate datetime={new Date(row.original.updated)} />
+            </span>
           ) : (
             ''
           );
@@ -398,8 +440,7 @@ export function DocumentsTable({
         pageIndex: query.page - 1,
         pageSize: query.pageSize,
       };
-      const next =
-        typeof updater === 'function' ? updater(current) : updater;
+      const next = typeof updater === 'function' ? updater(current) : updater;
       handleSearch({
         page: next.pageIndex + 1,
         pageSize: next.pageSize,
@@ -415,22 +456,25 @@ export function DocumentsTable({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div className="flex flex-row items-center gap-2">
+      <div className="border-border/70 bg-card grid gap-3 rounded-xl border p-4 shadow-sm lg:grid-cols-[1fr_auto] lg:items-center">
+        <div className="relative max-w-xl">
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
           <Input
+            className="bg-background/70 h-10 rounded-lg pl-9"
             placeholder={page_documents('search_document')}
             value={searchValue}
             onChange={(e) => setSearchValue(e.currentTarget.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 handleSearch({
+                  page: 1,
                   search: e.currentTarget.value,
                 });
               }
             }}
           />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 lg:justify-end">
           <Button asChild className="cursor-pointer">
             <Link
               href={`/workspace/collections/${collection.id}/documents/upload`}
@@ -488,7 +532,7 @@ export function DocumentsTable({
           </DropdownMenu>
         </div>
       </div>
-      <DataGrid table={table} />
+      <DataGrid table={table} className="border-border/70 bg-card shadow-sm" />
       <DataGridPagination table={table} />
     </div>
   );

--- a/web/src/app/workspace/collections/[collectionId]/documents/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/page.tsx
@@ -57,7 +57,7 @@ export default async function Page({
         ]}
       />
       <CollectionHeader />
-      <PageContent>
+      <PageContent className="pt-4">
         <DocumentsTable data={toJson(documents)} pageCount={pageCount} />
       </PageContent>
     </PageContainer>

--- a/web/src/app/workspace/collections/[collectionId]/search/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/search/page.tsx
@@ -33,7 +33,7 @@ export default async function Page({
         ]}
       />
       <CollectionHeader />
-      <PageContent>
+      <PageContent className="pt-4">
         <SearchTable data={searchRes.items ?? []} />
       </PageContent>
     </PageContainer>

--- a/web/src/app/workspace/collections/[collectionId]/search/search-result-drawer.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/search/search-result-drawer.tsx
@@ -1,4 +1,5 @@
 import { Markdown } from '@/components/markdown';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Collapsible,
@@ -52,13 +53,13 @@ export const SearchResultDrawer = ({
           {children}
         </Slot>
       </DrawerTrigger>
-      <DrawerContent className="flex sm:min-w-xl md:min-w-2xl">
-        <DrawerHeader>
-          <DrawerTitle className="font-bold">
+      <DrawerContent className="bg-background flex sm:min-w-xl md:min-w-2xl">
+        <DrawerHeader className="border-b">
+          <DrawerTitle className="font-medium">
             {page_search('search_result')}
           </DrawerTitle>
         </DrawerHeader>
-        <div className="overflow-auto px-4 pb-4 select-text">
+        <div className="overflow-auto px-4 py-4 select-text">
           {visibleItems.map((item, index) => {
             return (
               <Collapsible
@@ -68,26 +69,30 @@ export const SearchResultDrawer = ({
               >
                 <CollapsibleTrigger asChild>
                   <Button
-                    variant="secondary"
-                    className="w-full cursor-pointer justify-between"
+                    variant="outline"
+                    className="bg-card hover:bg-muted/60 h-auto w-full cursor-pointer justify-between rounded-xl px-3 py-3"
                   >
                     <div className="flex flex-1 flex-row items-center gap-2">
                       <ChevronRight className="transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                       <div className="block flex-1 text-left">
                         {item.rank}.{' '}
                         {item.source ||
-                          _.truncate(item.content, { length: 30 })}
+                          _.truncate(item.content ?? '', { length: 30 })}
                       </div>
                     </div>
                     <div className="text-muted-foreground flex flex-row items-center gap-4 text-xs">
-                      <span>{_.startCase(item.recall_type)}</span>
-                      <span>{(item.score || 0).toFixed(2)}</span>
+                      <Badge variant="secondary" className="rounded-sm">
+                        {_.startCase(item.recall_type || '')}
+                      </Badge>
+                      <span className="font-mono tabular-nums">
+                        {(item.score || 0).toFixed(2)}
+                      </span>
                     </div>
                   </Button>
                 </CollapsibleTrigger>
 
-                <CollapsibleContent className="mt-2 rounded-md border p-4">
-                  <Markdown>{item.content}</Markdown>
+                <CollapsibleContent className="border-border/70 bg-card mt-2 rounded-xl border p-4 shadow-sm">
+                  <Markdown>{item.content ?? ''}</Markdown>
                 </CollapsibleContent>
               </Collapsible>
             );

--- a/web/src/app/workspace/collections/[collectionId]/search/search-table.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/search/search-table.tsx
@@ -17,6 +17,7 @@ import * as React from 'react';
 
 import { Button } from '@/components/ui/button';
 
+import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 
 import {
@@ -38,6 +39,7 @@ import {
   Columns3,
   EllipsisVertical,
   FlaskConical,
+  Search,
   Trash,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -45,6 +47,21 @@ import { filterVisibleSearchItems } from '../../feature-visibility';
 import { SearchDelete } from './search-delete';
 import { SearchResultDrawer } from './search-result-drawer';
 import { SearchTest } from './search-test';
+
+const SearchParamBadge = ({
+  label,
+  value,
+}: {
+  label: string;
+  value?: number | string | null;
+}) => {
+  if (value === null || value === undefined || value === '') return null;
+  return (
+    <Badge variant="secondary" className="rounded-sm font-mono text-[10px]">
+      {label} {value}
+    </Badge>
+  );
+};
 
 export const SearchTable = ({ data }: { data: SearchResult[] }) => {
   const { collection } = useCollectionContext();
@@ -78,9 +95,15 @@ export const SearchTable = ({ data }: { data: SearchResult[] }) => {
         header: page_search('vector_search'),
         cell: ({ row }) => {
           return (
-            <div>
-              <div>topk: {row.original.vector_search?.topk}</div>
-              <div>similarity: {row.original.vector_search?.similarity}</div>
+            <div className="flex flex-wrap gap-1.5">
+              <SearchParamBadge
+                label="top"
+                value={row.original.vector_search?.topk}
+              />
+              <SearchParamBadge
+                label="sim"
+                value={row.original.vector_search?.similarity}
+              />
             </div>
           );
         },
@@ -93,11 +116,20 @@ export const SearchTable = ({ data }: { data: SearchResult[] }) => {
         header: page_search('fulltext_search'),
         cell: ({ row }) => {
           return (
-            <div>
-              <div>topk: {row.original.fulltext_search?.topk}</div>
-              <div>
-                keywords: {row.original.fulltext_search?.keywords?.join(',')}
-              </div>
+            <div className="flex flex-wrap gap-1.5">
+              <SearchParamBadge
+                label="top"
+                value={row.original.fulltext_search?.topk}
+              />
+              {row.original.fulltext_search?.keywords?.map((keyword) => (
+                <Badge
+                  key={keyword}
+                  variant="outline"
+                  className="rounded-sm text-[10px]"
+                >
+                  {keyword}
+                </Badge>
+              ))}
             </div>
           );
         },
@@ -109,7 +141,14 @@ export const SearchTable = ({ data }: { data: SearchResult[] }) => {
         accessorKey: 'graph_search',
         header: page_search('graph_search'),
         cell: ({ row }) => {
-          return <div>topk: {row.original.fulltext_search?.topk}</div>;
+          return (
+            <div className="flex flex-wrap gap-1.5">
+              <SearchParamBadge
+                label="top"
+                value={row.original.graph_search?.topk}
+              />
+            </div>
+          );
         },
       });
     }
@@ -153,12 +192,12 @@ export const SearchTable = ({ data }: { data: SearchResult[] }) => {
               <SearchResultDrawer result={row.original}>
                 <div
                   data-result={!_.isEmpty(visibleItems)}
-                  className="data-[result=true]:hover:text-primary max-w-md truncate data-[result=true]:cursor-pointer"
+                  className="data-[result=true]:hover:text-primary max-w-md truncate text-sm font-medium transition-colors data-[result=true]:cursor-pointer"
                 >
                   {row.original.query}
                 </div>
               </SearchResultDrawer>
-              <div className="text-muted-foreground flex flex-row items-center gap-4">
+              <div className="text-muted-foreground mt-1 flex flex-row items-center gap-4 text-xs">
                 {visibleItems.length} results
               </div>
             </div>
@@ -171,7 +210,9 @@ export const SearchTable = ({ data }: { data: SearchResult[] }) => {
         header: page_search('creation_time'),
         cell: ({ row }) => {
           return row.original.created ? (
-            <FormatDate datetime={new Date(row.original.created)} />
+            <span className="text-muted-foreground text-xs">
+              <FormatDate datetime={new Date(row.original.created)} />
+            </span>
           ) : undefined;
         },
       },
@@ -237,15 +278,17 @@ export const SearchTable = ({ data }: { data: SearchResult[] }) => {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div className="flex flex-row items-center gap-2">
+      <div className="border-border/70 bg-card grid gap-3 rounded-xl border p-4 shadow-sm lg:grid-cols-[1fr_auto] lg:items-center">
+        <div className="relative max-w-xl">
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
           <Input
+            className="bg-background/70 h-10 rounded-lg pl-9"
             placeholder={page_search('search')}
             value={searchValue}
             onChange={(e) => setSearchValue(e.currentTarget.value)}
           />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 lg:justify-end">
           <SearchTest>
             <Button>
               <FlaskConical />{' '}
@@ -285,7 +328,7 @@ export const SearchTable = ({ data }: { data: SearchResult[] }) => {
           </DropdownMenu>
         </div>
       </div>
-      <DataGrid table={table} />
+      <DataGrid table={table} className="border-border/70 bg-card shadow-sm" />
       <DataGridPagination table={table} />
     </div>
   );

--- a/web/src/app/workspace/collections/[collectionId]/search/search-test.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/search/search-test.tsx
@@ -146,7 +146,7 @@ export const SearchTest = ({ children }: { children: ReactNode }) => {
           {children}
         </Slot>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="sm:max-w-2xl">
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(handleSubmit)}
@@ -154,7 +154,9 @@ export const SearchTest = ({ children }: { children: ReactNode }) => {
           >
             <DialogHeader>
               <DialogTitle>{page_search('metadata.title')}</DialogTitle>
-              <DialogDescription></DialogDescription>
+              <DialogDescription>
+                {page_search('questions_placeholder')}
+              </DialogDescription>
             </DialogHeader>
 
             <div className="flex flex-col gap-4">
@@ -175,7 +177,7 @@ export const SearchTest = ({ children }: { children: ReactNode }) => {
               />
 
               {indexTypes.vector.available && (
-                <div className="bg-accent/40 hover:bg-accent/50 flex flex-row gap-4 rounded-md border p-4">
+                <div className="border-border/70 bg-muted/40 flex flex-col gap-4 rounded-xl border p-4 sm:flex-row">
                   <Label className="h-8 flex-1">
                     <Checkbox
                       checked={indexTypes.vector.checked}
@@ -189,7 +191,7 @@ export const SearchTest = ({ children }: { children: ReactNode }) => {
                     {page_search('vector_search')}
                   </Label>
 
-                  <div className="flex w-[65%] flex-col gap-2">
+                  <div className="flex flex-1 flex-col gap-2 sm:w-[65%]">
                     <FormField
                       control={form.control}
                       name="vector_search.topk"
@@ -239,7 +241,7 @@ export const SearchTest = ({ children }: { children: ReactNode }) => {
               )}
 
               {indexTypes.fulltext.available && (
-                <div className="bg-accent/40 hover:bg-accent/50 flex flex-row gap-4 rounded-md border p-4">
+                <div className="border-border/70 bg-muted/40 flex flex-col gap-4 rounded-xl border p-4 sm:flex-row">
                   <Label className="h-8 flex-1">
                     <Checkbox
                       checked={indexTypes.fulltext.checked}
@@ -253,7 +255,7 @@ export const SearchTest = ({ children }: { children: ReactNode }) => {
                     {page_search('fulltext_search')}
                   </Label>
 
-                  <div className="flex w-[65%] flex-col gap-2">
+                  <div className="flex flex-1 flex-col gap-2 sm:w-[65%]">
                     <FormField
                       control={form.control}
                       name="fulltext_search.topk"
@@ -281,7 +283,7 @@ export const SearchTest = ({ children }: { children: ReactNode }) => {
               )}
 
               {indexTypes.graph.available && (
-                <div className="bg-accent/40 hover:bg-accent/50 flex flex-row gap-4 rounded-md border p-4">
+                <div className="border-border/70 bg-muted/40 flex flex-col gap-4 rounded-xl border p-4 sm:flex-row">
                   <Label className="h-8 flex-1">
                     <Checkbox
                       checked={indexTypes.graph.checked}
@@ -294,7 +296,7 @@ export const SearchTest = ({ children }: { children: ReactNode }) => {
                     />
                     {page_search('graph_search')}
                   </Label>
-                  <div className="flex w-[65%] flex-col gap-2">
+                  <div className="flex flex-1 flex-col gap-2 sm:w-[65%]">
                     <FormField
                       control={form.control}
                       name="graph_search.topk"

--- a/web/src/app/workspace/collections/[collectionId]/settings/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/settings/page.tsx
@@ -24,7 +24,7 @@ export default async function Page() {
         ]}
       />
       <CollectionHeader />
-      <PageContent>
+      <PageContent className="pt-4">
         <CollectionForm action="edit" />
       </PageContent>
     </PageContainer>


### PR DESCRIPTION
## Summary
- Uplifted the workspace CollectionDetail shell/header with warm-token card treatment and restored the existing search-test route in the collection nav.
- Refined documents list, per-document preview/detail, and index rebuild typing while preserving document APIs and polling behavior.
- Refined search history, search-test dialog, and result drawer without changing retrieval request/response contracts.

## Validation
- yarn i18n:sync
- yarn lint
- yarn eslint targeted collection-detail files --max-warnings=0
- yarn tsc --noEmit still fails on existing mainline typed-i18n/nullability issues outside this PR; scoped grep for task #11 files is clean
- git diff --check

Ghost-check: G1-G10 all enforced; no billing, teams, folders, ingest-health charts, marketplace banner, or raw agent/tool debug surfaced.