### PR TITLE
docs(modularization): Phase 7 cleanup inventory v1 — hard-cut + 5-layer 禁删白名单

### DIFF
--- a/docs/modularization/cleanup-inventory.md
+++ b/docs/modularization/cleanup-inventory.md
@@ -1,246 +1,84 @@
-# Phase 7 Legacy Cleanup Inventory
+# Phase 7 Legacy Cleanup Inventory (v1 — hard-cut)
 
-**Baseline**: `origin/main @ 8946d867` (post-Phase 0→6 modularization + FE rewrite main branches merged).
-**Owner**: 符炫炜 (主架构师) — maintains this file as SSoT; PM (@架构师) drives batch scheduling; coding lanes execute per batch.
-**Scope**: identify backend + frontend hard-delete candidates remaining after Phase 0→6 modularization and the FE rewrite project.
+**Baseline**: `origin/main @ 97aa4bf8` (post-Phase 0→6 modularization + FE rewrite main branches merged + v0 inventory).
+**Owner**: 符炫炜 (主架构师) — canonical + 禁删白名单 + inventory SSoT；PM (@架构师) drives cadence + task split + owner；@Weston blocker-level minimal CR；coding lanes 优先 Opus。
+**Scope**: 一次性 hard-cut 前后端老代码 → 新架构 (Phase 0→6 domains + FE rewrite tokens)。允许 breaking changes，验收是 deployable end-state。
 
-Sibling docs: [`architecture.md`](./architecture.md) (post-Phase-6 canonical), [`../frontend-rewrite/mismatch-registry.md`](../frontend-rewrite/mismatch-registry.md) (FE ghost features + gates).
-
----
-
-## 0. Aggregate impact
-
-| Surface | Deletable now | Audit first | Must preserve |
-|---------|--------------:|------------:|--------------:|
-| Backend `aperag/service/` | 18 shim files / 455 LOC | 5 ACTIVE_LEGACY / 1 860 LOC | 3 PERMANENT / 1 058 LOC |
-| Backend `aperag/views/` | 12 shim + 1 empty `__init__` / 327 LOC | 13 ACTIVE_LEGACY / 1 910 LOC | — |
-| Backend `aperag/agent_runtime/` | 5 shim / 127 LOC | — | — |
-| Backend `aperag/evaluation_v2/` | 7 shim / 125 LOC | — | — |
-| Backend `aperag/db/models.py` re-export block | ~70 LOC in one file | retain local models | `Invitation` top-level `Role` import **must stay** |
-| Backend `aperag/schema/view_models.py` re-export blocks | ~160 LOC across 7 blocks | — | local schemas stay |
-| Backend misc dirs (`auth/`, `context/`, `graphindex/`, `graph_curation/`, `index/`, `query/`, `source/`, `concurrent_control/`, empty `chat/`, `graph/`, `misc/`) | 3 empty dirs (removable `__init__`) | all non-empty are ACTIVE shared infra (~7 900 LOC) | — |
-| Frontend `web/src/api/` (old openapi-gen client) | 202 files / 24 531 LOC DEAD | — | — |
-| Frontend `web/src/lib/api/{client,server}.ts` | 2 files / 105 LOC DEAD | — | `lib/api/typed/*` stays |
-| Frontend `web/src/app/globals.default.css` | 123 LOC DEAD | — | — |
-| Frontend `web/src/components/ui/*` unused | 6 files / 954 LOC UNUSED_EXPORT | — | active shadcn stays |
-| Frontend feature API unused exports | 15 functions across 8 files | trim in-place | — |
-| Frontend `package.json` | 7 deps removable (`react-pdf`, `@dnd-kit/*` ×4, `tw-animate-css`, `@stepperize/react`) | — | — |
-
-Back-end quick numbers: **43 files / ~1 034 LOC** deletable in shim/unused batches; **18 files / 3 770 LOC** need audit; **3 files / 1 058 LOC** PERMANENT.
-Front-end quick numbers: **211 files / ~25 713 LOC** DEAD or SUPERSEDED at zero product risk.
+Sibling docs: [`architecture.md`](./architecture.md) (post-Phase-6 canonical); [`../frontend-rewrite/mismatch-registry.md`](../frontend-rewrite/mismatch-registry.md) (FE ghost features + gates).
 
 ---
 
-## 1. PERMANENT — must NOT delete
+## 0. 口径变更（v0 → v1）
 
-### 1.1 Backend standalone-infra seams (cross-domain Protocol + DI)
+per earayu2 msg=78fdb6fc / msg=be4c5c19 / msg=ac0a9243:
 
