### PR TITLE
refactor(concurrent-control): make locks redis-first

### DIFF
--- a/aperag/concurrent_control/__init__.py
+++ b/aperag/concurrent_control/__init__.py
@@ -20,6 +20,7 @@ mechanisms for any Python application. Designed to handle different deployment
 scenarios and task queue environments.
 
 Features:
+- Redis-backed production locks by default
 - Auto-managed locks with default manager
 - Flexible timeout support
 - Universal applicability
@@ -27,12 +28,12 @@ Features:
 - Production ready with comprehensive error handling
 
 Quick Start:
-    from aperag.concurrent_control import get_or_create_lock, lock_context
+    from aperag.concurrent_control import create_distributed_lock, lock_context
 
-    # Create/get a managed lock (most common usage)
-    my_lock = get_or_create_lock("database_operations")
+    # Create a Redis-backed production lock
+    my_lock = create_distributed_lock("database_operations")
 
-    # Use with default behavior
+    # Use with distributed behavior
     async with my_lock:
         await critical_work()
 
@@ -43,10 +44,11 @@ Quick Start:
 
 from .manager import (
     LockManager,  # noqa: F401  # Available for testing and advanced usage
+    create_distributed_lock,  # Create Redis-backed production locks
     create_lock,  # Create new locks
     get_default_lock_manager,  # Access default manager for advanced operations
     get_lock,  # Retrieve existing locks
-    get_or_create_lock,  # Get existing or create new (recommended)
+    get_or_create_lock,  # Get existing or create new
 )
 from .protocols import LockProtocol  # noqa: F401  # Available for testing and advanced usage
 from .redis_lock import RedisLock  # noqa: F401  # Available for testing and advanced usage
@@ -55,7 +57,8 @@ from .utils import lock_context  # ⭐ Timeout support for locks
 
 __all__ = [
     # Main interface (recommended)
-    "get_or_create_lock",  # ⭐ Primary function - get existing or create new
+    "create_distributed_lock",  # ⭐ Primary production function - Redis-backed lock
+    "get_or_create_lock",  # Get existing or create new (defaults to Redis)
     "get_lock",  # Get existing lock only
     "create_lock",  # Create new locks
     "lock_context",  # ⭐ Timeout support for locks

--- a/aperag/concurrent_control/manager.py
+++ b/aperag/concurrent_control/manager.py
@@ -16,15 +16,35 @@
 Lock manager and factory functions for the concurrent control system.
 
 This module contains the LockManager class and factory functions for creating
-and managing lock instances across the application.
+and managing lock instances across the application. Production defaults are
+Redis-backed so locks work across workers and processes.
 """
 
+import os
 import threading
 from typing import Dict, Optional
+
+import redis.asyncio as async_redis
 
 from .protocols import LockProtocol
 from .redis_lock import RedisLock
 from .threading_lock import ThreadingLock
+
+LOCK_TYPE_ENV = "APERAG_LOCK_TYPE"
+DEFAULT_LOCK_TYPE = "redis"
+LOCK_TYPE_REDIS = "redis"
+LOCK_TYPE_THREADING = "threading"
+SUPPORTED_LOCK_TYPES = {LOCK_TYPE_REDIS, LOCK_TYPE_THREADING}
+
+
+def _resolve_lock_type(lock_type: Optional[str] = None) -> str:
+    resolved = (lock_type or os.getenv(LOCK_TYPE_ENV, DEFAULT_LOCK_TYPE)).strip().lower()
+    if resolved not in SUPPORTED_LOCK_TYPES:
+        raise ValueError(
+            f"Unknown lock type: {resolved}. Use '{LOCK_TYPE_REDIS}' or '{LOCK_TYPE_THREADING}'. "
+            f"Set {LOCK_TYPE_ENV} only for process-wide default override."
+        )
+    return resolved
 
 
 class LockManager:
@@ -53,7 +73,13 @@ class LockManager:
         return ThreadingLock(name=name)
 
     def create_redis_lock(
-        self, key: str, expire_time: int = 120, retry_times: int = 3, retry_delay: float = 0.1
+        self,
+        key: str,
+        expire_time: int = 120,
+        retry_times: int = 3,
+        retry_delay: float = 0.1,
+        name: Optional[str] = None,
+        redis_client: Optional[async_redis.Redis] = None,
     ) -> RedisLock:
         """
         Create a Redis lock for distributed scenarios.
@@ -63,6 +89,8 @@ class LockManager:
             expire_time: Lock expiration time in seconds
             retry_times: Number of retry attempts
             retry_delay: Delay between retry attempts
+            name: Optional lock name
+            redis_client: Optional Redis client override for tests or explicit callers
 
         Returns:
             RedisLock instance
@@ -72,34 +100,67 @@ class LockManager:
             expire_time=expire_time,
             retry_times=retry_times,
             retry_delay=retry_delay,
+            name=name,
+            redis_client=redis_client,
         )
 
