### PR TITLE
refactor(phase8/task53/g4d-be): conversation chat ops prefix /api/v1 → /api/v2 (chat-rooted)

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -236,7 +236,7 @@ app.include_router(retrieval_router, prefix="/api/v2", tags=["retrieval"])  # Ad
 app.include_router(
     knowledge_graph_router, prefix="/api/v2", tags=["knowledge_graph"]
 )  # Add knowledge_graph domain router
-app.include_router(chat_router, prefix="/api/v1")
+app.include_router(chat_router, prefix="/api/v2")
 app.include_router(openai_router, prefix="/v1")
 app.include_router(config_router, prefix="/api/v2/config")
 app.include_router(agent_runtime_router, prefix="/api/v2")

--- a/aperag/mcp/server.py
+++ b/aperag/mcp/server.py
@@ -339,7 +339,7 @@ async def search_chat_files(
         # Use longer timeout for search operations
         async with httpx.AsyncClient(timeout=120.0) as client:
             response = await client.post(
-                f"{API_BASE_URL}/api/v1/chats/{chat_id}/search",
+                f"{API_BASE_URL}/api/v2/chats/{chat_id}/search",
                 headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
                 json=search_data,
             )

--- a/tests/unit_test/test_chat_ops_v2_openapi_contract.py
+++ b/tests/unit_test/test_chat_ops_v2_openapi_contract.py
@@ -1,0 +1,75 @@
+"""Phase 8 #53 G4d-BE contract: conversation chat ops mounted at /api/v2.
+
+Locks the architect canonical (Option A, msg≈2026-04-25 16:18 in
+#模块化重构): chat_router prefix migrated from ``/api/v1`` to
+``/api/v2`` while keeping chat-rooted nesting unchanged.
+"""
+
+from __future__ import annotations
+
+from aperag.app import app
+from aperag.openapi_spec import build_full_openapi_spec
+
+# Per-method canonical chat-rooted paths owned by ``chat_router`` (tags=["chats"]).
+# bot-rooted chat CRUD lives in ``bots_router`` (tags=["bots-v2"]) and is out of scope.
+CHAT_OPS_V2_PATHS_BY_METHOD = {
+    "get": {
+        "/api/v2/chats/{chat_id}/feedback",
+        "/api/v2/chats/{chat_id}/documents/{document_id}",
+    },
+    "post": {
+        "/api/v2/chats/{chat_id}/turns/{turn_id}/feedback",
+        "/api/v2/chats/{chat_id}/search",
+        "/api/v2/chats/{chat_id}/documents",
+    },
+    "delete": {
+        "/api/v2/chats/{chat_id}/turns/{turn_id}/feedback",
+    },
+}
+
+
+def _chat_router_paths_by_method(spec: dict) -> dict[str, set[str]]:
+    """Collect paths from the spec keyed by method, restricted to the ``chats`` tag."""
+    out: dict[str, set[str]] = {"get": set(), "post": set(), "delete": set()}
+    for path, operations in (spec.get("paths") or {}).items():
+        if not isinstance(operations, dict):
+            continue
+        for method in ("get", "post", "delete"):
+            op = operations.get(method)
+            if not isinstance(op, dict):
+                continue
+            tags = op.get("tags") or []
+            if "chats" in tags:
+                out[method].add(path)
+    return out
+
+
+def test_chat_ops_mounted_under_api_v2():
+    """Every chat ops route must surface at /api/v2/chats/... (chat-rooted)."""
+    spec = build_full_openapi_spec(app)
+    by_method = _chat_router_paths_by_method(spec)
+    for method, expected_paths in CHAT_OPS_V2_PATHS_BY_METHOD.items():
+        actual_paths = by_method[method]
+        missing = expected_paths - actual_paths
+        assert not missing, (
+            f"chat ops {method.upper()} route(s) missing from /api/v2: {sorted(missing)}. "
+            "Did the chat_router mount prefix get reverted to /api/v1?"
+        )
+
+
+def test_chat_ops_no_v1_ghost():
+    """No chat_router route may remain under /api/v1 after G4d hard-cut."""
+    spec = build_full_openapi_spec(app)
+    by_method = _chat_router_paths_by_method(spec)
+    all_paths = set().union(*by_method.values())
+    v1_chat_ops = {p for p in all_paths if p.startswith("/api/v1/chats/")}
+    assert not v1_chat_ops, f"v1 chat_router ghost paths still present after G4d hard-cut: {sorted(v1_chat_ops)}"
+
+
+def test_chat_ops_chat_rooted_nesting_preserved():
+    """G4d Option A: chat-rooted (/chats/{chat_id}/...), NOT bot-rooted."""
+    spec = build_full_openapi_spec(app)
+    by_method = _chat_router_paths_by_method(spec)
+    all_paths = set().union(*by_method.values())
+    bot_rooted = {p for p in all_paths if "/bots/" in p}
+    assert not bot_rooted, f"chat ops were re-nested under /bots/ — Option A canonical violation: {sorted(bot_rooted)}"


### PR DESCRIPTION
## Summary

G4d backend: hard-cut `chat_router` mount from `/api/v1` to `/api/v2`, keeping the chat-rooted `/chats/{chat_id}/...` nesting unchanged (Option A canonical, locked by 符炫炜 ≈2026-04-25 16:18 in #模块化重构).

## Routes migrated

| Method | Old | New |
|---|---|---|
| GET | `/api/v1/chats/{chat_id}/feedback` | `/api/v2/chats/{chat_id}/feedback` |
| POST | `/api/v1/chats/{chat_id}/turns/{turn_id}/feedback` | `/api/v2/chats/{chat_id}/turns/{turn_id}/feedback` |
| DELETE | `/api/v1/chats/{chat_id}/turns/{turn_id}/feedback` | `/api/v2/chats/{chat_id}/turns/{turn_id}/feedback` |
| POST | `/api/v1/chats/{chat_id}/search` | `/api/v2/chats/{chat_id}/search` |
| POST | `/api/v1/chats/{chat_id}/documents` | `/api/v2/chats/{chat_id}/documents` |
| GET | `/api/v1/chats/{chat_id}/documents/{document_id}` | `/api/v2/chats/{chat_id}/documents/{document_id}` |

`bots_router` v2 chat CRUD (`/api/v2/bots/{bot_id}/chats/...`) is untouched; both routers now coexist under `/api/v2` with non-overlapping paths.

## Scope discipline

- **Hard cut, not alias** per D7-4 canonical (`/api/v1/chats/*` removed entirely)
- **`aperag/app.py:239`** — single mount prefix change `chat_router` `/api/v1` → `/api/v2`
- **`aperag/mcp/server.py:342`** — server-internal MCP `search` call retargeted to keep this PR self-consistent (no FE/external dep)
- **No FE writes** — `web/src/api-v2/schema.d.ts` regen + `web/src/features/bot/client-api.ts` caller swap + Hurl/e2e + `test_web_typed_api_contract.py` assertion update belong to companion task **#54 G4d-FE** (@dongdong claimed)

## Cross-task sequencing

After this PR merges to main, FE clients calling `/api/v1/chats/...` will get 404 until #54 G4d-FE PR also merges. dongdong has #54 claimed and is waiting on this PR's OpenAPI diff to regen `schema.d.ts`. Coordinate merge windows to keep the gap minimal.

## Gate

- `uv run pytest tests/unit_test/test_chat_ops_v2_openapi_contract.py` — 3/3 pass (3 new contract gates)
- `uv run pytest tests/unit_test/test_modularization_boundaries.py` — 21/21 pass (G1-G19 invariants intact)
- `uv run ruff format --check` / `ruff check` — clean
- `make openapi-generate` regenerates spec; tracked artifacts in `web/src/api-v2/` will be regenerated by #54 G4d-FE

## OpenAPI diff (5 paths)

After regen, `openapi.public.json` shifts the chat-rooted paths:
```
- /api/v1/chats/{chat_id}/feedback
+ /api/v2/chats/{chat_id}/feedback
- /api/v1/chats/{chat_id}/turns/{turn_id}/feedback
+ /api/v2/chats/{chat_id}/turns/{turn_id}/feedback
- /api/v1/chats/{chat_id}/search
+ /api/v2/chats/{chat_id}/search
- /api/v1/chats/{chat_id}/documents
+ /api/v2/chats/{chat_id}/documents
- /api/v1/chats/{chat_id}/documents/{document_id}
+ /api/v2/chats/{chat_id}/documents/{document_id}
```

Bot-rooted chat CRUD (`/api/v2/bots/{bot_id}/chats/...`) is unchanged.

## Test plan

- [x] All chat_router routes mounted under `/api/v2`
- [x] No `/api/v1/chats/` ghost remains
- [x] Nesting stays chat-rooted (Option A, no `/bots/` prefix)
- [ ] CI `lint-and-unit` green
- [ ] Companion #54 G4d-FE merges into main (sequencing dependency)

## Closes

Task #53 — Phase 8 第二批 G4d-BE conversation chat ops prefix migrate to /api/v2 (chat-rooted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)