-| Path | LOC | Reason |
-|------|----:|--------|
-| `aperag/service/quota_service.py` | 392 | Cross-domain quota Protocol (`app.py` lines 101–112); 4 consumers (KB / conversation / identity / agent_runtime) |
-| `aperag/service/prompt_template_service.py` | 625 | Cross-domain prompt Protocol (`app.py` lines 114–145); consumers in agent_runtime + conversation |
-| `aperag/service/search_pipeline_service.py` | 41 | Retrieval search pipeline re-export anchor; test fixtures monkeypatch this path |
-
-These map 1:1 to `architecture.md` Section F18 "2 permanent CRITICAL_WIRINGS + 1 standalone-infra".
-
-### 1.2 Backend `Invitation` class-body Role binding
-
-`aperag/db/models.py` line 36:
-```python
-from aperag.domains.identity.db.models import Role   # keep — Invitation class body depends on this at load time
-```
-`Invitation.role = Column(EnumColumn(Role), ...)` executes at import time; G15 (non-identity domains forbid Role import) is explicitly exempt here. Do not move `Invitation` without moving the `Role` import.
-
-### 1.3 Backend G17 / G18-alt CRITICAL_WIRINGS
-
-`tests/unit_test/test_modularization_boundaries.py` G17 (Phase 3+4: 7 entries) + G18-alt (Phase 5: 2 entries) assert runtime smoke of DI wire-up. Any shim deletion must still leave these 9 wirings intact; see `app.py` lines 101–145.
-
-### 1.4 Backend misc shared-infra dirs (keep, not shim)
-
-All non-empty under `aperag/`:
-- `aperag/auth/authentication.py` — fastapi-users backend config (272 LOC)
-- `aperag/concurrent_control/` — Redis + threading lock manager (831 LOC, 36 import sites)
-- `aperag/context/` — request context (167 LOC)
-- `aperag/graphindex/` — KG indexing infra (1 976 LOC, 36 sites)
-- `aperag/graph_curation/` — graph curation helper (1 057 LOC, 14 sites)
-- `aperag/index/` — multi-index manager (3 591 LOC, 5 sites)
-- `aperag/query/` — query builder (51 LOC, 9 sites)
-- `aperag/source/` — document source plugins (186 LOC, 9 sites)
-
-These are shared infra, not shims; they stay. Future domain absorption is a Phase 8+ candidate.
+- **破坏性 hard-cut**：默认删全部 shim / 老入口 / 兼容层；**不再保留兼容双轨**。
+- **大 PR**：目标压成 **1-2 个 PR**（默认：`PR-BE destructive backend cleanup` + `PR-FE destructive frontend cleanup`），不再按 batch-by-batch 小迭代。
+- **验收标准** = 主干可部署 + 可测试 + 可运行。盖过以前的 "保守兼容 + 慢慢迁" 策略。
+- **禁删白名单仍严格保护**（§1）— hard-cut 不是乱删，是 surgical。
+- **每候选文件 3 类**：`直接删` / `迁完再删` / `白名单禁删`（v0 里只分 SHIM/ACTIVE_LEGACY/PERMANENT，v1 重新归类到这 3 档）。
 
 ---
 
-## 2. Backend hard-delete candidates — batched
+## 1. 禁删白名单（3 层 distinction — per Bryce msg=647b2b17 canonical catch + PM msg=c179775c lock）
 
-### Batch B1 — `aperag/service/` pure re-export shims (18 files, 455 LOC)
+**规则**：coding lane 动任何 `aperag/service/*.py` 或 `aperag/db/models.py` Invitation 上下文 之前，必须先对这个清单 self-check。
 
-All files are single-line `from aperag.domains.<d>.service.<s> import *` (or narrow equivalents).
+### 1.1 Layer A — G18 alt CRITICAL_WIRINGS Protocol + DI seams（2 条，live runtime wire-up）
 
-```
-api_key_service.py            → domains.governance.service.api_key_service
-audit_service.py              → domains.governance.service.audit_service
-bot_service.py                → domains.conversation.service.bot_service
-chat_collection_service.py    → domains.conversation.service.chat_collection_service
-chat_document_service.py      → domains.conversation.service.chat_document_service
-chat_service.py               → domains.conversation.service.chat_service
-chat_title_service.py         → domains.conversation.service.chat_title_service
-collection_service.py         → domains.knowledge_base.service.collection_service
-collection_summary_service.py → domains.knowledge_base.service.collection_summary_service
-default_model_service.py      → domains.model_platform.service.default_model_service
-document_service.py           → domains.knowledge_base.service.document_service
-graph_service.py              → domains.knowledge_graph.service
-llm_available_model_service.py → domains.model_platform.service.llm_available_model_service
-llm_provider_service.py       → domains.model_platform.service.llm_provider_service
-marketplace_collection_service.py → domains.marketplace.service.marketplace_collection_service
-marketplace_service.py        → domains.marketplace.service.marketplace_service
-prompt_template_service.py    — PERMANENT (see §1.1)
-quota_service.py              — PERMANENT (see §1.1)
-search_pipeline_service.py    — PERMANENT (see §1.1)
-turn_feedback_service.py      → domains.conversation.service.turn_feedback_service
-```
+| Path | Consumer wire-up | 删了就炸 |
+|------|------------------|---------|
+| `aperag/service/quota_service.py` | `conversation.bot_service._quota_ops` (`app.py` lines 101–112) | `test_phase5_di_critical_wirings_at_app_startup` G18 alt |
+| `aperag/service/prompt_template_service.py` | `agent_runtime.runtime._prompt_template_ops` (`app.py` lines 114–145) | 同上 |
 
-Delete gate: `grep -R "from aperag.service\.\(api_key_service\|audit_service\|…\)" aperag tests` returns zero hits after consumer migration; then rm the file + rerun G1-G19.
+### 1.2 Layer B — Cross-domain standalone-infra（1 条，非 G18 alt 但仍禁删）
 
-### Batch B2 — `aperag/views/` pure router re-export shims (12 files, 313 LOC) + 1 empty `__init__` (14 LOC)
+| Path | 为什么禁删 | 删了就炸 |
+|------|------------|---------|
+| `aperag/service/search_pipeline_service.py` | retrieval / KB / indexing 多域消费；**非 re-export shim**，本身就是 implementation；test fixtures monkeypatch 直接挂它 | `tests/unit_test/test_es_p0_contract.py:10` `from aperag.service.search_pipeline_service import SearchPipelineService` + 若干 monkeypatch |
 
-```
-agent_runtime.py   → domains.agent_runtime.api.routes.router
-api_key.py         → domains.governance.api.routes (router not mounted from shim)
-audit.py           → domains.governance.api.routes
-bots_v2.py         → domains.conversation.api.routes.bots_router
-chat.py            → domains.conversation.api.routes.chat_router
-collections_v2.py  → domains.knowledge_base.api.routes
-documents_v2.py    → domains.knowledge_base.api.routes
-evaluation_v2.py   → domains.evaluation.api.routes
-llm.py             → domains.model_platform.api.llm_routes
-marketplace.py     → domains.marketplace.api.routes
-marketplace_collections.py → domains.marketplace.api.routes
-providers_v2.py    → domains.model_platform.api.providers_v2_routes
-__init__.py        empty (14 LOC)
-```
+**重要**：Layer A + Layer B 加起来 = **3 个 `aperag/service/*.py` permanent files**。任何 coding lane 按 "grep shim re-export 清零" 扫时，看到 Layer B 这个文件有 `class` 实现，**不许错判成 "残留老 service 需迁到 retrieval domain"** — 它是 canonical 保留为 standalone 的 cross-domain infra，与 G17 Phase 4 identity `UserInitOps` 性质一致。
 