-    def get_or_create_lock(self, lock_id: str, lock_type: str = "threading", **kwargs) -> LockProtocol:
+    def create_distributed_lock(
+        self,
+        name: str,
+        ttl: int = 120,
+        redis_client: Optional[async_redis.Redis] = None,
+        retry_times: int = 3,
+        retry_delay: float = 0.1,
+    ) -> RedisLock:
+        """
+        Create a Redis-backed production lock.
+
+        Args:
+            name: Stable distributed lock name. This becomes the Redis key.
+            ttl: Lock expiration time in seconds.
+            redis_client: Optional Redis client override.
+            retry_times: Number of retry attempts.
+            retry_delay: Delay between retry attempts.
+
+        Returns:
+            RedisLock instance.
+        """
+        return self.create_redis_lock(
+            key=name,
+            expire_time=ttl,
+            retry_times=retry_times,
+            retry_delay=retry_delay,
+            name=name,
+            redis_client=redis_client,
+        )
+
+    def get_or_create_lock(self, lock_id: str, lock_type: Optional[str] = None, **kwargs) -> LockProtocol:
         """
         Get an existing lock or create a new one.
 
         Args:
             lock_id: Unique identifier for the lock
-            lock_type: Type of lock ('threading' or 'redis')
+            lock_type: Type of lock ('redis' or 'threading'). Defaults to APERAG_LOCK_TYPE or redis.
             **kwargs: Additional arguments for lock creation
 
         Returns:
             Lock instance
         """
+        resolved_lock_type = _resolve_lock_type(lock_type)
         with self._lock:  # Thread-safe check-and-set operation
             # Check if lock already exists
             if lock_id in self._locks:
                 return self._locks[lock_id]
 
             # Create new lock
-            if lock_type == "threading":
+            if resolved_lock_type == LOCK_TYPE_THREADING:
                 lock = self.create_threading_lock(name=kwargs.get("name", lock_id))
-            elif lock_type == "redis":
+            elif resolved_lock_type == LOCK_TYPE_REDIS:
                 # For Redis locks, use lock_id as the key if no key is provided
                 key = kwargs.get("key", lock_id)
                 lock = self.create_redis_lock(key=key, **{k: v for k, v in kwargs.items() if k != "key"})
             else:
-                raise ValueError(f"Unknown lock type: {lock_type}")
+                raise ValueError(f"Unknown lock type: {resolved_lock_type}")
 
             # Store the new lock
             self._locks[lock_id] = lock
@@ -136,7 +197,29 @@ class LockManager:
 default_lock_manager = LockManager()
 
 
