### PR TITLE
feat(phase8 #76 D8.4a): FE AI SDK-compatible stream transport + part reducer

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "i18n:watch": "node scripts/i18n-watch.mjs --watch"
   },
   "dependencies": {
+    "@ai-sdk/react": "^2.0.0",
     "@diceui/mention": "^0.7.1",
     "@hookform/resolvers": "^5.2.1",
     "@jsdevtools/rehype-toc": "^3.0.2",
@@ -40,6 +41,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-table": "^8.21.3",
     "ahooks": "^3.9.3",
+    "ai": "^5.0.0",
     "async": "^3.2.6",
     "axios": "^1.15.2",
     "class-variance-authority": "^0.7.1",

--- a/web/src/components/chat/chat-messages.tsx
+++ b/web/src/components/chat/chat-messages.tsx
@@ -1,6 +1,15 @@
 'use client';
 
 import type { ChatDetails, ChatMessage, Feedback } from '@/features/bot/types';
+import {
+  cancelAgentTurn,
+  createAgentTurn,
+  getAgentTurnSnapshot,
+  projectToLegacySnapshot,
+  useAgentTurnStream,
+  type AgentTurnEnvelope,
+  type AgentTurnSnapshotEnvelope,
+} from '@/features/agent-runtime';
 import { useBotContext } from '@/components/providers/bot-provider';
 import _ from 'lodash';
 import { useParams } from 'next/navigation';
@@ -13,45 +22,18 @@ import {
 } from 'react';
 import { animateScroll as scroll } from 'react-scroll';
 import { toast } from 'sonner';
-import {
-  AgentArtifactEnvelope,
-  AgentTimelineEventEnvelope,
-  AgentTurnCard,
-  AgentTurnEnvelope,
-  AgentTurnSnapshot,
-} from './agent-turn-card';
+import { AgentTurnCard } from './agent-turn-card';
 import { ChatInput, ChatInputSubmitParams } from './chat-input';
 import { MessagePartsAi } from './message-parts-ai';
 import { MessagePartsUser } from './message-parts-user';
 
 const API_BASE_PATH = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2`;
-const AGENT_RUNTIME_BASE_PATH = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/agent`;
 const ACTIVE_TURN_STORAGE_PREFIX = 'agent-runtime-v3:active-turn:';
 
-const TURN_EVENT_TYPES = [
-  'turn.started',
-  'agent.state.changed',
-  'tool.started',
-  'tool.progress',
-  'tool.finished',
-  'external_action.started',
-  'external_action.finished',
-  'text.delta',
-  'artifact.created',
-  'turn.completed',
-  'turn.failed',
-  'turn.cancelled',
-  'heartbeat',
-] as const;
-
-type AgentTurnCreateResponse = {
-  turn: AgentTurnEnvelope;
-  stream_url: string;
-};
-
-type AgentTurnState = {
-  snapshot: AgentTurnSnapshot;
-  streamingAnswer: string;
+type LiveTurn = {
+  envelope: AgentTurnEnvelope;
+  baselineSnapshot?: AgentTurnSnapshotEnvelope;
+  streamUrl: string | null; // null = no live connection (terminal / paused)
   pending: boolean;
 };
 
@@ -64,24 +46,12 @@ type TurnFeedbackListResponse = {
 };
 
 function isTerminalStatus(status?: string) {
-  return (
-    status === 'COMPLETED' || status === 'FAILED' || status === 'CANCELLED'
-  );
+  const upper = String(status ?? '').toUpperCase();
+  return upper === 'COMPLETED' || upper === 'FAILED' || upper === 'CANCELLED';
 }
 
 function getActiveTurnStorageKey(chatId?: string) {
   return `${ACTIVE_TURN_STORAGE_PREFIX}${chatId || 'unknown'}`;
-}
-
-function createAiPlaceholder(turnId: string): ChatMessage[] {
-  return [
-    {
-      id: turnId,
-      type: 'start',
-      role: 'ai',
-      data: '',
-    },
-  ];
 }
 
 function createUserParts(query: string): ChatMessage[] {
@@ -91,6 +61,17 @@ function createUserParts(query: string): ChatMessage[] {
       role: 'human',
       data: query,
       timestamp: Math.floor(Date.now() / 1000),
+    },
+  ];
+}
+
+function createAiPlaceholder(turnId: string): ChatMessage[] {
+  return [
+    {
+      id: turnId,
+      type: 'start',
+      role: 'ai',
+      data: '',
     },
   ];
 }
@@ -106,16 +87,8 @@ function getAiGroupId(parts: ChatMessage[]) {
   return aiIds.length === 1 ? aiIds[0] : undefined;
 }
 
-function getErrorMessage(detail: unknown, fallback: string) {
-  if (typeof detail === 'string') return detail;
-  if (
-    typeof detail === 'object' &&
-    detail &&
-    'detail' in detail &&
-    typeof (detail as { detail?: unknown }).detail === 'string'
-  ) {
-    return (detail as { detail: string }).detail;
-  }
+function getErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error) return error.message;
   return fallback;
 }
 
@@ -123,55 +96,32 @@ function cloneMessages(messages: ChatMessage[][]) {
   return messages.map((parts) => [...parts]);
 }
 
-function hasAnswerArtifact(snapshot: AgentTurnSnapshot) {
-  return snapshot.artifacts.some((artifact) => artifact.artifact_type === 'answer');
-}
-
-function getStreamingAnswerFromSnapshot(snapshot: AgentTurnSnapshot) {
-  if (hasAnswerArtifact(snapshot)) return '';
-  return snapshot.timeline
-    .filter(
-      (event) =>
-        event.type === 'text.delta' && typeof event.data.delta === 'string',
-    )
-    .map((event) => event.data.delta as string)
-    .join('');
-}
-
 export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
   const { chatRename } = useBotContext();
   const { chatId } = useParams<{ chatId: string }>();
   const [messages, setMessages] = useState<ChatMessage[][]>(chat.history || []);
-  const [turnStates, setTurnStates] = useState<Record<string, AgentTurnState>>(
-    {},
-  );
+  const [liveTurns, setLiveTurns] = useState<Record<string, LiveTurn>>({});
   const [feedbackByTurnId, setFeedbackByTurnId] = useState<
     Record<string, Feedback>
   >({});
   const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
 
-  const streamsRef = useRef<Record<string, EventSource>>({});
-  const reconnectTimersRef = useRef<
-    Record<string, ReturnType<typeof setTimeout>>
-  >({});
-
-  const loading = useMemo(() => {
-    return Object.values(turnStates).some((turnState) => turnState.pending);
-  }, [turnStates]);
+  const liveTurnsRef = useRef(liveTurns);
+  liveTurnsRef.current = liveTurns;
 
   const activeTurnStorageKey = useMemo(
     () => getActiveTurnStorageKey(chat.id ?? undefined),
     [chat.id],
   );
 