-Delete-safety: `aperag/app.py` already mounts the canonical domain routers directly (lines 227–251). Shim views are imported by no live mount; they only linger in tests / legacy docs.
+### 1.3 Layer C — Special-case load-time binding
 
-Delete gate: same grep pattern on `aperag.views.*`, then rm + G1-G19.
+| Path | 为什么禁删 |
+|------|------------|
+| `aperag/db/models.py` line 36 `from aperag.domains.identity.db.models import Role` | `Invitation` class body line 211 `role = Column(EnumColumn(Role), ...)` 在 import-time 执行；G15 `Role` import ban 对 `aperag/db/models.py` 不适用 — canonical exempt |
 
-### Batch B3 — `aperag/agent_runtime/` (5 files, 127 LOC)
+### 1.4 Layer D — G17 Phase 3+4 CRITICAL_WIRINGS
 
-All 5 files are Phase 5 Step 5-S5b shim re-exports pointing at `aperag.domains.agent_runtime.*`. Known callers:
-- `aperag.evaluation_v2.worker` (also a shim, deleted in B4)
-- `aperag.views.agent_runtime` (shim, deleted in B2)
-- a handful of test modules
+7 条 Phase 3+4 DI wirings（identity 3 + KB 4），`test_phase3_p4_di_critical_wirings_at_app_startup` 保障。删掉任何 wire-up 在 `app.py` 内都会炸。具体入口见 `architecture.md` Section F17。
 
-Delete gate: after B2/B4 merges + test imports updated, rm entire `aperag/agent_runtime/`; G17 / G18-alt CRITICAL_WIRINGS still pass because wire-up already uses `aperag.domains.agent_runtime.*`.
+### 1.5 Layer E — `aperag/` 非 shim shared infra 目录（keep 全部，不属 Phase 7 cleanup）
 
-### Batch B4 — `aperag/evaluation_v2/` (7 files, 125 LOC)
-
-Same profile as B3; re-exports `aperag.domains.evaluation.*`. Callers: `aperag.views.evaluation_v2` (B2 shim), Celery task registry, tests.
-
-### Batch B5 — `aperag/db/models.py` re-export block (~70 LOC in-file)
-
-Strip lines 395–462 re-export block. Retain:
-- Local models: `ConfigModel`, `UserQuota`, `ModelServiceProvider`, `QuestionType`, `EvaluationStatus`, `EvaluationItemStatus`, `ExportTaskStatus`, `QuestionSet`, `Question`, `Evaluation`, `EvaluationItem`, `Setting`, `ExportTask`, `PromptTemplate`, `Invitation`
-- `Invitation` + top-level `Role` import (§1.2) — unchanged
-- `Base` (Alembic metadata anchor) — unchanged
-
-Delete gate: all `from aperag.db.models import <Bot | Chat | User | ApiKey | LLMProvider | Collection | Document | …>` re-routed to `from aperag.domains.<d>.db.models import …`; Alembic autogen diff must be empty.
-
-### Batch B6 — `aperag/schema/view_models.py` dual-hook blocks
-
-7 blocks (lines ~700–889): knowledge_base / identity / governance / marketplace / model_platform / conversation / agent_runtime re-exports via `sys.modules.get(...)` string lookup to avoid G1 AST scan. Delete in this order (lowest consumer count first):
-
-| Block | Domain | Schemas | Approx consumer sites |
-|-------|--------|---------|----------------------:|
-| 7 | agent_runtime | 1 | low |
-| 4 | marketplace | 3 | low |
-| 3 | governance | 6 | low |
-| 2 | identity | 12 | medium |
-| 5 | model_platform | 20+ | medium |
-| 1 | knowledge_base | 9 | medium |
-| 6 | conversation | 21 | high (Bot/Chat/User/ApiKey) |
-
-Each sub-batch: migrate callers to `aperag.domains.<d>.schemas`, verify `X is aperag.schema.view_models.X is aperag.domains.<d>.schemas.X` still holds (dual-hook invariant), then rm that block.
-
-Retain local schemas (`FailResponse`, `Settings`, `ParserHealthItem`, `PromptDetail`, etc.).
-
-### Batch B7 — empty dirs under `aperag/`
-
-`aperag/chat/`, `aperag/graph/`, `aperag/misc/` contain 0 meaningful content (empty package markers). Remove.
+`aperag/auth/` `aperag/concurrent_control/` `aperag/context/` `aperag/graphindex/` `aperag/graph_curation/` `aperag/index/` `aperag/query/` `aperag/source/` — 这些是 cross-domain shared infra（非 canonical domain code，非 shim），共 ~7 900 LOC；Phase 8+ domain absorption candidate，**本轮不动**。
 
 ---
 
-## 3. Backend ACTIVE_LEGACY — audit before delete (18 files, 3 770 LOC)
+## 2. 前端 frontend destructive cleanup（`PR-FE`）
 
-### 3.1 Services with real logic (5 files, 1 860 LOC)
+**Owner**：huangheng (FE L1 SME) 优先（per msg=8e203455 standby + msg=8a4fcf27 Opus 优先）。
+**Scope**：211 files / ~25 713 LOC DEAD/SUPERSEDED，一次性删。零产品风险。
 
-| File | LOC | Audit question |
-|------|----:|----------------|
-| `chat_completion_service.py` | 468 | Backs `/v1/chat/completions` OpenAI-compat endpoint. Does conversation domain fully own this, or does this remain a standalone streaming adapter? |
-| `evaluation_service.py` | 514 | Celery task lifecycle + polling. Compare with `aperag.domains.evaluation.services`; determine which layer owns Celery vs HTTP. |
-| `export_service.py` | 199 | Export task CSV pipeline. Candidate to move under `domains.knowledge_base.service.export_service`. |
-| `question_set_service.py` | 197 | Evaluation question-set CRUD. Candidate move to `domains.evaluation`. |
-| `setting_service.py` | 86 | User settings. Candidate move to `domains.governance` (ties with quota/audit) or split to identity. |
-| `test_mcp_agent.py` | 332 | Mixed test utility + live service. Likely belongs under `tests/` fixtures; confirm and relocate. |
+### 2.1 直接删（bundle 进 PR-FE）
 
