### PR TITLE
test(phase8 #44 H3): provider-aware Hurl sync to /api/v2 + v1 ghost guard

### DIFF
--- a/tests/e2e_http/hurl/full/10_provider_llm.hurl
+++ b/tests/e2e_http/hurl/full/10_provider_llm.hurl
@@ -6,12 +6,12 @@ Content-Type: application/json
 }
 HTTP 200
 
-GET {{base_url}}/api/v1/llm_configuration
+GET {{base_url}}/api/v2/providers/configuration
 HTTP 200
 [Asserts]
 header "content-type" contains "application/json"
 
-PUT {{base_url}}/api/v1/llm_providers/alibabacloud
+PUT {{base_url}}/api/v2/providers/alibabacloud
 Content-Type: application/json
 {
   "api_key": "{{alibabacloud_api_key}}"
@@ -20,7 +20,7 @@ HTTP 200
 [Asserts]
 jsonpath "$.name" == "alibabacloud"
 
-PUT {{base_url}}/api/v1/llm_providers/openrouter
+PUT {{base_url}}/api/v2/providers/openrouter
 Content-Type: application/json
 {
   "api_key": "{{openrouter_api_key}}"
@@ -29,14 +29,14 @@ HTTP 200
 [Asserts]
 jsonpath "$.name" == "openrouter"
 
-POST {{base_url}}/api/v1/available_models
+POST {{base_url}}/api/v2/providers/available-models
 Content-Type: application/json
 {}
 HTTP 200
 [Asserts]
 header "content-type" contains "application/json"
 
-POST {{base_url}}/api/v1/available_models
+POST {{base_url}}/api/v2/providers/available-models
 Content-Type: application/json
 {
   "tag_filters": [
@@ -50,15 +50,14 @@ HTTP 200
 [Asserts]
 header "content-type" contains "application/json"
 
-GET {{base_url}}/api/v1/llm_providers/openrouter/models
+GET {{base_url}}/api/v2/providers/openrouter/models
 HTTP 200
 [Asserts]
 header "content-type" contains "application/json"
 
-POST {{base_url}}/api/v1/llm_providers/openrouter/models
+POST {{base_url}}/api/v2/providers/openrouter/models
 Content-Type: application/json
 {
-  "provider_name": "openrouter",
   "api": "completion",
   "model": "test-org/test-model-{{run_id}}",
   "custom_llm_provider": "openrouter",
@@ -70,7 +69,7 @@ HTTP 200
 jsonpath "$.provider_name" == "openrouter"
 jsonpath "$.model" == "test-org/test-model-{{run_id}}"
 
-PUT {{base_url}}/api/v1/llm_providers/openrouter/models/completion/test-org%2Ftest-model-{{run_id}}
+PUT {{base_url}}/api/v2/providers/openrouter/models/completion/test-org%2Ftest-model-{{run_id}}
 Content-Type: application/json
 {
   "context_window": 8192,
@@ -81,10 +80,10 @@ HTTP 200
 jsonpath "$.model" == "test-org/test-model-{{run_id}}"
 jsonpath "$.context_window" == 8192
 
-DELETE {{base_url}}/api/v1/llm_providers/openrouter/models/completion/test-org%2Ftest-model-{{run_id}}
-HTTP 200
+DELETE {{base_url}}/api/v2/providers/openrouter/models/completion/test-org%2Ftest-model-{{run_id}}
+HTTP 204
 
-PUT {{base_url}}/api/v1/default_models
+PUT {{base_url}}/api/v2/default-models
 Content-Type: application/json
 {
   "defaults": [

--- a/tests/unit_test/test_provider_v2_openapi_contract.py
+++ b/tests/unit_test/test_provider_v2_openapi_contract.py
@@ -16,23 +16,16 @@ def _json_ref(spec: dict, path: str, method: str, status: str = "200") -> str:
     return spec["paths"][path][method]["responses"][status]["content"]["application/json"]["schema"]["$ref"]
 
 
-# Known v1 ghost paths in the provider domain. v1 LLM provider / default-models /
-# available-models routes are still wired in main pending the #26 final sweep;
-# this baseline pins the current inventory so we catch unexpected regrowth but
-# allow the #26 sweep to shrink it (subset semantics).
-PROVIDER_V1_GHOST_PATHS = frozenset(
-    {
-        "/api/v1/available_models",
-        "/api/v1/default_models",
-        "/api/v1/llm_configuration",
-        "/api/v1/llm_provider_models",
-        "/api/v1/llm_providers",
-        "/api/v1/llm_providers/{provider_name}",
-        "/api/v1/llm_providers/{provider_name}/models",
-        "/api/v1/llm_providers/{provider_name}/models/{api}/{model}",
-        "/api/v1/llm_providers/{provider_name}/publish",
-    }
-)
+# v1 LLM provider / default-models / available-models routes are no longer mounted on main —
+# the #26 final sweep is complete and only OpenAI-compat ``/api/v1/embeddings`` + ``/api/v1/rerank``
+# remain under ``/api/v1`` (those live in ``llm_routes.py`` and are intentionally outside this
+# baseline because they are the OpenAI-compat permanent allowlist, not v1 ghosts).
+#
+# Baseline is empty: the test now strictly forbids regrowth of any internal v1 LLM/provider
+# CRUD paths (the OpenAI-compat allowlist is excluded by the path filter in
+# ``_provider_v1_ghosts`` below — it only matches ``/api/v1/llm_*`` plus the two specific
+# legacy default/available-models paths).
+PROVIDER_V1_GHOST_PATHS: frozenset[str] = frozenset()
 
 
 def _provider_v1_ghosts(spec: dict) -> set[str]:

--- a/tests/unit_test/test_v1_ghost_guard.py
+++ b/tests/unit_test/test_v1_ghost_guard.py
@@ -1,0 +1,115 @@
+"""Guard against regrowth of internal ``/api/v1`` references in e2e Hurl tests.
+
+The end-state allowlist (canonical D7-1 / msg=8b6b4bc3) is:
+
+- ``/api/v1/embeddings`` — OpenAI-compatible public endpoint, permanent ``/api/v1`` mount
+- ``/api/v1/rerank``     — OpenAI-compatible public endpoint, permanent ``/api/v1`` mount
+
+Phase 8 task #44 (H3) cleaned the provider-aware Hurl suite to use
+``/api/v2/providers/*`` so it no longer hits dead v1 provider CRUD routes.
+A few other domains (apikeys, audit, marketplace, settings, prompts, chat
+ops, export, document upload variants) still legitimately live at
+``/api/v1`` until tasks #50–#52 / #47–#49 land. Those paths are listed
+in ``TRANSITIONAL_V1_PREFIXES`` below and each follow-up PR is expected
+to shrink the set as it migrates the corresponding domain to ``/api/v2``.
+
+This test scans every ``.hurl`` file under ``tests/e2e_http/`` and asserts
+each ``/api/v1/...`` literal matches either the permanent allowlist or a
+transitional prefix, so a future PR can not silently re-introduce dead
+internal v1 CRUD calls.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HURL_ROOT = REPO_ROOT / "tests" / "e2e_http" / "hurl"
+
+# OpenAI-compat permanent allowlist (canonical D7-1 / msg=8b6b4bc3).
+OPENAI_COMPAT_V1_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "/api/v1/embeddings",
+        "/api/v1/rerank",
+    }
+)
+
+# Transitional prefixes — these v1 routes are still mounted in main and used
+# by e2e Hurl as long as the corresponding G* migration tasks have not landed.
+# Each follow-up PR (G4a audit / G4b apikeys / G4c marketplace / G3 prompts /
+# G1 export / G2 settings / G4d chat ops) is expected to remove the matching
+# entry from this set together with its Hurl rewrite.
+#
+# Anything outside both sets is an unrecognised v1 reference and must be
+# either migrated or moved into one of these sets in the same PR.
+TRANSITIONAL_V1_PREFIXES: frozenset[str] = frozenset(
+    {
+        "/api/v1/apikeys",  # G4b → /api/v2/apikeys
+        "/api/v1/audit-logs",  # G4a → /api/v2/audit-logs
+        "/api/v1/marketplace",  # G4c → /api/v2/marketplace
+        "/api/v1/prompts",  # G3  → /api/v2/prompts
+        "/api/v1/settings",  # G2  → /api/v2/settings
+        "/api/v1/collections",  # G1 (export) + G5 (document upload variants)
+        "/api/v1/export-tasks",  # G1  → /api/v2/export-tasks
+        "/api/v1/chats",  # G4d → /api/v2/chats
+        "/api/v1/quotas",  # G5 caller cleanup (FE references only)
+        "/api/v1/system",  # G5 caller cleanup (admin default-quotas)
+        "/api/v1/bots",  # G5 caller cleanup (pytest fixtures)
+        "/api/v1/test",  # G5 caller cleanup (test fixtures)
+    }
+)
+
+V1_PATH_RE = re.compile(r"/api/v1/[A-Za-z0-9_\-/{}.%]+")
+
+
+def _normalise(path: str) -> str:
+    return path.rstrip(",;)\"'")
+
+
+def _is_allowed(path: str) -> bool:
+    if path in OPENAI_COMPAT_V1_ALLOWLIST:
+        return True
+    for prefix in OPENAI_COMPAT_V1_ALLOWLIST | TRANSITIONAL_V1_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/") or path.startswith(prefix + "?"):
+            return True
+    return False
+
+
+def test_e2e_hurl_v1_routes_match_allowlist():
+    offenders: dict[str, set[str]] = {}
+    for hurl in HURL_ROOT.rglob("*.hurl"):
+        text = hurl.read_text()
+        seen: set[str] = set()
+        for raw_match in V1_PATH_RE.findall(text):
+            path = _normalise(raw_match)
+            if not _is_allowed(path):
+                seen.add(path)
+        if seen:
+            offenders[str(hurl.relative_to(REPO_ROOT))] = seen
+
+    assert not offenders, (
+        "tests/e2e_http/hurl/** may only reference /api/v1 paths in the OpenAI-compat "
+        "permanent allowlist or the transitional pre-migration set "
+        "(see TRANSITIONAL_V1_PREFIXES). Unrecognised v1 references must either be "
+        "migrated to /api/v2 or, if they are a new mount, added to the allowlist in "
+        f"the same PR. Offenders:\n{offenders}"
+    )
+
+
+def test_provider_v1_crud_routes_are_gone_from_hurl():
+    """After H3, no Hurl test references the dead provider CRUD/config/default v1 routes."""
+    forbidden_provider_v1 = (
+        "/api/v1/llm_configuration",
+        "/api/v1/llm_providers",
+        "/api/v1/available_models",
+        "/api/v1/default_models",
+    )
+    offenders: dict[str, set[str]] = {}
+    for hurl in HURL_ROOT.rglob("*.hurl"):
+        text = hurl.read_text()
+        seen = {p for p in forbidden_provider_v1 if p in text}
+        if seen:
+            offenders[str(hurl.relative_to(REPO_ROOT))] = seen
+    assert not offenders, (
+        "Provider v1 CRUD/config/default routes have been removed from main; "
+        f"Hurl tests must not reference them. Offenders:\n{offenders}"
+    )


### PR DESCRIPTION
## Summary

Phase 8 第二批 task #44 (H3 — provider-aware Hurl sync after `/api/v1` ghost hard-cut). Sibling to #43 (H1 ruff format sweep, weihong) and #46 (H4 graceful chat collection, chenyexuan).

Per architect canonical D7-1 (msg=8b6b4bc3) `/api/v1/embeddings` and `/api/v1/rerank` are pinned as permanent OpenAI-compat mounts. The other v1 LLM provider routes (`/api/v1/llm_configuration`, `/api/v1/llm_providers/*`, `/api/v1/available_models`, `/api/v1/default_models`) were already removed from main when `providers_v2_routes.py` shipped, so the provider-aware Hurl test was hitting 404s and bringing `e2e-http-smoke` red on every Phase 8 first-batch PR (root cause flagged in #41 H3 evidence by weihong).

## Changes

- **`tests/e2e_http/hurl/full/10_provider_llm.hurl`** — rewrite all internal provider/model/default CRUD calls to `/api/v2/providers/*` and `/api/v2/default-models`. Keep `/api/v1/embeddings` and `/api/v1/rerank` calls unchanged (allowlist). Adjust the create-model body to drop `provider_name` (now path param in v2) and the delete-model assertion to expect 204 (v2 pure-command contract).
- **`tests/unit_test/test_provider_v2_openapi_contract.py`** — empty out `PROVIDER_V1_GHOST_PATHS` baseline; the v1 LLM provider routes are no longer mounted, so the inventory baseline shrinks to zero and the existing stability test now strictly forbids regrowth.
- **`tests/unit_test/test_v1_ghost_guard.py`** — new negative-allowlist guard that scans `tests/e2e_http/hurl/**` and asserts every `/api/v1/...` literal matches either the OpenAI-compat permanent allowlist (`/api/v1/embeddings`, `/api/v1/rerank`) or the transitional pre-migration set (apikeys, audit, marketplace, prompts, settings, export, collections, chats, quotas, system, bots, test). Each follow-up G* PR shrinks `TRANSITIONAL_V1_PREFIXES` as it migrates the corresponding domain to `/api/v2`.

Net: +136 / -29 LOC (1 new test file 115 LOC, 2 edits).

## Scope discipline

This PR strictly does **not** include:
- G5 dead-route caller cleanup outside provider lane (FE quotas/admin/document/marketplace/bot, pytest fixtures) — covered by future G* tasks
- Any backend route changes — backend already removed these routes in earlier work
- Format sweep on other files (handled by #43 H1 — weihong)

## Test plan

- [x] `uv run python -m pytest tests/unit_test/test_v1_ghost_guard.py tests/unit_test/test_provider_v2_openapi_contract.py tests/unit_test/test_modularization_boundaries.py -x -q` → **28 passed**
- [x] `uv run python -m pytest tests/unit_test -q --deselect 'tests/unit_test/test_web_typed_api_contract.py::test_phase1_fe_complete_identity_auth_admin_audit_adapter_boundary'` → **688 passed / 28 skipped / 1 deselected / 0 failed**
- [x] `uv run ruff check aperag/ tests/ config/` → clean
- [x] `uv run ruff format --check tests/unit_test/test_v1_ghost_guard.py` → clean (other tests/ format drift is mainline existing, scoped to #43 H1)
- [ ] e2e-http-smoke `full/10_provider_llm.hurl` — runs in CI; expected to no longer 404 on `/api/v1/llm_configuration` etc.

## CR ask

@Weston blocker-level minimal CR — write-set is provider-aware Hurl + 2 unit tests; no backend touched.
@符炫炜 canonical drift quick check — preserve allowlist (embeddings/rerank), no scope creep into G5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)