### PR TITLE
refactor(phase8-g4b): apikeys prefix migrate /api/v1 → /api/v2 (#51)

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -234,7 +234,7 @@ async def health_check():
 app.include_router(auth_router, prefix="/api/v2/auth")
 app.include_router(export_router, prefix="/api/v2")  # KB-domain export router (Phase 8 #47 G1, D7 v2 hard-cut)
 app.include_router(audit_router, prefix="/api/v2")  # Governance: audit-logs (hard-cut to v2 in #50)
-app.include_router(apikeys_router, prefix="/api/v1")  # Governance: api_keys (#51 G4b will flip to /api/v2)
+app.include_router(apikeys_router, prefix="/api/v2")  # Governance: api_keys (hard-cut to v2 in #51)
 app.include_router(llm_router, prefix="/api/v1")  # Model platform: embed/rerank (OpenAI-compat)
 app.include_router(marketplace_router, prefix="/api/v2")  # Marketplace domain router (Phase 8 #52 G4c, D7 v2 hard-cut)
 app.include_router(settings_router, prefix="/api/v2")  # KB domain settings (carved from views/ in #48)

--- a/aperag/domains/governance/api/apikeys_routes.py
+++ b/aperag/domains/governance/api/apikeys_routes.py
@@ -20,8 +20,8 @@ mounted both API keys and audit logs) is split into two single-purpose
 routers so that #50 (audit-logs) and #51 (apikeys) can migrate to
 ``/api/v2`` independently per architect canonical D7-2 (msg=25a30445).
 