-### 3.2 Views with real HTTP handlers (13 files, 1 910 LOC)
+| Group | 数量 | LOC | 说明 |
+|-------|-----:|----:|------|
+| `web/src/api/*` 整个目录 | 202 files | 24 531 | 老 openapi-gen client，被 `web/src/api-v2/` 完全替代；消费者已迁 |
+| `web/src/api/openapi.merged.yaml` | 1 | 0 | 生成 spec，无消费 |
+| `web/src/lib/api/client.ts` + `server.ts` | 2 | 105 | 老 wrapper；`lib/api/typed/*` 是 active 替代 |
+| `web/src/app/globals.default.css` | 1 | 123 | pre-rewrite oklch 备份；无 import |
+| `web/src/components/ui/menubar.tsx` | 1 | 276 | 0 callers |
+| `web/src/components/ui/combobox.tsx` | 1 | 274 | 0 callers |
+| `web/src/components/ui/navigation-menu.tsx` | 1 | 168 | 0 callers |
+| `web/src/components/ui/pagination.tsx` | 1 | 127 | 0 callers |
+| `web/src/components/ui/resizable.tsx` | 1 | 56 | 0 callers |
+| `web/src/components/ui/avatar.tsx` | 1 | 53 | 0 callers |
+| `package.json` 删 7 deps | — | — | `react-pdf` + `@dnd-kit/{core,modifiers,sortable,utilities}` + `tw-animate-css` + `@stepperize/react` |
 
-| File | LOC | Mount | Audit question |
-|------|----:|-------|----------------|
-| `auth.py` | 500 | `/api/v1/auth` | fastapi-users + OAuth (GitHub/Google/Authing/Logto). Identity domain has routes for basic auth; decide whether OAuth migration is in Phase 7 or stays here. |
-| `collections.py` | 108 | `/api/v1/collections` | Upload / staged / fetch-url flow. Domain `/api/v2/collections/…/documents/upload` already exists (knowledge_base domain). Confirm v2 coverage vs intentionally retained v1. |
-| `config.py` | 55 | `/api/v1/config` | `auth-config` endpoint. Identity/governance candidate. |
-| `export.py` | 69 | `/api/v1/export` | 3 routes paired with `export_service` (§3.1). |
-| `graph.py` | 155 | `/api/v1/graph` | Graph curation suggestions + status. Overlaps with `domains.knowledge_graph.api.routes`. |
-| `main.py` | 219 | `/api/v1/bots, /chats, /feedbacks` | Bot / chat / feedback CRUD. Conversation domain has v2 equivalents; decide if v1 is a client contract to keep. |
-| `openai.py` | 83 | `/v1/chat/completions` | OpenAI-compat entry. Depends on `chat_completion_service`. |
-| `prompts.py` | 205 | `/api/v1/user-prompts` | Prompt customization + mineru token. Depends on PERMANENT `prompt_template_service`. |
-| `quota.py` | 234 | `/api/v1/quota` | Quota admin routes. Uses PERMANENT `quota_service`. |
-| `settings.py` | 67 | `/api/v1/settings` | Parser health + update settings. Uses `setting_service` (§3.1). |
-| `test.py` | 60 | dev-only | reset-demo + token probe. |
-| `utils.py` | 134 | helper | OAuth method detection — imported by `auth.py` + `config.py`. |
-| `chat_documents.py` | 21 | not mounted | Looks like a stub, confirm unused and delete. |
+### 2.2 trim in-place（同 PR-FE commit）
 
