### PR TITLE
[codex] uplift admin governance surfaces

### DIFF
--- a/web/src/app/admin/audit-logs/page.tsx
+++ b/web/src/app/admin/audit-logs/page.tsx
@@ -2,15 +2,16 @@ import { AuditLogTable } from '@/app/workspace/audit-logs/audit-log-table';
 import {
   PageContainer,
   PageContent,
-  PageDescription,
   PageHeader,
-  PageTitle,
 } from '@/components/page-container';
+import { Card, CardContent } from '@/components/ui/card';
 import { listAuditLogs } from '@/features/audit/server-api';
 import type { ListAuditLogsParams } from '@/features/audit/types';
 import { parsePageParams, toJson } from '@/lib/utils';
+import { Activity, CheckCircle2, ScrollText, XCircle } from 'lucide-react';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 
 export async function generateMetadata(): Promise<Metadata> {
   const page_audit_logs = await getTranslations('page_audit_logs');
@@ -54,17 +55,63 @@ export default async function Page({
   }
 
   const data = res?.items || [];
+  const successCount = data.filter(
+    (item) => (item.status_code || 0) >= 200 && (item.status_code || 0) < 400,
+  ).length;
+  const errorCount = data.filter(
+    (item) => (item.status_code || 0) >= 400,
+  ).length;
+  const averageDuration =
+    data.length === 0
+      ? 0
+      : Math.round(
+          data.reduce((sum, item) => sum + (item.duration_ms || 0), 0) /
+            data.length,
+        );
 
   return (
     <PageContainer>
       <PageHeader
         breadcrumbs={[{ title: page_audit_logs('metadata.title') }]}
       />
-      <PageContent>
-        <PageTitle>{page_audit_logs('metadata.title')}</PageTitle>
-        <PageDescription>
-          {page_audit_logs('metadata.description')}
-        </PageDescription>
+      <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+              {page_audit_logs('metadata.label')}
+            </div>
+            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+              {page_audit_logs('metadata.title')}
+            </h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
+              {page_audit_logs('metadata.description')}
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-6 grid gap-3 md:grid-cols-4">
+          <AdminAuditMetric
+            icon={<ScrollText className="size-4" />}
+            label={page_audit_logs('metric_events')}
+            value={data.length}
+          />
+          <AdminAuditMetric
+            icon={<CheckCircle2 className="size-4" />}
+            label={page_audit_logs('metric_success')}
+            value={successCount}
+          />
+          <AdminAuditMetric
+            icon={<XCircle className="size-4" />}
+            label={page_audit_logs('metric_errors')}
+            value={errorCount}
+          />
+          <AdminAuditMetric
+            icon={<Activity className="size-4" />}
+            label={page_audit_logs('metric_avg_duration')}
+            value={averageDuration}
+            suffix="ms"
+          />
+        </div>
         <AuditLogTable
           data={toJson(data)}
           pageCount={res?.total_pages || 1}
@@ -74,3 +121,36 @@ export default async function Page({
     </PageContainer>
   );
 }
+
+const AdminAuditMetric = ({
+  icon,
+  label,
+  value,
+  suffix,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: number;
+  suffix?: string;
+}) => {
+  return (
+    <Card className="border-border/70 gap-0 rounded-xl py-0">
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="bg-accent-soft text-accent-ink flex size-9 items-center justify-center rounded-lg">
+          {icon}
+        </div>
+        <div>
+          <div className="font-mono text-xl leading-none tabular-nums">
+            {value}
+            {suffix ? (
+              <span className="text-muted-foreground ml-1 text-xs">
+                {suffix}
+              </span>
+            ) : null}
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/app/admin/configuration/page.tsx
+++ b/web/src/app/admin/configuration/page.tsx
@@ -1,16 +1,17 @@
 import {
   PageContainer,
   PageContent,
-  PageDescription,
   PageHeader,
-  PageTitle,
 } from '@/components/page-container';
+import { Card, CardContent } from '@/components/ui/card';
 import {
   getSettings,
   getSystemDefaultQuotas,
 } from '@/features/admin/server-api';
+import { FileSearch, Gauge, SlidersHorizontal } from 'lucide-react';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 import { ParserSettings } from './parser-settings';
 import { QuotaSettings } from './quota-settings';
 
@@ -29,15 +30,50 @@ export default async function Page() {
     getSettings(),
     getSystemDefaultQuotas(),
   ]);
+  const activeParserModes = [
+    settings?.use_markitdown,
+    settings?.use_mineru,
+  ].filter(Boolean).length;
+  const quotaPolicyCount = Object.keys(
+    systemDefaultQuotas?.quotas ?? {},
+  ).length;
+  const configurationPanels = 3 + (systemDefaultQuotas?.quotas ? 1 : 0);
 
   return (
     <PageContainer>
       <PageHeader breadcrumbs={[{ title: admin_config('metadata.title') }]} />
-      <PageContent>
-        <PageTitle>{admin_config('metadata.title')}</PageTitle>
-        <PageDescription className="mb-8">
-          {admin_config('metadata.description')}
-        </PageDescription>
+      <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+              {admin_config('metadata.label')}
+            </div>
+            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+              {admin_config('metadata.title')}
+            </h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
+              {admin_config('metadata.description')}
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-6 grid gap-3 md:grid-cols-3">
+          <ConfigMetric
+            icon={<FileSearch className="size-4" />}
+            label={admin_config('metric_parser_modes')}
+            value={activeParserModes}
+          />
+          <ConfigMetric
+            icon={<Gauge className="size-4" />}
+            label={admin_config('metric_quota_policies')}
+            value={quotaPolicyCount}
+          />
+          <ConfigMetric
+            icon={<SlidersHorizontal className="size-4" />}
+            label={admin_config('metric_control_sections')}
+            value={configurationPanels}
+          />
+        </div>
 
         <div className="flex flex-col gap-6">
           <ParserSettings data={settings ?? undefined} />
@@ -49,3 +85,29 @@ export default async function Page() {
     </PageContainer>
   );
 }
+
+const ConfigMetric = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: number;
+}) => {
+  return (
+    <Card className="border-border/70 gap-0 rounded-xl py-0">
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="bg-accent-soft text-accent-ink flex size-9 items-center justify-center rounded-lg">
+          {icon}
+        </div>
+        <div>
+          <div className="font-mono text-xl leading-none tabular-nums">
+            {value}
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/app/admin/configuration/parser-settings.tsx
+++ b/web/src/app/admin/configuration/parser-settings.tsx
@@ -1,12 +1,7 @@
 'use client';
 
-import {
-  testMineruToken,
-  updateSettings,
-} from '@/features/admin/client-api';
-import type { Settings } from '@/features/admin/types';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   Card,
   CardContent,
@@ -17,6 +12,8 @@ import {
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
+import { testMineruToken, updateSettings } from '@/features/admin/client-api';
+import type { Settings } from '@/features/admin/types';
 import { cn } from '@/lib/utils';
 import { LaptopMinimalCheck, LoaderCircle, RefreshCcw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -65,20 +62,21 @@ const getHealthBadgeClassName = (status: HealthStatus | SupportStatus) => {
   switch (status) {
     case 'ok':
     case 'available':
-      return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+      return 'border-primary/20 bg-accent-soft text-accent-ink';
     case 'warning':
     case 'limited':
-      return 'border-amber-200 bg-amber-50 text-amber-700';
+      return 'border-border bg-secondary text-muted-foreground';
     case 'error':
     case 'unavailable':
-      return 'border-red-200 bg-red-50 text-red-700';
+      return 'border-destructive/20 bg-destructive/10 text-destructive';
     case 'disabled':
-      return 'border-slate-200 bg-slate-50 text-slate-600';
+      return 'border-border bg-muted text-muted-foreground';
   }
-  return 'border-slate-200 bg-slate-50 text-slate-600';
+  return 'border-border bg-muted text-muted-foreground';
 };
 
-const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+const capitalize = (value: string) =>
+  value.charAt(0).toUpperCase() + value.slice(1);
 
 const StatusBadge = ({ status }: { status: HealthStatus | SupportStatus }) => (
   <Badge variant="outline" className={getHealthBadgeClassName(status)}>
@@ -128,9 +126,9 @@ export const ParserSettings = ({
 
   const handleSave = useCallback(async () => {
     await updateSettings(data);
-    toast.success('Saved successfully');
+    toast.success(common_tips('save_success'));
     await fetchParserHealth();
-  }, [data, fetchParserHealth]);
+  }, [common_tips, data, fetchParserHealth]);
 
   const handleSwitchChange = useCallback(
     async (key: keyof Settings, checked: boolean) => {
@@ -173,11 +171,13 @@ export const ParserSettings = ({
 
   return (
     <>
-      <Card>
-        <CardHeader>
+      <Card className="border-border/70 gap-0 rounded-xl py-0 shadow-sm">
+        <CardHeader className="border-border/70 border-b">
           <div className="flex flex-row items-center justify-between gap-4">
             <div>
-              <CardTitle>{admin_config('parser_health_title')}</CardTitle>
+              <CardTitle className="font-serif text-2xl font-normal">
+                {admin_config('parser_health_title')}
+              </CardTitle>
               <CardDescription>
                 {admin_config('parser_health_description')}
               </CardDescription>
@@ -192,7 +192,7 @@ export const ParserSettings = ({
             </Button>
           </div>
         </CardHeader>
-        <CardContent className="space-y-6">
+        <CardContent className="space-y-6 p-5">
           {healthLoading && !health ? (
             <div className="text-muted-foreground flex items-center gap-2 text-sm">
               <LoaderCircle className="animate-spin" />
@@ -203,17 +203,20 @@ export const ParserSettings = ({
           {health ? (
             <>
               <div className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-lg border p-4">
+                <div className="border-border/70 bg-muted rounded-xl border p-4">
                   <div className="mb-2 text-sm font-medium">
                     {admin_config('parser_health_default_parser')}
                   </div>
                   <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="border-blue-200 bg-blue-50 text-blue-700">
+                    <Badge
+                      variant="outline"
+                      className="border-primary/20 bg-accent-soft text-accent-ink"
+                    >
                       {health.default_parser}
                     </Badge>
                   </div>
                 </div>
-                <div className="rounded-lg border p-4">
+                <div className="border-border/70 bg-muted rounded-xl border p-4">
                   <div className="mb-2 text-sm font-medium">
                     {admin_config('parser_health_parser_order')}
                   </div>
@@ -228,7 +231,7 @@ export const ParserSettings = ({
               </div>
 
               <div className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-lg border p-4">
+                <div className="border-border/70 bg-muted rounded-xl border p-4">
                   <div className="mb-3 text-sm font-medium">
                     {admin_config('parser_health_dependencies')}
                   </div>
@@ -236,7 +239,9 @@ export const ParserSettings = ({
                     {health.dependencies.map((item) => (
                       <div key={item.key} className="space-y-1">
                         <div className="flex items-center justify-between gap-3">
-                          <div className="text-sm font-medium">{item.label}</div>
+                          <div className="text-sm font-medium">
+                            {item.label}
+                          </div>
                           <StatusBadge status={item.status} />
                         </div>
                         <div className="text-muted-foreground text-sm">
@@ -247,7 +252,7 @@ export const ParserSettings = ({
                   </div>
                 </div>
 
-                <div className="rounded-lg border p-4">
+                <div className="border-border/70 bg-muted rounded-xl border p-4">
                   <div className="mb-3 text-sm font-medium">
                     {admin_config('parser_health_services')}
                   </div>
@@ -255,7 +260,9 @@ export const ParserSettings = ({
                     {health.services.map((item) => (
                       <div key={item.key} className="space-y-1">
                         <div className="flex items-center justify-between gap-3">
-                          <div className="text-sm font-medium">{item.label}</div>
+                          <div className="text-sm font-medium">
+                            {item.label}
+                          </div>
                           <StatusBadge status={item.status} />
                         </div>
                         <div className="text-muted-foreground text-sm">
@@ -267,18 +274,25 @@ export const ParserSettings = ({
                 </div>
               </div>
 
-              <div className="rounded-lg border p-4">
+              <div className="border-border/70 bg-muted rounded-xl border p-4">
                 <div className="mb-3 text-sm font-medium">
                   {admin_config('parser_health_support_matrix')}
                 </div>
                 <div className="space-y-4">
                   {health.support_tiers.map((tier) => (
-                    <div key={tier.key} className="rounded-md border p-3">
+                    <div
+                      key={tier.key}
+                      className="border-border/70 bg-card rounded-xl border p-3"
+                    >
                       <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
                         <div className="flex flex-wrap items-center gap-2">
                           <div className="font-medium">{tier.label}</div>
-                          <Badge variant="outline">{tier.category}</Badge>
-                          <Badge variant="outline">{tier.parser}</Badge>
+                          <Badge variant="outline" className="bg-muted">
+                            {tier.category}
+                          </Badge>
+                          <Badge variant="outline" className="bg-muted">
+                            {tier.parser}
+                          </Badge>
                         </div>
                         <StatusBadge status={tier.status} />
                       </div>
@@ -287,13 +301,16 @@ export const ParserSettings = ({
                       </div>
                       <div className="mb-2 flex flex-wrap gap-2">
                         {tier.formats.map((format) => (
-                          <Badge key={`${tier.key}-${format}`} variant="outline">
+                          <Badge
+                            key={`${tier.key}-${format}`}
+                            variant="outline"
+                          >
                             {format}
                           </Badge>
                         ))}
                       </div>
                       {tier.requirements.length > 0 ? (
-                        <div className="text-xs text-slate-600">
+                        <div className="text-muted-foreground text-xs">
                           {admin_config('parser_health_requirements')}:{' '}
                           {tier.requirements.join(', ')}
                         </div>
@@ -304,7 +321,7 @@ export const ParserSettings = ({
               </div>
 
               <div className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-lg border p-4">
+                <div className="border-border/70 bg-muted rounded-xl border p-4">
                   <div className="mb-3 text-sm font-medium">
                     {admin_config('parser_health_warnings')}
                   </div>
@@ -321,7 +338,7 @@ export const ParserSettings = ({
                   )}
                 </div>
 
-                <div className="rounded-lg border p-4">
+                <div className="border-border/70 bg-muted rounded-xl border p-4">
                   <div className="mb-3 text-sm font-medium">
                     {admin_config('parser_health_recommendations')}
                   </div>
@@ -342,11 +359,13 @@ export const ParserSettings = ({
           ) : null}
         </CardContent>
       </Card>
-      <Card>
-        <CardHeader>
-          <div className="flex flex-row items-center justify-between">
+      <Card className="border-border/70 gap-0 rounded-xl py-0 shadow-sm">
+        <CardHeader className="border-border/70 border-b">
+          <div className="flex flex-row items-center justify-between gap-4">
             <div>
-              <CardTitle>{admin_config('mineru_api')}</CardTitle>
+              <CardTitle className="font-serif text-2xl font-normal">
+                {admin_config('mineru_api')}
+              </CardTitle>
               <CardDescription>
                 {admin_config('mineru_api_description')}
               </CardDescription>
@@ -360,9 +379,12 @@ export const ParserSettings = ({
           </div>
         </CardHeader>
 
-        <CardContent className={data.use_mineru ? 'block' : 'hidden'}>
-          <div className="flex flex-row gap-4">
+        <CardContent
+          className={cn('p-5', data.use_mineru ? 'block' : 'hidden')}
+        >
+          <div className="flex flex-col gap-3 md:flex-row">
             <Input
+              className="bg-background/70 rounded-xl"
               placeholder={admin_config('mineru_api_token')}
               value={data.mineru_api_token ?? ''}
               onChange={(e) => {
@@ -388,18 +410,23 @@ export const ParserSettings = ({
         </CardContent>
 
         <CardFooter
-          className={cn('justify-end', data.use_mineru ? 'flex' : 'hidden')}
+          className={cn(
+            'border-border/70 justify-end border-t p-4',
+            data.use_mineru ? 'flex' : 'hidden',
+          )}
         >
           <Button disabled={!checked} onClick={handleSave}>
             {common_action('save')}
           </Button>
         </CardFooter>
       </Card>
-      <Card>
+      <Card className="border-border/70 gap-0 rounded-xl py-0 shadow-sm">
         <CardHeader>
-          <div className="flex flex-row items-center justify-between">
+          <div className="flex flex-row items-center justify-between gap-4">
             <div>
-              <CardTitle>{admin_config('use_markitdown')}</CardTitle>
+              <CardTitle className="font-serif text-2xl font-normal">
+                {admin_config('use_markitdown')}
+              </CardTitle>
               <CardDescription>
                 {admin_config('use_markitdown_description')}
               </CardDescription>

--- a/web/src/app/admin/configuration/quota-settings.tsx
+++ b/web/src/app/admin/configuration/quota-settings.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { updateSystemDefaultQuotas } from '@/features/admin/client-api';
-import type { SystemDefaultQuotas } from '@/features/admin/types';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -13,6 +11,8 @@ import {
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { updateSystemDefaultQuotas } from '@/features/admin/client-api';
+import type { SystemDefaultQuotas } from '@/features/admin/types';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
@@ -50,18 +50,21 @@ export const QuotaSettings = ({
 
   return (
     <>
-      <Card>
-        <CardHeader>
-          <CardTitle>{admin_config('system_default_quota')}</CardTitle>
+      <Card className="border-border/70 gap-0 rounded-xl py-0 shadow-sm">
+        <CardHeader className="border-border/70 border-b">
+          <CardTitle className="font-serif text-2xl font-normal">
+            {admin_config('system_default_quota')}
+          </CardTitle>
           <CardDescription>
             {admin_config('system_default_quota_description')}
           </CardDescription>
         </CardHeader>
 
-        <CardContent className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <CardContent className="grid gap-4 p-5 md:grid-cols-2 xl:grid-cols-4">
           <div className="flex flex-col gap-2">
             <Label>{page_quota('bot_count.title')}</Label>
             <Input
+              className="bg-background/70 rounded-xl"
               type="number"
               value={data.max_bot_count}
               onChange={(e) => {
@@ -76,6 +79,7 @@ export const QuotaSettings = ({
           <div className="flex flex-col gap-2">
             <Label>{page_quota('collection_count.title')}</Label>
             <Input
+              className="bg-background/70 rounded-xl"
               type="number"
               value={data.max_collection_count}
               onChange={(e) => {
@@ -90,6 +94,7 @@ export const QuotaSettings = ({
           <div className="flex flex-col gap-2">
             <Label>{page_quota('document_count.title')}</Label>
             <Input
+              className="bg-background/70 rounded-xl"
               type="number"
               value={data.max_document_count}
               onChange={(e) => {
@@ -104,6 +109,7 @@ export const QuotaSettings = ({
           <div className="flex flex-col gap-2">
             <Label>{page_quota('documents_per_collection.title')}</Label>
             <Input
+              className="bg-background/70 rounded-xl"
               type="number"
               value={data.max_document_count_per_collection}
               onChange={(e) => {
@@ -118,7 +124,7 @@ export const QuotaSettings = ({
           </div>
         </CardContent>
 
-        <CardFooter className="justify-end">
+        <CardFooter className="border-border/70 justify-end border-t p-4">
           <Button onClick={handleSave}>{common_action('save')}</Button>
         </CardFooter>
       </Card>

--- a/web/src/app/admin/providers/[providerName]/models/page.tsx
+++ b/web/src/app/admin/providers/[providerName]/models/page.tsx
@@ -2,16 +2,17 @@ import { ModelTable } from '@/app/workspace/providers/[providerName]/models/mode
 import {
   PageContainer,
   PageContent,
-  PageDescription,
   PageHeader,
-  PageTitle,
 } from '@/components/page-container';
+import { Card, CardContent } from '@/components/ui/card';
 import {
   getProvider,
   getProviderModels,
 } from '@/features/providers/server-api';
+import { Boxes, BrainCircuit, GitBranch, Layers3 } from 'lucide-react';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 
 export async function generateMetadata(): Promise<Metadata> {
   const page_models = await getTranslations('page_models');
@@ -33,6 +34,13 @@ export default async function Page({
     getProviderModels(providerName),
     getProvider(providerName),
   ]);
+  const completionCount = models.filter(
+    (model) => model.api === 'completion',
+  ).length;
+  const embeddingCount = models.filter(
+    (model) => model.api === 'embedding',
+  ).length;
+  const rerankCount = models.filter((model) => model.api === 'rerank').length;
 
   return (
     <PageContainer>
@@ -46,17 +54,71 @@ export default async function Page({
           { title: page_models('metadata.model_title') },
         ]}
       />
-      <PageContent>
-        <PageTitle>{page_models('metadata.model_title')}</PageTitle>
-        <PageDescription>
-          {page_models('metadata.model_description')}
-        </PageDescription>
-        <ModelTable
-          provider={provider}
-          data={models}
-          pathnamePrefix="/admin"
-        />
+      <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+              {page_models('metadata.model_label')}
+            </div>
+            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+              {provider?.label ?? providerName}
+            </h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
+              {page_models('metadata.model_description')}
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-6 grid gap-3 md:grid-cols-4">
+          <AdminModelMetric
+            icon={<Boxes className="size-4" />}
+            label={page_models('model.metric_total')}
+            value={models.length}
+          />
+          <AdminModelMetric
+            icon={<BrainCircuit className="size-4" />}
+            label={page_models('model.metric_completion')}
+            value={completionCount}
+          />
+          <AdminModelMetric
+            icon={<Layers3 className="size-4" />}
+            label={page_models('model.metric_embedding')}
+            value={embeddingCount}
+          />
+          <AdminModelMetric
+            icon={<GitBranch className="size-4" />}
+            label={page_models('model.metric_rerank')}
+            value={rerankCount}
+          />
+        </div>
+        <ModelTable provider={provider} data={models} pathnamePrefix="/admin" />
       </PageContent>
     </PageContainer>
   );
 }
+
+const AdminModelMetric = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: number;
+}) => {
+  return (
+    <Card className="border-border/70 gap-0 rounded-xl py-0">
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="bg-accent-soft text-accent-ink flex size-9 items-center justify-center rounded-lg">
+          {icon}
+        </div>
+        <div>
+          <div className="font-mono text-xl leading-none tabular-nums">
+            {value}
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/app/admin/providers/page.tsx
+++ b/web/src/app/admin/providers/page.tsx
@@ -2,14 +2,15 @@ import { ProviderTable } from '@/app/workspace/providers/provider-table';
 import {
   PageContainer,
   PageContent,
-  PageDescription,
   PageHeader,
-  PageTitle,
 } from '@/components/page-container';
+import { Card, CardContent } from '@/components/ui/card';
 import { getProviderCatalog } from '@/features/providers/server-api';
 import { toJson } from '@/lib/utils';
+import { Boxes, BrainCircuit, Globe2, KeyRound } from 'lucide-react';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 
 export async function generateMetadata(): Promise<Metadata> {
   const page_models = await getTranslations('page_models');
@@ -22,24 +23,87 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Page() {
   const page_models = await getTranslations('page_models');
   const providerCatalog = await getProviderCatalog();
+  const providers = providerCatalog.providers;
+  const models = providerCatalog.models;
 
   return (
     <PageContainer>
       <PageHeader
         breadcrumbs={[{ title: page_models('metadata.provider_title') }]}
       />
-      <PageContent>
-        <PageTitle>{page_models('metadata.provider_title')}</PageTitle>
-        <PageDescription>
-          {page_models('metadata.provider_description')}
-        </PageDescription>
+      <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+              {page_models('metadata.provider_label')}
+            </div>
+            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+              {page_models('metadata.provider_title')}
+            </h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
+              {page_models('metadata.provider_description')}
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-6 grid gap-3 md:grid-cols-4">
+          <AdminProviderMetric
+            icon={<Boxes className="size-4" />}
+            label={page_models('provider.metric_providers')}
+            value={providers.length}
+          />
+          <AdminProviderMetric
+            icon={<KeyRound className="size-4" />}
+            label={page_models('provider.metric_enabled')}
+            value={providers.filter((provider) => provider.api_key).length}
+          />
+          <AdminProviderMetric
+            icon={<Globe2 className="size-4" />}
+            label={page_models('provider.metric_public')}
+            value={
+              providers.filter((provider) => provider.user_id === 'public')
+                .length
+            }
+          />
+          <AdminProviderMetric
+            icon={<BrainCircuit className="size-4" />}
+            label={page_models('provider.metric_models')}
+            value={models.length}
+          />
+        </div>
 
         <ProviderTable
-          data={toJson(providerCatalog.providers)}
-          models={toJson(providerCatalog.models)}
+          data={toJson(providers)}
+          models={toJson(models)}
           urlPrefix="/admin"
         />
       </PageContent>
     </PageContainer>
   );
 }
+
+const AdminProviderMetric = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: number;
+}) => {
+  return (
+    <Card className="border-border/70 gap-0 rounded-xl py-0">
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="bg-accent-soft text-accent-ink flex size-9 items-center justify-center rounded-lg">
+          {icon}
+        </div>
+        <div>
+          <div className="font-mono text-xl leading-none tabular-nums">
+            {value}
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -1,14 +1,15 @@
 import {
   PageContainer,
   PageContent,
-  PageDescription,
   PageHeader,
-  PageTitle,
 } from '@/components/page-container';
+import { Card, CardContent } from '@/components/ui/card';
 import { listUsers } from '@/features/admin/server-api';
 import { toJson } from '@/lib/utils';
+import { ShieldCheck, UserCheck, UsersRound } from 'lucide-react';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 import { UsersDataTable } from './users-data-table';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -24,15 +25,69 @@ export default async function Page() {
   const res = await listUsers();
 
   const users = res.items || [];
+  const activeUsers = users.filter((user) => user.is_active).length;
+  const adminUsers = users.filter((user) => user.role === 'admin').length;
 
   return (
     <PageContainer>
       <PageHeader breadcrumbs={[{ title: admin_users('metadata.title') }]} />
-      <PageContent>
-        <PageTitle>{admin_users('metadata.title')}</PageTitle>
-        <PageDescription>{admin_users('metadata.description')}</PageDescription>
+      <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+              {admin_users('metadata.label')}
+            </div>
+            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+              {admin_users('metadata.title')}
+            </h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
+              {admin_users('metadata.description')}
+            </p>
+          </div>
+        </div>
+        <div className="mb-6 grid gap-3 md:grid-cols-3">
+          <AdminMetric
+            icon={<UsersRound className="size-4" />}
+            label={admin_users('metric_users')}
+            value={users.length}
+          />
+          <AdminMetric
+            icon={<UserCheck className="size-4" />}
+            label={admin_users('metric_active')}
+            value={activeUsers}
+          />
+          <AdminMetric
+            icon={<ShieldCheck className="size-4" />}
+            label={admin_users('metric_admins')}
+            value={adminUsers}
+          />
+        </div>
         <UsersDataTable data={toJson(users)} />
       </PageContent>
     </PageContainer>
   );
 }
+
+const AdminMetric = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: number;
+}) => (
+  <Card className="border-border/70 gap-0 rounded-xl py-0">
+    <CardContent className="flex items-center gap-3 p-4">
+      <div className="bg-accent-soft text-accent-ink flex size-9 items-center justify-center rounded-lg">
+        {icon}
+      </div>
+      <div>
+        <div className="font-mono text-xl leading-none tabular-nums">
+          {value}
+        </div>
+        <div className="text-muted-foreground mt-1 text-xs">{label}</div>
+      </div>
+    </CardContent>
+  </Card>
+);

--- a/web/src/app/admin/users/user-quota-action.tsx
+++ b/web/src/app/admin/users/user-quota-action.tsx
@@ -1,16 +1,5 @@
 'use client';
 
-import {
-  getUserQuota as getUserQuotaApi,
-  recalculateUserQuota,
-  updateUserQuota,
-} from '@/features/admin/client-api';
-import type {
-  QuotaUpdateRequest,
-  QuotaUpdateResponse,
-  UserQuotaInfo,
-} from '@/features/admin/types';
-import type { User } from '@/features/identity/types';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -31,9 +20,21 @@ import {
 import { Input } from '@/components/ui/input';
 import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  getUserQuota as getUserQuotaApi,
+  recalculateUserQuota,
+  updateUserQuota,
+} from '@/features/admin/client-api';
+import type {
+  QuotaUpdateRequest,
+  QuotaUpdateResponse,
+  UserQuotaInfo,
+} from '@/features/admin/types';
+import type { User } from '@/features/identity/types';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Slot } from '@radix-ui/react-slot';
 import _ from 'lodash';
+import { Gauge } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -141,11 +142,22 @@ export const UserQuotaAction = ({
               // @ts-expect-error i18n error
               const label = page_quota(info.quota_type);
               return (
-                <div>
+                <div className="border-border/70 bg-muted rounded-xl border p-4">
                   <FormItem>
-                    <FormLabel>{label}</FormLabel>
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <div>
+                        <FormLabel className="font-medium">{label}</FormLabel>
+                        <div className="text-muted-foreground mt-1 text-xs">
+                          {page_quota('usage')}: {info.current_usage}
+                        </div>
+                      </div>
+                      <div className="bg-accent-soft text-accent-ink flex size-9 shrink-0 items-center justify-center rounded-lg">
+                        <Gauge className="size-4" />
+                      </div>
+                    </div>
                     <FormControl>
                       <Input
+                        className="bg-background/70 rounded-xl font-mono"
                         type="number"
                         {...field}
                         onChange={(e) => {
@@ -155,12 +167,12 @@ export const UserQuotaAction = ({
                       />
                     </FormControl>
                   </FormItem>
-                  <div className="my-1">
-                    <Progress className="h-1" value={percent} />
+                  <div className="my-3">
+                    <Progress className="bg-border h-1.5" value={percent} />
                   </div>
-                  <div className="text-muted-foreground flex flex-row justify-between text-sm">
+                  <div className="text-muted-foreground flex flex-row justify-between font-mono text-xs">
                     <div>
-                      {page_quota('usage')}: {info.current_usage}
+                      {page_quota('limit')}: {info.quota_limit}
                     </div>
                     <div>{percent.toFixed(2)}%</div>
                   </div>
@@ -191,25 +203,29 @@ export const UserQuotaAction = ({
           {children}
         </Slot>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="border-border/70 max-w-3xl rounded-xl p-0">
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleUpdateQuota)}>
-            <DialogHeader>
-              <DialogTitle>{admin_users('user_quotas')}</DialogTitle>
+            <DialogHeader className="border-border/70 border-b px-6 py-5">
+              <DialogTitle className="font-serif text-2xl font-normal">
+                {admin_users('user_quotas')}
+              </DialogTitle>
               <DialogDescription asChild>
-                <div className="flex flex-row gap-2">
-                  {user.username && <div>{user.username}</div>}
-                  {user.email && <div>{user.email}</div>}
+                <div className="text-muted-foreground mt-2 flex flex-wrap gap-2 text-sm">
+                  {user.username && <span>{user.username}</span>}
+                  {user.email && (
+                    <span className="font-mono">{user.email}</span>
+                  )}
                 </div>
               </DialogDescription>
             </DialogHeader>
 
-            <div className="flex flex-col gap-6 py-8">{content}</div>
+            <div className="grid gap-4 px-6 py-6 md:grid-cols-2">{content}</div>
 
-            <DialogFooter className="flex flex-col sm:justify-between">
+            <DialogFooter className="border-border/70 flex flex-col border-t px-6 py-4 sm:flex-row sm:justify-between">
               <Button
                 type="button"
-                variant="secondary"
+                variant="outline"
                 onClick={() => handleRecalculate()}
                 disabled={_.isEmpty(quotaInfo)}
               >

--- a/web/src/app/admin/users/users-data-table.tsx
+++ b/web/src/app/admin/users/users-data-table.tsx
@@ -44,11 +44,14 @@ import {
   BatteryMedium,
   Check,
   ChevronDown,
+  CircleMinus,
   Columns3,
   EllipsisVertical,
   Key,
   ScrollText,
+  Search,
   Trash,
+  UserRound,
 } from 'lucide-react';
 import { useFormatter, useTranslations } from 'next-intl';
 import Link from 'next/link';
@@ -105,14 +108,26 @@ export function UsersDataTable({ data }: { data: User[] }) {
         header: admin_users('user_name'),
         cell: ({ row }) => {
           return (
-            <div className="text-left">
-              <div>
-                {row.original.username}{' '}
-                {user?.id === row.original.id && (
-                  <Badge variant="destructive">Me</Badge>
-                )}
+            <div className="flex items-center gap-3 text-left">
+              <div className="bg-accent-soft text-accent-ink flex size-9 shrink-0 items-center justify-center rounded-lg">
+                <UserRound className="size-4" />
               </div>
-              <div className="text-muted-foreground">{row.original.email}</div>
+              <div className="min-w-0">
+                <div className="truncate font-medium">
+                  {row.original.username}
+                  {user?.id === row.original.id && (
+                    <Badge
+                      variant="outline"
+                      className="bg-accent-soft text-accent-ink ml-2 rounded-full"
+                    >
+                      {admin_users('self_badge')}
+                    </Badge>
+                  )}
+                </div>
+                <div className="text-muted-foreground truncate">
+                  {row.original.email}
+                </div>
+              </div>
             </div>
           );
         },
@@ -127,8 +142,13 @@ export function UsersDataTable({ data }: { data: User[] }) {
         cell: ({ row }) => {
           return (
             <Badge
-              className="w-18"
-              variant={row.original.role === 'admin' ? 'default' : 'secondary'}
+              className={cn(
+                'w-18 rounded-full',
+                row.original.role === 'admin'
+                  ? 'border-primary/20 bg-accent-soft text-accent-ink'
+                  : 'bg-muted text-muted-foreground',
+              )}
+              variant="outline"
             >
               {row.original.role}
             </Badge>
@@ -139,13 +159,24 @@ export function UsersDataTable({ data }: { data: User[] }) {
         accessorKey: 'is_active',
         header: admin_users('user_status'),
         cell: ({ row }) => {
+          const isActive = row.original.is_active;
           return (
-            <Check
+            <Badge
+              variant="outline"
               className={cn(
-                'size-4',
-                row.original.is_active ? 'text-green-500' : 'text-red-500',
+                'gap-1 rounded-full',
+                isActive
+                  ? 'border-primary/20 bg-accent-soft text-accent-ink'
+                  : 'bg-muted text-muted-foreground',
               )}
-            />
+            >
+              {isActive ? (
+                <Check className="size-3" />
+              ) : (
+                <CircleMinus className="size-3" />
+              )}
+              {admin_users(isActive ? 'status_active' : 'status_inactive')}
+            </Badge>
           );
         },
       },
@@ -248,20 +279,25 @@ export function UsersDataTable({ data }: { data: User[] }) {
   });
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div className="flex flex-row items-center gap-2">
+    <div className="flex flex-col gap-5">
+      <div className="border-border/70 bg-card grid gap-4 rounded-xl border p-4 shadow-sm lg:grid-cols-[1fr_auto] lg:items-center">
+        <div className="relative max-w-xl">
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
           <Input
+            className="bg-background/70 h-10 rounded-lg pl-9"
             placeholder={admin_users('search')}
             value={searchValue}
             onChange={(e) => setSearchValue(e.currentTarget.value)}
           />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 lg:justify-end">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline">
                 <Columns3 />
+                <span className="hidden sm:inline">
+                  {admin_users('columns')}
+                </span>
                 <ChevronDown />
               </Button>
             </DropdownMenuTrigger>
@@ -291,7 +327,9 @@ export function UsersDataTable({ data }: { data: User[] }) {
           </DropdownMenu>
         </div>
       </div>
-      <DataGrid table={table} />
+      <div className="border-border/70 bg-card rounded-xl border p-3 shadow-sm">
+        <DataGrid table={table} className="border-border/70 rounded-lg" />
+      </div>
       <DataGridPagination table={table} />
     </div>
   );

--- a/web/src/app/workspace/api-keys/api-key-actions.tsx
+++ b/web/src/app/workspace/api-keys/api-key-actions.tsx
@@ -1,11 +1,5 @@
 'use client';
 
-import {
-  createApiKey,
-  deleteApiKey,
-  updateApiKey,
-} from '@/features/api-key/client-api';
-import type { ApiKey } from '@/features/api-key/types';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -26,6 +20,12 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import {
+  createApiKey,
+  deleteApiKey,
+  updateApiKey,
+} from '@/features/api-key/client-api';
+import type { ApiKey } from '@/features/api-key/types';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Slot } from '@radix-ui/react-slot';
 import copy from 'copy-to-clipboard';
@@ -128,7 +128,10 @@ export const ApiKeyActions = ({
             {children}
           </Slot>
         </DialogTrigger>
-        <DialogContent showCloseButton={false}>
+        <DialogContent
+          showCloseButton={false}
+          className="border-border/70 rounded-xl"
+        >
           <DialogHeader>
             <DialogTitle>{common_tips('confirm')}</DialogTitle>
             <DialogDescription>
@@ -164,15 +167,22 @@ export const ApiKeyActions = ({
               {children}
             </Slot>
           </DialogTrigger>
-          <DialogContent showCloseButton={false}>
+          <DialogContent
+            showCloseButton={false}
+            className="border-border/70 max-w-2xl rounded-xl"
+          >
             <Form {...form}>
               <form
                 onSubmit={form.handleSubmit(handleCreateOrUpdate)}
-                className="space-y-8"
+                className="space-y-6"
               >
                 <DialogHeader>
-                  <DialogTitle>API Key</DialogTitle>
-                  <DialogDescription></DialogDescription>
+                  <DialogTitle className="font-serif text-2xl font-normal">
+                    {page_api_keys('dialog_title')}
+                  </DialogTitle>
+                  <DialogDescription>
+                    {page_api_keys('dialog_description')}
+                  </DialogDescription>
                 </DialogHeader>
                 <FormField
                   control={form.control}
@@ -181,6 +191,7 @@ export const ApiKeyActions = ({
                     <FormItem>
                       <FormControl>
                         <Textarea
+                          className="min-h-28 resize-y rounded-xl"
                           placeholder={page_api_keys('api_key_placeholder')}
                           {...field}
                         />
@@ -211,9 +222,12 @@ export const ApiKeyActions = ({
             showCloseButton={false}
             onEscapeKeyDown={(event) => event.preventDefault()}
             onInteractOutside={(event) => event.preventDefault()}
+            className="border-border/70 max-w-2xl rounded-xl"
           >
             <DialogHeader>
-              <DialogTitle>{page_api_keys('created_api_key_title')}</DialogTitle>
+              <DialogTitle className="font-serif text-2xl font-normal">
+                {page_api_keys('created_api_key_title')}
+              </DialogTitle>
               <DialogDescription>
                 {page_api_keys('created_api_key_description')}
               </DialogDescription>
@@ -226,7 +240,7 @@ export const ApiKeyActions = ({
                 <Input
                   readOnly
                   value={createdApiKey?.key || ''}
-                  className="font-mono text-xs"
+                  className="bg-muted font-mono text-xs"
                 />
               </div>
               <p className="text-muted-foreground text-sm">

--- a/web/src/app/workspace/api-keys/api-key-table.tsx
+++ b/web/src/app/workspace/api-keys/api-key-table.tsx
@@ -31,13 +31,15 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-import type { ApiKey } from '@/features/api-key/types';
 import { FormatDate } from '@/components/format-date';
+import type { ApiKey } from '@/features/api-key/types';
 import {
   ChevronDown,
   Columns3,
   EllipsisVertical,
+  KeyRound,
   Plus,
+  Search,
   SquarePen,
   Trash,
 } from 'lucide-react';
@@ -104,9 +106,21 @@ export function ApiKeyTable({ data }: { data: ApiKey[] }) {
       header: page_api_keys('api_keys'),
       cell: ({ row }) => {
         return (
-          <div className="flex flex-row items-center gap-2">
-            <span className="font-mono text-sm">{row.original.key}</span>
-            <Badge variant="outline">{page_api_keys('masked_badge')}</Badge>
+          <div className="flex items-center gap-3">
+            <div className="bg-accent-soft text-accent-ink flex size-9 shrink-0 items-center justify-center rounded-lg">
+              <KeyRound className="size-4" />
+            </div>
+            <div className="min-w-0">
+              <span className="block truncate font-mono text-sm">
+                {row.original.key}
+              </span>
+              <Badge
+                variant="outline"
+                className="bg-muted mt-1 rounded-full font-mono text-[10px]"
+              >
+                {page_api_keys('masked_badge')}
+              </Badge>
+            </div>
           </div>
         );
       },
@@ -193,19 +207,23 @@ export function ApiKeyTable({ data }: { data: ApiKey[] }) {
   });
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <Input
-            placeholder={page_api_keys('search_api_keys')}
-            value={searchValue}
-            onChange={(e) => setSearchValue(e.currentTarget.value)}
-          />
+    <div className="flex flex-col gap-5">
+      <div className="border-border/70 bg-card grid gap-4 rounded-xl border p-4 shadow-sm lg:grid-cols-[1fr_auto] lg:items-center">
+        <div className="min-w-0">
+          <div className="relative max-w-xl">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+            <Input
+              className="bg-background/70 h-10 rounded-lg pl-9"
+              placeholder={page_api_keys('search_api_keys')}
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.currentTarget.value)}
+            />
+          </div>
           <p className="text-muted-foreground mt-2 text-xs">
             {page_api_keys('masked_notice')}
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 lg:justify-end">
           <ApiKeyActions action="add">
             <Button>
               <Plus />
@@ -218,6 +236,9 @@ export function ApiKeyTable({ data }: { data: ApiKey[] }) {
             <DropdownMenuTrigger asChild>
               <Button variant="outline">
                 <Columns3 />
+                <span className="hidden sm:inline">
+                  {page_api_keys('columns')}
+                </span>
                 <ChevronDown />
               </Button>
             </DropdownMenuTrigger>
@@ -247,7 +268,9 @@ export function ApiKeyTable({ data }: { data: ApiKey[] }) {
           </DropdownMenu>
         </div>
       </div>
-      <DataGrid table={table} />
+      <div className="border-border/70 bg-card rounded-xl border p-3 shadow-sm">
+        <DataGrid table={table} className="border-border/70 rounded-lg" />
+      </div>
       <DataGridPagination table={table} />
     </div>
   );

--- a/web/src/app/workspace/api-keys/page.tsx
+++ b/web/src/app/workspace/api-keys/page.tsx
@@ -1,30 +1,84 @@
 import {
   PageContainer,
   PageContent,
-  PageDescription,
   PageHeader,
-  PageTitle,
 } from '@/components/page-container';
+import { Card, CardContent } from '@/components/ui/card';
 
 import { listApiKeys } from '@/features/api-key/server-api';
 import { toJson } from '@/lib/utils';
+import { KeyRound, ShieldCheck, TimerReset } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 import { ApiKeyTable } from './api-key-table';
 
 export default async function Page() {
   const data = await listApiKeys();
   const page_api_keys = await getTranslations('page_api_keys');
+  const usedKeys = data.filter((item) => item.last_used_at).length;
 
   return (
     <PageContainer>
       <PageHeader breadcrumbs={[{ title: page_api_keys('metadata.title') }]} />
-      <PageContent>
-        <PageTitle>{page_api_keys('metadata.title')}</PageTitle>
-        <PageDescription>
-          {page_api_keys('metadata.description')}
-        </PageDescription>
+      <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+              {page_api_keys('metadata.label')}
+            </div>
+            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+              {page_api_keys('metadata.title')}
+            </h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
+              {page_api_keys('metadata.description')}
+            </p>
+          </div>
+        </div>
+        <div className="mb-6 grid gap-3 md:grid-cols-3">
+          <GovernanceMetric
+            icon={<KeyRound className="size-4" />}
+            label={page_api_keys('metric_total')}
+            value={data.length}
+          />
+          <GovernanceMetric
+            icon={<TimerReset className="size-4" />}
+            label={page_api_keys('metric_used')}
+            value={usedKeys}
+          />
+          <GovernanceMetric
+            icon={<ShieldCheck className="size-4" />}
+            label={page_api_keys('metric_masked')}
+            value={data.length}
+          />
+        </div>
         <ApiKeyTable data={toJson(data)} />
       </PageContent>
     </PageContainer>
   );
 }
+
+const GovernanceMetric = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: number;
+}) => {
+  return (
+    <Card className="border-border/70 gap-0 rounded-xl py-0">
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="bg-accent-soft text-accent-ink flex size-9 items-center justify-center rounded-lg">
+          {icon}
+        </div>
+        <div>
+          <div className="font-mono text-xl leading-none tabular-nums">
+            {value}
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/app/workspace/audit-logs/audit-log-detail.tsx
+++ b/web/src/app/workspace/audit-logs/audit-log-detail.tsx
@@ -1,5 +1,4 @@
 'use client';
-import type { AuditLog } from '@/features/audit/types';
 import { Markdown } from '@/components/markdown';
 import {
   Drawer,
@@ -8,7 +7,8 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from '@/components/ui/drawer';
-import { useFormatter } from 'next-intl';
+import type { AuditLog } from '@/features/audit/types';
+import { useFormatter, useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 
 export const AuditLogDetail = ({
@@ -19,6 +19,7 @@ export const AuditLogDetail = ({
   children: React.ReactNode;
 }) => {
   const format = useFormatter();
+  const page_audit_logs = useTranslations('page_audit_logs');
 
   const responseData = useMemo(() => {
     const res = auditLog.response_data || '{}';
@@ -31,79 +32,88 @@ export const AuditLogDetail = ({
     }
     return result;
   }, [auditLog.response_data]);
+  const requestData = useMemo(() => {
+    const request = auditLog.request_data || '{}';
+    let result = request;
+    try {
+      result =
+        '``` json\n' +
+        JSON.stringify(JSON.parse(request), undefined, 2) +
+        '\n```';
+    } catch (err) {
+      console.log(err);
+    }
+    return result;
+  }, [auditLog.request_data]);
 
   return (
     <>
       <Drawer direction="right" handleOnly={true}>
         <DrawerTrigger asChild>{children}</DrawerTrigger>
-        <DrawerContent className="flex sm:min-w-lg md:min-w-xl lg:min-w-2xl">
-          <DrawerHeader>
-            <DrawerTitle className="font-bold">Audit Log</DrawerTitle>
+        <DrawerContent className="border-border/70 bg-card flex border-l sm:min-w-lg md:min-w-xl lg:min-w-2xl">
+          <DrawerHeader className="border-border/70 border-b">
+            <DrawerTitle className="font-serif text-2xl font-normal">
+              {page_audit_logs('metadata.title')}
+            </DrawerTitle>
           </DrawerHeader>
           <div className="flex flex-col gap-4 overflow-auto p-4 text-sm select-text">
-            <div>
-              <div className="text-muted-foreground">User Agent:</div>
-              <div>{auditLog.user_agent}</div>
+            <div className="border-border/70 bg-muted rounded-xl border p-3">
+              <div className="text-muted-foreground font-mono text-[11px] uppercase">
+                {page_audit_logs('detail.user_agent')}
+              </div>
+              <div className="mt-1 break-words">{auditLog.user_agent}</div>
             </div>
 
-            <div>
-              <div className="text-muted-foreground">IP:</div>
-              <div>{auditLog.ip_address}</div>
-            </div>
-
-            <div>
-              <div className="text-muted-foreground">User ID:</div>
-              <div>{auditLog.user_id}</div>
-            </div>
-
-            <div>
-              <div className="text-muted-foreground">Request ID:</div>
-              <div>{auditLog.request_id}</div>
-            </div>
-
-            <div>
-              <div className="text-muted-foreground">API:</div>
-              <div>{auditLog.api_name}</div>
-            </div>
-
-            <div>
-              <div className="text-muted-foreground">Path:</div>
-              <div>{auditLog.path}</div>
-            </div>
-
-            <div>
-              <div className="text-muted-foreground">Method:</div>
-              <div>{auditLog.http_method}</div>
-            </div>
-
-            <div>
-              <div className="text-muted-foreground">Status Code:</div>
-              <div>{auditLog.status_code}</div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <AuditMeta
+                label={page_audit_logs('detail.ip')}
+                value={auditLog.ip_address}
+              />
+              <AuditMeta
+                label={page_audit_logs('detail.user_id')}
+                value={auditLog.user_id}
+              />
+              <AuditMeta
+                label={page_audit_logs('detail.request_id')}
+                value={auditLog.request_id}
+              />
+              <AuditMeta
+                label={page_audit_logs('detail.api')}
+                value={auditLog.api_name}
+              />
+              <AuditMeta
+                label={page_audit_logs('detail.path')}
+                value={auditLog.path}
+              />
+              <AuditMeta
+                label={page_audit_logs('detail.method')}
+                value={auditLog.http_method}
+              />
+              <AuditMeta
+                label={page_audit_logs('detail.status_code')}
+                value={String(auditLog.status_code || '--')}
+              />
+              <AuditMeta
+                label={page_audit_logs('detail.resource_type')}
+                value={auditLog.resource_type}
+              />
             </div>
 
             <div>
               <div className="text-muted-foreground -mb-3 flex justify-between">
-                <div>Request Data:</div>
+                <div>{page_audit_logs('detail.request_data')}</div>
                 <div>
                   {auditLog.start_time
                     ? format.dateTime(new Date(auditLog.start_time), 'long')
                     : ''}
                 </div>
               </div>
-              <Markdown>
-                {'``` json\n' +
-                  JSON.stringify(
-                    JSON.parse(auditLog.request_data || ''),
-                    undefined,
-                    2,
-                  ) +
-                  '\n```'}
-              </Markdown>
+              <Markdown>{requestData}</Markdown>
             </div>
 
             <div>
               <div className="text-muted-foreground -mb-3 flex justify-between">
-                <div>Response Data:</div>
+                <div>{page_audit_logs('detail.response_data')}</div>
                 <div>
                   {auditLog.end_time
                     ? format.dateTime(new Date(auditLog.end_time), 'long')
@@ -113,23 +123,35 @@ export const AuditLogDetail = ({
               <Markdown>{responseData}</Markdown>
             </div>
 
-            <div>
-              <div className="text-muted-foreground">Error Messages:</div>
+            <div className="border-border/70 bg-muted rounded-xl border p-3">
+              <div className="text-muted-foreground font-mono text-[11px] uppercase">
+                {page_audit_logs('detail.error_messages')}
+              </div>
               <div>{auditLog.error_message || '--'}</div>
             </div>
 
-            <div>
-              <div className="text-muted-foreground">Resource ID:</div>
-              <div>{auditLog.resource_id || '--'}</div>
-            </div>
-
-            <div>
-              <div className="text-muted-foreground">Resource Type:</div>
-              <div>{auditLog.resource_type}</div>
-            </div>
+            <AuditMeta
+              label={page_audit_logs('detail.resource_id')}
+              value={auditLog.resource_id}
+            />
           </div>
         </DrawerContent>
       </Drawer>
     </>
   );
 };
+
+const AuditMeta = ({
+  label,
+  value,
+}: {
+  label: string;
+  value?: string | number | null;
+}) => (
+  <div className="border-border/70 bg-muted rounded-xl border p-3">
+    <div className="text-muted-foreground font-mono text-[11px] uppercase">
+      {label}
+    </div>
+    <div className="mt-1 font-mono text-xs break-words">{value || '--'}</div>
+  </div>
+);

--- a/web/src/app/workspace/audit-logs/audit-log-table.tsx
+++ b/web/src/app/workspace/audit-logs/audit-log-table.tsx
@@ -28,14 +28,14 @@ import {
 import { Input } from '@/components/ui/input';
 
 import type {
-  AuditLog,
   ListAuditLogsParams as AuditApiListAuditLogsRequest,
+  AuditLog,
 } from '@/features/audit/types';
 
 import { DataGrid, DataGridPagination } from '@/components/data-grid';
 import { DateTimePicker24h } from '@/components/date-time-picker-24h';
 import { cn, objectKeys, parsePageParams } from '@/lib/utils';
-import { ChevronDown, Columns3 } from 'lucide-react';
+import { ChevronDown, Columns3, Search } from 'lucide-react';
 import { useFormatter, useTranslations } from 'next-intl';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { AuditLogDetail } from './audit-log-detail';
@@ -132,11 +132,11 @@ export function AuditLogTable({
           return (
             <>
               <AuditLogDetail auditLog={row.original}>
-                <span className="hover:text-primary cursor-pointer">
+                <span className="hover:text-primary cursor-pointer font-medium">
                   {row.original.api_name}
                 </span>
               </AuditLogDetail>
-              <div className="text-muted-foreground truncate pt-0.5 sm:w-sm md:w-md lg:w-lg">
+              <div className="text-muted-foreground truncate pt-0.5 font-mono text-xs sm:w-sm md:w-md lg:w-lg">
                 {row.original.path}
               </div>
             </>
@@ -150,21 +150,29 @@ export function AuditLogTable({
           let color;
           switch (row.original.status_code) {
             case 200:
-              color = 'text-green-500';
+              color = 'text-accent-ink';
               break;
             case 500:
-              color = 'text-red-500';
+              color = 'text-destructive';
               break;
             default:
           }
-          return <div className={cn(color)}>{row.original.status_code}</div>;
+          return (
+            <div className={cn('font-mono tabular-nums', color)}>
+              {row.original.status_code}
+            </div>
+          );
         },
       },
       {
         accessorKey: 'duration_ms',
         header: page_audit_logs('duration'),
         cell: ({ row }) => {
-          return row.original.duration_ms + 'ms';
+          return (
+            <span className="font-mono tabular-nums">
+              {row.original.duration_ms}ms
+            </span>
+          );
         },
       },
       {
@@ -220,22 +228,26 @@ export function AuditLogTable({
   });
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div className="flex flex-row items-center gap-2">
-          <Input
-            placeholder={page_audit_logs('search_placeholder')}
-            value={apiNameValue}
-            onChange={(e) => setApiNameValue(e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                handleSearch({
-                  apiName: e.currentTarget.value,
-                });
-              }
-            }}
-          />
-          <div className="flex flex-row items-center gap-0.5">
+    <div className="flex flex-col gap-5">
+      <div className="border-border/70 bg-card grid gap-4 rounded-xl border p-4 shadow-sm lg:grid-cols-[1fr_auto] lg:items-center">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center">
+          <div className="relative min-w-0 flex-1 xl:min-w-80">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+            <Input
+              className="bg-background/70 h-10 rounded-lg pl-9"
+              placeholder={page_audit_logs('search_placeholder')}
+              value={apiNameValue}
+              onChange={(e) => setApiNameValue(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleSearch({
+                    apiName: e.currentTarget.value,
+                  });
+                }
+              }}
+            />
+          </div>
+          <div className="flex flex-col gap-2 md:flex-row md:items-center">
             <DateTimePicker24h
               className="w-48"
               date={query.startDate ? new Date(query.startDate) : undefined}
@@ -257,11 +269,14 @@ export function AuditLogTable({
             />
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 lg:justify-end">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline">
                 <Columns3 />
+                <span className="hidden sm:inline">
+                  {page_audit_logs('columns')}
+                </span>
                 <ChevronDown />
               </Button>
             </DropdownMenuTrigger>
@@ -291,7 +306,9 @@ export function AuditLogTable({
           </DropdownMenu>
         </div>
       </div>
-      <DataGrid table={table} />
+      <div className="border-border/70 bg-card rounded-xl border p-3 shadow-sm">
+        <DataGrid table={table} className="border-border/70 rounded-lg" />
+      </div>
       <DataGridPagination table={table} />
     </div>
   );

--- a/web/src/app/workspace/audit-logs/page.tsx
+++ b/web/src/app/workspace/audit-logs/page.tsx
@@ -1,14 +1,15 @@
 import {
   PageContainer,
   PageContent,
-  PageDescription,
   PageHeader,
-  PageTitle,
 } from '@/components/page-container';
+import { Card, CardContent } from '@/components/ui/card';
 import { listAuditLogs } from '@/features/audit/server-api';
 import type { ListAuditLogsParams } from '@/features/audit/types';
 import { parsePageParams, toJson } from '@/lib/utils';
+import { Activity, CheckCircle2, ScrollText, XCircle } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 import { AuditLogTable } from './audit-log-table';
 
 export default async function Page({
@@ -42,17 +43,62 @@ export default async function Page({
   }
 
   const data = res?.items || [];
+  const successCount = data.filter(
+    (item) => (item.status_code || 0) >= 200 && (item.status_code || 0) < 400,
+  ).length;
+  const errorCount = data.filter(
+    (item) => (item.status_code || 0) >= 400,
+  ).length;
+  const averageDuration =
+    data.length === 0
+      ? 0
+      : Math.round(
+          data.reduce((sum, item) => sum + (item.duration_ms || 0), 0) /
+            data.length,
+        );
 
   return (
     <PageContainer>
       <PageHeader
         breadcrumbs={[{ title: page_audit_logs('metadata.title') }]}
       />
-      <PageContent>
-        <PageTitle>{page_audit_logs('metadata.title')}</PageTitle>
-        <PageDescription>
-          {page_audit_logs('metadata.description')}
-        </PageDescription>
+      <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+              {page_audit_logs('metadata.label')}
+            </div>
+            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+              {page_audit_logs('metadata.title')}
+            </h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
+              {page_audit_logs('metadata.description')}
+            </p>
+          </div>
+        </div>
+        <div className="mb-6 grid gap-3 md:grid-cols-4">
+          <AuditMetric
+            icon={<ScrollText className="size-4" />}
+            label={page_audit_logs('metric_events')}
+            value={data.length}
+          />
+          <AuditMetric
+            icon={<CheckCircle2 className="size-4" />}
+            label={page_audit_logs('metric_success')}
+            value={successCount}
+          />
+          <AuditMetric
+            icon={<XCircle className="size-4" />}
+            label={page_audit_logs('metric_errors')}
+            value={errorCount}
+          />
+          <AuditMetric
+            icon={<Activity className="size-4" />}
+            label={page_audit_logs('metric_avg_duration')}
+            value={averageDuration}
+            suffix="ms"
+          />
+        </div>
         <AuditLogTable
           data={toJson(data)}
           pageCount={res?.total_pages || 1}
@@ -62,3 +108,36 @@ export default async function Page({
     </PageContainer>
   );
 }
+
+const AuditMetric = ({
+  icon,
+  label,
+  value,
+  suffix,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: number;
+  suffix?: string;
+}) => {
+  return (
+    <Card className="border-border/70 gap-0 rounded-xl py-0">
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="bg-accent-soft text-accent-ink flex size-9 items-center justify-center rounded-lg">
+          {icon}
+        </div>
+        <div>
+          <div className="font-mono text-xl leading-none tabular-nums">
+            {value}
+            {suffix ? (
+              <span className="text-muted-foreground ml-1 text-xs">
+                {suffix}
+              </span>
+            ) : null}
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/app/workspace/quotas/page.tsx
+++ b/web/src/app/workspace/quotas/page.tsx
@@ -1,26 +1,63 @@
 import {
   PageContainer,
   PageContent,
-  PageDescription,
   PageHeader,
-  PageTitle,
 } from '@/components/page-container';
+import { Card, CardContent } from '@/components/ui/card';
 
 import { getUserQuota } from '@/features/quota/server-api';
+import { Gauge, ShieldCheck, TimerReset } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 import { QuotaRadialChart } from './quota-radial-chart';
 
 export default async function Page() {
   const data = await getUserQuota();
   const page_quotas = await getTranslations('page_quota');
+  const totalUsage = data.quotas.reduce(
+    (sum, quota) => sum + (quota.current_usage || 0),
+    0,
+  );
+  const totalLimit = data.quotas.reduce(
+    (sum, quota) => sum + (quota.quota_limit || 0),
+    0,
+  );
 
   return (
     <PageContainer>
       <PageHeader breadcrumbs={[{ title: page_quotas('metadata.title') }]} />
-      <PageContent>
-        <PageTitle>{page_quotas('metadata.title')}</PageTitle>
-        <PageDescription>{page_quotas('metadata.description')}</PageDescription>
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+              {page_quotas('metadata.label')}
+            </div>
+            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+              {page_quotas('metadata.title')}
+            </h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
+              {page_quotas('metadata.description')}
+            </p>
+          </div>
+        </div>
+        <div className="mb-6 grid gap-3 md:grid-cols-3">
+          <QuotaMetric
+            icon={<Gauge className="size-4" />}
+            label={page_quotas('metric_policies')}
+            value={data.quotas.length}
+          />
+          <QuotaMetric
+            icon={<TimerReset className="size-4" />}
+            label={page_quotas('metric_usage')}
+            value={totalUsage}
+          />
+          <QuotaMetric
+            icon={<ShieldCheck className="size-4" />}
+            label={page_quotas('metric_limit')}
+            value={totalLimit}
+          />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {data.quotas.map((quota) => (
             <QuotaRadialChart key={quota.quota_type} data={quota} />
           ))}
@@ -29,3 +66,29 @@ export default async function Page() {
     </PageContainer>
   );
 }
+
+const QuotaMetric = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: number;
+}) => {
+  return (
+    <Card className="border-border/70 gap-0 rounded-xl py-0">
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="bg-accent-soft text-accent-ink flex size-9 items-center justify-center rounded-lg">
+          {icon}
+        </div>
+        <div>
+          <div className="font-mono text-xl leading-none tabular-nums">
+            {value}
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/app/workspace/quotas/quota-radial-chart.tsx
+++ b/web/src/app/workspace/quotas/quota-radial-chart.tsx
@@ -8,7 +8,6 @@ import {
   RadialBarChart,
 } from 'recharts';
 
-import type { QuotaInfo } from '@/features/quota/types';
 import { Badge } from '@/components/ui/badge';
 import {
   Card,
@@ -19,6 +18,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { ChartConfig, ChartContainer } from '@/components/ui/chart';
+import type { QuotaInfo } from '@/features/quota/types';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 
@@ -63,9 +63,11 @@ export const QuotaRadialChart = ({ data }: { data: QuotaInfo }) => {
   }, [data.quota_type, page_quota]);
 
   return (
-    <Card className="flex flex-col gap-0 border-none">
+    <Card className="border-border/70 flex flex-col gap-0 overflow-hidden rounded-xl py-0">
       <CardHeader>
-        <CardTitle>{quota.title}</CardTitle>
+        <CardTitle className="font-serif text-xl font-normal">
+          {quota.title}
+        </CardTitle>
         <CardDescription className="mb-2 h-10 overflow-hidden">
           {quota.description}
         </CardDescription>
@@ -104,7 +106,7 @@ export const QuotaRadialChart = ({ data }: { data: QuotaInfo }) => {
                         <tspan
                           x={viewBox.cx}
                           y={viewBox.cy}
-                          className="fill-foreground text-4xl font-bold"
+                          className="fill-foreground font-mono text-4xl"
                         >
                           {`${percent.toFixed(2)}%`}
                         </tspan>
@@ -124,11 +126,11 @@ export const QuotaRadialChart = ({ data }: { data: QuotaInfo }) => {
           </RadialBarChart>
         </ChartContainer>
       </CardContent>
-      <CardFooter className="text-muted-foreground flex flex-row items-center justify-center gap-2 text-sm">
-        <Badge variant="secondary">
+      <CardFooter className="border-border/70 flex flex-row items-center justify-center gap-2 border-t px-4 py-4 text-sm">
+        <Badge variant="secondary" className="font-mono">
           {page_quota('limit')}: {data.quota_limit}
         </Badge>
-        <Badge variant="secondary">
+        <Badge variant="outline" className="bg-muted font-mono">
           {page_quota('usage')}: {data.current_usage}
         </Badge>
       </CardFooter>

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -46,9 +46,13 @@
   },
   "admin_config": {
     "metadata": {
+      "label": "System controls",
       "title": "Configuration",
       "description": "This section allows administrators to define and manage system-wide settings that apply across the entire platform. These global parameters control core functionalities, security policies, performance thresholds, and other critical configurations."
     },
+    "metric_parser_modes": "Active parsers",
+    "metric_quota_policies": "Quota fields",
+    "metric_control_sections": "Control panels",
     "mineru_api": "Use MinerU API",
     "mineru_api_description": "When enabled, the system will prioritize using the MinerU API for document parsing to improve parsing quality and speed.",
     "mineru_api_token": "MinerU API Token",
@@ -77,10 +81,18 @@
   },
   "admin_users": {
     "metadata": {
+      "label": "Access control",
       "title": "User Management",
       "description": "This module enables administrators to centrally control and organize all system users with secure access configurations. Efficiently manage identities, permissions, and authentication policies across your organization."
     },
+    "metric_users": "Users",
+    "metric_active": "Active",
+    "metric_admins": "Admins",
     "search": "Search users",
+    "columns": "Columns",
+    "self_badge": "Me",
+    "status_active": "Active",
+    "status_inactive": "Inactive",
     "user_name": "User",
     "user_role": "Role",
     "user_status": "Status",
@@ -140,11 +152,16 @@
   },
   "page_api_keys": {
     "metadata": {
+      "label": "Programmatic access",
       "title": "API keys",
       "description": "This section allows you to securely store, update, and manage API keys for different AI services (such as OpenAI, Anthropic, Gemini, etc.). Connecting your keys enables personalized AI interactions while keeping your credentials protected."
     },
+    "metric_total": "Keys",
+    "metric_used": "Used",
+    "metric_masked": "Masked",
     "description": "Description",
     "search_api_keys": "Search",
+    "columns": "Columns",
     "creation_time": "Creation time",
     "last_used_time": "Last used time",
     "api_keys": "API Keys",
@@ -154,6 +171,8 @@
     "edit_api_keys": "Edit",
     "delete_api_key": "Delete Api Key",
     "delete_api_key_confirm": "Confirm deletion of the API key?",
+    "dialog_title": "API key",
+    "dialog_description": "Describe what this key is used for. The full credential is only revealed once after creation.",
     "created_api_key_title": "API key created",
     "created_api_key_description": "This is the only time the full API key will be shown. Copy and store it securely before closing this dialog.",
     "created_api_key_label": "Generated API key",
@@ -165,13 +184,34 @@
   },
   "page_audit_logs": {
     "metadata": {
+      "label": "Operational trace",
       "title": "Audit Logs",
       "description": "Track and review all critical system activities with Audit Logs—a detailed record of user actions, API calls, and administrative changes. Ensure transparency, security, and compliance by monitoring who did what, when, and from where."
     },
+    "metric_events": "Events",
+    "metric_success": "Success",
+    "metric_errors": "Errors",
+    "metric_avg_duration": "Avg duration",
     "search_placeholder": "Search by API Name",
+    "columns": "Columns",
     "status": "Status",
     "duration": "Duration",
-    "start_time": "Start Time"
+    "start_time": "Start Time",
+    "detail": {
+      "user_agent": "User Agent",
+      "ip": "IP",
+      "user_id": "User ID",
+      "request_id": "Request ID",
+      "api": "API",
+      "path": "Path",
+      "method": "Method",
+      "status_code": "Status Code",
+      "resource_type": "Resource Type",
+      "request_data": "Request Data",
+      "response_data": "Response Data",
+      "error_messages": "Error Messages",
+      "resource_id": "Resource ID"
+    }
   },
   "page_auth": {
     "account": "Account",
@@ -1035,9 +1075,13 @@
   },
   "page_quota": {
     "metadata": {
+      "label": "Usage guardrails",
       "title": "Quotas",
       "description": "Manage your usage limits for AI models, API calls, and other resources in this section. Quotas help you control costs, prevent overuse, and optimize your experience."
     },
+    "metric_policies": "Policies",
+    "metric_usage": "Current usage",
+    "metric_limit": "Total limit",
     "limit": "Limit",
     "usage": "Usage",
     "bot_count": {

--- a/web/src/i18n/en-US/admin_config.json
+++ b/web/src/i18n/en-US/admin_config.json
@@ -1,8 +1,12 @@
 {
   "metadata": {
+    "label": "System controls",
     "title": "Configuration",
     "description": "This section allows administrators to define and manage system-wide settings that apply across the entire platform. These global parameters control core functionalities, security policies, performance thresholds, and other critical configurations."
   },
+  "metric_parser_modes": "Active parsers",
+  "metric_quota_policies": "Quota fields",
+  "metric_control_sections": "Control panels",
   "mineru_api": "Use MinerU API",
   "mineru_api_description": "When enabled, the system will prioritize using the MinerU API for document parsing to improve parsing quality and speed.",
   "mineru_api_token": "MinerU API Token",

--- a/web/src/i18n/en-US/admin_users.json
+++ b/web/src/i18n/en-US/admin_users.json
@@ -1,9 +1,17 @@
 {
   "metadata": {
+    "label": "Access control",
     "title": "User Management",
     "description": "This module enables administrators to centrally control and organize all system users with secure access configurations. Efficiently manage identities, permissions, and authentication policies across your organization."
   },
+  "metric_users": "Users",
+  "metric_active": "Active",
+  "metric_admins": "Admins",
   "search": "Search users",
+  "columns": "Columns",
+  "self_badge": "Me",
+  "status_active": "Active",
+  "status_inactive": "Inactive",
   "user_name": "User",
   "user_role": "Role",
   "user_status": "Status",

--- a/web/src/i18n/en-US/page_api_keys.json
+++ b/web/src/i18n/en-US/page_api_keys.json
@@ -1,10 +1,15 @@
 {
   "metadata": {
+    "label": "Programmatic access",
     "title": "API keys",
     "description": "This section allows you to securely store, update, and manage API keys for different AI services (such as OpenAI, Anthropic, Gemini, etc.). Connecting your keys enables personalized AI interactions while keeping your credentials protected."
   },
+  "metric_total": "Keys",
+  "metric_used": "Used",
+  "metric_masked": "Masked",
   "description": "Description",
   "search_api_keys": "Search",
+  "columns": "Columns",
   "creation_time": "Creation time",
   "last_used_time": "Last used time",
   "api_keys": "API Keys",
@@ -14,13 +19,14 @@
   "edit_api_keys": "Edit",
   "delete_api_key": "Delete Api Key",
   "delete_api_key_confirm": "Confirm deletion of the API key?",
+  "dialog_title": "API key",
+  "dialog_description": "Describe what this key is used for. The full credential is only revealed once after creation.",
   "created_api_key_title": "API key created",
   "created_api_key_description": "This is the only time the full API key will be shown. Copy and store it securely before closing this dialog.",
   "created_api_key_label": "Generated API key",
   "created_api_key_hint": "Anyone with this key can access ApeRAG APIs using the permissions of your account.",
   "copy_created_api_key": "Copy API key",
-  "saved_api_key": "I have stored this key"
-  ,
+  "saved_api_key": "I have stored this key",
   "masked_badge": "Masked",
   "masked_notice": "Only a masked preview of each API key is shown in the table. The full key can only be copied once when it is created."
 }

--- a/web/src/i18n/en-US/page_audit_logs.json
+++ b/web/src/i18n/en-US/page_audit_logs.json
@@ -1,10 +1,31 @@
 {
   "metadata": {
+    "label": "Operational trace",
     "title": "Audit Logs",
     "description": "Track and review all critical system activities with Audit Logs—a detailed record of user actions, API calls, and administrative changes. Ensure transparency, security, and compliance by monitoring who did what, when, and from where."
   },
+  "metric_events": "Events",
+  "metric_success": "Success",
+  "metric_errors": "Errors",
+  "metric_avg_duration": "Avg duration",
   "search_placeholder": "Search by API Name",
+  "columns": "Columns",
   "status": "Status",
   "duration": "Duration",
-  "start_time": "Start Time"
+  "start_time": "Start Time",
+  "detail": {
+    "user_agent": "User Agent",
+    "ip": "IP",
+    "user_id": "User ID",
+    "request_id": "Request ID",
+    "api": "API",
+    "path": "Path",
+    "method": "Method",
+    "status_code": "Status Code",
+    "resource_type": "Resource Type",
+    "request_data": "Request Data",
+    "response_data": "Response Data",
+    "error_messages": "Error Messages",
+    "resource_id": "Resource ID"
+  }
 }

--- a/web/src/i18n/en-US/page_quota.json
+++ b/web/src/i18n/en-US/page_quota.json
@@ -1,8 +1,12 @@
 {
   "metadata": {
+    "label": "Usage guardrails",
     "title": "Quotas",
     "description": "Manage your usage limits for AI models, API calls, and other resources in this section. Quotas help you control costs, prevent overuse, and optimize your experience."
   },
+  "metric_policies": "Policies",
+  "metric_usage": "Current usage",
+  "metric_limit": "Total limit",
   "limit": "Limit",
   "usage": "Usage",
   "bot_count": {

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -46,9 +46,13 @@
   },
   "admin_config": {
     "metadata": {
+      "label": "系统控制台",
       "title": "系统配置",
       "description": "本模块允许管理员定义和管理适用于整个平台的全局设置。这些全局参数控制系统核心功能、安全策略、性能阈值及其他关键配置项。"
     },
+    "metric_parser_modes": "启用解析器",
+    "metric_quota_policies": "配额字段",
+    "metric_control_sections": "控制面板",
     "mineru_api": "启用 MinerU API",
     "mineru_api_description": "启用后，系统将优先使用 MinerU API 进行文档解析，以提升解析质量与速度",
     "mineru_api_token": "MinerU API 令牌",
@@ -77,10 +81,18 @@
   },
   "admin_users": {
     "metadata": {
+      "label": "访问控制",
       "title": "用户管理",
       "description": "该模块允许管理员通过安全访问配置集中控制和管理系统所有用户，高效管理组织内的身份、权限和认证策略。"
     },
+    "metric_users": "用户",
+    "metric_active": "活跃",
+    "metric_admins": "管理员",
     "search": "搜索用户",
+    "columns": "列设置",
+    "self_badge": "我",
+    "status_active": "活跃",
+    "status_inactive": "停用",
     "user_name": "用户",
     "user_role": "角色",
     "user_status": "状态",
@@ -140,11 +152,16 @@
   },
   "page_api_keys": {
     "metadata": {
+      "label": "程序化访问",
       "title": "API密钥",
       "description": "支持安全存储、更新和管理不同AI服务（如OpenAI、Anthropic、Gemini等）的API密钥。关联密钥既可实现个性化AI交互，又能确保凭证安全。"
     },
+    "metric_total": "密钥数",
+    "metric_used": "已使用",
+    "metric_masked": "已脱敏",
     "description": "描述信息",
     "search_api_keys": "搜索密钥",
+    "columns": "列设置",
     "creation_time": "创建时间",
     "last_used_time": "最后使用时间",
     "api_keys": "API密钥",
@@ -154,6 +171,8 @@
     "edit_api_keys": "编辑",
     "delete_api_key": "删除API密钥",
     "delete_api_key_confirm": "确认删除此API密钥？",
+    "dialog_title": "API 密钥",
+    "dialog_description": "描述该密钥的用途。完整凭证只会在创建后显示一次。",
     "created_api_key_title": "API密钥已创建",
     "created_api_key_description": "完整 API 密钥只会在这里显示一次。请在关闭对话框前复制并安全保存。",
     "created_api_key_label": "生成的 API 密钥",
@@ -165,13 +184,34 @@
   },
   "page_audit_logs": {
     "metadata": {
+      "label": "操作轨迹",
       "title": "审计日志",
       "description": "通过审计日志跟踪和审查所有关键系统活动—、API调用和管理变更，确保透明度、安全性和合规性。"
     },
+    "metric_events": "事件数",
+    "metric_success": "成功",
+    "metric_errors": "错误",
+    "metric_avg_duration": "平均耗时",
     "search_placeholder": "按API名称搜索",
+    "columns": "列设置",
     "status": "状态",
     "duration": "持续时间",
-    "start_time": "开始时间"
+    "start_time": "开始时间",
+    "detail": {
+      "user_agent": "用户代理",
+      "ip": "IP",
+      "user_id": "用户 ID",
+      "request_id": "请求 ID",
+      "api": "API",
+      "path": "路径",
+      "method": "方法",
+      "status_code": "状态码",
+      "resource_type": "资源类型",
+      "request_data": "请求数据",
+      "response_data": "响应数据",
+      "error_messages": "错误信息",
+      "resource_id": "资源 ID"
+    }
   },
   "page_auth": {
     "account": "我的账号",
@@ -1039,9 +1079,13 @@
   },
   "page_quota": {
     "metadata": {
+      "label": "用量护栏",
       "title": "配额管理",
       "description": "在此模块管理AI模型使用量、API调用次数等资源的额度限制。配额功能帮助您控制成本、防止过度使用并优化使用体验。"
     },
+    "metric_policies": "策略数",
+    "metric_usage": "当前用量",
+    "metric_limit": "总限额",
     "limit": "限额",
     "usage": "用量",
     "bot_count": {

--- a/web/src/i18n/zh-CN/admin_config.json
+++ b/web/src/i18n/zh-CN/admin_config.json
@@ -1,8 +1,12 @@
 {
   "metadata": {
+    "label": "系统控制台",
     "title": "系统配置",
     "description": "本模块允许管理员定义和管理适用于整个平台的全局设置。这些全局参数控制系统核心功能、安全策略、性能阈值及其他关键配置项。"
   },
+  "metric_parser_modes": "启用解析器",
+  "metric_quota_policies": "配额字段",
+  "metric_control_sections": "控制面板",
   "mineru_api": "启用 MinerU API",
   "mineru_api_description": "启用后，系统将优先使用 MinerU API 进行文档解析，以提升解析质量与速度",
   "mineru_api_token": "MinerU API 令牌",

--- a/web/src/i18n/zh-CN/admin_users.json
+++ b/web/src/i18n/zh-CN/admin_users.json
@@ -1,9 +1,17 @@
 {
   "metadata": {
+    "label": "访问控制",
     "title": "用户管理",
     "description": "该模块允许管理员通过安全访问配置集中控制和管理系统所有用户，高效管理组织内的身份、权限和认证策略。"
   },
+  "metric_users": "用户",
+  "metric_active": "活跃",
+  "metric_admins": "管理员",
   "search": "搜索用户",
+  "columns": "列设置",
+  "self_badge": "我",
+  "status_active": "活跃",
+  "status_inactive": "停用",
   "user_name": "用户",
   "user_role": "角色",
   "user_status": "状态",

--- a/web/src/i18n/zh-CN/page_api_keys.json
+++ b/web/src/i18n/zh-CN/page_api_keys.json
@@ -1,10 +1,15 @@
 {
   "metadata": {
+    "label": "程序化访问",
     "title": "API密钥",
     "description": "支持安全存储、更新和管理不同AI服务（如OpenAI、Anthropic、Gemini等）的API密钥。关联密钥既可实现个性化AI交互，又能确保凭证安全。"
   },
+  "metric_total": "密钥数",
+  "metric_used": "已使用",
+  "metric_masked": "已脱敏",
   "description": "描述信息",
   "search_api_keys": "搜索密钥",
+  "columns": "列设置",
   "creation_time": "创建时间",
   "last_used_time": "最后使用时间",
   "api_keys": "API密钥",
@@ -14,6 +19,8 @@
   "edit_api_keys": "编辑",
   "delete_api_key": "删除API密钥",
   "delete_api_key_confirm": "确认删除此API密钥？",
+  "dialog_title": "API 密钥",
+  "dialog_description": "描述该密钥的用途。完整凭证只会在创建后显示一次。",
   "created_api_key_title": "API密钥已创建",
   "created_api_key_description": "完整 API 密钥只会在这里显示一次。请在关闭对话框前复制并安全保存。",
   "created_api_key_label": "生成的 API 密钥",

--- a/web/src/i18n/zh-CN/page_audit_logs.json
+++ b/web/src/i18n/zh-CN/page_audit_logs.json
@@ -1,10 +1,31 @@
 {
   "metadata": {
+    "label": "操作轨迹",
     "title": "审计日志",
     "description": "通过审计日志跟踪和审查所有关键系统活动—、API调用和管理变更，确保透明度、安全性和合规性。"
   },
+  "metric_events": "事件数",
+  "metric_success": "成功",
+  "metric_errors": "错误",
+  "metric_avg_duration": "平均耗时",
   "search_placeholder": "按API名称搜索",
+  "columns": "列设置",
   "status": "状态",
   "duration": "持续时间",
-  "start_time": "开始时间"
+  "start_time": "开始时间",
+  "detail": {
+    "user_agent": "用户代理",
+    "ip": "IP",
+    "user_id": "用户 ID",
+    "request_id": "请求 ID",
+    "api": "API",
+    "path": "路径",
+    "method": "方法",
+    "status_code": "状态码",
+    "resource_type": "资源类型",
+    "request_data": "请求数据",
+    "response_data": "响应数据",
+    "error_messages": "错误信息",
+    "resource_id": "资源 ID"
+  }
 }

--- a/web/src/i18n/zh-CN/page_quota.json
+++ b/web/src/i18n/zh-CN/page_quota.json
@@ -1,8 +1,12 @@
 {
   "metadata": {
+    "label": "用量护栏",
     "title": "配额管理",
     "description": "在此模块管理AI模型使用量、API调用次数等资源的额度限制。配额功能帮助您控制成本、防止过度使用并优化使用体验。"
   },
+  "metric_policies": "策略数",
+  "metric_usage": "当前用量",
+  "metric_limit": "总限额",
   "limit": "限额",
   "usage": "用量",
   "bot_count": {


### PR DESCRIPTION
## Summary
- Uplift workspace API keys, quotas, and audit logs with L1 warm editorial tokens while preserving the existing API/data flow.
- Uplift admin users, admin providers/model pages, audit logs, and system configuration surfaces in the same L4 style.
- Add scoped i18n copy for metrics, labels, dialogs, and audit detail fields.

## Validation
- yarn i18n:sync
- yarn lint
- git diff --check
- scoped ghost/token scan: no bg-subtle, border-border-strong, legacy blue hex, billing/team/folder/spend/industry/tweaks additions
- npx tsc --noEmit still fails on known mainline typed API/nullability issues outside this PR path: src/app/page.tsx hero.points dynamic key; workspace collection-form payload embedding typing; chat-input localStorage/completion typing; collection-provider empty default object

Ghost-check: G1-G10 all enforced; no billing, teams, folders, ingest-health, runtime tweaks, or industry switch added.