-  const setTurnState = useCallback(
-    (
-      turnId: string,
-      updater: (
-        previous: AgentTurnState | undefined,
-      ) => AgentTurnState | undefined,
-    ) => {
-      setTurnStates((previous) => {
+  const loading = useMemo(
+    () => Object.values(liveTurns).some((turn) => turn.pending),
+    [liveTurns],
+  );
+
+  const updateLiveTurn = useCallback(
+    (turnId: string, updater: (previous: LiveTurn | undefined) => LiveTurn | undefined) => {
+      setLiveTurns((previous) => {
         const next = updater(previous[turnId]);
         if (!next) {
           if (!(turnId in previous)) return previous;
@@ -179,27 +129,11 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
           delete rest[turnId];
           return rest;
         }
-        return {
-          ...previous,
-          [turnId]: next,
-        };
+        return { ...previous, [turnId]: next };
       });
     },
     [],
   );
-
-  const closeStream = useCallback((turnId: string) => {
-    const stream = streamsRef.current[turnId];
-    if (stream) {
-      stream.close();
-      delete streamsRef.current[turnId];
-    }
-    const timer = reconnectTimersRef.current[turnId];
-    if (timer) {
-      clearTimeout(timer);
-      delete reconnectTimersRef.current[turnId];
-    }
-  }, []);
 
   const updateActiveTurn = useCallback(
     (turnId: string | null) => {
@@ -246,280 +180,36 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     [],
   );
 
-  const fetchJson = useCallback(
-    async <T,>(url: string, init?: RequestInit): Promise<T> => {
-      const response = await fetch(url, {
-        credentials: 'same-origin',
-        ...init,
-        headers: {
-          'Content-Type': 'application/json',
-          ...(init?.headers || {}),
-        },
-      });
-
-      if (!response.ok) {
-        let body: unknown = undefined;
-        try {
-          body = await response.json();
-        } catch {
-          body = undefined;
-        }
-        throw new Error(
-          getErrorMessage(
-            body,
-            `Request failed with status ${response.status}`,
-          ),
-        );
+  const seedFromSnapshot = useCallback(
+    (snapshot: AgentTurnSnapshotEnvelope) => {
+      const turnId = snapshot.turn.turn_id;
+      const terminal = isTerminalStatus(snapshot.turn.status);
+      updateLiveTurn(turnId, () => ({
+        envelope: snapshot.turn,
+        baselineSnapshot: snapshot,
+        streamUrl: terminal ? null : buildStreamUrl(chatId, turnId),
+        pending: !terminal,
+      }));
+      ensureTurnGroups(snapshot.turn, false);
+      if (terminal && activeTurnId === turnId) {
+        updateActiveTurn(null);
       }
-
-      if (response.status === 204) {
-        return undefined as T;
-      }
-
-      return (await response.json()) as T;
     },
-    [],
+    [activeTurnId, chatId, ensureTurnGroups, updateActiveTurn, updateLiveTurn],
   );
 
   const fetchTurnFeedbacks = useCallback(
     async () =>
-      fetchJson<TurnFeedbackListResponse>(`${API_BASE_PATH}/chats/${chatId}/feedback`, {
+      fetch(`${API_BASE_PATH}/chats/${chatId}/feedback`, {
         method: 'GET',
+        credentials: 'same-origin',
+      }).then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        return (await response.json()) as TurnFeedbackListResponse;
       }),
-    [chatId, fetchJson],
-  );
-
-  const fetchArtifact = useCallback(
-    async (artifactId: string) => {
-      return fetchJson<AgentArtifactEnvelope>(
-        `${AGENT_RUNTIME_BASE_PATH}/artifacts/${artifactId}`,
-        {
-          method: 'GET',
-        },
-      );
-    },
-    [fetchJson],
-  );
-
-  const fetchSnapshot = useCallback(
-    async (turnId: string) => {
-      return fetchJson<AgentTurnSnapshot>(
-        `${AGENT_RUNTIME_BASE_PATH}/chats/${chatId}/turns/${turnId}`,
-        {
-          method: 'GET',
-        },
-      );
-    },
-    [chatId, fetchJson],
-  );
-
-  const mergeSnapshot = useCallback(
-    (snapshot: AgentTurnSnapshot) => {
-      const streamingAnswer = getStreamingAnswerFromSnapshot(snapshot);
-      setTurnState(snapshot.turn.turn_id, () => ({
-        snapshot: {
-          turn: snapshot.turn,
-          timeline: snapshot.timeline,
-          artifacts: snapshot.artifacts,
-        },
-        streamingAnswer,
-        pending: !isTerminalStatus(snapshot.turn.status),
-      }));
-      ensureTurnGroups(snapshot.turn, false);
-      if (isTerminalStatus(snapshot.turn.status)) {
-        closeStream(snapshot.turn.turn_id);
-        if (activeTurnId === snapshot.turn.turn_id) {
-          updateActiveTurn(null);
-        }
-      }
-    },
-    [
-      activeTurnId,
-      closeStream,
-      ensureTurnGroups,
-      setTurnState,
-      updateActiveTurn,
-    ],
-  );
-
-  const fetchAndMergeSnapshot = useCallback(
-    async (turnId: string) => {
-      const snapshot = await fetchSnapshot(turnId);
-      mergeSnapshot(snapshot);
-      return snapshot;
-    },
-    [fetchSnapshot, mergeSnapshot],
-  );
-
-  const onStreamEvent = useCallback(
-    async (turnId: string, event: AgentTimelineEventEnvelope) => {
-      setTurnState(turnId, (previous) => {
-        if (!previous) return previous;
-        const timeline = previous.snapshot.timeline.some(
-          (item) => item.sequence === event.sequence,
-        )
-          ? previous.snapshot.timeline
-          : [...previous.snapshot.timeline, event];
-        const nextSnapshot: AgentTurnSnapshot = {
-          turn: {
-            ...previous.snapshot.turn,
-            timeline_cursor: Math.max(
-              previous.snapshot.turn.timeline_cursor || 0,
-              event.sequence,
-            ),
-          },
-          timeline,
-          artifacts: previous.snapshot.artifacts,
-        };
-
-        let nextStreamingAnswer = previous.streamingAnswer;
-        let nextPending = previous.pending;
-
-        if (
-          event.type === 'text.delta' &&
-          typeof event.data.delta === 'string'
-        ) {
-          nextStreamingAnswer += event.data.delta;
-        }
-
-        if (event.type === 'turn.completed') {
-          nextSnapshot.turn = { ...nextSnapshot.turn, status: 'COMPLETED' };
-          nextPending = false;
-        } else if (event.type === 'turn.failed') {
-          nextSnapshot.turn = {
-            ...nextSnapshot.turn,
-            status: 'FAILED',
-            error_message:
-              typeof event.data.error === 'string'
-                ? event.data.error
-                : previous.snapshot.turn.error_message,
-          };
-          nextPending = false;
-        } else if (event.type === 'turn.cancelled') {
-          nextSnapshot.turn = { ...nextSnapshot.turn, status: 'CANCELLED' };
-          nextPending = false;
-        }
-
-        return {
-          snapshot: nextSnapshot,
-          streamingAnswer: nextStreamingAnswer,
-          pending: nextPending,
-        };
-      });
-
-      if (event.type === 'artifact.created') {
-        const artifactId = String(event.data.artifact_id || '');
-        if (artifactId) {
-          try {
-            const artifact = await fetchArtifact(artifactId);
-            setTurnState(turnId, (previous) => {
-              if (!previous) return previous;
-              const artifacts = previous.snapshot.artifacts.some(
-                (item) => item.artifact_id === artifact.artifact_id,
-              )
-                ? previous.snapshot.artifacts.map((item) =>
-                    item.artifact_id === artifact.artifact_id ? artifact : item,
-                  )
-                : [...previous.snapshot.artifacts, artifact];
-
-              const turn = {
-                ...previous.snapshot.turn,
-                answer_artifact_id:
-                  artifact.artifact_type === 'answer'
-                    ? artifact.artifact_id
-                    : previous.snapshot.turn.answer_artifact_id,
-                reference_bundle_artifact_id:
-                  artifact.artifact_type === 'reference_bundle'
-                    ? artifact.artifact_id
-                    : previous.snapshot.turn.reference_bundle_artifact_id,
-              };
-
-              return {
-                ...previous,
-                snapshot: {
-                  ...previous.snapshot,
-                  turn,
-                  artifacts,
-                },
-              };
-            });
-          } catch (error) {
-            console.error('Failed to fetch artifact for turn', turnId, error);
-          }
-        }
-      }
-
-      if (
-        event.type === 'turn.completed' ||
-        event.type === 'turn.failed' ||
-        event.type === 'turn.cancelled'
-      ) {
-        try {
-          await fetchAndMergeSnapshot(turnId);
-        } catch (error) {
-          console.error(
-            'Failed to refresh terminal turn snapshot',
-            turnId,
-            error,
-          );
-        }
-        if (event.type === 'turn.completed' && chatRename && chat.id) {
-          chatRename(chat);
-        }
-      }
-    },
-    [chat, chatRename, fetchAndMergeSnapshot, fetchArtifact, setTurnState],
-  );
-
-  const connectTurnStream = useCallback(
-    (turnId: string, afterSequence: number, streamUrl?: string) => {
-      closeStream(turnId);
-
-      const url = new URL(
-        streamUrl ||
-          `${AGENT_RUNTIME_BASE_PATH}/chats/${chatId}/turns/${turnId}/events`,
-        window.location.origin,
-      );
-      url.searchParams.set('after_sequence', String(afterSequence));
-
-      const stream = new EventSource(url.toString(), { withCredentials: true });
-      streamsRef.current[turnId] = stream;
-
-      const handleReconnect = async () => {
-        closeStream(turnId);
-        try {
-          const snapshot = await fetchSnapshot(turnId);
-          mergeSnapshot(snapshot);
-          if (!isTerminalStatus(snapshot.turn.status)) {
-            reconnectTimersRef.current[turnId] = setTimeout(() => {
-              connectTurnStream(turnId, snapshot.turn.timeline_cursor || 0);
-            }, 1000);
-          }
-        } catch (error) {
-          console.error('Failed to reconnect turn stream', turnId, error);
-        }
-      };
-
-      TURN_EVENT_TYPES.forEach((eventType) => {
-        stream.addEventListener(eventType, (rawEvent) => {
-          if (eventType === 'heartbeat') return;
-          const messageEvent = rawEvent as MessageEvent<string>;
-          try {
-            const payload = JSON.parse(
-              messageEvent.data,
-            ) as AgentTimelineEventEnvelope;
-            void onStreamEvent(turnId, payload);
-          } catch (error) {
-            console.error('Failed to parse turn event', eventType, error);
-          }
-        });
-      });
-
-      stream.onerror = () => {
-        void handleReconnect();
-      };
-    },
-    [chatId, closeStream, fetchSnapshot, mergeSnapshot, onStreamEvent],
+    [chatId],
   );
 
   const handleSendMessage = useCallback(
@@ -532,108 +222,93 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
       ]);
 
       try {
-        const response = await fetchJson<AgentTurnCreateResponse>(
-          `${AGENT_RUNTIME_BASE_PATH}/chats/${chatId}/turns`,
-          {
-            method: 'POST',
-            body: JSON.stringify({
-              ...params,
-              client_idempotency_key: crypto.randomUUID(),
-            }),
-          },
-        );
-
+        const response = await createAgentTurn(chatId, {
+          ...params,
+        });
         const turnId = response.turn.turn_id;
         ensureTurnGroups(response.turn, false);
-        setTurnState(turnId, () => ({
-          snapshot: {
-            turn: response.turn,
-            timeline: [],
-            artifacts: [],
-          },
-          streamingAnswer: '',
-          pending: !isTerminalStatus(response.turn.status),
+        const terminal = isTerminalStatus(response.turn.status);
+        updateLiveTurn(turnId, () => ({
+          envelope: response.turn,
+          streamUrl: terminal ? null : response.stream_url,
+          pending: !terminal,
         }));
-        updateActiveTurn(turnId);
-        connectTurnStream(turnId, 0, response.stream_url);
+        updateActiveTurn(terminal ? null : turnId);
       } catch (error) {
         console.error('Failed to create agent turn', error);
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : 'Failed to create a new agent turn.',
-        );
+        toast.error(getErrorMessage(error, 'Failed to create a new agent turn.'));
       }
     },
-    [
-      chatId,
-      connectTurnStream,
-      ensureTurnGroups,
-      fetchJson,
-      setTurnState,
-      updateActiveTurn,
-    ],
+    [chatId, ensureTurnGroups, updateActiveTurn, updateLiveTurn],
   );
 
   const handleCancel = useCallback(async () => {
-    if (!activeTurnId) return;
-
+    if (!activeTurnId || !chatId) return;
     try {
-      await fetchJson(
-        `${AGENT_RUNTIME_BASE_PATH}/chats/${chatId}/turns/${activeTurnId}/cancel`,
-        {
-          method: 'POST',
-          body: JSON.stringify({}),
-        },
-      );
+      await cancelAgentTurn(chatId, activeTurnId);
     } catch (error) {
       console.error('Failed to cancel turn', error);
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : 'Failed to cancel the running turn.',
-      );
+      toast.error(getErrorMessage(error, 'Failed to cancel the running turn.'));
     }
-  }, [activeTurnId, chatId, fetchJson]);
+  }, [activeTurnId, chatId]);
+
+  const handleStreamTerminal = useCallback(
+    (turnId: string, finalEnvelope: AgentTurnEnvelope) => {
+      updateLiveTurn(turnId, (previous) => {
+        if (!previous) return previous;
+        return {
+          ...previous,
+          envelope: finalEnvelope,
+          streamUrl: null,
+          pending: false,
+        };
+      });
+      if (activeTurnId === turnId) {
+        updateActiveTurn(null);
+      }
+      if (chatRename && chat.id) {
+        chatRename(chat);
+      }
+    },
+    [activeTurnId, chat, chatRename, updateActiveTurn, updateLiveTurn],
+  );
 
   const handleMessageFeedback = useCallback(
     async (turnId: string, feedback: Feedback) => {
       if (!chatId || !turnId) return;
 
-      if (feedback.type) {
-        await fetchJson(
-          `${API_BASE_PATH}/chats/${chatId}/turns/${turnId}/feedback`,
-          {
-            method: 'POST',
-            body: JSON.stringify(feedback),
-          },
-        );
-        setFeedbackByTurnId((previous) => ({
-          ...previous,
-          [turnId]: feedback,
-        }));
-        return;
+      const init: RequestInit = {
+        method: feedback.type ? 'POST' : 'DELETE',
+        credentials: 'same-origin',
+        headers: feedback.type ? { 'Content-Type': 'application/json' } : undefined,
+        body: feedback.type ? JSON.stringify(feedback) : undefined,
+      };
+
+      const response = await fetch(
+        `${API_BASE_PATH}/chats/${chatId}/turns/${turnId}/feedback`,
+        init,
+      );
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
       }
 
-      await fetchJson(
-        `${API_BASE_PATH}/chats/${chatId}/turns/${turnId}/feedback`,
-        {
-          method: 'DELETE',
-        },
-      );
-      setFeedbackByTurnId((previous) => {
-        const next = { ...previous };
-        delete next[turnId];
-        return next;
-      });
+      if (feedback.type) {
+        setFeedbackByTurnId((previous) => ({ ...previous, [turnId]: feedback }));
+      } else {
+        setFeedbackByTurnId((previous) => {
+          const next = { ...previous };
+          delete next[turnId];
+          return next;
+        });
+      }
     },
-    [chatId, fetchJson],
+    [chatId],
   );
 
   useEffect(() => {
-    if (!messages.length && !Object.keys(turnStates).length) return;
+    if (!messages.length && !Object.keys(liveTurns).length) return;
     scroll.scrollToBottom({ duration: 0 });
-  }, [messages, turnStates]);
+  }, [messages, liveTurns]);
 
   useEffect(() => {
     scroll.scrollToBottom({ duration: 0 });
@@ -671,17 +346,19 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     };
 
     void loadTurnFeedbacks();
-
     return () => {
       cancelled = true;
     };
   }, [chatId, fetchTurnFeedbacks]);
 
   useEffect(() => {
+    if (!chatId) return;
+
     const storedActiveTurnId =
       typeof window === 'undefined'
         ? null
         : window.sessionStorage.getItem(activeTurnStorageKey);
+
     const potentialTurnIds = [
       ...new Set(
         (chat.history || [])
@@ -696,103 +373,75 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     if (!potentialTurnIds.length) return;
 
     let cancelled = false;
-
     const loadSnapshots = async () => {
       for (const turnId of potentialTurnIds) {
-        if (cancelled || turnStates[turnId]) continue;
+        if (cancelled || liveTurnsRef.current[turnId]) continue;
         try {
-          const snapshot = await fetchSnapshot(turnId);
-          if (!cancelled) {
-            mergeSnapshot(snapshot);
-          }
+          const snapshot = await getAgentTurnSnapshot(chatId, turnId);
+          if (!cancelled) seedFromSnapshot(snapshot);
         } catch (error) {
           console.error('Failed to load historical turn snapshot', turnId, error);
         }
       }
     };
-
     void loadSnapshots();
-
     return () => {
       cancelled = true;
     };
-  }, [
-    activeTurnStorageKey,
-    chat.history,
-    fetchSnapshot,
-    mergeSnapshot,
-    turnStates,
-  ]);
+  }, [activeTurnStorageKey, chat.history, chatId, seedFromSnapshot]);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !chat.id) return;
+    if (typeof window === 'undefined' || !chat.id || !chatId) return;
 
     const storedTurnId = window.sessionStorage.getItem(activeTurnStorageKey);
     if (!storedTurnId) return;
 
     let cancelled = false;
-
     const recoverActiveTurn = async () => {
       try {
-        const snapshot = await fetchSnapshot(storedTurnId);
+        const snapshot = await getAgentTurnSnapshot(chatId, storedTurnId);
         if (cancelled) return;
         ensureTurnGroups(snapshot.turn, true);
-        mergeSnapshot(snapshot);
+        seedFromSnapshot(snapshot);
         if (!isTerminalStatus(snapshot.turn.status)) {
           updateActiveTurn(snapshot.turn.turn_id);
-          connectTurnStream(
-            snapshot.turn.turn_id,
-            snapshot.turn.timeline_cursor || 0,
-          );
         } else {
           updateActiveTurn(null);
         }
       } catch {
-        if (!cancelled) {
-          updateActiveTurn(null);
-        }
+        if (!cancelled) updateActiveTurn(null);
       }
     };
-
     void recoverActiveTurn();
-
     return () => {
       cancelled = true;
     };
   }, [
     activeTurnStorageKey,
     chat.id,
-    connectTurnStream,
+    chatId,
     ensureTurnGroups,
-    fetchSnapshot,
-    mergeSnapshot,
+    seedFromSnapshot,
     updateActiveTurn,
   ]);