-def create_lock(lock_type: str = "threading", **kwargs) -> LockProtocol:
+def create_distributed_lock(
+    name: str,
+    ttl: int = 120,
+    redis_client: Optional[async_redis.Redis] = None,
+    retry_times: int = 3,
+    retry_delay: float = 0.1,
+) -> RedisLock:
+    """
+    Create a Redis-backed production lock.
+
+    This is the preferred public API for business code that needs mutual
+    exclusion across API workers, Celery workers, or multiple containers.
+    """
+    return default_lock_manager.create_distributed_lock(
+        name=name,
+        ttl=ttl,
+        redis_client=redis_client,
+        retry_times=retry_times,
+        retry_delay=retry_delay,
+    )
+
+
+def create_lock(lock_type: Optional[str] = None, **kwargs) -> LockProtocol:
     """
     Create a new lock instance.
 
@@ -144,7 +227,7 @@ def create_lock(lock_type: str = "threading", **kwargs) -> LockProtocol:
     in the default lock manager for later retrieval.
 
     Args:
-        lock_type: Type of lock to create ('threading' or 'redis')
+        lock_type: Type of lock to create ('redis' or 'threading'). Defaults to APERAG_LOCK_TYPE or redis.
         name: Optional lock name (if provided, auto-registered for retrieval)
         **kwargs: Additional arguments passed to lock constructor
 
@@ -152,22 +235,23 @@ def create_lock(lock_type: str = "threading", **kwargs) -> LockProtocol:
         LockProtocol: Lock implementation instance
 
     Examples:
-        # Create anonymous lock (not managed)
-        temp_lock = create_lock("threading")
-
-        # Create named lock (automatically managed)
-        managed_lock = create_lock("threading", name="my_lock")
+        # Create named Redis lock (automatically managed)
+        managed_lock = create_lock("redis", key="my_app:lock", name="my_lock")
         same_lock = get_lock("my_lock")  # Returns same instance
 
-        # Create Redis lock
-        redis_lock = create_lock("redis", key="my_app:lock", redis_url="redis://localhost:6379")
+        # Create a local single-process lock explicitly
+        local_lock = create_lock("threading", name="test_lock")
     """
-    if lock_type == "threading":
+    resolved_lock_type = _resolve_lock_type(lock_type)
+    if resolved_lock_type == LOCK_TYPE_REDIS and "key" not in kwargs and kwargs.get("name"):
+        kwargs["key"] = kwargs["name"]
+
+    if resolved_lock_type == LOCK_TYPE_THREADING:
         lock_instance = ThreadingLock(**kwargs)
-    elif lock_type == "redis":
+    elif resolved_lock_type == LOCK_TYPE_REDIS:
         lock_instance = RedisLock(**kwargs)
     else:
-        raise ValueError(f"Unknown lock type: {lock_type}. Use 'threading' or 'redis'.")
+        raise ValueError(f"Unknown lock type: {resolved_lock_type}. Use 'redis' or 'threading'.")
 
     # Auto-register named locks in default manager (thread-safe)
     lock_name = kwargs.get("name") or getattr(lock_instance, "_name", None)
@@ -204,7 +288,7 @@ def get_lock(name: str) -> Optional[LockProtocol]:
         return default_lock_manager._locks.get(name)
 
 
-def get_or_create_lock(name: str, lock_type: str = "threading", **kwargs) -> LockProtocol:
+def get_or_create_lock(name: str, lock_type: Optional[str] = None, **kwargs) -> LockProtocol:
     """
     Get an existing lock by name or create a new one.
 
@@ -212,19 +296,22 @@ def get_or_create_lock(name: str, lock_type: str = "threading", **kwargs) -> Loc
 
     Args:
         name: Name of the lock
-        lock_type: Type of lock to create if not found
+        lock_type: Type of lock to create if not found. Defaults to APERAG_LOCK_TYPE or redis.
         **kwargs: Additional arguments for lock creation
 
     Returns:
         Lock instance (existing or newly created)
 
     Examples:
-        # Get existing or create new
-        lock = get_or_create_lock("database_ops", "threading")
+        # Get existing or create new Redis-backed production lock
+        lock = get_or_create_lock("database_ops")
 
         # All subsequent calls return the same instance
-        same_lock = get_or_create_lock("database_ops", "threading")
+        same_lock = get_or_create_lock("database_ops")
         assert lock is same_lock
+
+        # Single-process local locks must opt in explicitly
+        local_lock = get_or_create_lock("local_ops", "threading")
     """
     # Use the LockManager's thread-safe get_or_create_lock method
     # This ensures atomic check-and-create operation

--- a/aperag/concurrent_control/redis_lock.py
+++ b/aperag/concurrent_control/redis_lock.py
@@ -227,7 +227,7 @@ class RedisLock(LockProtocol):
                     logger.debug(f"Redis lock '{self._key}' released successfully")
                 else:
                     logger.warning(
-                        f"Redis lock '{self._key}' was not released " f"(may have expired or been released already)"
+                        f"Redis lock '{self._key}' was not released (may have expired or been released already)"
                     )
 
             except Exception as e:

