### PR TITLE
Phase 8 G4d-FE: sync chat ops callers to /api/v2

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -1163,7 +1163,7 @@ def test_phase1_fe_complete_identity_auth_admin_audit_adapter_boundary():
     bot_client_api = (REPO_ROOT / "web/src/features/bot/client-api.ts").read_text()
     assert "uploadChatDocument" in bot_client_api
     assert "getChatDocument" in bot_client_api
-    assert "'/api/v1/chats/{chat_id}/documents'" in bot_client_api
+    assert "'/api/v2/chats/{chat_id}/documents'" in bot_client_api
 
     # feature-visibility.ts — document residual swaps
     # `RebuildIndexesRequestIndexTypesEnum` → `DOCUMENT_INDEX_TYPES`.

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -1288,7 +1288,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/chats/{chat_id}/feedback": {
+    "/api/v2/chats/{chat_id}/feedback": {
         parameters: {
             query?: never;
             header?: never;
@@ -1305,7 +1305,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/chats/{chat_id}/turns/{turn_id}/feedback": {
+    "/api/v2/chats/{chat_id}/turns/{turn_id}/feedback": {
         parameters: {
             query?: never;
             header?: never;
@@ -1323,7 +1323,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/chats/{chat_id}/search": {
+    "/api/v2/chats/{chat_id}/search": {
         parameters: {
             query?: never;
             header?: never;
@@ -1343,7 +1343,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/chats/{chat_id}/documents": {
+    "/api/v2/chats/{chat_id}/documents": {
         parameters: {
             query?: never;
             header?: never;
@@ -1363,7 +1363,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/chats/{chat_id}/documents/{document_id}": {
+    "/api/v2/chats/{chat_id}/documents/{document_id}": {
         parameters: {
             query?: never;
             header?: never;

--- a/web/src/components/chat/chat-messages.tsx
+++ b/web/src/components/chat/chat-messages.tsx
@@ -24,7 +24,7 @@ import { ChatInput, ChatInputSubmitParams } from './chat-input';
 import { MessagePartsAi } from './message-parts-ai';
 import { MessagePartsUser } from './message-parts-user';
 
-const API_BASE_PATH = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v1`;
+const API_BASE_PATH = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2`;
 const AGENT_RUNTIME_BASE_PATH = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/agent`;
 const ACTIVE_TURN_STORAGE_PREFIX = 'agent-runtime-v3:active-turn:';
 

--- a/web/src/features/bot/client-api.ts
+++ b/web/src/features/bot/client-api.ts
@@ -173,7 +173,7 @@ export async function generateBotChatTitle(
 }
 
 // Chat document attachment (for chat-input.tsx). Thin typed wrap of
-// `/api/v1/chats/{chat_id}/documents` (POST multipart upload +
+// `/api/v2/chats/{chat_id}/documents` (POST multipart upload +
 // GET {document_id} status poll). Lives in bot feature because chats are
 // owned by the bot domain; no separate features/chat/* surface per
 // design-lock msg=5f0a370b decision 2d.
@@ -183,7 +183,7 @@ export async function uploadChatDocument(
   file: File,
 ): Promise<Document> {
   const { data } = await browserApiClient.POST(
-    '/api/v1/chats/{chat_id}/documents',
+    '/api/v2/chats/{chat_id}/documents',
     {
       params: { path: { chat_id: chatId } },
       body: { file: file as unknown as string },
@@ -205,7 +205,7 @@ export async function getChatDocument(
   documentId: string,
 ): Promise<Document> {
   const { data } = await browserApiClient.GET(
-    '/api/v1/chats/{chat_id}/documents/{document_id}',
+    '/api/v2/chats/{chat_id}/documents/{document_id}',
     {
       params: { path: { chat_id: chatId, document_id: documentId } },
     },


### PR DESCRIPTION
## Scope
- Sync chat ops FE callers from `/api/v1/chats/...` to `/api/v2/chats/...` after backend PR #1680.
- Preserve chat-rooted nesting. No bot-rooted redesign.
- Update `web/src/api-v2/schema.d.ts` path keys for feedback, turn feedback, search, and chat documents.
- Update the typed contract assertion for chat document uploads.

## Gates
- `yarn lint`
- `uv run pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_chat_ops_v2_openapi_contract.py -q` -> 19 passed
- `rg "/api/v1/chats" web/src tests/e2e_http tests/e2e_pytest tests/unit_test --glob "!tests/unit_test/test_chat_ops_v2_openapi_contract.py"` -> 0 hits
- `git diff --check`

## Sequencing
Backend PR #1680 is merged at `13f9e7c3`; this PR closes the FE/schema/hurl-e2e side of G4d.