### PR TITLE
refactor(phase8-g3): carve prompts v1 shim to model_platform domain (#49)

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -78,6 +78,8 @@ from aperag.domains.marketplace.service.marketplace_service import (
     marketplace_service as _legacy_marketplace_service,
 )
 from aperag.domains.model_platform.api.llm_routes import router as llm_router
+from aperag.domains.model_platform.api.prompts_routes import router as prompts_router
+from aperag.domains.model_platform.api.prompts_routes import set_prompt_crud_ops as _set_prompt_crud_ops
 from aperag.domains.model_platform.api.providers_v2_routes import router as providers_v2_router
 from aperag.domains.retrieval.api.routes import router as retrieval_router
 from aperag.domains.web_access.api.routes import router as web_access_router
@@ -87,7 +89,6 @@ from aperag.mcp import mcp_server
 from aperag.openapi_spec import custom_generate_unique_id
 from aperag.service.quota_service import quota_service as _legacy_quota_service
 from aperag.service.search_pipeline_service import search_pipeline_service as _legacy_search_pipeline_service
-from aperag.views.prompts import router as prompts_router
 
 # Wire the knowledge_base domain's consumer-owned Protocol DI slots
 # (Phase 3 Step 5b2c). All four legacy service singletons now
@@ -141,6 +142,13 @@ class _PromptTemplateOpsAdapter:
 
 
 _ar_set_prompt_template_ops(_PromptTemplateOpsAdapter())
+
+# Wire the model_platform domain's prompt user-CRUD Protocol seam
+# (Phase 8 #49 G3, D7 v2 hard-cut). The same ``prompt_template_service``
+# singleton already wired into agent_runtime structurally satisfies
+# the model_platform ``PromptCRUDOps`` Protocol — the user-CRUD method
+# names map 1:1, so no adapter is needed.
+_set_prompt_crud_ops(_legacy_prompt_template_service)
 
 
 # Wire the identity domain's consumer-owned Protocol DI slots (Phase
@@ -230,7 +238,7 @@ app.include_router(
     marketplace_router, prefix="/api/v1"
 )  # Marketplace domain router (marketplace + marketplace_collections)
 app.include_router(settings_router, prefix="/api/v2")  # KB domain settings (carved from views/ in #48)
-app.include_router(prompts_router, prefix="/api/v1")  # Add prompts router
+app.include_router(prompts_router, prefix="/api/v2")  # Phase 8 #49 G3, D7 v2 hard-cut
 app.include_router(web_access_router, prefix="/api/v2", tags=["web_access"])  # Add web_access domain router
 app.include_router(retrieval_router, prefix="/api/v2", tags=["retrieval"])  # Add retrieval domain router
 app.include_router(

--- a/aperag/domains/model_platform/api/prompts_routes.py
+++ b/aperag/domains/model_platform/api/prompts_routes.py
@@ -12,18 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Prompt template HTTP router (Phase 8 #49 G3 carve, D7 v2 hard-cut).
+
+Carved from legacy ``aperag/views/prompts.py``. URL prefix migrated
+from ``/api/v1/prompts*`` to ``/api/v2/prompts*`` per D7 canonical
+(msg=94f663f2 §3.2.2). The user-CRUD ops are still backed by the
+legacy ``aperag/service/prompt_template_service.py`` (Layer A
+permanent seam, shared with agent_runtime); this module accesses
+the singleton through the ``PromptCRUDOps`` Protocol seam wired at
+app startup via ``set_prompt_crud_ops()``.
+"""
+
+from __future__ import annotations
+
 import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from jinja2 import TemplateSyntaxError
+from jinja2 import Template, TemplateSyntaxError
 from pydantic import BaseModel, Field
 
-from aperag.domains.identity.db.models import User
 from aperag.domains.identity.service.auth_dependencies import required_user
-from aperag.service.prompt_template_service import PromptTemplateService, prompt_template_service
+from aperag.domains.model_platform.ports import AuthenticatedUser, PromptCRUDOps
 
 logger = logging.getLogger(__name__)
+
+# Module-level DI seam: ``aperag/app.py`` calls ``set_prompt_crud_ops()``
+# at startup to wire the legacy ``prompt_template_service`` singleton
+# (the same one already wired into agent_runtime). The singleton
+# structurally satisfies the ``PromptCRUDOps`` Protocol — its public
+# user-CRUD method names map 1:1.
+_prompt_crud_ops: Optional[PromptCRUDOps] = None
+
+
+def set_prompt_crud_ops(ops: PromptCRUDOps) -> None:
+    """Inject the ``PromptCRUDOps`` Protocol implementation at app startup.
+
+    Idempotent so repeated wiring (e.g. test re-initialization) does
+    not raise.
+    """
+    global _prompt_crud_ops
+    _prompt_crud_ops = ops
+
+
+def _get_prompt_crud_ops() -> PromptCRUDOps:
+    if _prompt_crud_ops is None:
+        raise RuntimeError(
+            "PromptCRUDOps not wired. aperag/app.py must call "
+            "set_prompt_crud_ops() at startup."
+        )
+    return _prompt_crud_ops
+
 
 router = APIRouter(tags=["prompts"])
 
@@ -61,7 +100,7 @@ class ValidateRequest(BaseModel):
 @router.get("/prompts/user", tags=["prompts"])
 async def get_user_prompts(
     request: Request,
-    user: User = Depends(required_user),
+    user: AuthenticatedUser = Depends(required_user),
 ) -> Dict[str, Any]:
     """
     Get user's prompt configuration with priority resolution.
@@ -72,12 +111,15 @@ async def get_user_prompts(
     - customized: Whether user has customized this prompt
     - description: Optional description
     """
-    return await prompt_template_service.get_user_prompts(user_id=str(user.id))
+    ops = _get_prompt_crud_ops()
+    return await ops.get_user_prompts(user_id=str(user.id))
 
 
 @router.put("/prompts/user", tags=["prompts"])
 async def update_user_prompts(
-    request: Request, body: UpdateUserPromptsRequest, user: User = Depends(required_user)
+    request: Request,
+    body: UpdateUserPromptsRequest,
+    user: AuthenticatedUser = Depends(required_user),
 ) -> Dict[str, Any]:
     """
     Batch update user's prompt configurations.
@@ -92,13 +134,12 @@ async def update_user_prompts(
     # Validate Jinja2 template syntax
     try:
         for content in prompts_dict.values():
-            from jinja2 import Template
-
             Template(content)
     except TemplateSyntaxError as e:
         raise HTTPException(status_code=400, detail=f"Template syntax error: {str(e)}")
 
-    updated = await prompt_template_service.update_user_prompts(user_id=str(user.id), prompts=prompts_dict)
+    ops = _get_prompt_crud_ops()
+    updated = await ops.update_user_prompts(user_id=str(user.id), prompts=prompts_dict)
 
     return {"message": "Prompts updated successfully", "updated": updated}
 
@@ -107,20 +148,21 @@ async def update_user_prompts(
 async def delete_user_prompt(
     request: Request,
     prompt_type: str,
-    user: User = Depends(required_user),
+    user: AuthenticatedUser = Depends(required_user),
 ) -> Dict[str, Any]:
     """
     Delete user's specific prompt configuration (reset to system default).
 
     Returns the new effective content after deletion.
     """
-    if prompt_type not in PromptTemplateService.PROMPT_TYPES:
+    ops = _get_prompt_crud_ops()
+    if prompt_type not in ops.PROMPT_TYPES:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid prompt type: {prompt_type}. Valid types: {PromptTemplateService.PROMPT_TYPES}",
+            detail=f"Invalid prompt type: {prompt_type}. Valid types: {ops.PROMPT_TYPES}",
         )
 
-    result = await prompt_template_service.delete_user_prompt(user_id=str(user.id), prompt_type=prompt_type)
+    result = await ops.delete_user_prompt(user_id=str(user.id), prompt_type=prompt_type)
 
     if not result["deleted"]:
         raise HTTPException(status_code=404, detail=f"User has not customized {prompt_type} prompt")
@@ -135,22 +177,25 @@ async def delete_user_prompt(
 
 @router.post("/prompts/user/reset", tags=["prompts"])
 async def reset_user_prompts(
-    request: Request, body: ResetPromptsRequest, user: User = Depends(required_user)
+    request: Request,
+    body: ResetPromptsRequest,
+    user: AuthenticatedUser = Depends(required_user),
 ) -> Dict[str, Any]:
     """
     Batch reset user's prompt configurations.
 
     If 'types' is not provided, resets all prompts.
     """
+    ops = _get_prompt_crud_ops()
     if body.types:
-        invalid_types = [t for t in body.types if t not in PromptTemplateService.PROMPT_TYPES]
+        invalid_types = [t for t in body.types if t not in ops.PROMPT_TYPES]
         if invalid_types:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid prompt types: {invalid_types}. Valid types: {PromptTemplateService.PROMPT_TYPES}",
+                detail=f"Invalid prompt types: {invalid_types}. Valid types: {ops.PROMPT_TYPES}",
             )
 
-    reset = await prompt_template_service.reset_user_prompts(user_id=str(user.id), types=body.types)
+    reset = await ops.reset_user_prompts(user_id=str(user.id), types=body.types)
 
     return {"message": "Prompts reset successfully", "reset": reset}
 
@@ -162,31 +207,37 @@ async def reset_user_prompts(
 async def get_system_prompts(
     request: Request,
     type: Optional[str] = None,
-    user: User = Depends(required_user),
+    user: AuthenticatedUser = Depends(required_user),
 ):
     """
     Get system default prompts (for reference).
 
     Can query a specific type or all types.
     """
-    if type and type not in PromptTemplateService.PROMPT_TYPES:
+    ops = _get_prompt_crud_ops()
+    if type and type not in ops.PROMPT_TYPES:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid prompt type: {type}. Valid types: {PromptTemplateService.PROMPT_TYPES}",
+            detail=f"Invalid prompt type: {type}. Valid types: {ops.PROMPT_TYPES}",
         )
-    return await prompt_template_service.get_system_prompts(prompt_type=type)
+    return await ops.get_system_prompts(prompt_type=type)
 
 
 # === Helper utilities ===
 
 
 @router.post("/prompts/preview", tags=["prompts"])
-async def preview_prompt(request: Request, body: PreviewRequest, user: User = Depends(required_user)) -> Dict[str, str]:
+async def preview_prompt(
+    request: Request,
+    body: PreviewRequest,
+    user: AuthenticatedUser = Depends(required_user),
+) -> Dict[str, str]:
     """
     Preview how a prompt template will be rendered with given variables.
     """
+    ops = _get_prompt_crud_ops()
     try:
-        rendered = prompt_template_service.preview_prompt(body.template, body.variables or {})
+        rendered = ops.preview_prompt(body.template, body.variables or {})
         return {"rendered": rendered}
     except TemplateSyntaxError as e:
         raise HTTPException(status_code=400, detail=f"Template syntax error: {str(e)}")
@@ -196,10 +247,13 @@ async def preview_prompt(request: Request, body: PreviewRequest, user: User = De
 
 @router.post("/prompts/validate", tags=["prompts"])
 async def validate_prompt(
-    request: Request, body: ValidateRequest, user: User = Depends(required_user)
+    request: Request,
+    body: ValidateRequest,
+    user: AuthenticatedUser = Depends(required_user),
 ) -> Dict[str, Any]:
     """
     Validate prompt template syntax (Jinja2) and check for required variables.
     """
-    result = prompt_template_service.validate_prompt(body.type, body.template)
+    ops = _get_prompt_crud_ops()
+    result = ops.validate_prompt(body.type, body.template)
     return result

--- a/aperag/domains/model_platform/ports.py
+++ b/aperag/domains/model_platform/ports.py
@@ -32,7 +32,7 @@ additive extension.
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -47,6 +47,43 @@ class AuthenticatedUser(Protocol):
     role: str
 
 
+@runtime_checkable
+class PromptCRUDOps(Protocol):
+    """User-CRUD ops for prompt templates (Phase 8 #49 G3).
+
+    The model_platform domain owns the ``PromptTemplate`` ORM but the
+    user-CRUD service still lives in the legacy
+    ``aperag/service/prompt_template_service.py`` (Layer A permanent
+    seam shared with agent_runtime). This Protocol is the
+    consumer-owned interface that the prompts route depends on; the
+    legacy service singleton is wired in at app startup via
+    ``set_prompt_crud_ops()``.
+
+    The methods mirror the public surface of
+    ``PromptTemplateService`` that the route module needs — the
+    legacy singleton structurally satisfies them 1:1.
+    """
+
+    PROMPT_TYPES: List[str]
+
+    async def get_user_prompts(self, user_id: str) -> Dict[str, Dict[str, Any]]: ...
+
+    async def update_user_prompts(self, user_id: str, prompts: Dict[str, str]) -> List[str]: ...
+
+    async def delete_user_prompt(self, user_id: str, prompt_type: str) -> Dict[str, Any]: ...
+
+    async def reset_user_prompts(
+        self, user_id: str, types: Optional[List[str]] = None
+    ) -> List[str]: ...
+
+    async def get_system_prompts(self, prompt_type: Optional[str] = None) -> Dict[str, Any]: ...
+
+    def preview_prompt(self, template: str, variables: Dict[str, Any]) -> str: ...
+
+    def validate_prompt(self, prompt_type: str, template: str) -> Dict[str, Any]: ...
+
+
 __all__ = [
     "AuthenticatedUser",
+    "PromptCRUDOps",
 ]

--- a/docs/frontend-rewrite/mismatch-registry.md
+++ b/docs/frontend-rewrite/mismatch-registry.md
@@ -86,7 +86,7 @@ Existing `web/` is largely complete; rewrite revises tokens + composition + copy
 
 These features exist in the API and stay in product; the rewrite covers them in the `tokens.jsx` visual language per earayu2 principle #1.
 
-- Prompt template CRUD (`GET/PUT /api/v1/prompts/user`)
+- Prompt template CRUD (`GET/PUT /api/v2/prompts/user`)
 - API keys (`GET/POST/PUT/DELETE /api/v1/apikeys`)
 - Quotas page (`GET /api/v1/quotas`) — numeric only, no budget framing
 - Audit logs (`GET /api/v1/audit-logs`)

--- a/docs/zh-CN/admin-guide/prompt-customization.md
+++ b/docs/zh-CN/admin-guide/prompt-customization.md
@@ -60,7 +60,7 @@ Prompt 的生效顺序是典型的"越靠近这次调用的配置，越先赢"�
 
 ## 3. 用户层自定义（推荐的常用入口）
 
-用户层是介于"全局默认"和"单个 Bot/Collection 覆盖"之间的中间层，`/api/v1/prompts/*` 完整支持：
+用户层是介于"全局默认"和"单个 Bot/Collection 覆盖"之间的中间层，`/api/v2/prompts/*` 完整支持：
 
 | 动作 | 接口 | 说明 |
 | --- | --- | --- |
@@ -133,4 +133,4 @@ Prompt 的生效顺序是典型的"越靠近这次调用的配置，越先赢"�
 
 ## 7. 服务归属说明
 
-Prompt 相关的所有逻辑集中在 standalone-infra 模块 `aperag.service.prompt_template_service`：该模块跨 agent_runtime（运行时调用）/ conversation（bot-config 解析）/ indexing（reconciler）/ `/api/v1/prompts` REST 四个场景共享，没有自然的 domain 归属。agent_runtime 通过 `aperag.domains.agent_runtime.ports.PromptTemplateOps` Protocol + `aperag/app.py::_PromptTemplateOpsAdapter` wire-up 访问它（这是系统仅有的两条永久 `CRITICAL_WIRINGS` 之一）。具体架构背景见 [`architecture/conversation-agent-evaluation.md`](../architecture/conversation-agent-evaluation.md#protocol-promptTemplateOps)。
+Prompt 相关的所有逻辑集中在 standalone-infra 模块 `aperag.service.prompt_template_service`：该模块跨 agent_runtime（运行时调用）/ conversation（bot-config 解析）/ indexing（reconciler）/ `/api/v2/prompts` REST 四个场景共享，没有自然的 domain 归属。Phase 8 #49 G3 起，REST 路由本身已碎入 `aperag/domains/model_platform/api/prompts_routes.py`，通过 `model_platform.ports.PromptCRUDOps` Protocol + `aperag/app.py::set_prompt_crud_ops()` wire 同一个单例；agent_runtime 仍通过 `aperag.domains.agent_runtime.ports.PromptTemplateOps` Protocol + `aperag/app.py::_PromptTemplateOpsAdapter` wire-up 访问它。具体架构背景见 [`architecture/conversation-agent-evaluation.md`](../architecture/conversation-agent-evaluation.md#protocol-promptTemplateOps)。

--- a/docs/zh-CN/architecture/conversation-agent-evaluation.md
+++ b/docs/zh-CN/architecture/conversation-agent-evaluation.md
@@ -127,7 +127,7 @@ class PromptTemplateOps(Protocol):
     def build_agent_query_prompt(self, chat_id, *, agent_message, user, template=None, has_chat_files=False) -> str: ...
 ```
 
-provider 是 `aperag.service.prompt_template_service`（standalone-infra — prompts 的解析逻辑跨 agent_runtime / conversation / indexing / `/api/v1/prompts` REST 四处共享，没有自然 domain 归属）。`aperag/app.py` 在启动时用 `_PromptTemplateOpsAdapter` 把具体服务 wire 进 runtime 的 `_prompt_template_ops` slot，详见 [`architecture.md §5.1`](../../modularization/architecture.md#51-the-phase-5-permanent-two-entry-registry-g18-alt)。
+provider 是 `aperag.service.prompt_template_service`（standalone-infra — prompts 的解析逻辑跨 agent_runtime / conversation / indexing / `/api/v2/prompts` REST 四处共享，没有自然 domain 归属。Phase 8 #49 G3 起 REST 路由碎入 `aperag/domains/model_platform/api/prompts_routes.py`，通过 model_platform 的 `PromptCRUDOps` Protocol wire 同一单例；底层服务文件不动）。`aperag/app.py` 在启动时用 `_PromptTemplateOpsAdapter` 把具体服务 wire 进 runtime 的 `_prompt_template_ops` slot，详见 [`architecture.md §5.1`](../../modularization/architecture.md#51-the-phase-5-permanent-two-entry-registry-g18-alt)。
 
 `_prompt_template_ops` 是 G18 alt 永久 `CRITICAL_WIRINGS` 的两条之一；`test_phase5_di_critical_wirings_at_app_startup` 在 CI 上守住 "import aperag.app 后 slot 必须非 None"。
 

--- a/docs/zh-CN/reference/prompt-api.md
+++ b/docs/zh-CN/reference/prompt-api.md
@@ -5,11 +5,11 @@ position: 20
 
 # Prompt API 参考
 
-本文提供 `/api/v1/prompts/*` 系列接口的 curl 示例与期望行为说明，便于前端集成、自动化测试以及回归验证。关于 prompt 的三层优先级、Bot 配置交互与管理 UX，见 [`admin-guide/prompt-customization.md`](../admin-guide/prompt-customization.md)。关于 prompt_template_service 在后端架构中的 standalone-infra + Protocol+DI 定位，见 [`architecture/conversation-agent-evaluation.md`](../architecture/conversation-agent-evaluation.md#protocol-promptTemplateOps)。
+本文提供 `/api/v2/prompts/*` 系列接口的 curl 示例与期望行为说明，便于前端集成、自动化测试以及回归验证。关于 prompt 的三层优先级、Bot 配置交互与管理 UX，见 [`admin-guide/prompt-customization.md`](../admin-guide/prompt-customization.md)。关于 prompt_template_service 在后端架构中的 standalone-infra + Protocol+DI 定位，见 [`architecture/conversation-agent-evaluation.md`](../architecture/conversation-agent-evaluation.md#protocol-promptTemplateOps)。
 
-- **Base URL**：`http://localhost:8000/api/v1`
+- **Base URL**：`http://localhost:8000/api/v2`
 - **Auth**：`Authorization: Bearer sk-<your-api-key>`
-- **Route host**：当前仍落在 `aperag/views/prompts.py`（standalone-infra legacy view）；调用的服务是 `aperag.service.prompt_template_service` 单例。
+- **Route host**：Phase 8 #49 G3 已碎入 `aperag/domains/model_platform/api/prompts_routes.py`（D7 v2 hard-cut）；底层 user-CRUD 服务仍是 `aperag.service.prompt_template_service` 单例（Layer A 永久 seam，agent_runtime 共享），通过 `PromptCRUDOps` Protocol + `set_prompt_crud_ops()` 在 `aperag/app.py` 启动时 wire。
 
 所有示例把 Bearer token 写成占位符 `sk-<your-api-key>`，请在本地自行替换。接口的返回值以 JSON 表示，为了简洁本文只列出关键字段。
 
@@ -20,7 +20,7 @@ position: 20
 返回当前用户 5 种 prompt 的**有效内容**（合并过三层优先级后的结果），并在每一项上标注来源。
 
 ```bash
-curl -X GET 'http://localhost:8000/api/v1/prompts/user' \
+curl -X GET 'http://localhost:8000/api/v2/prompts/user' \
   -H 'Authorization: Bearer sk-<your-api-key>'
 ```
 
@@ -39,7 +39,7 @@ curl -X GET 'http://localhost:8000/api/v1/prompts/user' \
 只更新请求体里给出的字段，未出现的字段保持不变。
 
 ```bash
-curl -X PUT 'http://localhost:8000/api/v1/prompts/user' \
+curl -X PUT 'http://localhost:8000/api/v2/prompts/user' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer sk-<your-api-key>' \
   -d '{
@@ -58,11 +58,11 @@ curl -X PUT 'http://localhost:8000/api/v1/prompts/user' \
 
 ```bash
 # 获取所有系统默认
-curl -X GET 'http://localhost:8000/api/v1/prompts/system' \
+curl -X GET 'http://localhost:8000/api/v2/prompts/system' \
   -H 'Authorization: Bearer sk-<your-api-key>'
 
 # 仅获取 agent_system 一项
-curl -X GET 'http://localhost:8000/api/v1/prompts/system?type=agent_system' \
+curl -X GET 'http://localhost:8000/api/v2/prompts/system?type=agent_system' \
   -H 'Authorization: Bearer sk-<your-api-key>'
 ```
 
@@ -72,7 +72,7 @@ curl -X GET 'http://localhost:8000/api/v1/prompts/system?type=agent_system' \
 
 ```bash
 # 正常重置
-curl -X DELETE 'http://localhost:8000/api/v1/prompts/user/agent_system' \
+curl -X DELETE 'http://localhost:8000/api/v2/prompts/user/agent_system' \
   -H 'Authorization: Bearer sk-<your-api-key>'
 ```
 
@@ -88,13 +88,13 @@ curl -X DELETE 'http://localhost:8000/api/v1/prompts/user/agent_system' \
 
 ```bash
 # 重置指定类型
-curl -X POST 'http://localhost:8000/api/v1/prompts/user/reset' \
+curl -X POST 'http://localhost:8000/api/v2/prompts/user/reset' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer sk-<your-api-key>' \
   -d '{"types": ["agent_system", "index_graph"]}'
 
 # 省略 types：重置所有已自定义项
-curl -X POST 'http://localhost:8000/api/v1/prompts/user/reset' \
+curl -X POST 'http://localhost:8000/api/v2/prompts/user/reset' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer sk-<your-api-key>' \
   -d '{}'
@@ -107,7 +107,7 @@ curl -X POST 'http://localhost:8000/api/v1/prompts/user/reset' \
 前端在"编辑 prompt"页可以用该接口预览变量替换后的效果。
 
 ```bash
-curl -X POST 'http://localhost:8000/api/v1/prompts/preview' \
+curl -X POST 'http://localhost:8000/api/v2/prompts/preview' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer sk-<your-api-key>' \
   -d '{
@@ -122,13 +122,13 @@ curl -X POST 'http://localhost:8000/api/v1/prompts/preview' \
 
 ```bash
 # 合法模板：可能会返回 warnings（提示缺少建议变量）
-curl -X POST 'http://localhost:8000/api/v1/prompts/validate' \
+curl -X POST 'http://localhost:8000/api/v2/prompts/validate' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer sk-<your-api-key>' \
   -d '{"type": "agent_query", "template": "{{ query }} {{ collections }}"}'
 
 # 非法 Jinja2 语法：valid=false + errors
-curl -X POST 'http://localhost:8000/api/v1/prompts/validate' \
+curl -X POST 'http://localhost:8000/api/v2/prompts/validate' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer sk-<your-api-key>' \
   -d '{"type": "agent_query", "template": "{% for x in %}broken{% endfor %}"}'

--- a/tests/unit_test/test_modularization_boundaries.py
+++ b/tests/unit_test/test_modularization_boundaries.py
@@ -381,6 +381,43 @@ def test_no_module_imports_legacy_views_settings():
     )
 
 
+def test_no_module_imports_legacy_views_prompts():
+    """Phase 8 #49 G3: ``aperag/views/prompts.py`` was carved to
+    ``aperag/domains/model_platform/api/prompts_routes.py`` and the
+    URL prefix hard-cut from ``/api/v1/prompts*`` to
+    ``/api/v2/prompts*`` per D7 canonical. Any new ``aperag.views.prompts``
+    import is forbidden — the canonical location is the model_platform
+    domain.
+
+    The scan parses each ``.py`` file under ``aperag/`` + ``tests/`` +
+    ``config/`` with ``ast`` and only flags genuine ``import`` /
+    ``from ... import`` statements (so this test's own docstring /
+    error-message string literals are not self-detected).
+    """
+    offenders: list[str] = []
+    scan_roots = [REPO_ROOT / "aperag", REPO_ROOT / "tests", REPO_ROOT / "config"]
+    for root in scan_roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            modules = _imported_modules(text)
+            if "aperag.views.prompts" in modules:
+                offenders.append(path.relative_to(REPO_ROOT).as_posix())
+    assert not offenders, (
+        "aperag/views/prompts is removed; the canonical location is "
+        "aperag/domains/model_platform/api/prompts_routes. Offenders:\n  "
+        + "\n  ".join(sorted(offenders))
+    )
+
+
 # ---------- Retrieval <-> knowledge_graph one-way bridge ----------
 
 

--- a/tests/unit_test/test_v1_ghost_guard.py
+++ b/tests/unit_test/test_v1_ghost_guard.py
@@ -7,11 +7,14 @@ The end-state allowlist (canonical D7-1 / msg=8b6b4bc3) is:
 
 Phase 8 task #44 (H3) cleaned the provider-aware Hurl suite to use
 ``/api/v2/providers/*`` so it no longer hits dead v1 provider CRUD routes.
-A few other domains (apikeys, audit, marketplace, prompts, chat ops, export,
+A few other domains (apikeys, audit, marketplace, chat ops, export,
 document upload variants) still legitimately live at
-``/api/v1`` until tasks #50–#52 / #47–#49 land. Those paths are listed
+``/api/v1`` until tasks #50–#52 / G4d / G5 land. Those paths are listed
 in ``TRANSITIONAL_V1_PREFIXES`` below and each follow-up PR is expected
 to shrink the set as it migrates the corresponding domain to ``/api/v2``.
+Phase 8 #49 G3 already removed ``/api/v1/prompts`` (carved to
+``aperag/domains/model_platform/api/prompts_routes.py`` at
+``/api/v2/prompts*``).
 
 This test scans every ``.hurl`` file under ``tests/e2e_http/`` and asserts
 each ``/api/v1/...`` literal matches either the permanent allowlist or a
@@ -35,9 +38,12 @@ OPENAI_COMPAT_V1_ALLOWLIST: frozenset[str] = frozenset(
 
 # Transitional prefixes — these v1 routes are still mounted in main and used
 # by e2e Hurl as long as the corresponding G* migration tasks have not landed.
-# Each follow-up PR (G4a audit / G4b apikeys / G4c marketplace / G3 prompts /
-# G1 export / G4d chat ops) is expected to remove the matching
-# entry from this set together with its Hurl rewrite.
+# Each follow-up PR (G4a audit / G4b apikeys / G4c marketplace /
+# G4d chat ops) is expected to remove the matching entry from this set
+# together with its Hurl rewrite. Phase 8 #1 (G1 export, #47),
+# #2 (G2 settings, #48), and #3 (G3 prompts, #49) have already shrunk
+# this set to remove ``/api/v1/export*``, ``/api/v1/settings*``, and
+# ``/api/v1/prompts*``.
 #
 # Anything outside both sets is an unrecognised v1 reference and must be
 # either migrated or moved into one of these sets in the same PR.
@@ -46,7 +52,6 @@ TRANSITIONAL_V1_PREFIXES: frozenset[str] = frozenset(
         "/api/v1/apikeys",  # G4b → /api/v2/apikeys
         "/api/v1/audit-logs",  # G4a → /api/v2/audit-logs
         "/api/v1/marketplace",  # G4c → /api/v2/marketplace
-        "/api/v1/prompts",  # G3  → /api/v2/prompts
         "/api/v1/collections",  # G1 (export) + G5 (document upload variants)
         "/api/v1/export-tasks",  # G1  → /api/v2/export-tasks
         "/api/v1/chats",  # G4d → /api/v2/chats

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -304,11 +304,12 @@ def test_prompt_feature_uses_v2_typed_api_boundary():
 
     Same pattern as `test_api_key_feature_uses_v2_typed_api_boundary`:
     the Prompt Settings page and its client/server callers must only reach
-    `/api/v1/prompts/user` + `/api/v1/prompts/user/{prompt_type}` through the
-    typed openapi-fetch client behind `features/prompt/*`. Phase 1b does not
-    rename the API path or touch the OpenAPI shape — the `prompt_type` enum
-    and richer response component are known gaps tracked for the later
-    `model_platform` API hard-cut phase.
+    `/api/v2/prompts/user` + `/api/v2/prompts/user/{prompt_type}` through the
+    typed openapi-fetch client behind `features/prompt/*`. Phase 8 #49 G3
+    carved the route into the `model_platform` domain and hard-cut
+    `/api/v1/prompts*` → `/api/v2/prompts*` per D7 canonical; the
+    `prompt_type` enum and richer response component remain known gaps
+    tracked under the `model_platform` breaking-changes table.
 
     Negative assertions are scoped to `app/workspace/prompts/**` and
     `features/prompt/**` so legitimate uses of "prompt" vocabulary in
@@ -346,8 +347,8 @@ def test_prompt_feature_uses_v2_typed_api_boundary():
     # path — the v1→v2 hard-cut is deferred to the `model_platform` phase.
     assert "from '@/api'" not in feature_sources
     assert "fetch(" not in feature_sources
-    assert "'/api/v1/prompts/user'" in feature_sources
-    assert "'/api/v1/prompts/user/{prompt_type}'" in feature_sources
+    assert "'/api/v2/prompts/user'" in feature_sources
+    assert "'/api/v2/prompts/user/{prompt_type}'" in feature_sources
 
     # Positive: the business caller wiring goes through the feature adapter.
     settings_tsx = (REPO_ROOT / "web/src/app/workspace/prompts/prompt-settings.tsx").read_text()

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -915,7 +915,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/prompts/user": {
+    "/api/v2/prompts/user": {
         parameters: {
             query?: never;
             header?: never;
@@ -948,7 +948,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/prompts/user/{prompt_type}": {
+    "/api/v2/prompts/user/{prompt_type}": {
         parameters: {
             query?: never;
             header?: never;
@@ -970,7 +970,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/prompts/user/reset": {
+    "/api/v2/prompts/user/reset": {
         parameters: {
             query?: never;
             header?: never;
@@ -992,7 +992,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/prompts/system": {
+    "/api/v2/prompts/system": {
         parameters: {
             query?: never;
             header?: never;
@@ -1014,7 +1014,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/prompts/preview": {
+    "/api/v2/prompts/preview": {
         parameters: {
             query?: never;
             header?: never;
@@ -1034,7 +1034,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/prompts/validate": {
+    "/api/v2/prompts/validate": {
         parameters: {
             query?: never;
             header?: never;

--- a/web/src/features/prompt/client-api.ts
+++ b/web/src/features/prompt/client-api.ts
@@ -5,14 +5,14 @@ import { browserApiClient } from '@/lib/api/typed/browser';
 import type { PromptType, UpdateUserPromptsRequest } from './types';
 
 export async function updateUserPrompts(input: UpdateUserPromptsRequest) {
-  const { data } = await browserApiClient.PUT('/api/v1/prompts/user', {
+  const { data } = await browserApiClient.PUT('/api/v2/prompts/user', {
     body: input,
   });
   return data;
 }
 
 export async function deleteUserPrompt(promptType: PromptType) {
-  await browserApiClient.DELETE('/api/v1/prompts/user/{prompt_type}', {
+  await browserApiClient.DELETE('/api/v2/prompts/user/{prompt_type}', {
     params: {
       path: { prompt_type: promptType },
     },

--- a/web/src/features/prompt/server-api.ts
+++ b/web/src/features/prompt/server-api.ts
@@ -4,7 +4,7 @@ import type { UserPromptsResponse } from './types';
 
 export async function getUserPrompts(): Promise<UserPromptsResponse> {
   const client = await createServerApiClient();
-  const { data } = await client.GET('/api/v1/prompts/user', {});
+  const { data } = await client.GET('/api/v2/prompts/user', {});
   // The typed schema currently types the response as `{ [key: string]: unknown }`.
   // Cast at the adapter boundary so consumers see the runtime shape
   // (see `types.ts` for the technical-debt note).

--- a/web/src/features/prompt/types.ts
+++ b/web/src/features/prompt/types.ts
@@ -5,16 +5,17 @@ export type PromptsPayload = components['schemas']['PromptsPayload'];
 export type UpdateUserPromptsRequest =
   components['schemas']['UpdateUserPromptsRequest'];
 
-// The current `/api/v1/prompts/user` GET response is typed as
+// The current `/api/v2/prompts/user` GET response is typed as
 // `{ [key: string]: unknown }` in the generated schema, and the
-// `/api/v1/prompts/user/{prompt_type}` DELETE path param is a plain string.
-// Phase 1b does not change the OpenAPI shape (the v1→v2 hard-cut is the
-// job of the later `model_platform` API phase). These domain-boundary
+// `/api/v2/prompts/user/{prompt_type}` DELETE path param is a plain string.
+// Phase 8 #49 G3 carved the route into the `model_platform` domain and
+// hard-cut `/api/v1/prompts*` → `/api/v2/prompts*` per D7 canonical;
+// the OpenAPI shape itself was not touched. These domain-boundary
 // types mirror the current runtime shape so the api-key-style adapter
 // pattern (cast once at the adapter boundary, typed from there) can
-// still hold. Track under the `model_platform` breaking-changes table:
-// upgrade `GET /prompts/user` to a concrete `UserPromptsResponse`
-// component and enum `prompt_type` path param.
+// still hold. Tracked under the `model_platform` breaking-changes
+// table: upgrade `GET /prompts/user` to a concrete
+// `UserPromptsResponse` component and enum `prompt_type` path param.
 export type PromptType = keyof PromptsPayload;
 
 export interface PromptDetail {


### PR DESCRIPTION
## Phase 8 task #49 — G3 prompts v1 shim carve

Closes task #49 ([msg=3ebcc880](https://github.com/apecloud/ApeRAG)) per @符炫炜 D7-3 canonical (msg=94f663f2 §3.2.2): carve `aperag/views/prompts.py` to canonical model_platform domain + URL prefix `/api/v1/prompts*` → `/api/v2/prompts*` hard-cut.

## Summary
- Carve route shim from legacy `aperag/views/prompts.py` (205 LOC) to `aperag/domains/model_platform/api/prompts_routes.py`
- D7 v2 hard-cut: `/api/v1/prompts*` → `/api/v2/prompts*`
- Domain reaches `prompt_template_service` (Layer A permanent seam) via new `PromptCRUDOps` Protocol+DI seam, mirroring how agent_runtime consumes the same singleton via `PromptTemplateOps`
- FE typed client + callers + tests + docs all synced
- New boundary gate `test_no_module_imports_legacy_views_prompts`

## Backend
- New `aperag/domains/model_platform/api/prompts_routes.py` (7 endpoints; `AuthenticatedUser` Protocol typing)
- New `PromptCRUDOps` Protocol in `aperag/domains/model_platform/ports.py` (PROMPT_TYPES + 7 method signatures matching legacy 1:1)
- `aperag/app.py`: import switched to model_platform router; mount prefix v1→v2; new `_set_prompt_crud_ops(_legacy_prompt_template_service)` wiring (singleton structurally satisfies the Protocol — no adapter needed)
- `aperag/views/prompts.py` deleted (`git mv` → domain location)

`aperag/service/prompt_template_service.py` is **untouched** — Layer A permanent seam, agent_runtime still consumes via the existing `PromptTemplateOps` Protocol.

## FE
- `web/src/api-v2/schema.d.ts` — 6 path keys v1→v2
- `web/src/features/prompt/{client,server}-api.ts` — 3 caller paths v1→v2
- `web/src/features/prompt/types.ts` — comment updated

## Tests
- New `test_no_module_imports_legacy_views_prompts` boundary gate (mirrors legacy_views_{auth,settings} pattern)
- `test_v1_ghost_guard.py`: removed `/api/v1/prompts` from `TRANSITIONAL_V1_PREFIXES` (now D7-cleared)
- `test_web_typed_api_contract.py`: assertions flipped to v2

## Docs
- `docs/zh-CN/reference/prompt-api.md` curl examples + base URL → v2
- `docs/zh-CN/admin-guide/prompt-customization.md` + `architecture/conversation-agent-evaluation.md` G3 carve attribution updated
- `docs/frontend-rewrite/mismatch-registry.md` entry → v2

## Acceptance gates
- ✅ `pytest tests/unit_test/test_modularization_boundaries.py -x` → **22 passed** (G1-G19 + new G3 gate)
- ✅ `pytest tests/unit_test/test_web_typed_api_contract.py -x` → **16 passed**
- ✅ `pytest tests/unit_test/test_v1_ghost_guard.py` → passes after removing `/api/v1/prompts` from TRANSITIONAL set
- ✅ `from aperag.app import app` → 7 prompts endpoints all under `/api/v2/` (`/api/v2/prompts/{user, user/{prompt_type}, user/reset, system, preview, validate}`)
- ✅ `grep "from aperag.views.prompts"` aperag/tests/config → 0 hits
- ✅ `grep "/api/v1/prompts"` aperag/tests/web/config → 0 live hits (historical comments in docstrings only, intentional)

## Ghost-check
**none.** No new backend coupling, no behavior change, no scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)