--- a/aperag/concurrent_control/redis_lock.py
+++ b/aperag/concurrent_control/redis_lock.py
@@ -105,6 +105,7 @@ class RedisLock(LockProtocol):
         self._lock_value: Optional[str] = None
         self._is_locked = False
         self._redis_client = redis_client
+        self._operation_lock = asyncio.Lock()
 
     async def _get_redis_client(self):
         """Get Redis client from shared connection manager."""
@@ -129,67 +130,69 @@ class RedisLock(LockProtocol):
         Returns:
             True if lock was acquired successfully, False if timeout/retry exhausted.
         """
-        if self._is_locked:
-            logger.warning(f"Redis lock '{self._key}' is already held by this instance")
-            return True
+        async with self._operation_lock:
+            if self._is_locked:
+                logger.warning(f"Redis lock '{self._key}' is already held by this instance")
+                return True
 
-        # Generate unique lock value (UUID) to ensure only holder can release
-        lock_value = str(uuid.uuid4())
-        redis_client = await self._get_redis_client()
+            # Generate unique lock value (UUID) to ensure only holder can release
+            lock_value = str(uuid.uuid4())
+            redis_client = await self._get_redis_client()
 
-        start_time = time.time()
-        attempt = 0
-        max_attempts = self._retry_times + 1
+            start_time = time.time()
+            attempt = 0
+            max_attempts = self._retry_times + 1
 
-        while attempt < max_attempts:
-            # Check timeout
-            if timeout is not None:
-                elapsed = time.time() - start_time
-                if elapsed >= timeout:
-                    logger.debug(f"Redis lock '{self._key}' acquisition timed out after {elapsed:.3f}s")
-                    return False
-
-            try:
-                # Attempt to acquire lock using SET NX EX
-                result = await redis_client.set(
-                    self._key,
-                    lock_value,
-                    nx=True,  # Only set if key doesn't exist
-                    ex=self._expire_time,  # Set expiration time
-                )
-
-                if result:
-                    # Lock acquired successfully
-                    self._lock_value = lock_value
-                    self._is_locked = True
+            while attempt < max_attempts:
+                # Check timeout
+                if timeout is not None:
                     elapsed = time.time() - start_time
-                    logger.debug(
-                        f"Redis lock '{self._key}' acquired after {elapsed:.3f}s (attempt {attempt + 1}/{max_attempts})"
+                    if elapsed >= timeout:
+                        logger.debug(f"Redis lock '{self._key}' acquisition timed out after {elapsed:.3f}s")
+                        return False
+
+                try:
+                    # Attempt to acquire lock using SET NX EX
+                    result = await redis_client.set(
+                        self._key,
+                        lock_value,
+                        nx=True,  # Only set if key doesn't exist
+                        ex=self._expire_time,  # Set expiration time
                     )
-                    return True
 
-                # Lock not available, wait before retry
-                attempt += 1
-                if attempt < max_attempts:
-                    # Calculate remaining timeout for sleep
-                    sleep_time = self._retry_delay
-                    if timeout is not None:
-                        remaining_timeout = timeout - (time.time() - start_time)
-                        sleep_time = min(sleep_time, remaining_timeout)
-                        if sleep_time <= 0:
-                            break
+                    if result:
+                        # Lock acquired successfully
+                        self._lock_value = lock_value
+                        self._is_locked = True
+                        elapsed = time.time() - start_time
+                        logger.debug(
+                            f"Redis lock '{self._key}' acquired after {elapsed:.3f}s "
+                            f"(attempt {attempt + 1}/{max_attempts})"
+                        )
+                        return True
 
-                    await asyncio.sleep(sleep_time)
+                    # Lock not available, wait before retry
+                    attempt += 1
+                    if attempt < max_attempts:
+                        # Calculate remaining timeout for sleep
+                        sleep_time = self._retry_delay
+                        if timeout is not None:
+                            remaining_timeout = timeout - (time.time() - start_time)
+                            sleep_time = min(sleep_time, remaining_timeout)
+                            if sleep_time <= 0:
+                                break
 
-            except Exception as e:
-                logger.error(f"Error acquiring Redis lock '{self._key}' on attempt {attempt + 1}: {e}")
-                attempt += 1
-                if attempt < max_attempts:
-                    await asyncio.sleep(self._retry_delay)
+                        await asyncio.sleep(sleep_time)
 
-        elapsed = time.time() - start_time
-        logger.debug(f"Redis lock '{self._key}' acquisition failed after {elapsed:.3f}s ({attempt} attempts)")
-        return False
+                except Exception as e:
+                    logger.error(f"Error acquiring Redis lock '{self._key}' on attempt {attempt + 1}: {e}")
+                    attempt += 1
+                    if attempt < max_attempts:
+                        await asyncio.sleep(self._retry_delay)
+
+            elapsed = time.time() - start_time
+            logger.debug(f"Redis lock '{self._key}' acquisition failed after {elapsed:.3f}s ({attempt} attempts)")
+            return False
 
     async def release(self) -> None:
         """
