### PR TITLE
fix(web): restore local dev startup

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "api:build": "yarn api:v2:types",
     "api:v2:types": "mkdir -p ./src/api-v2 && openapi-typescript ../openapi.public.json -o ./src/api-v2/schema.d.ts",
     "build": "yarn install && yarn i18n:sync && next build && ts-node scripts/build.mjs",
-    "dev": "cp ./deploy/env.local.template ./.env && yarn install && yarn i18n:sync && next dev --turbopack",
+    "dev": "cp ./deploy/env.local.template ./.env && yarn install && yarn i18n:sync && next dev",
     "i18n:sync": "node scripts/i18n-watch.mjs",
     "lint": "next lint",
     "prettier": "prettier --cache --write ./ && yarn lint",

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -22,7 +22,6 @@ const fontSans = Manrope({
 const fontSerif = Fraunces({
   variable: '--font-serif',
   subsets: ['latin'],
-  weight: ['400', '500', '600'],
   axes: ['opsz'],
   display: 'swap',
 });


### PR DESCRIPTION
## Summary
- remove fixed Fraunces weights while keeping the `opsz` axis so Next 15.5 treats the font config as a legal variable-font setup
- remove `--turbopack` from the local dev entry so `yarn dev` / `make serve-web` can start with the existing MDX remark plugin options

## Validation
- `yarn lint`
- `git diff --check`
- `PORT=3001 yarn dev` started successfully, Next ready on <http://localhost:3001>
- `PORT=3001 make serve-web` started successfully, Next ready on <http://localhost:3001>
- smoke via `make serve-web`: `/` 200, `/auth/signin` 200, `/workspace/collections` 200
- API smoke: `/health` 200, invalid `/api/v1/login` returns expected 400

Task #34 fix-forward for local deployment smoke.