-
-  useEffect(() => {
-    const activeStreams = streamsRef.current;
-    return () => {
-      Object.keys(activeStreams).forEach((turnId) => closeStream(turnId));
-    };
-  }, [closeStream]);
 
   return (
     <div className="flex flex-col gap-6 pb-70">
       {messages.map((parts, index) => {
         const isAI = parts.some((part) => part.role === 'ai');
         const turnId = isAI ? getAiGroupId(parts) : undefined;
-        const turnState = turnId ? turnStates[turnId] : undefined;
+        const liveTurn = turnId ? liveTurns[turnId] : undefined;
 
         return (
           <div key={`${turnId || parts[0]?.timestamp || index}-${index}`}>
             {isAI ? (
-              turnState ? (
-                <AgentTurnCard
-                  snapshot={turnState.snapshot}
-                  pending={turnState.pending}
-                  streamingAnswer={turnState.streamingAnswer}
+              liveTurn ? (
+                <AgentTurnStreamCard
+                  chatId={chatId || ''}
+                  liveTurn={liveTurn}
                   feedback={turnId ? feedbackByTurnId[turnId] : undefined}
                   onFeedback={handleMessageFeedback}
+                  onTerminal={handleStreamTerminal}
                 />
               ) : (
                 <MessagePartsAi
@@ -820,3 +469,77 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     </div>
   );
 };
+
+function buildStreamUrl(chatId: string | undefined, turnId: string): string | null {
+  if (!chatId) return null;
+  const base = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/agent`;
+  return `${base}/chats/${chatId}/turns/${turnId}/events`;
+}
+
+// ---------------------------------------------------------------------------
+// AgentTurnStreamCard — child component that owns one live `useAgentTurnStream`
+// hook per turn and projects it back into the legacy `AgentTurnSnapshot` shape
+// the existing `AgentTurnCard` renders. The shim lives in
+// `features/agent-runtime/legacy-snapshot-shim.ts` and is scheduled for deletion
+// as part of #77 (parts renderer).
+// ---------------------------------------------------------------------------
+
+function AgentTurnStreamCard({
+  chatId,
+  liveTurn,
+  feedback,
+  onFeedback,
+  onTerminal,
+}: {
+  chatId: string;
+  liveTurn: LiveTurn;
+  feedback?: Feedback;
+  onFeedback: (turnId: string, feedback: Feedback) => Promise<void>;
+  onTerminal: (turnId: string, finalEnvelope: AgentTurnEnvelope) => void;
+}) {
+  const { envelope, baselineSnapshot, streamUrl } = liveTurn;
+  const initialSequence = baselineSnapshot?.turn.timeline_cursor || envelope.timeline_cursor || 0;
+
+  const stream = useAgentTurnStream({
+    chatId,
+    turnId: envelope.turn_id,
+    streamUrl,
+    initialSequence,
+  });
+
+  const projection = projectToLegacySnapshot({
+    turn: envelope,
+    parts: stream.parts,
+    status: stream.status,
+    errorText: stream.errorText,
+    lastSequence: stream.lastSequence,
+    baselineSnapshot,
+  });
+
+  const onTerminalRef = useRef(onTerminal);
+  onTerminalRef.current = onTerminal;
+
+  useEffect(() => {
+    if (
+      stream.status === 'completed' ||
+      stream.status === 'failed' ||
+      stream.status === 'cancelled' ||
+      stream.status === 'aborted'
+    ) {
+      onTerminalRef.current(envelope.turn_id, projection.legacySnapshot.turn);
+    }
+    // Only fire when status transitions; consumers track the latest envelope
+    // via projection on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stream.status, envelope.turn_id]);
+
+  return (
+    <AgentTurnCard
+      snapshot={projection.legacySnapshot}
+      pending={projection.pending}
+      streamingAnswer={projection.streamingAnswer}
+      feedback={feedback}
+      onFeedback={onFeedback}
+    />
+  );
+}

--- a/web/src/features/agent-runtime/api.ts
+++ b/web/src/features/agent-runtime/api.ts
@@ -1,0 +1,222 @@
+'use client';
+
+// HTTP client for the agent runtime (D8.4a). Wraps the FastAPI surface
+// declared in `aperag/domains/agent_runtime/api/routes.py`. The SSE
+// stream itself is handled separately by the stream client; this file
+// only covers the JSON request/response endpoints the chat UI calls
+// alongside the stream.
+
+import type { ToolConsentData, ElicitationData } from './types';
+
+const DEFAULT_BASE = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/agent`;
+
+export type AgentTurnEnvelope = {
+  schema_version: string;
+  turn_id: string;
+  chat_id: string;
+  user_id: string;
+  bot_id: string;
+  request_id: string;
+  client_idempotency_key: string;
+  status: string;
+  input_text: string;
+  model_profile: Record<string, unknown>;
+  error_code?: string | null;
+  error_message?: string | null;
+  answer_artifact_id?: string | null;
+  reference_bundle_artifact_id?: string | null;
+  timeline_cursor: number;
+  started_at?: string | null;
+  finished_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+export type AgentTimelineEventEnvelope = {
+  schema_version: string;
+  event_id: string;
+  turn_id: string;
+  sequence: number;
+  timestamp: string;
+  type: string;
+  technical_type?: string | null;
+  label?: string | null;
+  status?: string | null;
+  actor: 'agent' | 'tool' | 'system';
+  data: Record<string, unknown>;
+};
+
+export type AgentArtifactEnvelope = {
+  schema_version: string;
+  artifact_id: string;
+  turn_id: string;
+  artifact_type: string;
+  summary?: string | null;
+  payload: Record<string, unknown>;
+  storage_ref?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+export type AgentTurnSnapshotEnvelope = {
+  turn: AgentTurnEnvelope;
+  timeline: AgentTimelineEventEnvelope[];
+  artifacts: AgentArtifactEnvelope[];
+};
+
+export type AgentTurnCreateInput = {
+  query: string;
+  client_idempotency_key?: string;
+  // Forward-compat: any extra fields the chat input feeds into
+  // CreateTurnRequest (model_profile / locale / etc.) flow through
+  // unchanged.
+  [key: string]: unknown;
+};
+
+export type AgentTurnCreateResponse = {
+  turn: AgentTurnEnvelope;
+  stream_url: string;
+};
+
+type RequestOptions = Omit<RequestInit, 'body'> & {
+  body?: unknown;
+};
+
+async function request<T>(url: string, init?: RequestOptions): Promise<T> {
+  const headers = new Headers(init?.headers);
+  let serializedBody: BodyInit | null | undefined;
+  const rawBody = init?.body;
+  if (rawBody == null) {
+    serializedBody = undefined;
+  } else if (
+    rawBody instanceof FormData ||
+    rawBody instanceof Blob ||
+    rawBody instanceof URLSearchParams ||
+    rawBody instanceof ArrayBuffer ||
+    typeof rawBody === 'string'
+  ) {
+    serializedBody = rawBody as BodyInit;
+  } else {
+    headers.set('Content-Type', 'application/json');
+    serializedBody = JSON.stringify(rawBody);
+  }
+
+  const { body: _ignored, ...rest } = init ?? {};
+  void _ignored;
+  const response = await fetch(url, {
+    credentials: 'same-origin',
+    cache: 'no-store',
+    ...rest,
+    headers,
+    body: serializedBody,
+  });
+
+  if (!response.ok) {
+    let detail: unknown;
+    try {
+      detail = await response.json();
+    } catch {
+      detail = undefined;
+    }
+    throw new Error(extractError(detail, response.status));
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}
+
+function extractError(detail: unknown, status: number): string {
+  if (typeof detail === 'string' && detail) return detail;
+  if (
+    typeof detail === 'object' &&
+    detail &&
+    'detail' in detail &&
+    typeof (detail as { detail?: unknown }).detail === 'string'
+  ) {
+    return (detail as { detail: string }).detail;
+  }
+  return `Request failed with status ${status}`;
+}
+
+export async function createAgentTurn(
+  chatId: string,
+  input: AgentTurnCreateInput,
+): Promise<AgentTurnCreateResponse> {
+  return request<AgentTurnCreateResponse>(
+    `${DEFAULT_BASE}/chats/${chatId}/turns`,
+    {
+      method: 'POST',
+      body: {
+        client_idempotency_key:
+          input.client_idempotency_key ??
+          (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random()}`),
+        ...input,
+      },
+    },
+  );
+}
+
+export async function getAgentTurnSnapshot(
+  chatId: string,
+  turnId: string,
+): Promise<AgentTurnSnapshotEnvelope> {
+  return request<AgentTurnSnapshotEnvelope>(
+    `${DEFAULT_BASE}/chats/${chatId}/turns/${turnId}`,
+    { method: 'GET' },
+  );
+}
+
+export async function cancelAgentTurn(
+  chatId: string,
+  turnId: string,
+): Promise<{ turn_id: string; status: string }> {
+  return request<{ turn_id: string; status: string }>(
+    `${DEFAULT_BASE}/chats/${chatId}/turns/${turnId}/cancel`,
+    { method: 'POST', body: {} },
+  );
+}
+
+export async function getAgentArtifact(
+  artifactId: string,
+): Promise<AgentArtifactEnvelope> {
+  return request<AgentArtifactEnvelope>(
+    `${DEFAULT_BASE}/artifacts/${artifactId}`,
+    { method: 'GET' },
+  );
+}
+
+// D9 §3 — consent decision (placeholder client for #78 chenyexuan).
+export async function decideToolConsent(
+  chatId: string,
+  turnId: string,
+  toolCallId: string,
+  decision: 'approved' | 'denied',
+): Promise<{ consent_id: string; decision: string; state: ToolConsentData['state'] }> {
+  return request(
+    `${DEFAULT_BASE}/chats/${chatId}/turns/${turnId}/consent/${toolCallId}`,
+    {
+      method: 'POST',
+      body: { decision },
+    },
+  );
+}
+
+// D9 §5 — elicitation submission (placeholder client for #78).
+export async function submitElicitation(
+  chatId: string,
+  turnId: string,
+  elicitationId: string,
+  response: Record<string, unknown>,
+): Promise<{ elicitation_id: string; state: ElicitationData['state'] }> {
+  return request(
+    `${DEFAULT_BASE}/chats/${chatId}/turns/${turnId}/elicit/${elicitationId}`,
+    {
+      method: 'POST',
+      body: { response },
+    },
+  );
+}

--- a/web/src/features/agent-runtime/index.ts
+++ b/web/src/features/agent-runtime/index.ts
@@ -1,0 +1,57 @@
+'use client';
+
+export type {
+  ActivityData,
+  ActivityIntent,
+  AgentCitationPart,
+  AgentElicitationPart,
+  AgentMessagePart,
+  AgentSourceDocumentPart,
+  AgentSourceUrlPart,
+  AgentStreamStatus,
+  AgentTextPart,
+  AgentToolConsentPart,
+  AgentToolPart,
+  CitationData,
+  CitationLocation,
+  ElicitationData,
+  StreamPart,
+  ToolConsentData,
+  ToolConsentRisk,
+  UserActivityEnvelope,
+} from './types';
+
+export {
+  AI_SDK_V5_HEADER,
+  AI_SDK_V5_HEADER_VALUE,
+} from './types';
+
+export type {
+  AgentArtifactEnvelope,
+  AgentTimelineEventEnvelope,
+  AgentTurnCreateInput,
+  AgentTurnCreateResponse,
+  AgentTurnEnvelope,
+  AgentTurnSnapshotEnvelope,
+} from './api';
+
+export {
+  cancelAgentTurn,
+  createAgentTurn,
+  decideToolConsent,
+  getAgentArtifact,
+  getAgentTurnSnapshot,
+  submitElicitation,
+} from './api';
+
+export {
+  useAgentTurnStream,
+  type UseAgentTurnStreamInput,
+  type UseAgentTurnStreamResult,
+} from './use-agent-turn-stream';
+
+export {
+  getRunningToolName,
+  projectToLegacySnapshot,
+  type LegacySnapshotShim,
+} from './legacy-snapshot-shim';

--- a/web/src/features/agent-runtime/legacy-snapshot-shim.ts
+++ b/web/src/features/agent-runtime/legacy-snapshot-shim.ts
@@ -5,25 +5,27 @@
 // Narrow projection from the new `AgentMessagePart[]` seam back into
 // the legacy `AgentTurnSnapshot { turn, timeline, artifacts }` shape so
 // that `AgentTurnCard` keeps rendering during the D8.4a/4b transition.
-// Boundary (per architect lock msg=ed98280c):
+// Boundary (per architect lock msg=ed98280c + dongdong msg=f33e9039):
 //
-//   * Coverage: `streamingAnswer` (concatenated text per text-block id)
-//     + minimal `timeline` (one entry per running tool call) + empty
-//     `artifacts`. Citations + sources flow through `parts` only — the
-//     references sheet stays empty until #77 wires the new renderer.
+//   * Coverage: `streamingAnswer` (concatenation of every text-block in
+//     declaration order, joined with `\n\n`); patched turn `status` /
+//     `error_message` / `timeline_cursor` from the live stream;
+//     `timeline` and `artifacts` pass-through from `baselineSnapshot`
+//     only.
 //   * NOT covered: rich activity inference, debug previews, reference
-//     bundle items, error_summary translation, timeline merging. Those
-//     belong to the D8.4b renderer (#77).
+//     bundle items rendered from the new parts stream, error_summary
+//     translation, timeline merging from new parts. Those belong to
+//     the D8.4b renderer (#77).
 //
 // This shim has zero callers outside `chat-messages.tsx`. Do not
 // extend its surface — every new field would otherwise become a soft
 // requirement for the renderer rewrite.
 
 import type {
-  AgentTextPart,
-  AgentToolPart,
   AgentMessagePart,
   AgentStreamStatus,
+  AgentTextPart,
+  AgentToolPart,
 } from './types';
 import type {
   AgentTurnEnvelope,
@@ -34,9 +36,9 @@ export type LegacySnapshotShim = {
   /**
    * Streaming answer text — concatenation of every text block in
    * declaration order. AI SDK v5 spec allows multiple text blocks per
-   * turn (text-start{id} / text-delta{id} / text-end{id}); we group
-   * by id and join with `\n\n` so multi-block streams still read
-   * naturally in the existing card.
+   * turn (`text-start{id}` → `text-delta{id}` → `text-end{id}`); we
+   * group by id and join with `\n\n` so multi-block streams still
+   * read naturally in the existing card.
    */
   streamingAnswer: string;
   pending: boolean;
@@ -72,7 +74,9 @@ export function projectToLegacySnapshot(input: {
   const streamingAnswer = collectStreamingAnswer(input.parts);
 
   const liveStatus =
-    input.status === 'idle' ? input.turn.status : STREAM_TO_LEGACY_STATUS[input.status];
+    input.status === 'idle'
+      ? input.turn.status
+      : STREAM_TO_LEGACY_STATUS[input.status];
 
   const turn: AgentTurnEnvelope = {
     ...input.turn,
@@ -101,7 +105,7 @@ export function projectToLegacySnapshot(input: {
 function collectStreamingAnswer(parts: AgentMessagePart[]): string {
   const texts: string[] = [];
   for (const part of parts) {
-    if (part.kind === 'text') {
+    if (part.type === 'text') {
       const value = (part as AgentTextPart).text;
       if (value) texts.push(value);
     }
@@ -114,9 +118,12 @@ function collectStreamingAnswer(parts: AgentMessagePart[]): string {
 export function getRunningToolName(parts: AgentMessagePart[]): string | null {
   for (let i = parts.length - 1; i >= 0; i -= 1) {
     const part = parts[i];
-    if (part.kind !== 'tool') continue;
+    if (!part.type.startsWith('tool-')) continue;
     const tool = part as AgentToolPart;
-    if (tool.state === 'input-streaming' || tool.state === 'input-available') {
+    if (
+      tool.state === 'input-streaming' ||
+      tool.state === 'input-available'
+    ) {
       return tool.toolName || null;
     }
   }

--- a/web/src/features/agent-runtime/legacy-snapshot-shim.ts
+++ b/web/src/features/agent-runtime/legacy-snapshot-shim.ts
@@ -1,0 +1,124 @@
+'use client';
+
+// TODO(#77 dongdong): delete this file when the parts renderer ships.
+//
+// Narrow projection from the new `AgentMessagePart[]` seam back into
+// the legacy `AgentTurnSnapshot { turn, timeline, artifacts }` shape so
+// that `AgentTurnCard` keeps rendering during the D8.4a/4b transition.
+// Boundary (per architect lock msg=ed98280c):
+//
+//   * Coverage: `streamingAnswer` (concatenated text per text-block id)
+//     + minimal `timeline` (one entry per running tool call) + empty
+//     `artifacts`. Citations + sources flow through `parts` only — the
+//     references sheet stays empty until #77 wires the new renderer.
+//   * NOT covered: rich activity inference, debug previews, reference
+//     bundle items, error_summary translation, timeline merging. Those
+//     belong to the D8.4b renderer (#77).
+//
+// This shim has zero callers outside `chat-messages.tsx`. Do not
+// extend its surface — every new field would otherwise become a soft
+// requirement for the renderer rewrite.
+
+import type {
+  AgentTextPart,
+  AgentToolPart,
+  AgentMessagePart,
+  AgentStreamStatus,
+} from './types';
+import type {
+  AgentTurnEnvelope,
+  AgentTurnSnapshotEnvelope,
+} from './api';
+
+export type LegacySnapshotShim = {
+  /**
+   * Streaming answer text — concatenation of every text block in
+   * declaration order. AI SDK v5 spec allows multiple text blocks per
+   * turn (text-start{id} / text-delta{id} / text-end{id}); we group
+   * by id and join with `\n\n` so multi-block streams still read
+   * naturally in the existing card.
+   */
+  streamingAnswer: string;
+  pending: boolean;
+  /** Patched envelope with status reflecting the live stream state. */
+  legacySnapshot: AgentTurnSnapshotEnvelope;
+};
+
+const TERMINAL_STATUSES: ReadonlySet<AgentStreamStatus> = new Set([
+  'completed',
+  'failed',
+  'cancelled',
+  'aborted',
+]);
+
+const STREAM_TO_LEGACY_STATUS: Record<AgentStreamStatus, string> = {
+  idle: 'QUEUED',
+  connecting: 'RUNNING',
+  streaming: 'RUNNING',
+  completed: 'COMPLETED',
+  failed: 'FAILED',
+  cancelled: 'CANCELLED',
+  aborted: 'CANCELLED',
+};
+
+export function projectToLegacySnapshot(input: {
+  turn: AgentTurnEnvelope;
+  parts: AgentMessagePart[];
+  status: AgentStreamStatus;
+  errorText: string | null;
+  lastSequence: number;
+  baselineSnapshot?: AgentTurnSnapshotEnvelope;
+}): LegacySnapshotShim {
+  const streamingAnswer = collectStreamingAnswer(input.parts);
+
+  const liveStatus =
+    input.status === 'idle' ? input.turn.status : STREAM_TO_LEGACY_STATUS[input.status];
+
+  const turn: AgentTurnEnvelope = {
+    ...input.turn,
+    status: liveStatus,
+    error_message:
+      input.status === 'failed'
+        ? input.errorText ?? input.turn.error_message ?? null
+        : input.turn.error_message ?? null,
+    timeline_cursor: Math.max(
+      input.turn.timeline_cursor || 0,
+      input.lastSequence,
+    ),
+  };
+
+  return {
+    streamingAnswer,
+    pending: !TERMINAL_STATUSES.has(input.status),
+    legacySnapshot: {
+      turn,
+      timeline: input.baselineSnapshot?.timeline ?? [],
+      artifacts: input.baselineSnapshot?.artifacts ?? [],
+    },
+  };
+}
+
+function collectStreamingAnswer(parts: AgentMessagePart[]): string {
+  const texts: string[] = [];
+  for (const part of parts) {
+    if (part.kind === 'text') {
+      const value = (part as AgentTextPart).text;
+      if (value) texts.push(value);
+    }
+  }
+  return texts.join('\n\n');
+}
+
+// Re-exported helper: surface the running tool name (if any) so the
+// existing card's loading affordance stays meaningful pre-#77.
+export function getRunningToolName(parts: AgentMessagePart[]): string | null {
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i];
+    if (part.kind !== 'tool') continue;
+    const tool = part as AgentToolPart;
+    if (tool.state === 'input-streaming' || tool.state === 'input-available') {
+      return tool.toolName || null;
+    }
+  }
+  return null;
+}

--- a/web/src/features/agent-runtime/reducer.ts
+++ b/web/src/features/agent-runtime/reducer.ts
@@ -1,0 +1,390 @@
+'use client';
+
+// Stream reducer: collapses lifecycle wire parts into the consolidated,
+// dedup'd `AgentMessagePart[]` shape that downstream renderers (#77)
+// and interactive UI (#78) consume.
+//
+// Dedup contract (architect lock msg=f35c5a3d / Lock C):
+//   The BE replays an entire envelope on disconnect — every part
+//   produced by the same envelope is re-emitted on resume. The client
+//   is responsible for deduping by **stable part identifier**:
+//     * text-* parts: `id`
+//     * tool-* parts: `toolCallId`
+//     * source-* parts: `sourceId`
+//     * data-tool-consent: `data.toolCallId`
+//     * data-elicitation: `data.elicitationId`
+//     * data-citation: `cited_text + canonical(location)` fingerprint
+//       — there is no native id; the BE always re-emits the same
+//       payload on replay, so a content fingerprint is stable.
+//     * data-activity: TRANSIENT — replace-last only, never persisted.
+//
+// State semantics:
+//   * Status follows the lifecycle envelope: `connecting` → `streaming`
+//     (after first non-lifecycle part) → `completed` / `failed` /
+//     `aborted` / `cancelled`.
+//   * `errorText` is set by the `error` part; the stream client closes
+//     the connection right after dispatching it.
+//   * `lastSequence` is updated only when a frame carries an SSE
+//     `id:` field (the LAST part of a fan-out group), so reconnect
+//     resumes at the next envelope, never mid-fanout.
+
+import type {
+  AgentMessagePart,
+  AgentStreamStatus,
+  AgentTextPart,
+  AgentToolPart,
+  ActivityData,
+  StreamPart,
+} from './types';
+
+export type ReducerState = {
+  parts: AgentMessagePart[];
+  transientActivity: ActivityData | null;
+  status: AgentStreamStatus;
+  errorText: string | null;
+  lastSequence: number;
+};
+
+export const initialReducerState = (): ReducerState => ({
+  parts: [],
+  transientActivity: null,
+  status: 'idle',
+  errorText: null,
+  lastSequence: 0,
+});
+
+export function applyPart(
+  state: ReducerState,
+  part: StreamPart,
+  eventId: number | null,
+): ReducerState {
+  // Lifecycle frames first — they drive status, never appear in `parts`.
+  switch (part.type) {
+    case 'start':
+    case 'start-step':
+      return advanceStatus(state, 'streaming', eventId);
+    case 'finish-step':
+      // finish-step closes the inner step, but the turn may still emit
+      // more parts; status stays streaming.
+      return advanceStatus(state, state.status, eventId);
+    case 'finish':
+      return advanceStatus(state, 'completed', eventId);
+    case 'abort':
+      return advanceStatus(state, 'aborted', eventId);
+    case 'error':
+      return {
+        ...state,
+        status: 'failed',
+        errorText: part.errorText,
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+  }
+
+  // Content frames — collapse + dedup.
+  switch (part.type) {
+    case 'text-start':
+      return {
+        ...state,
+        status: state.status === 'idle' ? 'streaming' : state.status,
+        parts: upsertText(state.parts, part.id, '', 'streaming'),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'text-delta':
+      return {
+        ...state,
+        status: state.status === 'idle' ? 'streaming' : state.status,
+        parts: appendTextDelta(state.parts, part.id, part.delta),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'text-end':
+      return {
+        ...state,
+        parts: closeText(state.parts, part.id),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+
+    case 'tool-input-start':
+      return {
+        ...state,
+        parts: upsertTool(state.parts, part.toolCallId, {
+          toolName: part.toolName,
+          metadata: part.metadata,
+          state: 'input-streaming',
+        }),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'tool-input-delta':
+      // Args streaming — we don't surface partial JSON to the UI
+      // today (BE batches on `tool-input-available`), but we still
+      // keep the part registered so a later renderer can show "input
+      // streaming…" affordances.
+      return {
+        ...state,
+        parts: upsertTool(state.parts, part.toolCallId, {
+          state: 'input-streaming',
+        }),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'tool-input-available':
+      return {
+        ...state,
+        parts: upsertTool(state.parts, part.toolCallId, {
+          toolName: part.toolName,
+          input: part.input,
+          state: 'input-available',
+        }),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'tool-output-available': {
+      const failed =
+        typeof part.errorText === 'string' && part.errorText.length > 0;
+      return {
+        ...state,
+        parts: upsertTool(state.parts, part.toolCallId, {
+          output: part.output,
+          errorText: failed ? part.errorText! : undefined,
+          state: failed ? 'output-error' : 'output-available',
+        }),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    }
+
+    case 'source-url':
+      return {
+        ...state,
+        parts: upsertById(state.parts, 'sourceId', part.sourceId, () => ({
+          kind: 'source-url',
+          sourceId: part.sourceId,
+          url: part.url,
+          title: part.title,
+        })),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'source-document':
+      return {
+        ...state,
+        parts: upsertById(state.parts, 'sourceId', part.sourceId, () => ({
+          kind: 'source-document',
+          sourceId: part.sourceId,
+          mediaType: part.mediaType,
+          title: part.title,
+        })),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+
+    case 'data-citation': {
+      const key = citationKey(part.data);
+      return {
+        ...state,
+        parts: upsertCitation(state.parts, key, part.data),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    }
+
+    case 'data-tool-consent':
+      return {
+        ...state,
+        parts: upsertById(
+          state.parts,
+          'toolCallId',
+          part.data.toolCallId,
+          () => ({
+            kind: 'tool-consent',
+            toolCallId: part.data.toolCallId,
+            data: part.data,
+          }),
+          (existing) =>
+            existing.kind === 'tool-consent'
+              ? { ...existing, data: part.data }
+              : existing,
+        ),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+
+    case 'data-elicitation':
+      return {
+        ...state,
+        parts: upsertById(
+          state.parts,
+          'elicitationId',
+          part.data.elicitationId,
+          () => ({
+            kind: 'elicitation',
+            elicitationId: part.data.elicitationId,
+            data: part.data,
+          }),
+          (existing) =>
+            existing.kind === 'elicitation'
+              ? { ...existing, data: part.data }
+              : existing,
+        ),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+
+    case 'data-activity':
+      // Transient — replace-last only, never persisted to `parts`.
+      // The architect lock (msg=f35c5a3d) makes this explicit: the
+      // wire-side `transient: true` flag means the consumer must NOT
+      // include the part in any persistent message history.
+      return {
+        ...state,
+        transientActivity: part.data,
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+  }
+
+  return state;
+}
+
+function advanceStatus(
+  state: ReducerState,
+  next: AgentStreamStatus,
+  eventId: number | null,
+): ReducerState {
+  return {
+    ...state,
+    status: next,
+    lastSequence: maxSeq(state.lastSequence, eventId),
+  };
+}
+
+function maxSeq(current: number, candidate: number | null): number {
+  if (candidate == null) return current;
+  return candidate > current ? candidate : current;
+}
+
+// -- text helpers ---------------------------------------------------------
+
+function upsertText(
+  parts: AgentMessagePart[],
+  id: string,
+  initial: string,
+  state: AgentTextPart['state'],
+): AgentMessagePart[] {
+  const index = parts.findIndex((p) => p.kind === 'text' && p.id === id);
+  if (index >= 0) {
+    const existing = parts[index] as AgentTextPart;
+    return replaceAt(parts, index, { ...existing, state });
+  }
+  return [...parts, { kind: 'text', id, text: initial, state }];
+}
+
+function appendTextDelta(
+  parts: AgentMessagePart[],
+  id: string,
+  delta: string,
+): AgentMessagePart[] {
+  const index = parts.findIndex((p) => p.kind === 'text' && p.id === id);
+  if (index < 0) {
+    // text-delta arrived without text-start (BE emits text-start once
+    // per turn but defends against missing it). Synthesize a streaming
+    // block so the delta isn't dropped.
+    return [...parts, { kind: 'text', id, text: delta, state: 'streaming' }];
+  }
+  const existing = parts[index] as AgentTextPart;
+  return replaceAt(parts, index, {
+    ...existing,
+    text: existing.text + delta,
+    state: 'streaming',
+  });
+}
+
+function closeText(parts: AgentMessagePart[], id: string): AgentMessagePart[] {
+  const index = parts.findIndex((p) => p.kind === 'text' && p.id === id);
+  if (index < 0) return parts;
+  const existing = parts[index] as AgentTextPart;
+  return replaceAt(parts, index, { ...existing, state: 'done' });
+}
+
+// -- tool helpers ---------------------------------------------------------
+
+function upsertTool(
+  parts: AgentMessagePart[],
+  toolCallId: string,
+  patch: Partial<Omit<AgentToolPart, 'kind' | 'toolCallId'>>,
+): AgentMessagePart[] {
+  const index = parts.findIndex(
+    (p) => p.kind === 'tool' && p.toolCallId === toolCallId,
+  );
+  if (index < 0) {
+    return [
+      ...parts,
+      {
+        kind: 'tool',
+        toolCallId,
+        toolName: patch.toolName ?? '',
+        metadata: patch.metadata,
+        input: patch.input,
+        output: patch.output,
+        errorText: patch.errorText,
+        state: patch.state ?? 'input-streaming',
+      },
+    ];
+  }
+  const existing = parts[index] as AgentToolPart;
+  return replaceAt(parts, index, {
+    ...existing,
+    ...patch,
+    // Preserve toolName once it's known (input-start → input-available
+    // both carry it; output-available does not).
+    toolName: patch.toolName ?? existing.toolName,
+    state: patch.state ?? existing.state,
+  });
+}
+
+// -- generic helpers ------------------------------------------------------
+
+type AgentMessagePartByKey<K extends string> = Extract<
+  AgentMessagePart,
+  Record<K, string>
+>;
+
+function upsertById<K extends 'sourceId' | 'toolCallId' | 'elicitationId'>(
+  parts: AgentMessagePart[],
+  key: K,
+  value: string,
+  create: () => AgentMessagePartByKey<K>,
+  update?: (existing: AgentMessagePart) => AgentMessagePart,
+): AgentMessagePart[] {
+  const index = parts.findIndex(
+    (p) => (p as Record<string, unknown>)[key] === value,
+  );
+  if (index < 0) return [...parts, create()];
+  if (!update) return parts;
+  return replaceAt(parts, index, update(parts[index]));
+}
+
+function upsertCitation(
+  parts: AgentMessagePart[],
+  key: string,
+  data: import('./types').CitationData,
+): AgentMessagePart[] {
+  const index = parts.findIndex(
+    (p) => p.kind === 'citation' && p.key === key,
+  );
+  if (index < 0) {
+    return [...parts, { kind: 'citation', key, data }];
+  }
+  // Already seen — replay. Keep existing (data is byte-identical
+  // per envelope-atomic replay).
+  return parts;
+}
+
+function citationKey(data: import('./types').CitationData): string {
+  // Stable fingerprint: cited_text + JSON.stringify(location). The BE
+  // always replays the identical payload on reconnect, so this collides
+  // exactly when (and only when) we've already seen the citation.
+  // JSON.stringify is deterministic for primitive-keyed objects, which
+  // matches the BE Pydantic model shape.
+  try {
+    return `${data.cited_text}${JSON.stringify(data.location)}`;
+  } catch {
+    return data.cited_text;
+  }
+}
+
+function replaceAt<T>(items: T[], index: number, value: T): T[] {
+  const next = items.slice();
+  next[index] = value;
+  return next;
+}

--- a/web/src/features/agent-runtime/reducer.ts
+++ b/web/src/features/agent-runtime/reducer.ts
@@ -136,6 +136,10 @@ export function applyPart(
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
     case 'tool-output-available': {
+      // BE today (#73) emits failures here too with `errorText` set;
+      // task #89 splits failures onto `tool-output-error`. We accept
+      // both shapes so the FE rolls forward without coupling to BE
+      // timing.
       const failed =
         typeof part.errorText === 'string' && part.errorText.length > 0;
       return {
@@ -148,6 +152,16 @@ export function applyPart(
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
     }
+    case 'tool-output-error':
+      // Strict AI SDK v5 failure shape (task #89 fix-forward target).
+      return {
+        ...state,
+        parts: upsertTool(state.parts, part.toolCallId, {
+          errorText: part.errorText,
+          state: 'output-error',
+        }),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
 
     case 'source-url':
       return {

--- a/web/src/features/agent-runtime/reducer.ts
+++ b/web/src/features/agent-runtime/reducer.ts
@@ -2,21 +2,24 @@
 
 // Stream reducer: collapses lifecycle wire parts into the consolidated,
 // dedup'd `AgentMessagePart[]` shape that downstream renderers (#77)
-// and interactive UI (#78) consume.
+// and interactive UI (#78) consume. Output shapes are SDK-compatible
+// (see `types.ts` `_AgentMessagePartIsSDKCompatible` assertion).
 //
 // Dedup contract (architect lock msg=f35c5a3d / Lock C):
 //   The BE replays an entire envelope on disconnect — every part
 //   produced by the same envelope is re-emitted on resume. The client
 //   is responsible for deduping by **stable part identifier**:
-//     * text-* parts: `id`
-//     * tool-* parts: `toolCallId`
-//     * source-* parts: `sourceId`
-//     * data-tool-consent: `data.toolCallId`
-//     * data-elicitation: `data.elicitationId`
+//     * text parts: `id` (text-block id)
+//     * tool parts: `toolCallId`
+//     * source-url / source-document: `sourceId`
+//     * data-tool-consent: `data.toolCallId` (re-exposed as part `id`)
+//     * data-elicitation: `data.elicitationId` (re-exposed as part `id`)
 //     * data-citation: `cited_text + canonical(location)` fingerprint
-//       — there is no native id; the BE always re-emits the same
-//       payload on replay, so a content fingerprint is stable.
-//     * data-activity: TRANSIENT — replace-last only, never persisted.
+//       (re-exposed as part `id`) — there is no native id on the wire,
+//       and the BE always re-emits the same payload on replay so a
+//       content fingerprint is stable.
+//     * data-activity: TRANSIENT — replace-last only, never persisted
+//       into the parts array.
 //
 // State semantics:
 //   * Status follows the lifecycle envelope: `connecting` → `streaming`
@@ -29,11 +32,12 @@
 //     resumes at the next envelope, never mid-fanout.
 
 import type {
+  ActivityData,
   AgentMessagePart,
   AgentStreamStatus,
   AgentTextPart,
   AgentToolPart,
-  ActivityData,
+  CitationData,
   StreamPart,
 } from './types';
 
@@ -114,9 +118,9 @@ export function applyPart(
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
     case 'tool-input-delta':
-      // Args streaming — we don't surface partial JSON to the UI
-      // today (BE batches on `tool-input-available`), but we still
-      // keep the part registered so a later renderer can show "input
+      // Args streaming — we don't surface partial JSON to the UI today
+      // (BE batches on `tool-input-available`), but we still keep the
+      // part registered so a later renderer can show "input
       // streaming…" affordances.
       return {
         ...state,
@@ -166,31 +170,27 @@ export function applyPart(
     case 'source-url':
       return {
         ...state,
-        parts: upsertById(state.parts, 'sourceId', part.sourceId, () => ({
-          kind: 'source-url',
-          sourceId: part.sourceId,
+        parts: upsertSourceUrl(state.parts, part.sourceId, {
           url: part.url,
-          title: part.title,
-        })),
+          title: nullToUndefined(part.title),
+        }),
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
     case 'source-document':
       return {
         ...state,
-        parts: upsertById(state.parts, 'sourceId', part.sourceId, () => ({
-          kind: 'source-document',
-          sourceId: part.sourceId,
+        parts: upsertSourceDocument(state.parts, part.sourceId, {
           mediaType: part.mediaType,
           title: part.title,
-        })),
+        }),
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
 
     case 'data-citation': {
-      const key = citationKey(part.data);
+      const id = citationFingerprint(part.data);
       return {
         ...state,
-        parts: upsertCitation(state.parts, key, part.data),
+        parts: upsertCitation(state.parts, id, part.data),
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
     }
@@ -198,46 +198,20 @@ export function applyPart(
     case 'data-tool-consent':
       return {
         ...state,
-        parts: upsertById(
-          state.parts,
-          'toolCallId',
-          part.data.toolCallId,
-          () => ({
-            kind: 'tool-consent',
-            toolCallId: part.data.toolCallId,
-            data: part.data,
-          }),
-          (existing) =>
-            existing.kind === 'tool-consent'
-              ? { ...existing, data: part.data }
-              : existing,
-        ),
+        parts: upsertToolConsent(state.parts, part.data),
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
 
     case 'data-elicitation':
       return {
         ...state,
-        parts: upsertById(
-          state.parts,
-          'elicitationId',
-          part.data.elicitationId,
-          () => ({
-            kind: 'elicitation',
-            elicitationId: part.data.elicitationId,
-            data: part.data,
-          }),
-          (existing) =>
-            existing.kind === 'elicitation'
-              ? { ...existing, data: part.data }
-              : existing,
-        ),
+        parts: upsertElicitation(state.parts, part.data),
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
 
     case 'data-activity':
-      // Transient — replace-last only, never persisted to `parts`.
-      // The architect lock (msg=f35c5a3d) makes this explicit: the
+      // Transient — replace-last only, never persisted to `parts`. The
+      // architect lock (msg=f35c5a3d) makes this explicit: the
       // wire-side `transient: true` flag means the consumer must NOT
       // include the part in any persistent message history.
       return {
@@ -267,7 +241,19 @@ function maxSeq(current: number, candidate: number | null): number {
   return candidate > current ? candidate : current;
 }
 
+function nullToUndefined<T>(value: T | null | undefined): T | undefined {
+  return value == null ? undefined : value;
+}
+
 // -- text helpers ---------------------------------------------------------
+
+function isTextPart(part: AgentMessagePart): part is AgentTextPart {
+  return part.type === 'text';
+}
+
+function isToolPart(part: AgentMessagePart): part is AgentToolPart {
+  return part.type.startsWith('tool-');
+}
 
 function upsertText(
   parts: AgentMessagePart[],
@@ -275,12 +261,12 @@ function upsertText(
   initial: string,
   state: AgentTextPart['state'],
 ): AgentMessagePart[] {
-  const index = parts.findIndex((p) => p.kind === 'text' && p.id === id);
+  const index = parts.findIndex((p) => isTextPart(p) && p.id === id);
   if (index >= 0) {
     const existing = parts[index] as AgentTextPart;
     return replaceAt(parts, index, { ...existing, state });
   }
-  return [...parts, { kind: 'text', id, text: initial, state }];
+  return [...parts, { type: 'text', id, text: initial, state }];
 }
 
 function appendTextDelta(
@@ -288,12 +274,12 @@ function appendTextDelta(
   id: string,
   delta: string,
 ): AgentMessagePart[] {
-  const index = parts.findIndex((p) => p.kind === 'text' && p.id === id);
+  const index = parts.findIndex((p) => isTextPart(p) && p.id === id);
   if (index < 0) {
     // text-delta arrived without text-start (BE emits text-start once
     // per turn but defends against missing it). Synthesize a streaming
     // block so the delta isn't dropped.
-    return [...parts, { kind: 'text', id, text: delta, state: 'streaming' }];
+    return [...parts, { type: 'text', id, text: delta, state: 'streaming' }];
   }
   const existing = parts[index] as AgentTextPart;
   return replaceAt(parts, index, {
@@ -304,7 +290,7 @@ function appendTextDelta(
 }
 
 function closeText(parts: AgentMessagePart[], id: string): AgentMessagePart[] {
-  const index = parts.findIndex((p) => p.kind === 'text' && p.id === id);
+  const index = parts.findIndex((p) => isTextPart(p) && p.id === id);
   if (index < 0) return parts;
   const existing = parts[index] as AgentTextPart;
   return replaceAt(parts, index, { ...existing, state: 'done' });
@@ -312,86 +298,143 @@ function closeText(parts: AgentMessagePart[], id: string): AgentMessagePart[] {
 
 // -- tool helpers ---------------------------------------------------------
 
+type ToolPatch = Partial<
+  Pick<
+    AgentToolPart,
+    'toolName' | 'metadata' | 'input' | 'output' | 'errorText' | 'state'
+  >
+>;
+
 function upsertTool(
   parts: AgentMessagePart[],
   toolCallId: string,
-  patch: Partial<Omit<AgentToolPart, 'kind' | 'toolCallId'>>,
+  patch: ToolPatch,
 ): AgentMessagePart[] {
   const index = parts.findIndex(
-    (p) => p.kind === 'tool' && p.toolCallId === toolCallId,
+    (p) => isToolPart(p) && p.toolCallId === toolCallId,
   );
   if (index < 0) {
-    return [
-      ...parts,
-      {
-        kind: 'tool',
-        toolCallId,
-        toolName: patch.toolName ?? '',
-        metadata: patch.metadata,
-        input: patch.input,
-        output: patch.output,
-        errorText: patch.errorText,
-        state: patch.state ?? 'input-streaming',
-      },
-    ];
+    const toolName = patch.toolName ?? '';
+    const created: AgentToolPart = {
+      type: `tool-${toolName}`,
+      toolCallId,
+      toolName,
+      metadata: patch.metadata,
+      input: patch.input,
+      output: patch.output,
+      errorText: patch.errorText,
+      state: patch.state ?? 'input-streaming',
+    };
+    return [...parts, created];
   }
   const existing = parts[index] as AgentToolPart;
-  return replaceAt(parts, index, {
+  // Preserve toolName once it's known (input-start / input-available
+  // both carry it; output-* parts do not). The `type` discriminator is
+  // recomputed when toolName changes so SDK guards still see a stable
+  // `tool-${name}` shape after the toolName resolves.
+  const nextToolName = patch.toolName ?? existing.toolName;
+  const merged: AgentToolPart = {
     ...existing,
     ...patch,
-    // Preserve toolName once it's known (input-start → input-available
-    // both carry it; output-available does not).
-    toolName: patch.toolName ?? existing.toolName,
+    toolName: nextToolName,
+    type: `tool-${nextToolName}`,
     state: patch.state ?? existing.state,
-  });
+  };
+  return replaceAt(parts, index, merged);
 }
 
-// -- generic helpers ------------------------------------------------------
+// -- source helpers -------------------------------------------------------
 
-type AgentMessagePartByKey<K extends string> = Extract<
-  AgentMessagePart,
-  Record<K, string>
->;
-
-function upsertById<K extends 'sourceId' | 'toolCallId' | 'elicitationId'>(
+function upsertSourceUrl(
   parts: AgentMessagePart[],
-  key: K,
-  value: string,
-  create: () => AgentMessagePartByKey<K>,
-  update?: (existing: AgentMessagePart) => AgentMessagePart,
+  sourceId: string,
+  fields: { url: string; title?: string },
 ): AgentMessagePart[] {
   const index = parts.findIndex(
-    (p) => (p as Record<string, unknown>)[key] === value,
-  );
-  if (index < 0) return [...parts, create()];
-  if (!update) return parts;
-  return replaceAt(parts, index, update(parts[index]));
-}
-
-function upsertCitation(
-  parts: AgentMessagePart[],
-  key: string,
-  data: import('./types').CitationData,
-): AgentMessagePart[] {
-  const index = parts.findIndex(
-    (p) => p.kind === 'citation' && p.key === key,
+    (p) => p.type === 'source-url' && p.sourceId === sourceId,
   );
   if (index < 0) {
-    return [...parts, { kind: 'citation', key, data }];
+    return [...parts, { type: 'source-url', sourceId, ...fields }];
   }
-  // Already seen — replay. Keep existing (data is byte-identical
-  // per envelope-atomic replay).
+  // Already seen — replay. Same payload byte-stable per
+  // envelope-atomic replay; keep existing.
   return parts;
 }
 
-function citationKey(data: import('./types').CitationData): string {
+function upsertSourceDocument(
+  parts: AgentMessagePart[],
+  sourceId: string,
+  fields: { mediaType: string; title: string },
+): AgentMessagePart[] {
+  const index = parts.findIndex(
+    (p) => p.type === 'source-document' && p.sourceId === sourceId,
+  );
+  if (index < 0) {
+    return [...parts, { type: 'source-document', sourceId, ...fields }];
+  }
+  return parts;
+}
+
+// -- data part helpers ----------------------------------------------------
+
+function upsertCitation(
+  parts: AgentMessagePart[],
+  id: string,
+  data: CitationData,
+): AgentMessagePart[] {
+  const index = parts.findIndex(
+    (p) => p.type === 'data-citation' && p.id === id,
+  );
+  if (index < 0) {
+    return [...parts, { type: 'data-citation', id, data }];
+  }
+  // Already seen — replay; data is byte-identical per envelope-atomic
+  // replay so we keep the existing entry.
+  return parts;
+}
+
+function upsertToolConsent(
+  parts: AgentMessagePart[],
+  data: import('./types').ToolConsentData,
+): AgentMessagePart[] {
+  const id = data.toolCallId;
+  const index = parts.findIndex(
+    (p) => p.type === 'data-tool-consent' && p.id === id,
+  );
+  if (index < 0) {
+    return [...parts, { type: 'data-tool-consent', id, data }];
+  }
+  // Consent decision can transition (pending → approved/denied/expired);
+  // the BE re-emits the part with the new state, so we replace data.
+  return replaceAt(parts, index, { type: 'data-tool-consent', id, data });
+}
+
+function upsertElicitation(
+  parts: AgentMessagePart[],
+  data: import('./types').ElicitationData,
+): AgentMessagePart[] {
+  const id = data.elicitationId;
+  const index = parts.findIndex(
+    (p) => p.type === 'data-elicitation' && p.id === id,
+  );
+  if (index < 0) {
+    return [...parts, { type: 'data-elicitation', id, data }];
+  }
+  // Same reasoning as consent: state transitions (pending → answered /
+  // cancelled) are re-emitted; replace data on hit.
+  return replaceAt(parts, index, { type: 'data-elicitation', id, data });
+}
+
+function citationFingerprint(data: CitationData): string {
   // Stable fingerprint: cited_text + JSON.stringify(location). The BE
   // always replays the identical payload on reconnect, so this collides
   // exactly when (and only when) we've already seen the citation.
-  // JSON.stringify is deterministic for primitive-keyed objects, which
-  // matches the BE Pydantic model shape.
+  // Symphony msg=2f9225f5: JSON.stringify key order is engine-stable
+  // for primitive-keyed objects (matches BE Pydantic shape) within a
+  // process; if cross-session ghost duplicates surface later, swap to
+  // a canonical sorted-keys hash.
   try {
-    return `${data.cited_text}${JSON.stringify(data.location)}`;
+    return `${data.cited_text}${JSON.stringify(data.location)}`;
   } catch {
     return data.cited_text;
   }

--- a/web/src/features/agent-runtime/stream-client.ts
+++ b/web/src/features/agent-runtime/stream-client.ts
@@ -144,6 +144,9 @@ export async function consumeAgentStream(
         }
         options.onPart(frame.part, frame.id);
         if (isTerminalPart(frame.part)) {
+          // Terminal part dispatched — the BE will close TCP next
+          // tick. We return early so the hook flips to the matching
+          // status without waiting on EOF.
           return { reason: 'completed' };
         }
       }
@@ -161,7 +164,15 @@ export async function consumeAgentStream(
     }
   }
 
-  return { reason: 'completed' };
+  // EOF without a terminal part — the HTTP stream closed cleanly but
+  // the turn was not finished/aborted/errored. Treat as recoverable
+  // stream loss so the hook's reconnect loop resumes from
+  // `lastEventId`. Without this guard a clean mid-turn TCP close
+  // would mark the turn completed (Weston msg=63a796f3 blocker #1).
+  return {
+    reason: 'error',
+    error: 'stream closed before terminal frame',
+  };
 }
 
 function buildStreamUrl(rawUrl: string, lastEventId?: number): string {

--- a/web/src/features/agent-runtime/stream-client.ts
+++ b/web/src/features/agent-runtime/stream-client.ts
@@ -1,0 +1,195 @@
+'use client';
+
+// AI SDK-compatible stream transport for the ApeRAG agent runtime (D8.4a).
+//
+// Why fetch + ReadableStream instead of `EventSource` / `useChat`:
+//   * Contract #2 — we must validate the
+//     `x-vercel-ai-ui-message-stream: v1` response header before
+//     consuming the stream. EventSource exposes no response headers.
+//   * Contract #3 — Last-Event-ID resume is driven explicitly from the
+//     persisted last `id:` field; we cannot rely on the browser's
+//     EventSource auto-reconnect.
+//   * `useChat`'s default lifecycle is single-step POST+stream;
+//     ApeRAG's runtime is two-phase (POST `/turns` returns a
+//     `stream_url`, then GET that URL begins the SSE body), so adapting
+//     `useChat` would mean writing a custom `ChatTransport` of
+//     comparable complexity to this consumer.
+//
+// The 6 client-side contracts (architect msg=bad0cd0f) are enforced
+// here:
+//   1. AI SDK v5 typed parts surface — we deserialize into `StreamPart`
+//      which mirrors `aperag/domains/agent_runtime/wire/parts.py`. The
+//      reducer downstream emits `AgentMessagePart` shaped to align with
+//      `@ai-sdk/react`'s `UIMessagePart` so the renderer can lean on
+//      the SDK's type guards.
+//   2. Header marker validation — `x-vercel-ai-ui-message-stream: v1`
+//      verified before any `onPart` dispatch.
+//   3. Resume / error / abort — `Last-Event-ID` header on reconnect;
+//      `error` part dispatched then connection terminates (no
+//      auto-retry); `abort` part terminates the stream and the consumer
+//      cleans up.
+//   4. Part-level dedup — handled by the reducer; the client is
+//      authoritative on `lastEventId` so `Last-Event-ID` always points
+//      at the next envelope.
+//   5. Wire shape adoption — wrapped `{type, data:{...}}` for
+//      `data-citation/data-tool-consent/data-elicitation/data-activity`
+//      passes through unchanged (typed in `types.ts`).
+//   6. Transient `data-activity` — emitted to `onPart` as usual; the
+//      reducer keeps it out of the persistent parts list.
+
+import { parseSseChunk } from './stream-parser';
+import {
+  AI_SDK_V5_HEADER,
+  AI_SDK_V5_HEADER_VALUE,
+  type StreamPart,
+} from './types';
+
+export type AgentStreamClientOptions = {
+  url: string;
+  signal: AbortSignal;
+  /**
+   * Last sequence id observed by the consumer. Sent as both the
+   * `Last-Event-ID` HTTP header and the `after_sequence` query
+   * parameter — the BE accepts either, but the header is canonical
+   * per the AI SDK v5 spec.
+   */
+  lastEventId?: number;
+  onPart: (part: StreamPart, eventId: number | null) => void;
+  /**
+   * Called when the BE response advertises a `Last-Event-ID`-style
+   * marker on a frame; the client uses this to keep `lastEventId` in
+   * sync so the next reconnect resumes correctly.
+   */
+  onEventId?: (eventId: number) => void;
+};
+
+export type AgentStreamCloseReason =
+  | 'completed' // BE closed the stream cleanly (terminal envelope reached)
+  | 'aborted' // local AbortController fired
+  | 'error'; // network or protocol error — `error` is set
+
+export type AgentStreamCloseInfo = {
+  reason: AgentStreamCloseReason;
+  error?: string;
+};
+
+/**
+ * Open a single SSE connection and pump frames into `onPart`. Resolves
+ * once the stream is fully drained (BE-closed or aborted) and rejects
+ * only on protocol-level failures (header mismatch, fetch error).
+ *
+ * The caller is expected to handle reconnect: this function performs
+ * exactly one HTTP request.
+ */
+export async function consumeAgentStream(
+  options: AgentStreamClientOptions,
+): Promise<AgentStreamCloseInfo> {
+  const url = buildStreamUrl(options.url, options.lastEventId);
+  const headers: Record<string, string> = {
+    Accept: 'text/event-stream',
+  };
+  if (options.lastEventId != null && options.lastEventId > 0) {
+    headers['Last-Event-ID'] = String(options.lastEventId);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers,
+      signal: options.signal,
+    });
+  } catch (error) {
+    if (options.signal.aborted) {
+      return { reason: 'aborted' };
+    }
+    return { reason: 'error', error: errorText(error) };
+  }
+
+  if (!response.ok) {
+    return {
+      reason: 'error',
+      error: `stream HTTP ${response.status}`,
+    };
+  }
+
+  const protocolHeader = response.headers.get(AI_SDK_V5_HEADER);
+  if (protocolHeader !== AI_SDK_V5_HEADER_VALUE) {
+    return {
+      reason: 'error',
+      error: `protocol header mismatch (${AI_SDK_V5_HEADER}=${protocolHeader ?? 'missing'})`,
+    };
+  }
+
+  const body = response.body;
+  if (!body) {
+    return { reason: 'error', error: 'empty stream body' };
+  }
+
+  const reader = body.pipeThrough(new TextDecoderStream()).getReader();
+  let carry = '';
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      carry += value;
+      const { frames, carry: nextCarry } = parseSseChunk(carry);
+      carry = nextCarry;
+      for (const frame of frames) {
+        if (frame.id != null) {
+          options.onEventId?.(frame.id);
+        }
+        options.onPart(frame.part, frame.id);
+        if (isTerminalPart(frame.part)) {
+          return { reason: 'completed' };
+        }
+      }
+    }
+  } catch (error) {
+    if (options.signal.aborted) {
+      return { reason: 'aborted' };
+    }
+    return { reason: 'error', error: errorText(error) };
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // already released
+    }
+  }
+
+  return { reason: 'completed' };
+}
+
+function buildStreamUrl(rawUrl: string, lastEventId?: number): string {
+  // Resume hint as a query param too — the BE accepts `after_sequence`
+  // as a fallback path for clients that cannot set `Last-Event-ID`
+  // (e.g. when reconnecting through a same-origin redirect that drops
+  // custom headers).
+  let url: URL;
+  try {
+    url = new URL(rawUrl, window.location.origin);
+  } catch {
+    return rawUrl;
+  }
+  if (lastEventId != null && lastEventId > 0) {
+    url.searchParams.set('after_sequence', String(lastEventId));
+  }
+  return url.toString();
+}
+
+function isTerminalPart(part: StreamPart): boolean {
+  // The BE always closes the stream after `finish` / `error` / `abort`;
+  // detecting these client-side lets us return early without waiting
+  // for the BE's TCP close. `error` and `abort` are surfaced through
+  // `onPart` first so the reducer can still react.
+  return part.type === 'finish' || part.type === 'error' || part.type === 'abort';
+}
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/web/src/features/agent-runtime/stream-parser.ts
+++ b/web/src/features/agent-runtime/stream-parser.ts
@@ -1,0 +1,91 @@
+'use client';
+
+// SSE frame parser used by the agent runtime stream client.
+//
+// AI SDK v5 wire shape: `id: <seq>\ndata: <single-line JSON>\n\n`.
+// `event:` is never set (the BE keys discrimination on the JSON `type`
+// field). Only the LAST part of a fan-out group carries `id:`; mid-group
+// frames are continuation frames without it. SSE comments (`: ...`) and
+// blank-only buffers are heartbeats — we keep the connection alive but
+// do not surface them.
+//
+// We deliberately re-implement the wire framing instead of using the AI
+// SDK's `readUIMessageStream` because (a) we need to validate the
+// response header before consuming, which the SDK helper does not
+// expose, (b) the SDK helper expects a `ReadableStream<UIMessageChunk>`
+// already deserialized — we are the layer that does the deserialize.
+
+import type { StreamPart } from './types';
+
+export type SseFrame = {
+  id: number | null;
+  part: StreamPart;
+};
+
+export type SseParseResult = {
+  frames: SseFrame[];
+  carry: string;
+};
+
+const FRAME_DELIMITER = /\r?\n\r?\n/;
+
+/**
+ * Split an SSE buffer into frames at blank-line delimiters and parse
+ * each frame's `id:` and `data:` fields. The trailing partial frame
+ * (if any) is returned in `carry` so the caller can prepend it to the
+ * next chunk. Comment-only frames (heartbeats) are skipped.
+ */
+export function parseSseChunk(buffer: string): SseParseResult {
+  const segments = buffer.split(FRAME_DELIMITER);
+  const carry = segments.pop() ?? '';
+  const frames: SseFrame[] = [];
+
+  for (const segment of segments) {
+    if (!segment) continue;
+    const frame = parseSseFrame(segment);
+    if (frame) frames.push(frame);
+  }
+
+  return { frames, carry };
+}
+
+function parseSseFrame(segment: string): SseFrame | null {
+  let id: number | null = null;
+  const dataLines: string[] = [];
+
+  for (const rawLine of segment.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (!line) continue;
+    if (line.startsWith(':')) continue; // comment / heartbeat
+    const colon = line.indexOf(':');
+    const field = colon < 0 ? line : line.slice(0, colon);
+    const value =
+      colon < 0
+        ? ''
+        : line[colon + 1] === ' '
+          ? line.slice(colon + 2)
+          : line.slice(colon + 1);
+
+    if (field === 'data') {
+      dataLines.push(value);
+    } else if (field === 'id') {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isFinite(parsed)) id = parsed;
+    }
+  }
+
+  if (dataLines.length === 0) return null;
+
+  let part: StreamPart;
+  try {
+    part = JSON.parse(dataLines.join('\n')) as StreamPart;
+  } catch {
+    return null;
+  }
+
+  if (!part || typeof (part as { type?: unknown }).type !== 'string') {
+    return null;
+  }
+
+  return { id, part };
+}

--- a/web/src/features/agent-runtime/types.ts
+++ b/web/src/features/agent-runtime/types.ts
@@ -159,18 +159,28 @@ export type StreamPart =
 
 // --- At-rest agent message parts (consumed by #77 renderer + #78 UI) ------
 // These are the dedup'd, lifecycle-collapsed parts the hook publishes.
-// Shape aligns with AI SDK v5 UIMessagePart so the renderer can use SDK
-// type guards (isTextUIPart / isToolUIPart / etc.) where convenient.
+// Shape aligns 1:1 with AI SDK v5 `UIMessagePart` discriminators so the
+// renderer can use the SDK's `isTextUIPart` / `isToolUIPart` /
+// `isDataUIPart` guards directly. The compile-time `_AgentMessagePartIsSDKCompatible`
+// assertion at the bottom of this file enforces this contract — if a
+// shape drifts, type-check fails.
 
 export type AgentTextPart = {
-  kind: 'text';
+  type: 'text';
+  /** Wire `text-block id` (also re-exposed for #77 dedup-by-id rendering). */
   id: string;
   text: string;
   state: 'streaming' | 'done';
 };
 
+/**
+ * Tool part. Type discriminator follows the AI SDK v5 dynamic-tool
+ * pattern: `tool-${SafeToolName}` (per D8 §2.4 / D9 §A1+A6).
+ * `isToolUIPart` from `ai` accepts any `tool-${string}` literal so
+ * this shape is exchangeable with the SDK's `ToolUIPart`.
+ */
 export type AgentToolPart = {
-  kind: 'tool';
+  type: `tool-${string}`;
   toolCallId: string;
   toolName: string;
   metadata?: Record<string, unknown>;
@@ -185,34 +195,41 @@ export type AgentToolPart = {
 };
 
 export type AgentSourceUrlPart = {
-  kind: 'source-url';
+  type: 'source-url';
   sourceId: string;
   url: string;
-  title?: string | null;
+  title?: string;
 };
 
 export type AgentSourceDocumentPart = {
-  kind: 'source-document';
+  type: 'source-document';
   sourceId: string;
   mediaType: string;
   title: string;
 };
 
+/** Anthropic-shape citation, wrapped per AI SDK v5 `DataUIPart`. */
 export type AgentCitationPart = {
-  kind: 'citation';
-  key: string;
+  type: 'data-citation';
+  /** Synthetic stable fingerprint (`cited_text + canonical(location)`). */
+  id: string;
   data: CitationData;
 };
 
+/** Tool-consent prompt, wrapped per AI SDK v5 `DataUIPart`. */
 export type AgentToolConsentPart = {
-  kind: 'tool-consent';
-  toolCallId: string;
+  type: 'data-tool-consent';
+  /** `data.toolCallId` — re-exposed at the part envelope so SDK
+   *  consumers can dedup without inspecting the inner payload. */
+  id: string;
   data: ToolConsentData;
 };
 
+/** Elicitation prompt, wrapped per AI SDK v5 `DataUIPart`. */
 export type AgentElicitationPart = {
-  kind: 'elicitation';
-  elicitationId: string;
+  type: 'data-elicitation';
+  /** `data.elicitationId` — see comment on `AgentToolConsentPart.id`. */
+  id: string;
   data: ElicitationData;
 };
 
@@ -224,6 +241,64 @@ export type AgentMessagePart =
   | AgentCitationPart
   | AgentToolConsentPart
   | AgentElicitationPart;
+
+// --- Compile-time SDK compatibility assertion (Weston msg=63a796f3 B2) ---
+//
+// Each part type below must be structurally assignable to the
+// corresponding shape in `@ai-sdk/react` (sourced from the `ai`
+// package). If any shape drifts, this file fails to type-check and
+// the renderer's `isTextUIPart` / `isToolUIPart` / `isDataUIPart`
+// guards would silently misclassify our parts at runtime.
+
+import type {
+  TextUIPart as _SDKTextUIPart,
+  SourceUrlUIPart as _SDKSourceUrlUIPart,
+  SourceDocumentUIPart as _SDKSourceDocumentUIPart,
+  DataUIPart as _SDKDataUIPart,
+} from 'ai';
+
+// The data discriminators we actually emit. Used to parameterize
+// the SDK's `DataUIPart<DATA_TYPES>` for the assertion below.
+export type ApeRAGUIDataTypes = {
+  citation: CitationData;
+  'tool-consent': ToolConsentData;
+  elicitation: ElicitationData;
+};
+
+type _AssertText = AgentTextPart extends _SDKTextUIPart ? true : never;
+type _AssertSourceUrl =
+  AgentSourceUrlPart extends _SDKSourceUrlUIPart ? true : never;
+type _AssertSourceDocument =
+  AgentSourceDocumentPart extends _SDKSourceDocumentUIPart ? true : never;
+type _AssertCitation =
+  AgentCitationPart extends _SDKDataUIPart<ApeRAGUIDataTypes>
+    ? true
+    : never;
+type _AssertToolConsent =
+  AgentToolConsentPart extends _SDKDataUIPart<ApeRAGUIDataTypes>
+    ? true
+    : never;
+type _AssertElicitation =
+  AgentElicitationPart extends _SDKDataUIPart<ApeRAGUIDataTypes>
+    ? true
+    : never;
+// Tool parts are intentionally not asserted against `ToolUIPart<TOOLS>`
+// (which requires a static `TOOLS` schema) — the SDK's `isToolUIPart`
+// guard branches on `type.startsWith('tool-')`, which our
+// `tool-${string}` template-literal discriminator satisfies.
+
+// One read of every assertion alias so the compiler keeps them around.
+// Each member here would be `never` if the corresponding `extends`
+// failed, which would propagate a type error to anyone importing this
+// constant — making the compatibility check load-bearing.
+export const _AgentMessagePartIsSDKCompatible: [
+  _AssertText,
+  _AssertSourceUrl,
+  _AssertSourceDocument,
+  _AssertCitation,
+  _AssertToolConsent,
+  _AssertElicitation,
+] = [true, true, true, true, true, true];
 
 // --- Stream status ---------------------------------------------------------
 

--- a/web/src/features/agent-runtime/types.ts
+++ b/web/src/features/agent-runtime/types.ts
@@ -1,0 +1,235 @@
+'use client';
+
+// Wire-shape and at-rest types for the agent runtime stream client (D8.4a).
+// Mirrors aperag/domains/agent_runtime/wire/parts.py and uimessage.py byte-for-byte
+// so wire frames round-trip without a translator on the FE side.
+
+// --- Citation location (Anthropic-shape, D8 §2.5) -------------------------
+
+export type CitationLocation =
+  | {
+      type: 'char_location';
+      start_char_index?: number;
+      end_char_index?: number;
+      doc_index?: number;
+      doc_title?: string | null;
+      url?: string | null;
+      title?: string | null;
+    }
+  | {
+      type: 'page_location';
+      page_number?: number;
+      doc_index?: number;
+      doc_title?: string | null;
+      url?: string | null;
+      title?: string | null;
+    }
+  | {
+      type: 'content_block_location';
+      content_block_index?: number;
+      doc_index?: number;
+      doc_title?: string | null;
+      url?: string | null;
+      title?: string | null;
+    }
+  | {
+      type: 'url_citation';
+      url?: string | null;
+      title?: string | null;
+    };
+
+export type CitationData = {
+  cited_text: string;
+  location: CitationLocation;
+};
+
+// --- Transient activity (data-activity, D8.1) -----------------------------
+
+export type ActivityIntent =
+  | 'thinking'
+  | 'searching_knowledge'
+  | 'reading_source'
+  | 'comparing_results'
+  | 'writing_answer'
+  | 'waiting'
+  | 'completed'
+  | 'error';
+
+export type ActivityContext = {
+  source_name?: string | null;
+  keyword?: string | null;
+  count?: number | null;
+  target_type?: 'knowledge_base' | 'document' | 'web' | null;
+  scope_label?: string | null;
+};
+
+export type UserActivityEnvelope = {
+  intent: ActivityIntent;
+  title_key?: string;
+  subtitle_key?: string;
+  detail_key?: string | null;
+  context?: ActivityContext | null;
+};
+
+export type ActivityData = {
+  activity?: UserActivityEnvelope;
+  intent?: string;
+  label?: string | null;
+};
+
+// --- Tool consent + elicitation (D9 §3 + §5) ------------------------------
+
+export type ToolConsentRisk =
+  | 'writes_user_data'
+  | 'calls_external_api'
+  | 'modifies_system'
+  | 'admin_only';
+
+export type ToolConsentData = {
+  toolCallId: string;
+  toolName: string;
+  metadata?: Record<string, unknown>;
+  argsPreview: string;
+  argsHash: string;
+  risk: ToolConsentRisk;
+  requestedAt: string;
+  state: 'pending' | 'approved' | 'denied' | 'expired';
+};
+
+export type ElicitationData = {
+  elicitationId: string;
+  serverName: string;
+  prompt: string;
+  schema: Record<string, unknown>;
+  response?: Record<string, unknown> | null;
+  state: 'pending' | 'answered' | 'cancelled';
+};
+
+// --- Wire StreamPart discriminated union ----------------------------------
+// Mirrors wire/parts.py StreamPart 1:1. Always camelCase outer keys; inner
+// `data` payloads carry whatever shape the BE Pydantic model declared
+// (snake_case for citation/activity, camelCase for consent/elicitation).
+
+export type StreamPart =
+  | { type: 'start'; messageId?: string | null }
+  | { type: 'start-step' }
+  | { type: 'finish-step' }
+  | { type: 'finish' }
+  | { type: 'abort' }
+  | { type: 'error'; errorText: string }
+  | { type: 'text-start'; id: string }
+  | { type: 'text-delta'; id: string; delta: string }
+  | { type: 'text-end'; id: string }
+  | {
+      type: 'tool-input-start';
+      toolCallId: string;
+      toolName: string;
+      metadata?: Record<string, unknown>;
+    }
+  | { type: 'tool-input-delta'; toolCallId: string; inputTextDelta: string }
+  | {
+      type: 'tool-input-available';
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+    }
+  | {
+      type: 'tool-output-available';
+      toolCallId: string;
+      output: unknown;
+      errorText?: string | null;
+    }
+  | { type: 'source-url'; sourceId: string; url: string; title?: string | null }
+  | {
+      type: 'source-document';
+      sourceId: string;
+      mediaType: string;
+      title: string;
+    }
+  | { type: 'data-citation'; data: CitationData }
+  | { type: 'data-activity'; data: ActivityData; transient: true }
+  | { type: 'data-tool-consent'; data: ToolConsentData }
+  | { type: 'data-elicitation'; data: ElicitationData };
+
+// --- At-rest agent message parts (consumed by #77 renderer + #78 UI) ------
+// These are the dedup'd, lifecycle-collapsed parts the hook publishes.
+// Shape aligns with AI SDK v5 UIMessagePart so the renderer can use SDK
+// type guards (isTextUIPart / isToolUIPart / etc.) where convenient.
+
+export type AgentTextPart = {
+  kind: 'text';
+  id: string;
+  text: string;
+  state: 'streaming' | 'done';
+};
+
+export type AgentToolPart = {
+  kind: 'tool';
+  toolCallId: string;
+  toolName: string;
+  metadata?: Record<string, unknown>;
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+  state:
+    | 'input-streaming'
+    | 'input-available'
+    | 'output-available'
+    | 'output-error';
+};
+
+export type AgentSourceUrlPart = {
+  kind: 'source-url';
+  sourceId: string;
+  url: string;
+  title?: string | null;
+};
+
+export type AgentSourceDocumentPart = {
+  kind: 'source-document';
+  sourceId: string;
+  mediaType: string;
+  title: string;
+};
+
+export type AgentCitationPart = {
+  kind: 'citation';
+  key: string;
+  data: CitationData;
+};
+
+export type AgentToolConsentPart = {
+  kind: 'tool-consent';
+  toolCallId: string;
+  data: ToolConsentData;
+};
+
+export type AgentElicitationPart = {
+  kind: 'elicitation';
+  elicitationId: string;
+  data: ElicitationData;
+};
+
+export type AgentMessagePart =
+  | AgentTextPart
+  | AgentToolPart
+  | AgentSourceUrlPart
+  | AgentSourceDocumentPart
+  | AgentCitationPart
+  | AgentToolConsentPart
+  | AgentElicitationPart;
+
+// --- Stream status ---------------------------------------------------------
+
+export type AgentStreamStatus =
+  | 'idle'
+  | 'connecting'
+  | 'streaming'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'aborted';
+
+// AI SDK v5 protocol marker (BE response header value).
+export const AI_SDK_V5_HEADER = 'x-vercel-ai-ui-message-stream';
+export const AI_SDK_V5_HEADER_VALUE = 'v1';

--- a/web/src/features/agent-runtime/types.ts
+++ b/web/src/features/agent-runtime/types.ts
@@ -137,8 +137,14 @@ export type StreamPart =
       type: 'tool-output-available';
       toolCallId: string;
       output: unknown;
+      // BE `parts.py` (#73) currently sets `errorText` here on failure;
+      // AI SDK v5 strict spec migrates failure to `tool-output-error`
+      // (see task #89 D8.0c+ hygiene fix-forward). The reducer accepts
+      // both shapes so the FE rolls forward without coupling to the
+      // BE's split timing.
       errorText?: string | null;
     }
+  | { type: 'tool-output-error'; toolCallId: string; errorText: string }
   | { type: 'source-url'; sourceId: string; url: string; title?: string | null }
   | {
       type: 'source-document';

--- a/web/src/features/agent-runtime/use-agent-turn-stream.ts
+++ b/web/src/features/agent-runtime/use-agent-turn-stream.ts
@@ -1,0 +1,211 @@
+'use client';
+
+// React hook around the agent runtime stream client (D8.4a).
+//
+// Public seam consumed by #77 (parts renderer) and #78 (interactive
+// consent + elicitation UI):
+//
+//   const { parts, transientActivity, status, errorText, lastSequence,
+//           abort } = useAgentTurnStream({ chatId, turnId, streamUrl,
+//                                          initialSequence });
+//
+// `streamUrl == null` means "do not connect" — used for terminal turns
+// loaded from snapshot (status will resolve from the snapshot fetch in
+// the caller).
+
+import { useEffect, useReducer, useRef } from 'react';
+
+import { consumeAgentStream } from './stream-client';
+import {
+  applyPart,
+  initialReducerState,
+  type ReducerState,
+} from './reducer';
+import type { ActivityData, AgentMessagePart, AgentStreamStatus, StreamPart } from './types';
+
+type ReducerAction =
+  | { kind: 'reset'; initialSequence: number }
+  | { kind: 'connect' }
+  | { kind: 'part'; part: StreamPart; eventId: number | null }
+  | { kind: 'closed'; reason: 'completed' | 'aborted' | 'error'; error?: string };
+
+function reduce(state: ReducerState, action: ReducerAction): ReducerState {
+  switch (action.kind) {
+    case 'reset':
+      return {
+        ...initialReducerState(),
+        lastSequence: action.initialSequence,
+      };
+    case 'connect':
+      // Only flip to connecting if we are not already mid-stream; this
+      // keeps `status` stable across silent reconnects (the consumer
+      // hides reconnect blips from the UI).
+      if (state.status === 'streaming') return state;
+      if (
+        state.status === 'completed' ||
+        state.status === 'failed' ||
+        state.status === 'cancelled' ||
+        state.status === 'aborted'
+      ) {
+        return state;
+      }
+      return { ...state, status: 'connecting' };
+    case 'part':
+      return applyPart(state, action.part, action.eventId);
+    case 'closed':
+      if (action.reason === 'completed') {
+        // BE-side terminal — reducer already moved status off
+        // 'streaming' via the finish/error/abort frame. If we missed
+        // it, pin to 'completed' so the UI doesn't get stuck.
+        if (state.status === 'streaming' || state.status === 'connecting') {
+          return { ...state, status: 'completed' };
+        }
+        return state;
+      }
+      if (action.reason === 'aborted') {
+        // Local abort triggered by the user; we don't clobber a
+        // BE-driven completion that landed in the same tick.
+        if (
+          state.status === 'completed' ||
+          state.status === 'failed' ||
+          state.status === 'cancelled'
+        ) {
+          return state;
+        }
+        return { ...state, status: 'aborted' };
+      }
+      // 'error'
+      return {
+        ...state,
+        status: 'failed',
+        errorText: action.error ?? state.errorText ?? 'stream error',
+      };
+  }
+}
+
+export type UseAgentTurnStreamInput = {
+  chatId: string;
+  turnId: string;
+  /** Absolute or relative SSE URL for the turn stream. `null` skips connection. */
+  streamUrl: string | null;
+  /** Sequence id of the last envelope already in `parts` (snapshot reload, etc.). */
+  initialSequence?: number;
+};
+
+export type UseAgentTurnStreamResult = {
+  parts: AgentMessagePart[];
+  transientActivity: ActivityData | null;
+  status: AgentStreamStatus;
+  errorText: string | null;
+  lastSequence: number;
+  abort: () => void;
+};
+
+export function useAgentTurnStream(
+  input: UseAgentTurnStreamInput,
+): UseAgentTurnStreamResult {
+  const { chatId: _chatId, turnId, streamUrl, initialSequence = 0 } = input;
+  void _chatId; // chatId is currently identity-bound via the same-origin cookie; reserved for future scoping.
+
+  const [state, dispatch] = useReducer(
+    reduce,
+    initialSequence,
+    (seq): ReducerState => ({
+      ...initialReducerState(),
+      lastSequence: seq,
+    }),
+  );
+
+  // Keep the latest sequence in a ref so the reconnect loop can read
+  // it without re-running effects on every part arrival.
+  const sequenceRef = useRef(initialSequence);
+  sequenceRef.current = state.lastSequence;
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!streamUrl || !turnId) return;
+
+    let cancelled = false;
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+    dispatch({ kind: 'reset', initialSequence });
+
+    (async () => {
+      // Reconnect loop with exponential-ish backoff. We stop as soon as
+      // the stream closes for a non-recoverable reason (completed,
+      // aborted, or after `MAX_ATTEMPTS` consecutive errors).
+      let attempt = 0;
+      const MAX_ATTEMPTS = 5;
+      while (!cancelled && !abortController.signal.aborted) {
+        dispatch({ kind: 'connect' });
+        const closeInfo = await consumeAgentStream({
+          url: streamUrl,
+          signal: abortController.signal,
+          lastEventId: sequenceRef.current,
+          onPart: (part, eventId) => {
+            if (cancelled) return;
+            dispatch({ kind: 'part', part, eventId });
+          },
+          onEventId: (eventId) => {
+            if (cancelled) return;
+            // Track the highest seen id directly; the reducer also
+            // bumps lastSequence on parts that carry an id, but the
+            // ref needs to lead so the next reconnect picks up
+            // immediately.
+            if (eventId > sequenceRef.current) {
+              sequenceRef.current = eventId;
+            }
+          },
+        });
+
+        if (cancelled) break;
+
+        if (closeInfo.reason === 'completed') {
+          dispatch({ kind: 'closed', reason: 'completed' });
+          break;
+        }
+        if (closeInfo.reason === 'aborted') {
+          dispatch({ kind: 'closed', reason: 'aborted' });
+          break;
+        }
+        attempt += 1;
+        if (attempt >= MAX_ATTEMPTS) {
+          dispatch({
+            kind: 'closed',
+            reason: 'error',
+            error: closeInfo.error,
+          });
+          break;
+        }
+        await sleep(Math.min(2000, 200 * 2 ** (attempt - 1)));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+      if (abortRef.current === abortController) {
+        abortRef.current = null;
+      }
+    };
+    // initialSequence is read once at hook-mount time via the lazy
+    // reducer initializer; we intentionally do not re-run on changes
+    // because the runtime always increments the cursor and we don't
+    // want to silently drop accumulated parts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [streamUrl, turnId]);
+
+  return {
+    parts: state.parts,
+    transientActivity: state.transientActivity,
+    status: state.status,
+    errorText: state.errorText,
+    lastSequence: state.lastSequence,
+    abort: () => abortRef.current?.abort(),
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2,6 +2,41 @@
 # yarn lockfile v1
 
 
+"@ai-sdk/gateway@2.0.82":
+  version "2.0.82"
+  resolved "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.82.tgz#af89fd832b36e6da3e17a84898cc72422c26e461"
+  integrity sha512-vtoCSEBGPcxzChI3eqe9C9AJSlc/WUZp92tzpOqVd4B6Tnu4583S+qR7TknB0tPta15TEoOIkK0ENW6D/DgRJQ==
+  dependencies:
+    "@ai-sdk/provider" "2.0.1"
+    "@ai-sdk/provider-utils" "3.0.23"
+    "@vercel/oidc" "3.1.0"
+
+"@ai-sdk/provider-utils@3.0.23":
+  version "3.0.23"
+  resolved "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.23.tgz#2ec7bff22335facc72563388971fac1f0cedb02c"
+  integrity sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==
+  dependencies:
+    "@ai-sdk/provider" "2.0.1"
+    "@standard-schema/spec" "^1.0.0"
+    eventsource-parser "^3.0.6"
+
+"@ai-sdk/provider@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz#4aba415f1815da33a7a81e5f41a0219af53278c0"
+  integrity sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/react@^2.0.0":
+  version "2.0.181"
+  resolved "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.181.tgz#bf9e1b8a6bfcd47242a91ec59a0a5550bdb8a923"
+  integrity sha512-Jay7zyuy8+RHHIZdrM1M4KLi8wAbFzyBAb37HfVSLeIE6HiU43qFN5bI+Xyi9p946AmBNZ7tokuxjXhsUS+V4w==
+  dependencies:
+    "@ai-sdk/provider-utils" "3.0.23"
+    ai "5.0.179"
+    swr "^2.2.5"
+    throttleit "2.1.0"
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
@@ -1038,6 +1073,11 @@
   resolved "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
   integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
 
+"@opentelemetry/api@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
+  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
+
 "@parcel/watcher-android-arm64@2.5.6":
   version "2.5.6"
   resolved "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz#5f32e0dba356f4ac9a11068d2a5c134ca3ba6564"
@@ -1643,6 +1683,11 @@
   version "1.21.5"
   resolved "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz#75989085bbbf80ee325874a0137437bde77e9baf"
   integrity sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==
+
+"@standard-schema/spec@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
 "@standard-schema/utils@^0.3.0":
   version "0.3.0"
@@ -2494,6 +2539,11 @@
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
+"@vercel/oidc@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz#066caee449b84079f33c7445fc862464fe10ec32"
+  integrity sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==
+
 accepts@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
@@ -2543,6 +2593,16 @@ ahooks@^3.9.3:
     resize-observer-polyfill "^1.5.1"
     screenfull "^5.0.0"
     tslib "^2.4.1"
+
+ai@5.0.179, ai@^5.0.0:
+  version "5.0.179"
+  resolved "https://registry.npmjs.org/ai/-/ai-5.0.179.tgz#591f470bcf4cebb931dea07252d98d9217ad8ade"
+  integrity sha512-tuq/r2FH/pBuY3jo0yHF3UglDV73WONGLhW80DuwgO6w0ftPIqRsAm5p9cE3Bu4LfEuCkMXpiUG/pQRzqKRRaA==
+  dependencies:
+    "@ai-sdk/gateway" "2.0.82"
+    "@ai-sdk/provider" "2.0.1"
+    "@ai-sdk/provider-utils" "3.0.23"
+    "@opentelemetry/api" "1.9.0"
 
 ajv-formats@^3.0.1:
   version "3.0.1"
@@ -4257,6 +4317,11 @@ eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
   resolved "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.5.tgz#1346314851df0a3bd72450339f58bd9bc8cb77df"
   integrity sha512-bSRG85ZrMdmWtm7qkF9He9TNRzc/Bm99gEJMaQoHJ9E6Kv9QBbsldh2oMj7iXmYNEAVvNgvv5vPorG6W+XtBhQ==
 
+eventsource-parser@^3.0.6:
+  version "3.0.8"
+  resolved "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz#1c792503e4080455d00701bb1f7a1d60734d0e58"
+  integrity sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==
+
 eventsource@^3.0.2:
   version "3.0.7"
   resolved "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
@@ -5423,6 +5488,11 @@ json-schema-typed@^8.0.2:
   version "8.0.2"
   resolved "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
   integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
+
+json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -8230,6 +8300,14 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swr@^2.2.5:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz#c9e48abff6bf4b04846342e2f1f6be108a078cf6"
+  integrity sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==
+  dependencies:
+    dequal "^2.0.3"
+    use-sync-external-store "^1.6.0"
+
 synckit@0.11.11:
   version "0.11.11"
   resolved "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz#c0b619cf258a97faa209155d9cd1699b5c998cb0"
@@ -8267,6 +8345,11 @@ tar@>=7.5.11, tar@^7.4.3:
     minipass "^7.1.2"
     minizlib "^3.1.0"
     yallist "^5.0.0"
+
+throttleit@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz#a7e4aa0bf4845a5bd10daa39ea0c783f631a07b4"
+  integrity sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==
 
 tiny-invariant@^1.0.0, tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
   version "1.3.3"
@@ -8700,6 +8783,11 @@ use-sidecar@^1.1.3:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Summary

D8.4a first-cut. Replaces the legacy `AgentRuntimeRedisStore` SSE consumer with a `fetch + ReadableStream` transport that speaks the AI SDK v5 UI Message Stream Protocol, hooks the new client into `chat-messages.tsx` through a narrow `legacy-snapshot-shim`, and lays the `parts + transientActivity + status/error/abort/resume` seam that #77 (parts renderer) and #78 (interactive consent + elicitation UI) will plug into. Architect msg=bad0cd0f locked the 6 client-side contracts; this PR delivers each in a verifiable form (see below).

## Module layout (`web/src/features/agent-runtime/`)

| File | Purpose |
|---|---|
| `types.ts` | Wire `StreamPart` typed union (mirrors `aperag/domains/agent_runtime/wire/parts.py:1`) + at-rest `AgentMessagePart` (`text` / `tool` / `source-url` / `source-document` / `citation` / `tool-consent` / `elicitation`) shaped to align with `@ai-sdk/react`'s `UIMessagePart`. |
| `stream-parser.ts` | SSE frame parser — `id:` + `data:` only, comments/heartbeats skipped, trailing partial frames carried. |
| `stream-client.ts` | Single-connection consumer: validates `x-vercel-ai-ui-message-stream: v1` response header, forwards `Last-Event-ID` on resume, terminates on `finish` / `error` / `abort` and on local `AbortSignal`. |
| `reducer.ts` | Collapses wire lifecycle parts (`tool-input-*` / `tool-output-available`) into consolidated tool parts; dedups by stable id (text-block id / toolCallId / sourceId / elicitationId / citation fingerprint); transient \`data-activity\` is replace-last only and never reaches the persistent parts list. |
| `use-agent-turn-stream.ts` | React hook with reconnect loop; surfaces \`{ parts, transientActivity, status, errorText, lastSequence, abort }\` (this is the contract #77 / #78 build on). |
| `api.ts` | Typed JSON wrappers for create / cancel / snapshot / artifact + consent / elicitation submit endpoints. |
| `legacy-snapshot-shim.ts` | **TODO(#77 dongdong)** projection back to \`AgentTurnSnapshot { turn, timeline, artifacts }\` so the existing card renders during the transition. Narrow by design — see boundary below. |

## Consumer rationale: AI SDK-compatible transport (not \`useChat\`)

Per architect lock msg=ed98280c + Weston msg=563157a8 + symphony msg=592de041 + dongdong msg=8883b85f, this PR ships an **AI SDK-compatible stream transport** rather than a \`useChat\` adoption. Why:

* ApeRAG's turn lifecycle is two-phase: client must \`POST /agent/chats/{cid}/turns\` first to obtain a \`stream_url\`, then \`GET\` that URL to begin the SSE body. \`useChat\`'s default lifecycle is single-step POST+stream; bending it would mean writing a custom \`ChatTransport\` of comparable complexity to this consumer.
* All 6 client-side contracts are at the wire-protocol level, orthogonal to the hook implementation.
* \`@ai-sdk/react@^2.0.0\` + \`ai@^5.0.0\` are still added so #77 can lean on the SDK's \`isTextUIPart\` / \`isToolUIPart\` / \`isDataUIPart\` type guards directly when rendering.

(Captured for D10 reference: ApeRAG agent runtime SSE is two-phase — POST \`/turns\` → GET \`stream_url\`. Worth normalising in the D8 doc later if symphony agrees, follow-up of D8.0c.)

## 6 client-side contracts (architect msg=bad0cd0f) — all delivered

1. **AI SDK v5 typed parts surface** — \`StreamPart\` (\`web/src/features/agent-runtime/types.ts\`) mirrors BE wire parts 1:1; index re-exports \`AgentMessagePart\` shaped to align with \`@ai-sdk/react\`'s \`UIMessagePart\` so the renderer can use SDK type guards.
2. **Header marker validation** — \`stream-client.ts\` rejects any response that does not advertise \`x-vercel-ai-ui-message-stream: v1\` before dispatching any \`onPart\`. Header constants exported as \`AI_SDK_V5_HEADER\` / \`AI_SDK_V5_HEADER_VALUE\`.
3. **Resume / error / abort** — Reconnect loop in \`use-agent-turn-stream.ts\` sends \`Last-Event-ID\` header (from the highest seen SSE \`id:\` field) + \`after_sequence\` query on every connection attempt. \`error\` part flips \`status='failed'\` and the connection terminates; \`abort\` part flips \`status='aborted'\`. Local \`abort()\` triggers an \`AbortController.abort()\` so in-flight \`fetch\` is cancelled. Reconnect bounded at 5 attempts before surfacing \`failed\`.
4. **Part-level dedup by stable identifier** (architect msg=f35c5a3d Lock C) — \`reducer.ts\` keys by \`text-block id\` / \`toolCallId\` / \`sourceId\` / \`elicitationId\` per part type. Citations have no native id; we fingerprint \`cited_text + JSON.stringify(location)\` since the BE replays the identical payload byte-for-byte (envelope-atomic replay).
5. **Wire shape adoption** — wrapped \`{type, data: {...}}\` for \`data-citation\` / \`data-tool-consent\` / \`data-elicitation\` / \`data-activity\` passes through unchanged. Outer keys camelCase (\`toolCallId\`, \`errorText\`, \`sourceId\`, \`mediaType\`, \`inputTextDelta\`, \`argsPreview\`, etc.); inner \`data\` payloads keep the BE Pydantic alias casing exactly.
6. **Transient \`data-activity\` is render-only** — never appears in \`parts\`; lives on the separate \`transientActivity\` slot, replace-last on each new frame. Doc'd at \`reducer.ts\` (\`case 'data-activity':\`).

## Tool-output failure shape (minor architect-canonical drift, please confirm)

BE \`parts.py:184\` emits \`tool-output-available\` with an optional \`errorText\` field set on failure. The strict AI SDK v5 spec splits this into \`tool-output-available\` (success) / \`tool-output-error\` (failure). The reducer normalises both shapes onto a single \`AgentToolPart.state ∈ {output-available, output-error}\` with \`errorText\`, so consumers don't need to care. Calling out for symphony's review — happy to amend either side.

## \`legacy-snapshot-shim.ts\` boundary (per PM lock msg=ed98280c)

* **Covered**: \`streamingAnswer\` (grouped per text-block id, joined with \`\n\n\` so multi-block streams read naturally), patched turn status from the live stream, timeline + artifacts pass through from \`baselineSnapshot\` only (i.e. the snapshot endpoint's read-only history).
* **NOT covered**: rich activity inference, debug previews, reference bundle items rendered from new \`AgentMessagePart\`, error_summary translation, timeline merging from the new \`parts\` stream. Those belong to the D8.4b renderer (#77).
* Zero callers outside \`chat-messages.tsx\`. The shim is scheduled for deletion as part of #77.

## Verification

* **\`yarn lint\`** — clean (\`✔ No ESLint warnings or errors\`).
* **\`tsc --noEmit\`** — clean for the touched files. Pre-existing main-branch errors in \`chat-input.tsx\` / \`page.tsx\` / \`collection-form.tsx\` / \`collection-provider.tsx\` are unrelated and untouched here.
* **Dev boot smoke** (per \`feedback_fe_runtime_gate.md\`) — \`yarn dev\` boots in 2.3s on port 3010; \`GET /\`, \`GET /auth/signin\`, \`GET /workspace/collections\`, \`GET /workspace\` all return 200; no new runtime errors in the dev log (the \`Invalid keys: status.queued (...)\` i18n warnings are pre-existing on main).

## Test plan

- [ ] Symphony architect canonical drift quick check (esp. tool-output failure shape; citation fingerprint as dedup key)
- [ ] Weston blocker-level minimal CR — focus on the 6 wire/protocol contracts being verifiable
- [ ] dongdong scoped review — part union shape, dedup keys, reload/resume contract, #77 renderer seam stability
- [ ] Manual smoke on a live agent chat once a fresh tenant is available (POST a turn → live text stream → tool call lifecycle → completion)
- [ ] Confirm \`Last-Event-ID\` resume on a forced disconnect (DevTools → throttling → offline → online)

## Hand-off seams for #77 / #78

* **#77 parts renderer** → consumes \`useAgentTurnStream(...) → { parts, transientActivity, status, errorText, ... }\`. Will replace the \`AgentTurnCard\` consumer of \`legacy-snapshot-shim\`. Can delete \`legacy-snapshot-shim.ts\` once the new renderer ships.
* **#78 interactive consent / elicitation UI** → filters \`parts\` for \`kind === 'tool-consent'\` / \`kind === 'elicitation'\` and calls \`decideToolConsent(...)\` / \`submitElicitation(...)\` from \`api.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)