@@ -198,36 +201,41 @@ class RedisLock(LockProtocol):
         Uses Lua script for atomic check-and-delete to ensure only
         the lock holder can release the lock.
         """
-        if not self._is_locked:
-            logger.warning(f"Redis lock '{self._key}' is not held by this instance")
-            return
+        async with self._operation_lock:
+            if not self._is_locked:
+                logger.warning(f"Redis lock '{self._key}' is not held by this instance")
+                return
 
-        if not self._lock_value:
-            logger.error(f"Redis lock '{self._key}' has no lock value, cannot release safely")
-            return
+            lock_value = self._lock_value
+            if not lock_value:
+                logger.error(f"Redis lock '{self._key}' has no lock value, cannot release safely")
+                self._is_locked = False
+                return
 
-        try:
-            redis_client = await self._get_redis_client()
+            try:
+                redis_client = await self._get_redis_client()
 
-            # Use Lua script for atomic release - simplified to always use eval
-            result = await redis_client.eval(
-                self.RELEASE_SCRIPT,
-                1,  # Number of keys
-                self._key,  # KEYS[1]
-                self._lock_value,  # ARGV[1]
-            )
+                # Use Lua script for atomic release - simplified to always use eval
+                result = await redis_client.eval(
+                    self.RELEASE_SCRIPT,
+                    1,  # Number of keys
+                    self._key,  # KEYS[1]
+                    lock_value,  # ARGV[1]
+                )
 
-            if result == 1:
-                logger.debug(f"Redis lock '{self._key}' released successfully")
-            else:
-                logger.warning(f"Redis lock '{self._key}' was not released (may have expired or been released already)")
+                if result == 1:
+                    logger.debug(f"Redis lock '{self._key}' released successfully")
+                else:
+                    logger.warning(
+                        f"Redis lock '{self._key}' was not released " f"(may have expired or been released already)"
+                    )
 
-        except Exception as e:
-            logger.error(f"Error releasing Redis lock '{self._key}': {e}")
-        finally:
-            # Clear local state regardless of Redis operation result
-            self._lock_value = None
-            self._is_locked = False
+            except Exception as e:
+                logger.error(f"Error releasing Redis lock '{self._key}': {e}")
+            finally:
+                # Clear local state regardless of Redis operation result
+                self._lock_value = None
+                self._is_locked = False
 
     def is_locked(self) -> bool:
         """

--- a/tests/unit_test/concurrent_control/test_lock_manager.py
+++ b/tests/unit_test/concurrent_control/test_lock_manager.py
@@ -7,7 +7,14 @@ management, and lifecycle operations.
 
 import pytest
 
-from aperag.concurrent_control import LockManager, RedisLock, ThreadingLock, get_default_lock_manager
+from aperag.concurrent_control import (
+    LockManager,
+    RedisLock,
+    ThreadingLock,
+    create_distributed_lock,
+    get_default_lock_manager,
+    get_or_create_lock,
+)
 
 
 class TestLockManager:
@@ -91,6 +98,62 @@ class TestLockManager:
         lock3 = manager.get_or_create_lock("redis_lock_2", "redis")
         assert isinstance(lock3, RedisLock)
         assert lock3._key == "redis_lock_2"  # Uses lock_id as key
