### PR TITLE
refactor(phase8 #65 G5c): retire /api/v1/test/register_admin bootstrap shortcut

### DIFF
--- a/tests/e2e_http/bootstrap/PROTOCOL.md
+++ b/tests/e2e_http/bootstrap/PROTOCOL.md
@@ -23,8 +23,16 @@ The current bootstrap script reads these environment variables:
 
 - `E2E_BOOTSTRAP_MODE`
   Supported values:
-  - `public-register` (default): register the first user through `/api/v2/auth/register`
-  - `dev-api`: create an admin user through `/api/v1/test/register_admin`
+  - `public-register` (default and only mode): register the first user through
+    `/api/v2/auth/register`. On a fresh database the first registered user is
+    automatically promoted to admin by the canonical register flow (see
+    `aperag/domains/identity/api/auth_routes.py::register_view` and
+    `aperag/domains/identity/service/user_manager.py::on_after_register`),
+    so no dev-only API surface is needed.
+
+  Phase 8 task #65 (G5c) removed the historical `dev-api` shortcut: it
+  bypassed `on_after_register` and skipped per-user resource initialisation,
+  so the canonical flow is strictly better even for tests.
 
 - `E2E_RUN_ID`
   Optional explicit run identifier. If omitted, bootstrap generates one.

--- a/tests/e2e_http/bootstrap/bootstrap.sh
+++ b/tests/e2e_http/bootstrap/bootstrap.sh
@@ -65,38 +65,6 @@ EOF
   return 1
 }
 
-register_via_dev_api() {
-  local payload response body status
-  payload="$(cat <<EOF
-{"username":"${E2E_USERNAME}","email":"${E2E_EMAIL}","password":"${E2E_PASSWORD}"}
-EOF
-)"
-
-  response="$(
-    curl --silent --show-error \
-      --write-out $'\n%{http_code}' \
-      --header 'Content-Type: application/json' \
-      --request POST \
-      --data "${payload}" \
-      "${E2E_BASE_URL}/api/v1/test/register_admin"
-  )"
-  status="$(printf '%s' "${response}" | tail -n 1)"
-  body="$(printf '%s' "${response}" | sed '$d')"
-
-  if [[ "${status}" == "200" ]]; then
-    echo "Registered ${E2E_USERNAME} via dev API"
-    return 0
-  fi
-
-  if [[ "${status}" == "400" && "${body}" == *"already exists"* ]]; then
-    echo "User ${E2E_USERNAME} already exists, continuing with login"
-    return 0
-  fi
-
-  echo "Dev bootstrap failed with status ${status}: ${body}" >&2
-  return 1
-}
-
 verify_login() {
   local payload cookie_file
   payload="$(cat <<EOF
@@ -133,11 +101,8 @@ main() {
     public-register)
       register_via_public_api
       ;;
-    dev-api)
-      register_via_dev_api
-      ;;
     *)
-      echo "Unsupported E2E_BOOTSTRAP_MODE=${E2E_BOOTSTRAP_MODE}" >&2
+      echo "Unsupported E2E_BOOTSTRAP_MODE=${E2E_BOOTSTRAP_MODE} (only 'public-register' is supported after Phase 8 task #65)" >&2
       exit 1
       ;;
   esac

--- a/tests/e2e_pytest/conftest.py
+++ b/tests/e2e_pytest/conftest.py
@@ -170,7 +170,14 @@ def bot(client, document, collection):
 
 @pytest.fixture(scope="module")
 def register_user():
-    """Register a new user and return user info and password"""
+    """Register a new user via the canonical public ``/api/v2/auth/register``
+    endpoint. On a fresh database the first user is automatically promoted to
+    admin by ``aperag.domains.identity.api.auth_routes.register_view`` /
+    ``user_manager.on_after_register`` — so test runs that target a freshly
+    seeded DB get an admin user without any dev-only API surface.
+
+    See ``tests/e2e_http/bootstrap/PROTOCOL.md`` for the bootstrap contract.
+    """
     import random
     import string
 
@@ -179,7 +186,7 @@ def register_user():
     password = f"TestPwd!{random.randint(1000, 9999)}"
     data = {"username": username, "email": email, "password": password}
     resp = httpx.post(
-        f"{API_BASE_URL}/api/v1/test/register_admin",
+        f"{API_BASE_URL}/api/v2/auth/register",
         json=data,
     )
     assert resp.status_code == HTTPStatus.OK, f"register failed: {resp.text}"

