### PR TITLE
Phase 8 G2-FE: sync admin settings callers to /api/v2

### DIFF
--- a/tests/unit_test/test_v1_ghost_guard.py
+++ b/tests/unit_test/test_v1_ghost_guard.py
@@ -7,8 +7,8 @@ The end-state allowlist (canonical D7-1 / msg=8b6b4bc3) is:
 
 Phase 8 task #44 (H3) cleaned the provider-aware Hurl suite to use
 ``/api/v2/providers/*`` so it no longer hits dead v1 provider CRUD routes.
-A few other domains (apikeys, audit, marketplace, settings, prompts, chat
-ops, export, document upload variants) still legitimately live at
+A few other domains (apikeys, audit, marketplace, prompts, chat ops, export,
+document upload variants) still legitimately live at
 ``/api/v1`` until tasks #50–#52 / #47–#49 land. Those paths are listed
 in ``TRANSITIONAL_V1_PREFIXES`` below and each follow-up PR is expected
 to shrink the set as it migrates the corresponding domain to ``/api/v2``.
@@ -36,7 +36,7 @@ OPENAI_COMPAT_V1_ALLOWLIST: frozenset[str] = frozenset(
 # Transitional prefixes — these v1 routes are still mounted in main and used
 # by e2e Hurl as long as the corresponding G* migration tasks have not landed.
 # Each follow-up PR (G4a audit / G4b apikeys / G4c marketplace / G3 prompts /
-# G1 export / G2 settings / G4d chat ops) is expected to remove the matching
+# G1 export / G4d chat ops) is expected to remove the matching
 # entry from this set together with its Hurl rewrite.
 #
 # Anything outside both sets is an unrecognised v1 reference and must be
@@ -47,7 +47,6 @@ TRANSITIONAL_V1_PREFIXES: frozenset[str] = frozenset(
         "/api/v1/audit-logs",  # G4a → /api/v2/audit-logs
         "/api/v1/marketplace",  # G4c → /api/v2/marketplace
         "/api/v1/prompts",  # G3  → /api/v2/prompts
-        "/api/v1/settings",  # G2  → /api/v2/settings
         "/api/v1/collections",  # G1 (export) + G5 (document upload variants)
         "/api/v1/export-tasks",  # G1  → /api/v2/export-tasks
         "/api/v1/chats",  # G4d → /api/v2/chats

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -863,7 +863,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/settings": {
+    "/api/v2/settings": {
         parameters: {
             query?: never;
             header?: never;
@@ -881,7 +881,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/settings/parser_health": {
+    "/api/v2/settings/parser_health": {
         parameters: {
             query?: never;
             header?: never;
@@ -898,7 +898,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/settings/test_mineru_token": {
+    "/api/v2/settings/test_mineru_token": {
         parameters: {
             query?: never;
             header?: never;

--- a/web/src/app/admin/configuration/parser-settings.tsx
+++ b/web/src/app/admin/configuration/parser-settings.tsx
@@ -105,7 +105,7 @@ export const ParserSettings = ({
     setHealthLoading(true);
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v1/settings/parser_health`,
+        `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/settings/parser_health`,
         {
           credentials: 'include',
           cache: 'no-store',

--- a/web/src/features/admin/client-api.ts
+++ b/web/src/features/admin/client-api.ts
@@ -19,7 +19,7 @@ import type {
 // kept separate per design-lock msg=5f0a370b decision 2e.
 
 export async function updateSettings(input: Settings): Promise<Settings> {
-  const { data } = await browserApiClient.PUT('/api/v1/settings', {
+  const { data } = await browserApiClient.PUT('/api/v2/settings', {
     body: input,
   });
   if (!data) {
@@ -37,7 +37,7 @@ export async function testMineruToken(
   token: string,
 ): Promise<MineruTokenTestResponse> {
   const { data } = await browserApiClient.POST(
-    '/api/v1/settings/test_mineru_token',
+    '/api/v2/settings/test_mineru_token',
     {
       body: { token },
     },

--- a/web/src/features/admin/server-api.ts
+++ b/web/src/features/admin/server-api.ts
@@ -9,7 +9,7 @@ import type { Settings, SystemDefaultQuotasResponse } from './types';
 
 export async function getSettings(): Promise<Settings | null> {
   const client = await createServerApiClient();
-  const { data } = await client.GET('/api/v1/settings', {});
+  const { data } = await client.GET('/api/v2/settings', {});
   return data ?? null;
 }
 


### PR DESCRIPTION
## Scope
- Switch admin settings FE callers from `/api/v1/settings*` to `/api/v2/settings*` for G2 backend hard-cut PR #1678.
- Update `web/src/api-v2/schema.d.ts` path keys for settings / parser health / MinerU token test.
- No other admin quota/auth routes changed.

## Gates
- `yarn lint`
- `uv run pytest tests/unit_test/test_web_typed_api_contract.py -q` -> 16 passed
- `rg "/api/v1/settings" web/src tests` -> 0 hits
- `git diff --check`

## Sequencing
Pair with backend PR #1678. Preferred merge window: #1678 first, then this PR immediately after (or rebase if #1678 updates generated schema).