+
+    def test_get_or_create_lock_defaults_to_redis(self, monkeypatch):
+        """Test default lock type is Redis-backed for production safety."""
+        monkeypatch.delenv("APERAG_LOCK_TYPE", raising=False)
+        manager = LockManager()
+
+        lock = manager.get_or_create_lock("default_distributed_lock")
+
+        assert isinstance(lock, RedisLock)
+        assert lock._key == "default_distributed_lock"
+
+    def test_get_or_create_lock_env_threading_opt_in(self, monkeypatch):
+        """Test threading default requires explicit process-wide opt-in."""
+        monkeypatch.setenv("APERAG_LOCK_TYPE", "threading")
+        manager = LockManager()
+
+        lock = manager.get_or_create_lock("local_only_lock")
+
+        assert isinstance(lock, ThreadingLock)
+
+    def test_get_or_create_lock_invalid_env_type(self, monkeypatch):
+        """Test invalid APERAG_LOCK_TYPE fails closed."""
+        monkeypatch.setenv("APERAG_LOCK_TYPE", "process")
+        manager = LockManager()
+
+        with pytest.raises(ValueError, match="Unknown lock type: process"):
+            manager.get_or_create_lock("test")
+
+    def test_create_distributed_lock(self):
+        """Test public Redis-first production lock helper."""
+        redis_client = object()
+
+        lock = create_distributed_lock(
+            "distributed_operation",
+            ttl=45,
+            redis_client=redis_client,
+            retry_times=7,
+            retry_delay=0.25,
+        )
+
+        assert isinstance(lock, RedisLock)
+        assert lock._key == "distributed_operation"
+        assert lock._name == "distributed_operation"
+        assert lock._expire_time == 45
+        assert lock._retry_times == 7
+        assert lock._retry_delay == 0.25
+        assert lock._redis_client is redis_client
+
+    def test_module_get_or_create_defaults_to_redis(self, monkeypatch):
+        """Test module-level helper also defaults to Redis."""
+        monkeypatch.delenv("APERAG_LOCK_TYPE", raising=False)
+
+        lock = get_or_create_lock("module_default_distributed_lock")
+
+        assert isinstance(lock, RedisLock)
+        assert lock._key == "module_default_distributed_lock"
 
     def test_get_or_create_lock_invalid_type(self):
         """Test get_or_create_lock with invalid lock type."""

--- a/tests/unit_test/concurrent_control/test_redis_lock.py
+++ b/tests/unit_test/concurrent_control/test_redis_lock.py
@@ -107,6 +107,24 @@ class TestRedisLockWithConnectionManager:
         assert lock._lock_value is None
 
     @pytest.mark.asyncio
+    async def test_same_key_instances_are_mutually_exclusive(self):
+        """Test two RedisLock instances with the same key rely on Redis NX mutual exclusion."""
+        mock_client = AsyncMock()
+        mock_client.set = AsyncMock(side_effect=[True, False])
+        mock_client.eval = AsyncMock(return_value=1)
+
+        first = RedisLock(key="shared_key", retry_times=0, redis_client=mock_client)
+        second = RedisLock(key="shared_key", retry_times=0, redis_client=mock_client)
+
+        assert await first.acquire() is True
+        assert await second.acquire() is False
+        assert first.is_locked() is True
+        assert second.is_locked() is False
+        assert mock_client.set.call_count == 2
+
+        await first.release()
+
+    @pytest.mark.asyncio
     async def test_context_manager(self, mock_connection_manager):
         """Test using RedisLock as async context manager."""
         mock_manager, mock_client = mock_connection_manager
@@ -138,12 +156,14 @@ class TestRedisLockWithConnectionManager:
         mock_manager, mock_client = mock_connection_manager
         # First two calls fail, third succeeds
         mock_client.set.side_effect = [False, False, True]
+        mock_client.eval.return_value = 1
 
         lock = RedisLock(key="test_retry", retry_times=3, retry_delay=0.01)
 
         success = await lock.acquire()
         assert success is True
         assert mock_client.set.call_count == 3
+        await lock.release()
 
     @pytest.mark.asyncio
     async def test_timeout_respected(self, mock_connection_manager):
@@ -176,6 +196,27 @@ class TestRedisLockWithConnectionManager:
         lock._is_locked = True
         lock._lock_value = None
         await lock.release()  # Should log error but not crash