-Phase 8 #50 lands this file with no URL change — apikeys stays at
-``/api/v1/apikeys`` until #51 G4b flips the mount to ``/api/v2``.
+Phase 8 #51 G4b flipped the mount in ``aperag/app.py`` from ``/api/v1``
+to ``/api/v2`` — the canonical apikeys URL is now ``/api/v2/apikeys``.
 """
 
 from fastapi import APIRouter, Depends, Request

--- a/tests/e2e_http/hurl/smoke/04_api_key.hurl
+++ b/tests/e2e_http/hurl/smoke/04_api_key.hurl
@@ -6,7 +6,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-POST {{base_url}}/api/v1/apikeys
+POST {{base_url}}/api/v2/apikeys
 Content-Type: application/json
 {
   "description": "smoke key {{run_id}}"
@@ -21,7 +21,7 @@ jsonpath "$.id" == "{{api_key_id}}"
 jsonpath "$.key" == "{{api_key_value}}"
 jsonpath "$.description" == "smoke key {{run_id}}"
 
-GET {{base_url}}/api/v1/apikeys
+GET {{base_url}}/api/v2/apikeys
 HTTP 200
 
 POST {{base_url}}/api/v2/auth/logout
@@ -39,7 +39,7 @@ Content-Type: application/json
 }
 HTTP 200
 
-PUT {{base_url}}/api/v1/apikeys/{{api_key_id}}
+PUT {{base_url}}/api/v2/apikeys/{{api_key_id}}
 Content-Type: application/json
 {
   "description": "smoke key {{run_id}} updated"
@@ -49,7 +49,7 @@ HTTP 200
 jsonpath "$.id" == "{{api_key_id}}"
 jsonpath "$.description" == "smoke key {{run_id}} updated"
 
-DELETE {{base_url}}/api/v1/apikeys/{{api_key_id}}
+DELETE {{base_url}}/api/v2/apikeys/{{api_key_id}}
 HTTP 200
 
 POST {{base_url}}/api/v2/auth/logout

--- a/tests/e2e_pytest/conftest.py
+++ b/tests/e2e_pytest/conftest.py
@@ -23,11 +23,11 @@ from tests.e2e_pytest.utils import assert_dict_subset
 @pytest.fixture(scope="module")
 def api_key(cookie_client):
     """Dynamically create an API key for testing and yield its value, then delete it after tests."""
-    resp = cookie_client.post("/api/v1/apikeys", json={"description": "e2e dynamic key"})
+    resp = cookie_client.post("/api/v2/apikeys", json={"description": "e2e dynamic key"})
     assert resp.status_code == HTTPStatus.OK, f"Failed to create API key: {resp.text}"
     api_key = resp.json()["key"]
     yield api_key
-    resp = cookie_client.delete(f"/api/v1/apikeys/{resp.json()['id']}")
+    resp = cookie_client.delete(f"/api/v2/apikeys/{resp.json()['id']}")
     assert resp.status_code == HTTPStatus.OK, f"Failed to delete API key: {resp.text}"
 
 

--- a/tests/unit_test/test_v1_ghost_guard.py
+++ b/tests/unit_test/test_v1_ghost_guard.py
@@ -38,18 +38,18 @@ OPENAI_COMPAT_V1_ALLOWLIST: frozenset[str] = frozenset(
 
 # Transitional prefixes — these v1 routes are still mounted in main and used
 # by e2e Hurl as long as the corresponding G* migration tasks have not landed.
-# Each follow-up PR (G4b apikeys / G4d chat ops) is expected to remove
-# the matching entry from this set together with its Hurl rewrite.
-# Phase 8 #1 (G1 export, #47), #2 (G2 settings, #48), #3 (G3 prompts,
-# #49), #50 (G4a audit-logs), and #52 (G4c marketplace) have already
-# shrunk this set to remove ``/api/v1/export*``, ``/api/v1/settings*``,
-# ``/api/v1/prompts*``, ``/api/v1/audit-logs``, and ``/api/v1/marketplace``.
+# Each follow-up PR (G4d chat ops) is expected to remove the matching
+# entry from this set together with its Hurl rewrite. Phase 8 #1 (G1
+# export, #47), #2 (G2 settings, #48), #3 (G3 prompts, #49), #50 (G4a
+# audit-logs), #52 (G4c marketplace), and #51 (G4b apikeys) have
+# already shrunk this set to remove ``/api/v1/export*``,
+# ``/api/v1/settings*``, ``/api/v1/prompts*``, ``/api/v1/audit-logs``,
+# ``/api/v1/marketplace``, and ``/api/v1/apikeys``.
 #
 # Anything outside both sets is an unrecognised v1 reference and must be
 # either migrated or moved into one of these sets in the same PR.
 TRANSITIONAL_V1_PREFIXES: frozenset[str] = frozenset(
     {
-        "/api/v1/apikeys",  # G4b → /api/v2/apikeys
         "/api/v1/collections",  # G1 (export) + G5 (document upload variants)
         "/api/v1/export-tasks",  # G1  → /api/v2/export-tasks
         "/api/v1/chats",  # G4d → /api/v2/chats

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -61,8 +61,8 @@ def test_api_key_feature_uses_v2_typed_api_boundary():
     # path — that is deferred to a later domain/API phase.
     assert "from '@/api'" not in feature_sources
     assert "fetch(" not in feature_sources
-    assert "'/api/v1/apikeys'" in feature_sources
-    assert "'/api/v1/apikeys/{apikey_id}'" in feature_sources
+    assert "'/api/v2/apikeys'" in feature_sources
+    assert "'/api/v2/apikeys/{apikey_id}'" in feature_sources
 
     # Positive: the business caller wiring goes through the feature adapter,
     # not the old generated SDK.

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -609,7 +609,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/apikeys": {
+    "/api/v2/apikeys": {
         parameters: {
             query?: never;
             header?: never;
@@ -633,7 +633,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/apikeys/{apikey_id}": {
+    "/api/v2/apikeys/{apikey_id}": {
         parameters: {
             query?: never;
             header?: never;

--- a/web/src/features/api-key/client-api.ts
+++ b/web/src/features/api-key/client-api.ts
@@ -5,14 +5,14 @@ import { browserApiClient } from '@/lib/api/typed/browser';
 import type { ApiKeyCreate, ApiKeyUpdate } from './types';
 
 export async function createApiKey(input: ApiKeyCreate) {
-  const { data } = await browserApiClient.POST('/api/v1/apikeys', {
+  const { data } = await browserApiClient.POST('/api/v2/apikeys', {
     body: input,
   });
   return data;
 }
 
 export async function updateApiKey(apikeyId: string, input: ApiKeyUpdate) {
-  const { data } = await browserApiClient.PUT('/api/v1/apikeys/{apikey_id}', {
+  const { data } = await browserApiClient.PUT('/api/v2/apikeys/{apikey_id}', {
     params: {
       path: { apikey_id: apikeyId },
     },
@@ -22,7 +22,7 @@ export async function updateApiKey(apikeyId: string, input: ApiKeyUpdate) {
 }
 
 export async function deleteApiKey(apikeyId: string) {
-  await browserApiClient.DELETE('/api/v1/apikeys/{apikey_id}', {
+  await browserApiClient.DELETE('/api/v2/apikeys/{apikey_id}', {
     params: {
       path: { apikey_id: apikeyId },
     },

--- a/web/src/features/api-key/server-api.ts
+++ b/web/src/features/api-key/server-api.ts
@@ -4,6 +4,6 @@ import type { ApiKey } from './types';
 
 export async function listApiKeys(): Promise<ApiKey[]> {
   const client = await createServerApiClient();
-  const { data } = await client.GET('/api/v1/apikeys', {});
+  const { data } = await client.GET('/api/v2/apikeys', {});
   return data?.items ?? [];
 }


### PR DESCRIPTION
## Phase 8 task #51 — G4b apikeys prefix migrate

Closes task #51 ([msg=774644ee](https://github.com/apecloud/ApeRAG)) per architect canonical D7-2 (msg=25a30445) + PM Option A (msg=f294c82e): hard-cut `/api/v1/apikeys*` → `/api/v2/apikeys*`.

## Summary
**1-line mount flip + sync-face**. The `apikeys_router` was carved into its own single-purpose module by #50 G4a (so #50 audit-logs and #51 apikeys could migrate independently). This PR flips the mount prefix only — no carve, no behavior change, no scope creep into audit-logs.

## Backend
- `aperag/app.py` — `apikeys_router` mount `/api/v1` → `/api/v2`
- `aperag/domains/governance/api/apikeys_routes.py` — docstring updated to reflect the v2 hard-cut

## FE
- `web/src/api-v2/schema.d.ts` — 2 apikeys path keys v1 → v2
- `web/src/features/api-key/{client,server}-api.ts` — caller paths v1 → v2

## Tests
- `tests/unit_test/test_v1_ghost_guard.py` — drop `/api/v1/apikeys` from `TRANSITIONAL_V1_PREFIXES`, docstring synced
- `tests/unit_test/test_web_typed_api_contract.py` — assertions flipped to v2
- `tests/e2e_pytest/conftest.py` — dynamic key fixture v2
- `tests/e2e_http/hurl/smoke/04_api_key.hurl` — 4 hurl callers flipped

## Acceptance gates
- ✅ `pytest test_modularization_boundaries + test_v1_ghost_guard + test_web_typed_api_contract` → 42 passed
- ✅ `from aperag.app import app` → 4 apikeys endpoint paths all under `/api/v2/apikeys*`
- ✅ `grep "/api/v1/apikeys"` aperag/tests/web/src → 0 hits (only docstring historical reference left)

## TRANSITIONAL_V1_PREFIXES progress
After this PR: 7 prefixes left (`collections`, `export-tasks`, `chats`, `quotas`, `system`, `bots`, `test`). G4d chat ops + G5 caller cleanup remain.

## Ghost-check
**none.** No new backend coupling, no behavior change, no audit-logs scope creep. Pure URL prefix flip + FE caller sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)