-Audit rule: for each route, either (a) confirm a `/api/v2/` (or other) canonical equivalent already exists and the FE has migrated → remove the v1 route, or (b) mark as **keep-v1** in this inventory with rationale (client contract stability, OpenAI-compat, etc.).
-
-### 3.3 Test files referencing legacy paths
-
-- OpenAPI-contract tests hitting `aperag.views.<shim>` — keep until B2 merges, then point at domain routers or delete.
-- Tests using `monkeypatch.setattr("aperag.service.…", …)` — re-target to `aperag.domains.<d>.service…` before B1 delete.
-
----
-
-## 4. Frontend hard-delete candidates
-
-### 4.1 Batch F1 — `web/src/api/` old openapi-gen client (202 files, 24 531 LOC)
-
-Pre-`api-v2` OpenAPI generated client. All callers have migrated to `web/src/api-v2/schema.d.ts` + `openapi-fetch`. Remaining grep hits only inside `web/src/lib/api/{client,server}.ts` which are themselves dead (F2).
-
-Delete gate: one grep for `from '@/api/` or `from 'src/api/` across `web/src/` returns zero hits outside F1/F2.
-
-### 4.2 Batch F2 — `web/src/lib/api/client.ts` + `server.ts` (2 files, 105 LOC)
-
-Old wrappers. `web/src/lib/api/typed/{browser,server,errors,index}.ts` is the active replacement (openapi-fetch-based). Delete the two old files; keep typed/*.
-
-### 4.3 Batch F3 — `web/src/app/globals.default.css` (1 file, 123 LOC)
-
-Dead pre-rewrite backup of oklch tokens before the amber/Manrope migration. Not imported.
-
-### 4.4 Batch F4 — unused shadcn UI components (6 files, 954 LOC)
-
-Zero imports across `web/src/`:
-- `components/ui/menubar.tsx` (276)
-- `components/ui/combobox.tsx` (274)
-- `components/ui/navigation-menu.tsx` (168)
-- `components/ui/pagination.tsx` (127)
-- `components/ui/resizable.tsx` (56)
-- `components/ui/avatar.tsx` (53)
-
-Delete gate: confirm not re-exported by `components/ui/index.ts` (if present), confirm `components.json` doesn't list as required, then rm.
-
-### 4.5 Batch F5 — unused feature exports (15 symbols across 8 files)
-
-Trim in-place, do not delete files:
+15 unused feature exports across 8 files — 保留文件本身，只删函数签名/类型：
 - `features/admin/client-api.ts`: `listUserQuotas`
 - `features/bot/client-api.ts`: `toTitleLanguage`, `TitleGenerateInput`, `buildTitleGenerateRequest`, `updateBot`, `deleteBot`
 - `features/collection/client-api.ts`: `triggerCollectionSummary`
@@ -250,96 +88,178 @@ Trim in-place, do not delete files:
 - `features/evaluation/server-api.ts`: `listEvaluationRunItemAttempts`
 - `features/knowledge-graph/client-api.ts`: `mergeGraphNodes`
 
-### 4.6 Batch F6 — `web/package.json` unused dependencies (7 packages)
+### 2.3 FE 白名单（禁删）
 
-Zero `import` sites across `web/src/`:
-- `react-pdf ^10.1.0`
-- `@dnd-kit/core ^6.3.1`
-- `@dnd-kit/modifiers ^9.0.0`
-- `@dnd-kit/sortable ^10.0.0`
-- `@dnd-kit/utilities ^3.2.2`
-- `tw-animate-css ^1.3.6`
-- `@stepperize/react ^5.1.6`
+- `web/src/api-v2/schema.d.ts` (auto-generated)，`web/src/lib/api/typed/*` active；
+- `web/src/lib/design-tokens.ts` — 所有 exports（`COLORS` / `ENTITY_PALETTE` / `ENTITY_LABELS_*` / `RADIUS` / `SHADOW` / `FONTS` / `LAYOUT` / `CANVAS_DARK` / `entityTypeToPaletteKey` / `EntityType`）即便某些 TS export 暂无 callsite，**仍保留作为 reserved canonical**（类似 BE search_pipeline_service 的 "当前 grep unused 但设计 reserved"）；
+- 所有 chat / graph / workspace 新视觉 components；
+- 所有 i18n namespace (27 × 2 locales)；
+- Framework-required (`middleware.ts` / `mdx-components.tsx` / `hooks/use-mobile` / `services/cookies` / `middlewares/apiProxy`).
 
-Remove from `package.json`, `yarn install`, confirm `yarn build` passes.
+### 2.4 FE 可选收尾（非阻塞，可 PR-FE 内含或 follow-up）
 
-### 4.7 Frontend style residue (no-delete, refactor in-place)
+- 3 处 inline `var(--primary)` 仍然 valid（`--primary` 已指向 `#C96442`）— 确认即可，不改；
+- `--chart-1`…`--chart-5` CSS vars 无 TS/TSX 引用但定义保留 — reserved for future chart；
+- `web/src/app/docs/*` 保留（MDX renderer active）。
 
-- 3 inline `var(--primary)` sites: `quota-radial-chart.tsx`, `app/layout.tsx`, `documents-table.tsx` — align with the amber token set (keep `var(--primary)` since it now resolves to `#C96442`, but audit that each is the intended brand accent vs a leftover blue expectation).
-- `--chart-1`…`--chart-5` CSS vars defined in `globals.css` but no TS/TSX references — remove or wire into `ENTITY_PALETTE`/recharts usages; leave for F-style follow-up.
-
-### 4.8 Do-not-delete frontend
-
-- `web/src/api-v2/schema.d.ts` (11 313 LOC, auto-generated) — active.
-- `web/src/lib/api/typed/*` — active.
-- All chat components (`chat/*`) — active post-L2 rewrite.
-- All i18n namespaces — every `page_*.json` maps to a live route; no orphans.
-- `web/src/app/docs/*` — active MDX renderer (unless product decides to remove `/docs` route; treat as product decision, not cleanup).
-- Framework-required files (`middleware.ts`, `mdx-components.tsx`, services/cookies, hooks/use-mobile, middlewares/apiProxy).
-
----
-
-## 5. Gates
-
-Every Phase 7 delete PR must pass all of:
+### 2.5 FE PR gate
 
 ```bash
-# Backend boundary gates
-uv run pytest tests/unit_test/test_modularization_boundaries.py -x -q
-
-# OpenAPI byte stability
-uv run python scripts/export_openapi.py --check
-
-# Python lint
-uv run ruff check aperag/ tests/
-
-# Frontend lint (when touching web/)
-cd web && yarn lint
+cd web && yarn install   # package.json 删 7 deps 后
+cd web && yarn lint      # ESLint 0 errors
+cd web && yarn build     # production build 过
+grep -R "from '@/api/" web/src                  # → 0 hits
+grep -R "from '@/lib/api/client'" web/src       # → 0 hits
+grep -R "from '@/lib/api/server'" web/src       # → 0 hits
 ```
 
-Also recommended per batch:
-- Full `uv run pytest tests/` for B5/B6 (risk high — import identity changes).
-- Manual `yarn dev` smoke for F1/F2 (no visual regression expected since only removing unused code).
-- `grep -R "from aperag\.service\." aperag tests` / `grep -R "from aperag\.schema\.view_models" aperag tests` / `grep -R "from '@/api/" web/src` returning zero before rm.
+---
+
+## 3. 后端 backend destructive cleanup（`PR-BE`）
+
+**Owner**：Bryce (Phase 4 SME — identity / governance / model_platform / marketplace + db.models + schema/view_models) + chenyexuan (Phase 5/6 SME — conversation / agent_runtime / evaluation) + cuiwenbo (Phase 3 SME — KB / indexing / retrieval / knowledge_graph) 协作 on 1 PR。
+**PM** (@架构师) 决定主 author + co-author 分工。
+**Scope**：43 直接删 shim + 3 770 LOC ACTIVE_LEGACY audit → hard-cut，一次性合进 main。
+
+### 3.1 直接删（bundle 进 PR-BE）
+
+**A. `aperag/service/` 18 pure re-export shims** — 455 LOC
+```
+api_key_service.py        → rm
+audit_service.py          → rm
+bot_service.py            → rm
+chat_collection_service.py → rm
+chat_document_service.py  → rm
+chat_service.py           → rm
+chat_title_service.py     → rm
+collection_service.py     → rm
+collection_summary_service.py → rm
+default_model_service.py  → rm
+document_service.py       → rm
+graph_service.py          → rm
+llm_available_model_service.py → rm
+llm_provider_service.py   → rm
+marketplace_collection_service.py → rm
+marketplace_service.py    → rm
+prompt_template_service.py    — KEEP (Layer A)
+quota_service.py              — KEEP (Layer A)
+search_pipeline_service.py    — KEEP (Layer B)
+turn_feedback_service.py  → rm
+```
+同批 rewrite consumer imports: `from aperag.service.<name>` → `from aperag.domains.<d>.service.<name>`.
+
+**B. `aperag/views/` 12 pure router re-export shims + 1 empty `__init__`** — 327 LOC
+```
+agent_runtime.py / api_key.py / audit.py / bots_v2.py / chat.py /
+collections_v2.py / documents_v2.py / evaluation_v2.py / llm.py /
+marketplace.py / marketplace_collections.py / providers_v2.py / __init__.py → rm
+```
+`app.py` 已经直接 mount domain routers (lines 227–251)；shim 是死的。
+
+**C. `aperag/agent_runtime/` 整个包 5 files / 127 LOC** → rm
+- `__init__.py` / `runtime.py` / `schemas.py` / `services.py` / `storage.py`
+- 同批 rewrite callers 到 `aperag.domains.agent_runtime.*`
+
+**D. `aperag/evaluation_v2/` 整个包 7 files / 125 LOC** → rm
+- 同批 rewrite Celery task imports + test fixtures 到 `aperag.domains.evaluation.*`
+
+**E. `aperag/db/models.py` re-export block** (lines 395–462) → strip
+- 保留：`ConfigModel` / `UserQuota` / `ModelServiceProvider` / `QuestionType` / `EvaluationStatus` / `EvaluationItemStatus` / `ExportTaskStatus` / `QuestionSet` / `Question` / `Evaluation` / `EvaluationItem` / `Setting` / `ExportTask` / `PromptTemplate` / `Invitation` / `Base`
+- 保留：line 36 `from aperag.domains.identity.db.models import Role`（Layer C special-case）
+- 同批 rewrite callers: `from aperag.db.models import <Bot|Chat|User|ApiKey|LLMProvider|Collection|Document|…>` → `from aperag.domains.<d>.db.models import …`
+
+**F. `aperag/schema/view_models.py` 7 dual-hook blocks** (lines ~700–889) → strip
+- 同批 rewrite callers 到 `aperag.domains.<d>.schemas`
+- 保留 local schemas: `FailResponse` / `Settings` / `ParserHealthItem` / `PromptDetail` / `UserPromptsResponse` / `Prompts` / `UpdateUserPromptsRequest` 等 + `PromptSupportTier` 等本地 enum
+- dual-hook identity invariant (`X is view_models.X is domain.schemas.X`) 在 rewrite 完成后自然失效 — 接受这个破坏（hard-cut 口径），只保证 callers 全切完
+
+**G. 空目录 `aperag/chat/` + `aperag/graph/` + `aperag/misc/`** → rm
+
+### 3.2 迁完再删（bundle 进 PR-BE — hard-cut ACTIVE_LEGACY decisions）
+
+对每个 ACTIVE_LEGACY 文件，以下为 canonical 迁移决策。PM 可以在 PR-BE 内拆 co-author 分工，但结论一次性落。
+
+| File | LOC | canonical decision |
+|------|----:|--------------------|
+| `aperag/service/chat_completion_service.py` | 468 | **迁到** `aperag/domains/conversation/service/chat_completion_service.py`（OpenAI-compat 归 conversation 域），然后 rm 老 path + rewire `aperag/views/openai.py` |
+| `aperag/service/evaluation_service.py` | 514 | **迁到** `aperag/domains/evaluation/service/evaluation_task_service.py`（Celery task lifecycle 归 evaluation 域），然后 rm |
+| `aperag/service/export_service.py` | 199 | **迁到** `aperag/domains/knowledge_base/service/export_service.py`，然后 rm |
+| `aperag/service/question_set_service.py` | 197 | **迁到** `aperag/domains/evaluation/service/question_set_service.py`，然后 rm |
+| `aperag/service/setting_service.py` | 86 | **迁到** `aperag/domains/governance/service/setting_service.py`（与 quota / audit 同域），然后 rm |
+| `aperag/service/test_mcp_agent.py` | 332 | **迁到** `tests/fixtures/mcp_agent.py`（本来是 test util），然后 rm |
+| `aperag/views/auth.py` | 500 | **迁到** `aperag/domains/identity/api/auth_routes.py`（OAuth + fastapi-users 归 identity 域的新 sub-router），挂 `/api/v1/auth` 保留路径；rm 老 view |
+| `aperag/views/collections.py` (v1 upload) | 108 | v2 已覆盖 (`POST /api/v2/collections/{id}/documents/upload`)；**直接 rm**，FE 确认没再消费 v1 |
+| `aperag/views/config.py` | 55 | **迁到** `aperag/domains/identity/api/config_routes.py`，挂 `/api/v1/config` 保留 |
+| `aperag/views/export.py` | 69 | **迁到** `aperag/domains/knowledge_base/api/export_routes.py`，挂 `/api/v1/export` 保留 |
+| `aperag/views/graph.py` | 155 | **迁到** `aperag/domains/knowledge_graph/api/curation_routes.py`，挂 `/api/v1/graph` 保留 |
+| `aperag/views/main.py` | 219 | bot / chat / feedback v1 CRUD — v2 已覆盖 (`/api/v2/bots`, `/api/v2/chats`, `/api/v2/feedback`)；**直接 rm** 老路径；FE 若消费 v1 需要同批迁到 v2 |
+| `aperag/views/openai.py` | 83 | **迁到** `aperag/domains/conversation/api/openai_routes.py`（OpenAI-compat 归 conversation），挂 `/v1/chat/completions` 保留 |
+| `aperag/views/prompts.py` | 205 | **迁到** `aperag/domains/model_platform/api/prompt_routes.py`，挂 `/api/v1/user-prompts` 保留 |
+| `aperag/views/quota.py` | 234 | **迁到** `aperag/domains/governance/api/quota_routes.py`，挂 `/api/v1/quota` 保留 |
+| `aperag/views/settings.py` | 67 | **迁到** `aperag/domains/knowledge_base/api/settings_routes.py`（parser health），挂 `/api/v1/settings` 保留 |
+| `aperag/views/test.py` | 60 | **dev-only**；**直接 rm** 或迁 `tests/fixtures/`（PM 决定） |
+| `aperag/views/utils.py` | 134 | `auth.py` + `config.py` 依赖；**随它们迁到 identity 域 `_utils.py`**，然后 rm |
+| `aperag/views/chat_documents.py` | 21 | 空 stub，app.py 未 mount；**直接 rm** |
+
+### 3.3 ACTIVE_LEGACY decision 原则
+
+1. **保留 `/api/v1/` URL contract**：hard-cut 只动内部 canonical 归属，**不破坏 v1 客户端契约**。外部 curl/SDK 仍然走 `/api/v1/...`。
+2. **若 v2 已完全覆盖 v1 功能**，v1 URL 可以一并删（上面 `collections.py` / `main.py` 两条），前提是 FE 和外部 SDK 已经切完（PM coordinate with FE + docs 团队）。
+3. **OpenAPI schema byte-check**：`scripts/export_openapi.py --check` 必须 pass — 如果 v1 URL 还在契约里，迁移后 handler 签名 + response model 必须 bit-identical。
+
+### 3.4 BE PR gate
+
+```bash
+# 所有 hard-cut 在一个 PR 里，所以 gate 一次性跑
+uv run pytest tests/unit_test/test_modularization_boundaries.py -x -q       # G1-G19 全过
+uv run pytest tests/ -x -q                                                    # 完整 pytest
+uv run python scripts/export_openapi.py --check                               # OpenAPI bit-stable
+uv run ruff check aperag/ tests/                                              # lint
+grep -R "from aperag\.service\.\(api_key_service\|audit_service\|bot_service\|chat_collection_service\|chat_document_service\|chat_service\|chat_title_service\|collection_service\|collection_summary_service\|default_model_service\|document_service\|graph_service\|llm_available_model_service\|llm_provider_service\|marketplace_collection_service\|marketplace_service\|turn_feedback_service\)" aperag tests   # → 0 hits
+grep -R "from aperag\.views\.\(agent_runtime\|api_key\|audit\|bots_v2\|chat\|collections_v2\|documents_v2\|evaluation_v2\|llm\|marketplace\|marketplace_collections\|providers_v2\)" aperag tests   # → 0 hits
+grep -R "from aperag\.agent_runtime" aperag tests   # → 0 hits outside tests/aperag.domains.agent_runtime
+grep -R "from aperag\.evaluation_v2" aperag tests   # → 0 hits
+grep -R "from aperag\.schema\.view_models import" aperag tests | grep -v "FailResponse\|Settings\|ParserHealth\|Prompt\|UpdateUserPrompts\|UserPromptsResponse"   # → 0 hits（只剩 local schema 的 import）
+```
 
 ---
 
-## 6. Batch → lane proposal (PM input)
+## 4. 组织口径（per PM msg=ec47711e / msg=8fff00a8）
 
-Delivery model inherits the successful pattern from the FE rewrite: fast-merge discipline + 最小 review + Weston blocker-level CR 补位 + 10 min PM cadence.
+| Item | 决策 |
+|------|------|
+| PR 数量 | 目标 **2 PR**：`PR-BE destructive backend cleanup` + `PR-FE destructive frontend cleanup` |
+| PR 规模 | 每个 PR 可以 **非常大**（backend 可能 ~5 000 LOC diff；frontend ~26 000 LOC diff，主要是删除）— 接受 |
+| 允许压成 1 PR | 若 PM 判断 BE/FE 同 PR 更顺（如有跨 layer 的 `/api/v1/` contract FE 同步需要），接受合并为 1 PR |
+| CR 口径 | Weston blocker-level minimal CR；Opus lane 做 canonical drift（每个主写 owner 自检 §1 白名单 + §3.4 / §2.5 gate） |
+| Cadence | 10 min PM checkpoint；但 PR 本身不分 batch — 一次性做完一次性 review |
+| 架构边界 | @符炫炜 inventory SSoT + canonical lock；PM 不做架构判断 (per earayu2 msg=92ddf593) |
+| Coding owner | 优先 Opus（Bryce Phase 4 + chenyexuan Phase 5/6 + cuiwenbo Phase 3 + huangheng FE L1），GPT (dongdong / weihong) 补并行位 |
 
-Owner preference (per lane SME + msg=54d910eb / msg=be8d6f21 prep):
+### 4.1 Owner 建议（PM 最终决定）
 
-| Batch | Scope | Recommended owner | Notes |
-|-------|-------|-------------------|-------|
-| B1 | `aperag/service/` 18 shim delete + caller migration | Opus lane (Bryce or chenyexuan split by domain) | Can split Phase 3 vs Phase 4/5 sub-batches |
-| B2 | `aperag/views/` 12 shim delete + `__init__` | Opus lane (Bryce for Phase 4 views, chenyexuan for Phase 5 views) | Low risk; routers already direct-mount |
-| B3 | `aperag/agent_runtime/*` 5 shim delete | chenyexuan (Phase 5 SME) | After B2 agent_runtime shim is gone |
-| B4 | `aperag/evaluation_v2/*` 7 shim delete | chenyexuan (Phase 5/6 SME) | Touch Celery task imports |
-| B5 | `aperag/db/models.py` 53 re-export cleanup (preserve `Invitation` + `Role` import) | Bryce (Phase 4 SME) | Highest DB risk; verify Alembic autogen clean |
-| B6 | `aperag/schema/view_models.py` 7 sub-batches (low→high consumer count) | split by domain SME (Bryce Phase 4 blocks, chenyexuan Phase 5 block, cuiwenbo Phase 3 block) | dual-hook identity invariant; run full pytest |
-| B7 | empty `aperag/{chat,graph,misc}/` removal | any lane | trivial |
-| B-audit | ACTIVE_LEGACY §3 audit + per-route decision | Bryce + chenyexuan + cuiwenbo by Phase | Output: rm routes with domain equivalents; keep-v1 list with rationale |
-| F1 | `web/src/api/` 202-file delete | huangheng (FE L1 SME) | zero code risk once F2 also removed |
-| F2 | `web/src/lib/api/{client,server}.ts` delete | huangheng | paired with F1 |
-| F3 | `globals.default.css` delete | huangheng | trivial |
-| F4 | unused shadcn ui delete | huangheng | verify `components.json` + `components/ui/index.ts` |
-| F5 | trim 15 unused feature exports | any FE lane | low risk |
-| F6 | trim 7 unused deps | huangheng + run `yarn install` | CI build confirms |
+- **PR-BE 主 author**：Bryce（Phase 4 SME，跨域经验最广，能抓 view_models dual-hook 和 db.models 两个高危点）
+- **PR-BE co-author**：chenyexuan（Phase 5/6 agent_runtime + evaluation + conversation 域） + cuiwenbo（Phase 3 KB + indexing + retrieval + KG 域） + Bryce 协调
+- **PR-FE 主 author**：huangheng（FE L1 SME）
+- **Single-author alternative**：若 PM 决定 BE 一人主写，Bryce 最合适；chenyexuan / cuiwenbo 做 parallel spot-check（不改同文件）
 
-GPT lanes (dongdong / weihong) absorb overflow or `B-audit` leg work once Opus lanes are saturated.
+### 4.2 执行纪律
+
+1. 主 author 开 branch 前 fetch latest main；PR body `Ghost-check:` line 引用 `docs/modularization/cleanup-inventory.md §1`（禁删白名单 self-check 确认）
+2. 大 PR 在 branch 上 commit-by-commit 组织（便于 rollback 到任意 intermediate commit），最终 squash-merge
+3. 每个高危 block（§3.1 E/F db.models re-export + view_models dual-hook）独立 commit，便于 bisect
+4. PR 内 gate 全绿才请 Weston review；不做多轮 back-and-forth，一次性提交 final state
 
 ---
 
-## 7. Execution discipline
+## 5. 历史：v0 → v1 diff
 
-1. **Canonical SSoT = this file.** Every batch PR references it in commit body (`per docs/modularization/cleanup-inventory.md §Bx`).
-2. **PERMANENT list (§1) is strictly off-limits.** Every coding lane self-checks the file being deleted is not in §1.
-3. **Every batch PR ends with `Ghost-check:` line** reusing the FE rewrite convention (`docs/frontend-rewrite/mismatch-registry.md` §6). Example:
-   ```
-   Ghost-check: none — batch B1 sub-batch 2; no PERMANENT §1.1 files touched; G17/G18-alt unchanged.
-   ```
-4. **10 min PM cadence.** `@架构师` drives checkpoints; coding lanes post status + gate results per batch thread.
-5. **Weston blocker-level minimal CR** continues; Opus 可 restored → prefer Opus CR for high-risk batches (B5/B6), Weston still covers when Opus 限流.
-6. **Fix-forward discipline.** Small style/residue cleanup (F4.7 chart vars, inline `var(--primary)` spot-check) 作为 follow-up tiny patches，不阻塞主批次。
-7. **Roll-back guarantee.** Every batch PR is small (≤ ~500 LOC diff, often much smaller) + squash-merged with commit body linking to this SSoT; revert path is trivial if a regression surfaces.
+v0 (PR #1662 `97aa4bf8` / 345 LOC) → v1（本文件）主要变化：
+
+1. §1 禁删白名单重写成 5 层 distinction（Layer A G18 alt 2 / Layer B standalone-infra 1 含 `search_pipeline_service` / Layer C Invitation / Layer D G17 / Layer E misc infra dirs）— 修正 Bryce msg=647b2b17 指出的 v0 Section 5 漏列 `search_pipeline_service` 的 canonical drift。
+2. §6 原推荐"B1-B7 多 batch 小 PR" → v1 §4 重写为"1-2 大 PR hard-cut"（per earayu2 msg=be4c5c19 / msg=ac0a9243）。
+3. §3 ACTIVE_LEGACY 从"audit 后单独决策" → v1 §3.2 直接给出每文件 canonical migration destination + 是否保留 v1 URL。
+4. 加 §2.3 FE 白名单（`design-tokens.ts` reserved exports 不删）— per huangheng msg=8e203455 提的 "reserved export" 类比 BE standalone-infra。
+5. §4 明确架构 / PM 角色边界（per earayu2 msg=92ddf593 / msg=90c75cce）。
+
+这份 v1 替换 v0 作为 Phase 7 cleanup canonical SSoT。v0 PR 已 merge，历史记录保留在 git history。


### PR DESCRIPTION
## Summary

per earayu2 msg=78fdb6fc / msg=be4c5c19 / msg=ac0a9243 / msg=92ddf593 updates:
1. **Hard-cut 口径** — 一次性删全部 shim / 老入口 / 兼容层；不再保留兼容双轨
2. **1-2 大 PR** — 默认 `PR-BE` + `PR-FE`，不再 batch-by-batch 小迭代
3. **架构 = @符炫炜；PM = @架构师**（PM 不做架构判断）
4. **Bryce msg=647b2b17 canonical drift catch** — v0 Section 5 漏列 `search_pipeline_service` (standalone-infra 非 shim)，v1 修正为 5 层 distinction

## Key changes (v0 → v1)

- §1 禁删白名单 = 5 层 distinction:
  - Layer A: G18 alt CRITICAL_WIRINGS (2) — quota/prompt_template
  - Layer B: cross-domain standalone-infra (1) — search_pipeline_service
  - Layer C: Invitation Role binding special-case
  - Layer D: G17 Phase 3+4 wirings (7)
  - Layer E: misc shared-infra dirs (keep, Phase 8+ candidate)
- §3.2 ACTIVE_LEGACY 每条直接给 canonical migration destination（不再 audit-wait）
- §4 组织口径：2 PR default + 允许 single PR + Opus 优先 owner 分工

## Rollback

本 v1 替换 v0 (PR #1662) 作为 canonical SSoT。v0 历史保留在 git log。

🤖 Generated with [Claude Code](https://claude.com/claude-code)