+
+    @pytest.mark.asyncio
+    async def test_release_uses_captured_owner_value(self):
+        """Test release does not race against later local _lock_value changes."""
+        mock_client = AsyncMock()
+        mock_client.eval = AsyncMock(return_value=1)
+        lock = RedisLock(key="test_release_owner", redis_client=mock_client)
+        lock._is_locked = True
+        lock._lock_value = "owner-before-await"
+
+        async def get_client_with_racy_state_change():
+            lock._lock_value = "owner-after-await"
+            return mock_client
+
+        lock._get_redis_client = get_client_with_racy_state_change
+
+        await lock.release()
+
+        assert mock_client.eval.call_args[0][3] == "owner-before-await"
+        assert lock._lock_value is None
+        assert lock.is_locked() is False
 
     @pytest.mark.asyncio
     async def test_connection_manager_integration(self):

--- a/tests/unit_test/concurrent_control/test_utilities.py
+++ b/tests/unit_test/concurrent_control/test_utilities.py
@@ -13,6 +13,7 @@ import pytest
 from aperag.concurrent_control import (
     RedisLock,
     ThreadingLock,
+    create_distributed_lock,
     create_lock,
     get_default_lock_manager,
     lock_context,
@@ -58,10 +59,36 @@ class TestCreateLockFactory:
         with pytest.raises(ValueError, match="Unknown lock type: invalid"):
             create_lock("invalid")
 
-    def test_create_lock_default_type(self):
-        """Test create_lock with default type."""
-        lock = create_lock()  # Should default to "threading"
+    def test_create_lock_default_type_requires_distributed_key(self, monkeypatch):
+        """Test create_lock defaults to Redis and therefore requires a key or name."""
+        monkeypatch.delenv("APERAG_LOCK_TYPE", raising=False)
+
+        with pytest.raises(TypeError):
+            create_lock()
+
+        lock = create_lock(name="default_distributed")
+        assert isinstance(lock, RedisLock)
+        assert lock._key == "default_distributed"
+
+    def test_create_lock_env_threading_opt_in(self, monkeypatch):
+        """Test APERAG_LOCK_TYPE can opt into local threading locks explicitly."""
+        monkeypatch.setenv("APERAG_LOCK_TYPE", "threading")
+
+        lock = create_lock()
+
         assert isinstance(lock, ThreadingLock)
+
+    def test_create_distributed_lock_public_api(self):
+        """Test public distributed-lock helper."""
+        redis_client = object()
+
+        lock = create_distributed_lock("public_api_lock", ttl=30, redis_client=redis_client)
+
+        assert isinstance(lock, RedisLock)
+        assert lock._key == "public_api_lock"
+        assert lock._name == "public_api_lock"
+        assert lock._expire_time == 30
+        assert lock._redis_client is redis_client
 
     def test_create_redis_lock_missing_key(self):
         """Test creating Redis lock without required key."""


### PR DESCRIPTION
## Scope

Task #38: concurrent_control Redis-first hardening.

- Default lock resolution now uses `APERAG_LOCK_TYPE`, defaulting to `redis` instead of `threading`.
- Added public `create_distributed_lock(...)` API for Redis-backed production locks.
- Kept `threading` locks as explicit opt-in for single-process/test/local usage.
- Serialized RedisLock acquire/release operations and captured owner value before async release work to fix the local `_lock_value` race.
- Latest main already removed old `aperag/service/evaluation_service.py` in #1670/#39, so there is no remaining legacy eval bridge to update in this PR.

## Gates

- `uv run --extra test python -m pytest tests/unit_test/concurrent_control tests/unit_test/test_modularization_boundaries.py -q` -> 110 passed, 3 warnings
- `uv run ruff format --check aperag/concurrent_control tests/unit_test/concurrent_control` -> pass
- `uv run ruff check aperag/concurrent_control tests/unit_test/concurrent_control` -> pass
- `git diff --check` -> pass
- `rg "get_or_create_lock\\(" aperag -g '*.py' -g '!aperag/concurrent_control/manager.py'` -> no production callers
- `rg "lock_type=\\\"threading\\\"|\\\"threading\\\"\\)" aperag -g '*.py' -g '!aperag/concurrent_control/manager.py'` -> no production callers
- `rg "evaluation_service|from aperag\\.concurrent_control\\.redis_lock import RedisLock|RedisLock\\(" aperag -g '*.py'` -> only concurrent_control internals
