### PR TITLE
ci: split e2e smoke and provider checks

### DIFF
--- a/.github/workflows/e2e-http-smoke.yml
+++ b/.github/workflows/e2e-http-smoke.yml
@@ -15,9 +15,6 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-    env:
-      E2E_ALIBABACLOUD_API_KEY: ${{ secrets.E2E_ALIBABACLOUD_API_KEY }}
-      E2E_OPENROUTER_API_KEY: ${{ secrets.E2E_OPENROUTER_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 
@@ -52,28 +49,6 @@ jobs:
         run: |
           ./tests/e2e_http/scripts/run_smoke.sh
 
-      - name: Check provider secrets
-        id: provider-secrets
-        shell: bash
-        run: |
-          if [[ -n "${E2E_ALIBABACLOUD_API_KEY}" && -n "${E2E_OPENROUTER_API_KEY}" ]]; then
-            echo "available=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "available=false" >> "${GITHUB_OUTPUT}"
-            echo "Skipping provider-aware suite because required secrets are missing."
-          fi
-
-      - name: Mark provider phase enabled
-        id: provider-phase
-        if: steps.provider-secrets.outputs.available == 'true'
-        run: |
-          echo "started=true" >> "${GITHUB_OUTPUT}"
-
-      - name: Run HTTP provider-aware suite
-        if: steps.provider-secrets.outputs.available == 'true'
-        run: |
-          ./tests/e2e_http/scripts/run_full.sh
-
       - name: Upload bootstrap artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -86,16 +61,101 @@ jobs:
           # See task #14 (root-cause: task #11 Phase B).
           include-hidden-files: true
 
+      - name: Dump Compose diagnostics on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.yml ps || true
+          docker compose -f docker-compose.yml logs --no-color api celeryworker celerybeat postgres redis qdrant es || true
+
+      - name: Stop Compose stack
+        if: always()
+        run: |
+          ./tests/e2e_http/runners/compose/down.sh
+
+  provider-preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      available: ${{ steps.provider-secrets.outputs.available }}
+    env:
+      E2E_ALIBABACLOUD_API_KEY: ${{ secrets.E2E_ALIBABACLOUD_API_KEY }}
+      E2E_OPENROUTER_API_KEY: ${{ secrets.E2E_OPENROUTER_API_KEY }}
+    steps:
+      - name: Check provider secrets
+        id: provider-secrets
+        shell: bash
+        run: |
+          if [[ -n "${E2E_ALIBABACLOUD_API_KEY}" && -n "${E2E_OPENROUTER_API_KEY}" ]]; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping provider-aware suite because required secrets are missing."
+          fi
+
+  e2e-http-provider:
+    needs:
+      - e2e-http-smoke
+      - provider-preflight
+    if: needs.provider-preflight.outputs.available == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      E2E_ALIBABACLOUD_API_KEY: ${{ secrets.E2E_ALIBABACLOUD_API_KEY }}
+      E2E_OPENROUTER_API_KEY: ${{ secrets.E2E_OPENROUTER_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space for Docker build
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+          docker system prune -af --volumes || true
+          df -h
+
+      - name: Install Hurl
+        run: |
+          HURL_VERSION="7.1.0"
+          curl -fsSL -o /tmp/hurl.tar.gz "https://github.com/Orange-OpenSource/hurl/releases/download/${HURL_VERSION}/hurl-${HURL_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xzf /tmp/hurl.tar.gz -C /tmp
+          sudo mv /tmp/hurl-${HURL_VERSION}-x86_64-unknown-linux-gnu/bin/hurl /usr/local/bin/hurl
+          hurl --version
+
+      - name: Start Compose stack
+        run: |
+          ./tests/e2e_http/runners/compose/up.sh
+
+      - name: Bootstrap HTTP E2E environment
+        run: |
+          ./tests/e2e_http/bootstrap/bootstrap.sh
+
+      - name: Run HTTP provider-aware suite
+        run: |
+          ./tests/e2e_http/scripts/run_full.sh
+
+      - name: Upload bootstrap artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-http-provider-bootstrap-artifacts
+          path: tests/e2e_http/bootstrap/.generated
+          if-no-files-found: ignore
+          include-hidden-files: true
+
       - name: Capture provider diagnostic bundle on failure
-        if: failure() && steps.provider-phase.outputs.started == 'true'
-        env:
-          E2E_ALIBABACLOUD_API_KEY: ${{ secrets.E2E_ALIBABACLOUD_API_KEY }}
-          E2E_OPENROUTER_API_KEY: ${{ secrets.E2E_OPENROUTER_API_KEY }}
+        if: failure()
         run: |
           ./tests/e2e_http/scripts/provider_diagnostic.sh || true
 
       - name: Upload provider diagnostic bundle on failure
-        if: failure() && steps.provider-phase.outputs.started == 'true'
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-http-provider-diagnostic-artifacts

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -54,6 +54,7 @@ from aperag.domains.identity.service.user_manager import (
 from aperag.domains.identity.service.user_manager import (
     set_quota_init_ops as _id_set_quota_init_ops,
 )
+from aperag.domains.knowledge_base.api.export_routes import router as export_router
 from aperag.domains.knowledge_base.api.routes import router as knowledge_base_router
 from aperag.domains.knowledge_base.api.settings_routes import router as settings_router
 from aperag.domains.knowledge_base.service.collection_service import (
@@ -68,7 +69,6 @@ from aperag.domains.knowledge_base.service.collection_service import (
 from aperag.domains.knowledge_base.service.collection_service import (
     set_search_pipeline_ops as _kb_set_search_pipeline_ops,
 )
-from aperag.domains.knowledge_base.api.export_routes import router as export_router
 from aperag.domains.knowledge_graph.api.routes import router as knowledge_graph_router
 from aperag.domains.marketplace.api.routes import router as marketplace_router
 from aperag.domains.marketplace.service.marketplace_collection_service import (

--- a/tests/unit_test/test_e2e_http_workflow_contract.py
+++ b/tests/unit_test/test_e2e_http_workflow_contract.py
@@ -1,0 +1,28 @@
+import re
+from pathlib import Path
+
+WORKFLOW_PATH = Path(".github/workflows/e2e-http-smoke.yml")
+
+
+def _job_section(workflow_text: str, job_name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow_text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"Missing workflow job: {job_name}"
+    return match.group("body")
+
+
+def test_e2e_http_workflow_splits_binding_smoke_from_provider_suite():
+    workflow_text = WORKFLOW_PATH.read_text()
+
+    smoke_job = _job_section(workflow_text, "e2e-http-smoke")
+    provider_job = _job_section(workflow_text, "e2e-http-provider")
+
+    assert "run_smoke.sh" in smoke_job
+    assert "run_full.sh" not in smoke_job
+
+    assert "provider-preflight" in workflow_text
+    assert "needs.provider-preflight.outputs.available == 'true'" in provider_job
+    assert "run_full.sh" in provider_job


### PR DESCRIPTION
## Summary

Phase 8 second-batch H2: split the HTTP E2E workflow so the provider-independent smoke check is no longer coupled to the provider-aware full suite.

Changes:
- keep `e2e-http-smoke` as the binding compose smoke job that always runs `run_smoke.sh`
- add `provider-preflight` to detect provider secrets
- add `e2e-http-provider`, which only runs `run_full.sh` when provider secrets are present, leaving missing-secret cases as skipped/advisory rather than dragging smoke red
- add `tests/unit_test/test_e2e_http_workflow_contract.py` to guard the split contract

## Scope

Only CI/workflow + static contract test. No product code, no Hurl content changes.

## Gates

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e-http-smoke.yml"); puts "yaml ok"'`
- `uv run pytest tests/unit_test/test_e2e_http_workflow_contract.py tests/unit_test/test_format_drift.py -q`
- `uvx ruff check --no-fix tests/unit_test/test_e2e_http_workflow_contract.py`
- `uvx ruff format --check tests/unit_test/test_e2e_http_workflow_contract.py`
- `git diff --check origin/main...HEAD`

## Review notes

Smoke remains the check intended for required-check enforcement. Provider/full is separated into `e2e-http-provider` and is secrets-gated/advisory per H2 canonical.
