### PR TITLE
Phase 8 G4a-FE: sync audit log callers to /api/v2

### DIFF
--- a/tests/unit_test/test_modularization_boundaries.py
+++ b/tests/unit_test/test_modularization_boundaries.py
@@ -996,7 +996,7 @@ HIDDEN_API_OWNERS = {
     # (decisions R + S) unhides both and promotes them to typed
     # wrappers; at that point this gate's entry for the promoted path
     # is removed (or the gate is dropped if the set becomes empty).
-    "/api/v1/audit-logs": "features/audit/",
+    "/api/v2/audit-logs": "features/audit/",
     "/api/v2/config": "features/auth/",
 }
 

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -1143,7 +1143,7 @@ def test_phase1_fe_complete_identity_auth_admin_audit_adapter_boundary():
         assert method in admin_server_api, f"features/admin/server-api.ts missing `{method}`"
 
     # audit — hand-written mirror + raw fetch (hidden path
-    # `/api/v1/audit-logs`). `features/audit/types.ts` must NOT import
+    # `/api/v2/audit-logs`). `features/audit/types.ts` must NOT import
     # raw schema; its header must self-document the Phase 4 +1
     # raw_schema impact so future readers don't hunt for history.
     audit_types = (REPO_ROOT / "web/src/features/audit/types.ts").read_text()
@@ -1151,8 +1151,10 @@ def test_phase1_fe_complete_identity_auth_admin_audit_adapter_boundary():
     audit_server_api = (REPO_ROOT / "web/src/features/audit/server-api.ts").read_text()
     assert "from '@/api-v2/schema'" not in audit_types
     assert "raw_schema 13 → 16" in audit_types
-    assert "/api/v1/audit-logs" in audit_client_api
-    assert "/api/v1/audit-logs" in audit_server_api
+    assert "/api/v2/audit-logs" in audit_client_api
+    assert "/api/v2/audit-logs" in audit_server_api
+    assert "/api/v1/audit-logs" not in audit_client_api
+    assert "/api/v1/audit-logs" not in audit_server_api
 
     # chat-input — #13 Option A thin caller migrates off
     # `apiClient.chatDocumentsApi.*` onto `features/bot/client-api`.

--- a/web/src/features/audit/client-api.ts
+++ b/web/src/features/audit/client-api.ts
@@ -24,7 +24,7 @@ function buildAuditLogsUrl(params?: ListAuditLogsParams): string {
   if (params?.startTime != null) qs.set('start_time', String(params.startTime));
   if (params?.endTime != null) qs.set('end_time', String(params.endTime));
   const query = qs.toString();
-  return `${BASE_PATH}/api/v1/audit-logs${query ? `?${query}` : ''}`;
+  return `${BASE_PATH}/api/v2/audit-logs${query ? `?${query}` : ''}`;
 }
 
 export async function listAuditLogs(
@@ -41,7 +41,7 @@ export async function listAuditLogs(
 
 export async function getAuditLog(id: string): Promise<AuditLog> {
   const response = await fetch(
-    `${BASE_PATH}/api/v1/audit-logs/${encodeURIComponent(id)}`,
+    `${BASE_PATH}/api/v2/audit-logs/${encodeURIComponent(id)}`,
     { credentials: 'same-origin' },
   );
   if (!response.ok) {

--- a/web/src/features/audit/server-api.ts
+++ b/web/src/features/audit/server-api.ts
@@ -44,7 +44,7 @@ function buildAuditLogsUrl(params?: ListAuditLogsParams): string {
   if (params?.sortBy) qs.set('sort_by', params.sortBy);
   if (params?.sortOrder) qs.set('sort_order', params.sortOrder);
   const query = qs.toString();
-  return `${API_SERVER_ENDPOINT}/api/v1/audit-logs${query ? `?${query}` : ''}`;
+  return `${API_SERVER_ENDPOINT}/api/v2/audit-logs${query ? `?${query}` : ''}`;
 }
 
 export async function listAuditLogs(

--- a/web/src/features/audit/types.ts
+++ b/web/src/features/audit/types.ts
@@ -8,7 +8,7 @@
 // explicit without committing the backend to a public API shape.
 //
 // Counting note: this file intentionally does NOT import from
-// `@/api-v2/schema`. When Phase 4 unhides `/api/v1/audit-logs` and this
+// `@/api-v2/schema`. When Phase 4 unhides `/api/v2/audit-logs` and this
 // mirror is promoted to schema-derived aliases, the
 // `web_raw_schema_allowlist.txt` target will rise by 1 (current #13
 // canonical is `raw_schema 13 → 16`; Phase 4 takes it to `16 → 17`).


### PR DESCRIPTION
## Scope

G4a-FE sibling for backend PR #1684.

- Switch audit log FE raw-fetch callers from `/api/v1/audit-logs*` to `/api/v2/audit-logs*`.
- Keep audit logs hidden from public OpenAPI; no typed schema changes are forced.
- Update the audit typed-contract assertions and hidden-path ownership guard to the v2 hidden path.
- Leave apikeys, marketplace, and other governance callers untouched.

## Gates

- `uv run pytest tests/unit_test/test_web_typed_api_contract.py tests/unit_test/test_modularization_boundaries.py -q` -> 38 passed / 3 warnings
- `cd web && yarn lint` -> pass
- `git diff --check` -> pass
- `rg "/api/v1/audit-logs" web/src` -> 0 hits

## Sequencing

Merge after #1684 backend lands, then task #51 can continue with apikeys-only follow-up.
