### PR TITLE
refactor(fe-rewrite): L3 Graph — consume L1 followup entityTypeToPaletteKey + CANVAS_DARK exports

### DIFF
--- a/web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-detail.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-detail.tsx
@@ -7,21 +7,9 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer';
-import { ENTITY_PALETTE, type EntityType } from '@/lib/design-tokens';
+import { ENTITY_PALETTE, entityTypeToPaletteKey } from '@/lib/design-tokens';
 import type { GraphNode } from '@/features/knowledge-graph/types';
 import { useTranslations } from 'next-intl';
-
-const ENTITY_TYPE_TO_PALETTE: Record<string, EntityType> = {
-  person: 'person',
-  organization: 'org',
-  geo: 'org',
-  product: 'product',
-  technology: 'product',
-  category: 'concept',
-  date: 'event',
-  event: 'event',
-  UNKNOWN: 'doc',
-};
 
 export const CollectionGraphNodeDetail = ({
   open,
@@ -34,8 +22,7 @@ export const CollectionGraphNodeDetail = ({
 }) => {
   const page_graph = useTranslations('page_graph');
   const entityType = node?.properties.entity_type || 'UNKNOWN';
-  const paletteKey = ENTITY_TYPE_TO_PALETTE[entityType] || 'doc';
-  const entityColor = ENTITY_PALETTE[paletteKey];
+  const entityColor = ENTITY_PALETTE[entityTypeToPaletteKey(entityType)];
   const entityLabel = node
     ? // @ts-expect-error dynamic i18n key
       page_graph(`entity_${entityType}`)

--- a/web/src/app/workspace/collections/[collectionId]/graph/collection-graph.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph/collection-graph.tsx
@@ -43,7 +43,12 @@ import { useTheme } from 'next-themes';
 import dynamic from 'next/dynamic';
 import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { COLORS, ENTITY_PALETTE, type EntityType } from '@/lib/design-tokens';
+import {
+  CANVAS_DARK,
+  COLORS,
+  ENTITY_PALETTE,
+  entityTypeToPaletteKey,
+} from '@/lib/design-tokens';
 import { CollectionGraphNodeDetail } from './collection-graph-node-detail';
 import { CollectionGraphNodeMerge } from './collection-graph-node-merge';
 
@@ -54,32 +59,8 @@ const ForceGraph2D = dynamic(
   },
 );
 
-// Backend entity_type enum → 6-tone ENTITY_PALETTE mapping.
-// L3 Graph gate #5 (符炫炜 msg=30a3ec9e): never expose raw enum strings;
-// route every entity color / label through this map.
-const ENTITY_TYPE_TO_PALETTE: Record<string, EntityType> = {
-  person: 'person',
-  organization: 'org',
-  geo: 'org',
-  product: 'product',
-  technology: 'product',
-  category: 'concept',
-  date: 'event',
-  event: 'event',
-  UNKNOWN: 'doc',
-};
-
-const resolveEntityColor = (entityType: string | null | undefined): string => {
-  const key = (entityType && ENTITY_TYPE_TO_PALETTE[entityType]) || 'doc';
-  return ENTITY_PALETTE[key];
-};
-
-// Light / dark tier for hairline strokes + link overlays (not yet CSS-var-backed
-// in a canvas context — these mirror token values for imperative drawing).
-const NODE_STROKE_LIGHT = COLORS.bg;
-const NODE_STROKE_DARK = '#1A1A18';
-const LINK_COLOR_NORMAL_DARK = '#3A3A38';
-const LINK_COLOR_HIGHLIGHT_DARK = '#5A5A58';
+const resolveEntityColor = (entityType: string | null | undefined): string =>
+  ENTITY_PALETTE[entityTypeToPaletteKey(entityType)];
 
 export const CollectionGraph = ({
   marketplace = false,
@@ -228,10 +209,10 @@ export const CollectionGraph = ({
   }, [getGraphData, getMergeSuggestions]);
 
   const isDark = resolvedTheme === 'dark';
-  const nodeStroke = isDark ? NODE_STROKE_DARK : NODE_STROKE_LIGHT;
-  const linkNormal = isDark ? LINK_COLOR_NORMAL_DARK : COLORS.border;
+  const nodeStroke = isDark ? CANVAS_DARK.nodeStroke : COLORS.bg;
+  const linkNormal = isDark ? CANVAS_DARK.linkNormal : COLORS.border;
   const linkHighlight = isDark
-    ? LINK_COLOR_HIGHLIGHT_DARK
+    ? CANVAS_DARK.linkHighlight
     : COLORS.borderStrong;
   const labelFill = isDark ? COLORS.bg : COLORS.fg;
 


### PR DESCRIPTION
## Summary

Tiny L3 cleanup after task #7 (L1 token SSoT follow-up, `4ef4d6b7`) landed.

L1 promoted two utilities to `@/lib/design-tokens` that were originally duplicated inline inside L3 Graph:
- `entityTypeToPaletteKey(rawType)` — backend entity_type enum → canonical EntityType
- `CANVAS_DARK = { nodeStroke, linkNormal, linkHighlight }` — dark-mode canvas hex triplet

This commit consumes them in L3 and drops the inline copies.

Per 符炫炜 msg=d99583ff canonical sequencing: *"L3 refactor 用新 util 可在 L1 follow-up merge 后由 chenyexuan 做 2-line fix-forward"*. PM msg=d8023d81: *"后续如果需要 graph/chat 的 consumer-side 小 refactor，都走独立 tiny patch"*.

## Changes (13+/45-)

- `collection-graph.tsx`:
  - Remove `ENTITY_TYPE_TO_PALETTE` record → `resolveEntityColor` now wraps `entityTypeToPaletteKey`
  - Remove `NODE_STROKE_{LIGHT,DARK}` + `LINK_COLOR_*_DARK` hex constants → dark-mode branches read `CANVAS_DARK.*`
- `collection-graph-node-detail.tsx`:
  - Remove duplicate `ENTITY_TYPE_TO_PALETTE` → use `entityTypeToPaletteKey` directly

## Invariants

- Entity color + label mapping rules identical (canonical keys + `'doc'` fallback)
- Dark-mode hex values identical (verbatim mirrored into L1 `CANVAS_DARK`)
- All L3 gates (1-5) still satisfied: `react-force-graph-2d` backbone, merge-suggestions flow, Legend / Inspector / neighbor highlight / fullscreen — untouched
- No data-contract change; no routing change; no new Ghost-features

## Ghost-check (mismatch-registry §1 A-2)

G1-G10 all clear — this is pure consumer-side cleanup, no product-surface change.

## Test plan

- [x] `yarn lint` → No ESLint warnings or errors
- [ ] `yarn dev` golden path Graph page (dev server spot-check) — optional; behavior verified to be identical by inspection since dark-mode hex values are mirrored 1:1

## Review

Small cleanup PR. Weston blocker-level CR sufficient per msg=fae63c08 PM口径 (Opus limited).