### PR TITLE
fix(phase8 #57): seed system LLM providers + their default models

### DIFF
--- a/aperag/migration/versions/20260425172700-7c4e9e1f8b21_seed_system_llm_providers.py
+++ b/aperag/migration/versions/20260425172700-7c4e9e1f8b21_seed_system_llm_providers.py
@@ -1,0 +1,48 @@
+"""seed system LLM providers + their default models
+
+Phase 8 task #57 — restore the system-provider seed that was dropped when
+Phase 7's destructive baseline regen rebuilt ``aperag/migration/versions``
+from scratch. Without this seed the post-cleanup ``llm_provider`` table is
+empty on a fresh deployment, so e2e-http-provider hurl tests that ``PUT
+/api/v2/providers/{name}`` to set the API key against a system-provided
+``alibabacloud`` / ``openrouter`` row receive ``404 Provider not found``
+(v2 ``update_llm_provider`` is strict-update only — no upsert).
+
+The actual seed payload lives in ``aperag/migration/sql/model_configs_init.sql``
+and is generated from ``models/generate_model_configs.py``. Each row uses
+``ON CONFLICT (name) DO UPDATE SET ...`` so re-running this migration on a
+DB that already has the providers is a no-op (or a label/base_url refresh
+when the seed file is regenerated).
+
+Revision ID: 7c4e9e1f8b21
+Revises: a639b0e5515f
+Create Date: 2026-04-25 17:27:00.000000
+"""
+
+from typing import Sequence, Union
+
+from aperag.migration.utils import execute_sql_file
+
+# revision identifiers, used by Alembic.
+revision: str = "7c4e9e1f8b21"
+down_revision: Union[str, None] = "a639b0e5515f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Seed (or refresh, via ON CONFLICT) the system providers + default models."""
+    execute_sql_file("model_configs_init.sql")
+
+
+def downgrade() -> None:
+    """No-op.
+
+    The seed is idempotent and the data is product-default content (system
+    providers + their model catalogs). Rolling back this migration on a DB
+    that has accumulated user-supplied API keys would either lose those keys
+    (if we ``DELETE`` the rows) or leave the rows in place anyway — either
+    way the safer no-op matches how alembic handles other ``execute_sql_file``
+    seed migrations elsewhere in the project.
+    """
+    pass


### PR DESCRIPTION
## Summary

Phase 8 task #57 (H2 follow-up) — restore the system-provider seed that was dropped when Phase 7's destructive baseline regen rebuilt `aperag/migration/versions` from scratch. Without this seed the post-cleanup `llm_provider` table is empty on a fresh deployment, so e2e-http-provider hurl tests that `PUT /api/v2/providers/{name}` to set the API key against a system-provided `alibabacloud` / `openrouter` row receive **`404 Provider not found`**.

## Root cause investigation

Per architect/PM scope (msg=1c4321e9 → "复现 → 判断原因 → 修"), I investigated all three hypotheses:

| Hypothesis | Verdict |
|---|---|
| (a) v2 PUT semantics changed (was upsert, now strict) | ❌ — v2 has always been strict update; the issue is the seed, not the semantics |
| (b) **Seed mechanism existed and was removed** | ✅ **Root cause** |
| (c) Provider name mismatch (`alibabacloud` vs `alibaba_cloud`) | ❌ — names match across hurl, SQL seed, and registry |

### Evidence

- `aperag/domains/model_platform/service/llm_provider_service.py:275` raises `ResourceNotFoundException("Provider", provider_name)` when v2 PUT can't find an existing row → 404 to the caller.
- `aperag/migration/sql/model_configs_init.sql` (410 KB) contains `INSERT ... ON CONFLICT (name) DO UPDATE SET ...` seeds for `openai` / `anthropic` / `gemini` / `alibabacloud` / `openrouter` / etc., generated from `models/generate_model_configs.py`. **This file is on disk but never executed.**
- `aperag/migration/utils.py::execute_sql_file` knows how to run it; pre-Phase-7 migrations called it, but the destructive baseline regen (post-Phase-7 `6a8fc31427d9` + post-Phase-8 `a639b0e5515f`) dropped that call along with the rest of the old chain.
- Hurl test `tests/e2e_http/hurl/full/10_provider_llm.hurl:14` jumps straight to `PUT /api/v2/providers/alibabacloud` without a `POST` first, on the assumption the system seed has registered the provider.

## Fix

Single new alembic revision after `a639b0e5515f` that calls `execute_sql_file("model_configs_init.sql")`:

```
aperag/migration/versions/20260425172700-7c4e9e1f8b21_seed_system_llm_providers.py
```

- **Idempotent** — every row uses `ON CONFLICT (name) DO UPDATE SET ...` so re-running on a populated DB is a no-op (or a label/base_url refresh when the seed file regenerates).
- **Downgrade is a no-op** — the data is product-default content and rolling back risks losing user-supplied API keys; matches how alembic handles other `execute_sql_file` seed migrations elsewhere in the project.
- **No semantic change** — v2 PUT stays strict update (per D7-1 canonical); v1 / OpenAI-compat allowlist unchanged.
- **No backend / FE / hurl change** in this PR — just the missing migration step.

Net: 1 new migration file / +48 LOC.

## Why this doesn't roll back #45 H2

H2 (split smoke/provider check) is canonical correct — provider-aware tests should be advisory and gated on secrets. The 404 was orthogonal: even with secrets, the seed was missing. After this PR, `e2e-http-provider` can actually pass when secrets are configured.

## Test plan

- [x] `uv run python -m pytest tests/unit_test/test_modularization_boundaries.py -x -q` → **22 passed**
- [x] `uv run python -m pytest tests/unit_test -q --deselect 'tests/unit_test/test_web_typed_api_contract.py::test_phase1_fe_complete_identity_auth_admin_audit_adapter_boundary'` → **698 passed / 29 skipped / 1 deselected / 0 failed**
- [x] `uv run ruff check + format --check` → clean
- [ ] Real Postgres `alembic upgrade head` smoke (deploy-time verification — same approach as the post-Phase-8 baseline regen verified by Phase 7 close-out, per `project_aperag_post_phase7.md`)
- [ ] e2e-http-provider in CI — expected to no longer 404 on `PUT /api/v2/providers/alibabacloud` (when secrets are configured; otherwise still skip per H2)

## CR ask

@chenyexuan replacement blocker-level minimal CR — pure migration addition, no semantic change. Verify (1) the new revision chains correctly off `a639b0e5515f`, (2) `execute_sql_file` invocation matches the existing dormant utility, (3) no scope creep into v2 endpoint behavior.
@符炫炜 canonical drift quick check — does seed-via-migration align with team convention? (Alternative paths: app-startup seed, separate make target, manual deploy step. Migration is the most idempotent + deploy-safe.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)