--- a/tests/unit_test/test_register_admin_dead_path.py
+++ b/tests/unit_test/test_register_admin_dead_path.py
@@ -1,0 +1,64 @@
+"""Phase 8 task #65 (G5c) — guard against regrowth of the
+``/api/v1/test/register_admin`` dev-only bootstrap shortcut.
+
+The path was deleted from the backend in earlier Phase 8 cleanup; this
+PR also removed the only remaining callers (pytest fixture, bootstrap
+shell, protocol doc). The canonical replacement is
+``POST /api/v2/auth/register`` — on a fresh database the first user is
+automatically promoted to admin by the existing register flow
+(``aperag/domains/identity/api/auth_routes.py::register_view`` plus the
+``on_after_register`` hook in ``user_manager.py``), so test bootstrap
+gets an admin user via the same code path production deployments use.
+
+This test pins that promise: nothing under ``aperag/``,
+``tests/e2e_pytest/``, ``tests/e2e_http/``, or ``docs/`` may reference
+the dead ``/api/v1/test/register_admin`` path again.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEAD_PATHS = ("/api/v1/test/register_admin",)
+
+# Scan these trees only — bootstrap callers + any leftover docs.
+SCAN_ROOTS = (
+    REPO_ROOT / "aperag",
+    REPO_ROOT / "tests" / "e2e_pytest",
+    REPO_ROOT / "tests" / "e2e_http",
+    REPO_ROOT / "tests" / "unit_test",
+    REPO_ROOT / "docs",
+)
+
+# Extensions to scan. Skip binaries / generated artefacts.
+SCAN_SUFFIXES = {".py", ".sh", ".hurl", ".md", ".ts", ".tsx", ".yaml", ".yml", ".json"}
+
+
+def test_no_module_references_dead_register_admin_path():
+    offenders: dict[str, set[str]] = {}
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix not in SCAN_SUFFIXES:
+                continue
+            # Skip this guard file itself — it documents the dead path.
+            if path.resolve() == Path(__file__).resolve():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            hits = {p for p in DEAD_PATHS if p in text}
+            if hits:
+                offenders[str(path.relative_to(REPO_ROOT))] = hits
+
+    assert not offenders, (
+        "`/api/v1/test/register_admin` was deleted in Phase 8 task #65 (G5c). "
+        "Use the canonical `POST /api/v2/auth/register` instead — on a fresh DB "
+        "the first registered user is auto-promoted to admin by the existing "
+        "register flow. Offenders:\n  "
+        + "\n  ".join(f"{path}: {sorted(hits)}" for path, hits in sorted(offenders.items()))
+    )

--- a/tests/unit_test/test_v1_ghost_guard.py
+++ b/tests/unit_test/test_v1_ghost_guard.py
@@ -38,25 +38,23 @@ OPENAI_COMPAT_V1_ALLOWLIST: frozenset[str] = frozenset(
 
 # Transitional prefixes — residual ``/api/v1`` references awaiting an
 # explicit disposition. After Phase 8 #63 G5a flipped the confirmed
-# dead-caller set (collections / export-tasks / chats / bots), only
-# three transitional entries remain — all tied to follow-up tasks that
-# require backend or product decisions before any caller can be flipped:
+# dead-caller set (collections / export-tasks / chats / bots) and #65
+# (G5c) retired the dev-only test bootstrap shortcut (callers now go
+# through the canonical ``/api/v2/auth/register`` flow, whose existing
+# first-user-promote logic gives the bootstrap user admin role on a
+# fresh DB), only the ``quotas / system`` pair remains:
 #
 #   - ``/api/v1/quotas`` + ``/api/v1/system``: router defined in
 #     ``aperag/views/quota.py`` but **not mounted in main**; FE callers
-#     are live but currently 404. ``#64`` (G5b) decides router truthing
-#     vs. v2 carve.
-#   - ``/api/v1/test``: ``register_admin`` bootstrap path with **no
-#     backend definition**. ``#65`` (G5c) decides cleanup vs.
-#     replacement.
+#     are live but currently 404. ``#66`` (G5b-impl) decides router
+#     carve to governance domain + ``/api/v2`` contract restore.
 #
 # Anything outside both sets is an unrecognised v1 reference and must be
 # either migrated or moved into one of these sets in the same PR.
 TRANSITIONAL_V1_PREFIXES: frozenset[str] = frozenset(
     {
-        "/api/v1/quotas",  # G5b (#64) — router truthing pending
-        "/api/v1/system",  # G5b (#64) — same router as quotas
-        "/api/v1/test",  # G5c (#65) — register_admin bootstrap
+        "/api/v1/quotas",  # G5b-impl (#66) — router carve + /api/v2 restore pending
+        "/api/v1/system",  # G5b-impl (#66) — same router as quotas
     }
 )
 


### PR DESCRIPTION
## Summary

Phase 8 task #65 (G5c) — replace the dead `/api/v1/test/register_admin` dev-only bootstrap path with the canonical `POST /api/v2/auth/register` flow per architect canonical **Option B-α** (msg=fa423a40 / msg=22652042).

## Investigation finding: no backend change needed

The existing register flow **already auto-promotes the first user** on a fresh DB:

| Site | Mechanism | Trigger |
|---|---|---|
| `aperag/domains/identity/api/auth_routes.py::register_view` (line 154/186) | Calls `async_db_ops.query_first_user_exists()` and assigns `Role.ADMIN` directly when the new account is the first user | At user creation, before DB commit |
| `aperag/domains/identity/service/user_manager.py::on_after_register` (line 113) | Re-asserts `count == 1 → ADMIN` as a defense-in-depth guard, then initialises quota / system + default API keys / default bot / default chat | Post-registration hook |

So this PR is **purely caller / doc cleanup** — no identity domain changes, no env gate, no permanent test-only API surface left in the public OpenAPI spec.

## Changes (5 files / +91 / -47)

| File | Change |
|---|---|
| `tests/e2e_pytest/conftest.py` | `register_user` fixture POSTs to `/api/v2/auth/register`; request body shape unchanged |
| `tests/e2e_http/bootstrap/bootstrap.sh` | Drop `register_via_dev_api()` helper + `dev-api` branch of `E2E_BOOTSTRAP_MODE` switch; `public-register` is now the only supported mode |
| `tests/e2e_http/bootstrap/PROTOCOL.md` | Update env-var contract prose; document the canonical flow + first-user-becomes-admin behaviour |
| `tests/unit_test/test_v1_ghost_guard.py` | `TRANSITIONAL_V1_PREFIXES` shrinks `/api/v1/test` (one of the remaining transitional entries declared by the H3 ledger) |
| `tests/unit_test/test_register_admin_dead_path.py` (new) | Static guard that scans `aperag/` + `tests/` + `docs/` and forbids any re-introduction of `/api/v1/test/register_admin` as a string literal — so a future PR can not silently re-grow the dev-only API |

## Why this is strictly better than the dead shortcut

The old `/api/v1/test/register_admin` bypassed `on_after_register` and skipped per-user resource init — e2e tests bootstrapped via that shortcut got an admin **without** quota, API keys, default bot, or default chat. Switching to `/api/v2/auth/register` fixes that incidentally; bootstrap now goes through exactly the same code path production deployments use.

## Test plan

- [x] `uv run python -m pytest tests/unit_test -q --deselect 'tests/unit_test/test_web_typed_api_contract.py::test_phase1_fe_complete_identity_auth_admin_audit_adapter_boundary'` → **702 passed / 29 skipped / 1 deselected / 0 failed**
- [x] `uv run python -m pytest tests/unit_test/test_register_admin_dead_path.py tests/unit_test/test_v1_ghost_guard.py tests/unit_test/test_modularization_boundaries.py -x -q` → **27 passed**
- [x] `uv run ruff check aperag/ tests/ config/` → clean
- [x] `uv run ruff format --check aperag/ tests/` → clean
- [ ] Real e2e bootstrap smoke (deploy-time CI verification)

## CR ask

@chenyexuan replacement blocker-level minimal CR — pure caller/doc replacement, no backend semantic change. Verify (1) no live `/api/v1/test/register_admin` call site remains, (2) `dev-api` mode fully removed (not just hidden behind a flag), (3) the new static guard correctly fences future re-introductions, (4) `TRANSITIONAL_V1_PREFIXES` shrinks by exactly one entry (`/api/v1/test`).

@符炫炜 canonical drift quick check — Option B-α (first-user-becomes-admin via canonical register) honored without touching identity domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)