### PR TITLE
feat(phase8 #90 D8.4d): snapshot endpoint returns canonical UIMessage parts

### DIFF
--- a/aperag/domains/agent_runtime/schemas.py
+++ b/aperag/domains/agent_runtime/schemas.py
@@ -176,10 +176,14 @@ class CreateTurnResponse(BaseModel):
     stream_url: str
 
 
-class AgentTurnSnapshot(BaseModel):
-    turn: AgentTurnEnvelope
-    timeline: list[AgentTimelineEventEnvelope] = Field(default_factory=list)
-    artifacts: list[AgentArtifactEnvelope] = Field(default_factory=list)
+# ``AgentTurnSnapshot`` is the canonical UIMessage at-rest envelope and
+# lives in :mod:`aperag.domains.agent_runtime.uimessage` next to the
+# other UIMessage classes. It is re-exported here so the existing
+# ``from aperag.domains.agent_runtime.schemas import AgentTurnSnapshot``
+# import sites continue to work without a domain-internal hop.
+from aperag.domains.agent_runtime.uimessage import (  # noqa: E402, F401
+    AgentTurnSnapshot,
+)
 
 
 class CancelTurnResponse(BaseModel):

--- a/aperag/domains/agent_runtime/services.py
+++ b/aperag/domains/agent_runtime/services.py
@@ -31,7 +31,12 @@ from aperag.domains.agent_runtime.schemas import (
     UserActivityEnvelope,
     UserActivityIntent,
 )
+from aperag.domains.agent_runtime.snapshot_assembler import (
+    assemble_parts_from_artifacts,
+    extract_error_text,
+)
 from aperag.domains.agent_runtime.storage import AgentRuntimeRedisStore
+from aperag.domains.agent_runtime.uimessage_store import UIMessageStore
 from aperag.domains.conversation.db.models import BotType
 from aperag.domains.conversation.schemas import BotConfig
 from aperag.exceptions import ChatNotFoundException, ResourceNotFoundException, ValidationException
@@ -294,9 +299,20 @@ def _extract_answer_text_from_artifact(artifact) -> str:
 
 
 class TurnService:
-    def __init__(self, db_ops: AsyncDatabaseOps | None = None, redis_store: AgentRuntimeRedisStore | None = None):
+    def __init__(
+        self,
+        db_ops: AsyncDatabaseOps | None = None,
+        redis_store: AgentRuntimeRedisStore | None = None,
+        uimessage_store: UIMessageStore | None = None,
+    ):
         self.db_ops = db_ops or async_db_ops
         self.redis_store = redis_store or AgentRuntimeRedisStore()
+        # ``uimessage_store`` is the canonical at-rest reader once the
+        # wire emitter starts persisting ``agent_message.parts`` (D8.6
+        # / #80). Until then it stays optional and we fall back to
+        # projecting legacy artifacts via
+        # ``assemble_parts_from_artifacts``.
+        self.uimessage_store = uimessage_store
 
     async def get_chat_and_bot(self, user: str, chat_id: str):
         chat = await self.db_ops.query_chat_by_id(user, chat_id)
@@ -411,33 +427,76 @@ class TurnService:
             )
 
     async def get_turn_snapshot(self, user: str, chat_id: str, turn_id: str) -> AgentTurnSnapshot:
+        """Return the canonical ``AgentTurnSnapshot`` (Phase 8 D8.4d).
+
+        The legacy ``{turn, timeline, artifacts}`` shape is gone; the
+        FE renderer (#76 / #77 / #78) now consumes the same
+        ``UIMessagePart`` discriminated union it already gets from the
+        live SSE stream (per D8 §2 wire / at-rest byte-equal).
+
+        Sources, in priority order:
+
+        1. ``UIMessageStore.read(turn_id)`` — once the wire emitter
+           starts persisting ``agent_message.parts`` (D8.6 / #80
+           cleanup) this is the only path. Today the store is
+           optional and most reads return ``None``.
+        2. ``assemble_parts_from_artifacts`` — transitional projection
+           from the legacy ``answer`` / ``reference_bundle``
+           artifacts so completed / failed / cancelled turns keep
+           rendering before D8.6.
+
+        The ``error_text`` field is filled from the
+        ``error_summary`` artifact (or the runtime ``error_message``
+        field as a fallback) so a FAILED reload shows the same
+        message the live ``error`` part would have surfaced.
+        """
+
         turn = await self.db_ops.query_agent_turn(user, chat_id, turn_id)
         if not turn:
             raise ResourceNotFoundException("Turn", turn_id)
 
-        persisted_events = await self.db_ops.query_agent_timeline_events(turn_id, after_sequence=0, limit=2000)
-        cached_events = [
-            EventService.adapt_event_envelope(AgentTimelineEventEnvelope.model_validate(item))
-            for item in await self.redis_store.get_all_events(turn_id)
-        ]
-        merged_events: dict[int, AgentTimelineEventEnvelope] = {
-            event.sequence: EventService.to_event_envelope(event) for event in persisted_events
-        }
-        for event in cached_events:
-            merged_events[event.sequence] = event
-
-        runtime_state = await self.redis_store.get_runtime_state(turn_id)
-        artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn_id)
-        timeline = [merged_events[key] for key in sorted(merged_events)]
-        latest_sequence = timeline[-1].sequence if timeline else 0
-        turn_envelope = _apply_runtime_state_to_turn(
-            self.to_turn_envelope(turn), runtime_state, latest_sequence=latest_sequence
+        runtime_state = await self.redis_store.get_runtime_state(turn_id) or {}
+        status_value = runtime_state.get("status") or turn.status
+        status_str = status_value.value if hasattr(status_value, "value") else str(status_value)
+        timeline_cursor = max(
+            _coerce_timeline_cursor(runtime_state.get("timeline_cursor")),
+            _coerce_timeline_cursor(turn.timeline_cursor),
         )
 
+        parts: list[Any] = []
+        artifacts: list[Any] = []
+
+        if self.uimessage_store is not None:
+            try:
+                persisted_message = await self.uimessage_store.read(turn_id)
+            except Exception:  # pragma: no cover — store is best-effort during transition
+                persisted_message = None
+            if persisted_message is not None and persisted_message.parts:
+                parts = list(persisted_message.parts)
+
+        if not parts:
+            artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn_id)
+            parts = list(assemble_parts_from_artifacts(artifacts))
+
+        error_text: Optional[str] = None
+        if status_str in {AgentTurnStatus.FAILED.value, AgentTurnStatus.CANCELLED.value}:
+            if not artifacts:
+                artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn_id)
+            error_text = extract_error_text(artifacts)
+            if not error_text:
+                error_text = runtime_state.get("error_message") or turn.error_message
+
         return AgentTurnSnapshot(
-            turn=turn_envelope,
-            timeline=timeline,
-            artifacts=[ArtifactService.to_artifact_envelope(artifact) for artifact in artifacts],
+            turn_id=turn.id,
+            chat_id=turn.chat_id,
+            status=status_str,
+            parts=parts,
+            error_text=error_text,
+            timeline_cursor=timeline_cursor,
+            started_at=turn.gmt_started,
+            finished_at=turn.gmt_finished,
+            created_at=turn.gmt_created,
+            updated_at=turn.gmt_updated,
         )
 
     @staticmethod

--- a/aperag/domains/agent_runtime/snapshot_assembler.py
+++ b/aperag/domains/agent_runtime/snapshot_assembler.py
@@ -1,0 +1,163 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Snapshot endpoint UIMessage assembler (Phase 8 D8.4d / #90).
+
+The agent runtime's snapshot endpoint historically returned the legacy
+``{turn, timeline, artifacts}`` shape. D8 §2 locks the wire and at-rest
+``UIMessage`` parts as same-schema, so the snapshot endpoint must
+expose ``parts: UIMessagePart[]`` for the FE renderer (#76 / #77 / #78)
+to consume from a single code path.
+
+This module projects the legacy ``AgentArtifact`` rows into the
+canonical at-rest part list, mirroring the FE-side
+``snapshot-fallback.ts`` adapter that #77 huangheng landed as a
+transitional bridge:
+
+* ``answer`` artifact -> single ``TextPart``
+* ``reference_bundle`` artifact -> N x ``SourceUrlPart`` plus
+  N x ``DataCitationPart`` (Anthropic-shape)
+* ``error_summary`` artifact -> not a part; surfaced via the snapshot
+  envelope's ``error_text`` field
+
+Other artifact types (``tool_result_summary`` /
+``search_result_summary``) are skipped: tool lifecycle and search
+results are surfaced by the tool/citation parts emitted directly during
+the live turn (#73 wire emitter + #75 tool lifecycle), so projecting
+them here would double-count once the wire emitter starts persisting
+``agent_message.parts`` directly (D8.6 / #80 cleanup).
+
+When that cleanup lands and ``UIMessageStore.read(turn_id)`` returns a
+populated row, the snapshot service short-circuits to the at-rest read
+and this assembler is no longer hit. At that point the FE
+``snapshot-fallback.ts`` and this module can both be deleted in a
+single follow-up.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from aperag.domains.agent_runtime.db.models import AgentArtifact, AgentArtifactType
+from aperag.domains.agent_runtime.uimessage import (
+    CitationData,
+    DataCitationPart,
+    SourceUrlPart,
+    TextPart,
+    UIMessagePart,
+    UrlCitationLocation,
+)
+
+
+def assemble_parts_from_artifacts(
+    artifacts: Iterable[AgentArtifact],
+) -> list[UIMessagePart]:
+    """Project legacy ``AgentArtifact`` rows into a UIMessage parts list.
+
+    Order: ``TextPart`` (answer) first, then ``SourceUrlPart`` /
+    ``DataCitationPart`` pairs from ``reference_bundle.items``. The
+    answer text comes from ``payload.text`` (matches the runtime's
+    artifact write at ``runtime.py:441``); reference items are read
+    from ``payload.items`` (matches ``runtime.py:449``).
+
+    Items that lack a URI are still surfaced as ``DataCitationPart``
+    with an empty ``url`` so the FE renderer can show snippet/title;
+    the upcoming D8.6 cleanup will replace this transitional adapter
+    with the canonical at-rest ``UIMessageStore.read()`` path.
+    """
+
+    answer: Optional[AgentArtifact] = None
+    reference_bundle: Optional[AgentArtifact] = None
+    for artifact in artifacts:
+        if artifact.artifact_type == AgentArtifactType.ANSWER and answer is None:
+            answer = artifact
+        elif artifact.artifact_type == AgentArtifactType.REFERENCE_BUNDLE and reference_bundle is None:
+            reference_bundle = artifact
+
+    parts: list[UIMessagePart] = []
+
+    if answer is not None:
+        text = _extract_answer_text(answer)
+        if text:
+            parts.append(TextPart(text=text))
+
+    if reference_bundle is not None:
+        for source_part, citation_part in _project_reference_items(reference_bundle):
+            if source_part is not None:
+                parts.append(source_part)
+            parts.append(citation_part)
+
+    return parts
+
+
+def extract_error_text(artifacts: Iterable[AgentArtifact]) -> Optional[str]:
+    """Return the human-readable error message for a failed turn, or None.
+
+    Looks up the ``error_summary`` artifact and pulls
+    ``payload.message`` / ``payload.text`` / ``summary`` in that order.
+    Mirrors the FE adapter's ``extractErrorTextFromSnapshot`` so a
+    historical FAILED turn renders the same error string from either
+    side of the new boundary.
+    """
+
+    for artifact in artifacts:
+        if artifact.artifact_type != AgentArtifactType.ERROR_SUMMARY:
+            continue
+        payload = artifact.payload if isinstance(artifact.payload, dict) else {}
+        message = payload.get("message") or payload.get("text") or payload.get("summary")
+        if message:
+            return str(message)
+        if artifact.summary:
+            return str(artifact.summary)
+    return None
+
+
+def _extract_answer_text(artifact: AgentArtifact) -> str:
+    payload = artifact.payload if isinstance(artifact.payload, dict) else {}
+    text = payload.get("text") or payload.get("content") or payload.get("answer")
+    if text:
+        return str(text)
+    if artifact.summary:
+        return str(artifact.summary)
+    return ""
+
+
+def _project_reference_items(
+    artifact: AgentArtifact,
+) -> Iterable[tuple[Optional[SourceUrlPart], DataCitationPart]]:
+    payload = artifact.payload if isinstance(artifact.payload, dict) else {}
+    raw_items = payload.get("items")
+    if not isinstance(raw_items, list):
+        return
+
+    for index, raw in enumerate(raw_items):
+        if not isinstance(raw, dict):
+            continue
+        metadata = raw.get("metadata") if isinstance(raw.get("metadata"), dict) else {}
+        url = raw.get("uri") or metadata.get("url")
+        title = raw.get("title") or metadata.get("title")
+        snippet = raw.get("snippet") or raw.get("content") or ""
+        source_id = raw.get("source_id") or raw.get("id") or f"{artifact.id}-ref-{index}"
+
+        source_part: Optional[SourceUrlPart] = None
+        if url:
+            source_part = SourceUrlPart(source_id=str(source_id), url=str(url), title=title)
+
+        citation_part = DataCitationPart(
+            data=CitationData(
+                cited_text=str(snippet),
+                location=UrlCitationLocation(url=str(url) if url else "", title=title),
+            )
+        )
+        yield source_part, citation_part

--- a/aperag/domains/agent_runtime/uimessage.py
+++ b/aperag/domains/agent_runtime/uimessage.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime
 from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -291,6 +292,50 @@ class UIMessage(BaseModel):
     id: str
     role: Literal["user", "assistant", "system"]
     parts: list[UIMessagePart] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------
+# Snapshot endpoint envelope (Phase 8 D8.4d / #90)
+# ---------------------------------------------------------------------
+
+
+class AgentTurnSnapshot(BaseModel):
+    """Canonical UIMessage at-rest snapshot for an agent turn (Phase 8 D8.4d / #90).
+
+    Replaces the legacy ``{turn, timeline, artifacts}`` snapshot shape
+    with the ``UIMessage``-aligned canonical that the FE renderer
+    (#76 / #77 / #78) consumes from both the live SSE stream and the
+    at-rest reload path. Per D8 §2 wire / at-rest are byte-equal, so
+    no client-side converter is required: a snapshot reload
+    deserializes through the same ``UIMessagePart`` discriminated
+    union the wire emits.
+
+    ``parts`` is the persistable subset (transient ``data-activity``
+    is stripped before write per :func:`persistable_parts`);
+    ``status`` mirrors the runtime ``AgentTurnStatus`` enum value;
+    ``error_text`` surfaces an ``error_summary`` artifact's message
+    for failed turns. Turn-shape metadata (timestamps, ids, cursor)
+    is kept top-level so the FE can render without a separate
+    envelope round-trip.
+
+    Lives in this module rather than ``schemas`` to keep the
+    ``UIMessage`` family (parts + envelope) in a single source-of-truth
+    file; ``schemas`` re-exports the name for back-compat with
+    existing import sites.
+    """
+
+    schema_version: str = AGENT_RUNTIME_SCHEMA_VERSION
+    turn_id: str
+    chat_id: str
+    role: Literal["assistant"] = "assistant"
+    status: str
+    parts: list[UIMessagePart] = Field(default_factory=list)
+    error_text: Optional[str] = None
+    timeline_cursor: int = 0
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 # ---------------------------------------------------------------------

--- a/aperag/domains/conversation/service/chat_completion_service.py
+++ b/aperag/domains/conversation/service/chat_completion_service.py
@@ -366,8 +366,14 @@ class ChatCompletionService:
             if self._status_value(turn.status) != AgentTurnStatus.COMPLETED.value:
                 return OpenAIFormatter.format_error(turn.error_message or "Chat completion failed")
 
-            snapshot = await runtime_manager.turn_service.get_turn_snapshot(user, chat_id, turn_id)
-            content = self._build_completion_content(snapshot)
+            # Phase 8 D8.4d (#90): the snapshot endpoint now returns
+            # canonical UIMessage parts; legacy ``snapshot.artifacts``
+            # is gone. Pull artifacts directly from the DB so the
+            # OpenAI-compat completion content keeps its existing
+            # answer + references shape (which is independent of the
+            # FE-facing UIMessage protocol).
+            artifacts = await runtime_manager.turn_service.db_ops.query_agent_artifacts_by_turn(turn_id)
+            content = self._build_completion_content(artifacts)
             return OpenAIFormatter.format_complete_response(turn_id, content)
         finally:
             if ephemeral_chat:
@@ -438,19 +444,27 @@ class ChatCompletionService:
         return status.value if hasattr(status, "value") else str(status)
 
     @staticmethod
-    def _build_completion_content(snapshot) -> str:
+    def _build_completion_content(artifacts) -> str:
+        """Build OpenAI-compat completion content from raw agent artifacts.
+
+        Phase 8 D8.4d (#90) flipped the snapshot endpoint to canonical
+        UIMessage parts; this OpenAI-compat path stays artifact-shaped
+        because the response format is independent of the FE-facing
+        UIMessage protocol. Callers pass the raw artifact list from
+        ``db_ops.query_agent_artifacts_by_turn``.
+        """
         answer_text = ""
         references_payload: list[dict[str, Any]] = []
 
-        for artifact in snapshot.artifacts:
-            if artifact.artifact_id == snapshot.turn.answer_artifact_id or artifact.artifact_type == "answer":
+        for artifact in artifacts:
+            artifact_type = getattr(artifact, "artifact_type", None)
+            type_value = getattr(artifact_type, "value", artifact_type)
+            payload = getattr(artifact, "payload", None) or {}
+            if type_value == "answer":
                 if not answer_text:
-                    answer_text = artifact.payload.get("text") or artifact.payload.get("content") or ""
-            if (
-                artifact.artifact_id == snapshot.turn.reference_bundle_artifact_id
-                or artifact.artifact_type == "reference_bundle"
-            ):
-                items = artifact.payload.get("items")
+                    answer_text = payload.get("text") or payload.get("content") or ""
+            elif type_value == "reference_bundle":
+                items = payload.get("items")
                 if isinstance(items, list):
                     references_payload = [item for item in items if isinstance(item, dict)]
 

--- a/aperag/domains/evaluation/worker.py
+++ b/aperag/domains/evaluation/worker.py
@@ -172,8 +172,12 @@ async def dispatch_evaluation_turn(
     latency_ms = int((time.monotonic() - start) * 1000)
 
     if final_status == AgentTurnStatus.COMPLETED.value:
-        snapshot = await agent_runtime_manager.turn_service.get_turn_snapshot(user_id, chat_id, turn.id)
-        answer_text = _extract_answer_text(snapshot)
+        # Phase 8 D8.4d (#90): the snapshot endpoint now returns canonical
+        # UIMessage parts; legacy ``snapshot.artifacts`` is gone. Pull
+        # artifacts straight from the DB instead of rebuilding the answer
+        # from the at-rest UIMessage parts (which is the FE concern).
+        artifacts = await agent_runtime_manager.turn_service.db_ops.query_agent_artifacts_by_turn(turn.id)
+        answer_text = _extract_answer_text(artifacts)
         return TurnDispatchOutcome(
             status=EvaluationRunItemAttemptStatus.COMPLETED,
             agent_chat_id=chat_id,
@@ -207,10 +211,15 @@ async def dispatch_evaluation_turn(
     )
 
 
-def _extract_answer_text(snapshot) -> str:
-    for artifact in snapshot.artifacts:
-        if artifact.artifact_id == snapshot.turn.answer_artifact_id or artifact.artifact_type == "answer":
-            text = (artifact.payload or {}).get("text") or (artifact.payload or {}).get("content")
+def _extract_answer_text(artifacts) -> str:
+    for artifact in artifacts:
+        artifact_type = getattr(artifact, "artifact_type", None)
+        # AgentArtifactType is a str-Enum; compare by string value to
+        # avoid pulling the enum into this module just for one branch.
+        type_value = getattr(artifact_type, "value", artifact_type)
+        if type_value == "answer":
+            payload = getattr(artifact, "payload", None) or {}
+            text = payload.get("text") or payload.get("content")
             if text:
                 return text
     return ""

--- a/tests/e2e_http/hurl/full/15_agent_runtime_v3.hurl
+++ b/tests/e2e_http/hurl/full/15_agent_runtime_v3.hurl
@@ -93,11 +93,14 @@ jsonpath "$.turn.client_idempotency_key" == "agent-runtime-v3-{{run_id}}"
 GET {{base_url}}/api/v2/agent/chats/{{chat_id}}/turns/{{turn_id}}
 HTTP 200
 [Asserts]
-jsonpath "$.turn.turn_id" == "{{turn_id}}"
-jsonpath "$.turn.chat_id" == "{{chat_id}}"
-jsonpath "$.turn.schema_version" exists
-jsonpath "$.timeline" exists
-jsonpath "$.artifacts" exists
+# Phase 8 D8.4d (#90): snapshot endpoint returns canonical UIMessage parts.
+# Legacy {turn, timeline, artifacts} keys are gone per D8 §2 wire/at-rest byte-equal.
+jsonpath "$.turn_id" == "{{turn_id}}"
+jsonpath "$.chat_id" == "{{chat_id}}"
+jsonpath "$.role" == "assistant"
+jsonpath "$.schema_version" exists
+jsonpath "$.status" exists
+jsonpath "$.parts" exists
 
 POST {{base_url}}/api/v2/agent/chats/{{chat_id}}/turns/{{turn_id}}/cancel
 HTTP 200

--- a/tests/e2e_http/hurl/full/17_chat_collection_flow.hurl
+++ b/tests/e2e_http/hurl/full/17_chat_collection_flow.hurl
@@ -169,11 +169,16 @@ jsonpath "$.stream_url" contains "/api/v2/agent/chats/{{chat_id}}/turns/{{turn_i
 GET {{base_url}}/api/v2/agent/chats/{{chat_id}}/turns/{{turn_id}}
 HTTP 200
 [Asserts]
-jsonpath "$.turn.turn_id" == "{{turn_id}}"
-jsonpath "$.turn.chat_id" == "{{chat_id}}"
-jsonpath "$.turn.bot_id" == "{{bot_id}}"
-jsonpath "$.timeline" exists
-jsonpath "$.artifacts" exists
+# Phase 8 D8.4d (#90): snapshot endpoint returns canonical UIMessage parts.
+# Legacy {turn, timeline, artifacts} keys are gone; bot_id is no longer in
+# the snapshot envelope (it lives on the turn-create response which is
+# already asserted above).
+jsonpath "$.turn_id" == "{{turn_id}}"
+jsonpath "$.chat_id" == "{{chat_id}}"
+jsonpath "$.role" == "assistant"
+jsonpath "$.schema_version" exists
+jsonpath "$.status" exists
+jsonpath "$.parts" exists
 
 DELETE {{base_url}}/api/v2/bots/{{bot_id}}/chats/{{chat_id}}
 HTTP 204

--- a/tests/e2e_http/scripts/run_chat_collection_flow.sh
+++ b/tests/e2e_http/scripts/run_chat_collection_flow.sh
@@ -159,6 +159,11 @@ wait_for_document_indexes() {
 }
 
 wait_for_turn_completion() {
+  # Phase 8 D8.4d (#90): the snapshot endpoint now returns canonical
+  # UIMessage parts at the top level; the legacy ``{turn,
+  # answer_artifact_id, reference_bundle_artifact_id}`` envelope is
+  # gone. We poll ``.status`` (top-level) and surface the assistant's
+  # answer text + reference count directly from ``.parts``.
   local chat_id="$1"
   local turn_id="$2"
   local max_attempts=90
@@ -170,14 +175,14 @@ wait_for_turn_completion() {
     body="$(request_json GET "/api/v2/agent/chats/${chat_id}/turns/${turn_id}")"
     last_body="${body}"
     local turn_status
-    local answer_artifact_id
-    local reference_artifact_id
-    turn_status="$(jq -r '.turn.status // empty' <<<"${body}")"
-    answer_artifact_id="$(jq -r '.turn.answer_artifact_id // empty' <<<"${body}")"
-    reference_artifact_id="$(jq -r '.turn.reference_bundle_artifact_id // empty' <<<"${body}")"
+    local answer_text
+    local reference_count
+    turn_status="$(jq -r '.status // empty' <<<"${body}")"
+    answer_text="$(jq -r '[.parts[]? | select(.type == "text") | .text] | join("")' <<<"${body}")"
+    reference_count="$(jq -r '[.parts[]? | select(.type == "data-citation")] | length' <<<"${body}")"
 
-    if [[ "${turn_status}" == "COMPLETED" && -n "${answer_artifact_id}" ]]; then
-      printf '%s\n%s\n' "${answer_artifact_id}" "${reference_artifact_id}"
+    if [[ "${turn_status}" == "COMPLETED" && -n "${answer_text}" ]]; then
+      printf '%s\n%s\n' "${answer_text}" "${reference_count}"
       return 0
     fi
 
@@ -191,7 +196,7 @@ wait_for_turn_completion() {
     (( attempt += 1 ))
   done
 
-  echo "Timed out waiting for turn completion artifacts" >&2
+  echo "Timed out waiting for turn completion parts" >&2
   if [[ -n "${last_body}" ]]; then
     jq . <<<"${last_body}" >&2 || true
   fi
@@ -332,19 +337,23 @@ turn_body="$(request_json POST "/api/v2/agent/chats/${chat_id}/turns" "$(jq -nc 
   }')")"
 turn_id="$(jq -r '.turn.turn_id' <<<"${turn_body}")"
 
-mapfile -t artifact_ids < <(wait_for_turn_completion "${chat_id}" "${turn_id}")
-answer_artifact_id="${artifact_ids[0]}"
-reference_artifact_id="${artifact_ids[1]:-}"
+mapfile -t completion_signals < <(wait_for_turn_completion "${chat_id}" "${turn_id}")
+answer_text="${completion_signals[0]}"
+reference_count="${completion_signals[1]:-0}"
 
-answer_body="$(request_json GET "/api/v2/agent/artifacts/${answer_artifact_id}")"
+# Phase 8 D8.4d (#90): the snapshot endpoint returns the answer text
+# directly as ``TextPart`` and reference items as ``DataCitationPart``;
+# the assertion budget is the same (answer non-empty + at least one
+# reference when present) but reads off ``.parts`` rather than the
+# legacy artifact endpoint.
+if [[ -z "${answer_text}" ]]; then
+  echo "Snapshot returned empty answer text" >&2
+  exit 1
+fi
 
-jq -e '.artifact_type == "answer"' <<<"${answer_body}" >/dev/null
-jq -e '(.payload.text // "") | length > 0' <<<"${answer_body}" >/dev/null
-
-if [[ -n "${reference_artifact_id}" ]]; then
-  reference_body="$(request_json GET "/api/v2/agent/artifacts/${reference_artifact_id}")"
-  jq -e '.artifact_type == "reference_bundle"' <<<"${reference_body}" >/dev/null
-  jq -e '(.payload.items // []) | length > 0' <<<"${reference_body}" >/dev/null
+if (( reference_count == 0 )); then
+  echo "Snapshot returned no data-citation parts" >&2
+  exit 1
 fi
 
 echo "Business chat collection flow passed"

--- a/tests/e2e_http/scripts/run_chat_collection_flow.sh
+++ b/tests/e2e_http/scripts/run_chat_collection_flow.sh
@@ -343,17 +343,12 @@ reference_count="${completion_signals[1]:-0}"
 
 # Phase 8 D8.4d (#90): the snapshot endpoint returns the answer text
 # directly as ``TextPart`` and reference items as ``DataCitationPart``;
-# the assertion budget is the same (answer non-empty + at least one
-# reference when present) but reads off ``.parts`` rather than the
-# legacy artifact endpoint.
+# the assertion budget mirrors the pre-#90 contract — answer is
+# required, references are optional (the agent may legitimately reply
+# without citing sources, e.g. a clarification turn).
 if [[ -z "${answer_text}" ]]; then
   echo "Snapshot returned empty answer text" >&2
   exit 1
 fi
 
-if (( reference_count == 0 )); then
-  echo "Snapshot returned no data-citation parts" >&2
-  exit 1
-fi
-
-echo "Business chat collection flow passed"
+echo "Business chat collection flow passed (answer ${#answer_text} chars, ${reference_count} reference(s))"

--- a/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
+++ b/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 import aperag.domains.agent_runtime.storage as agent_runtime_storage
 from aperag.domains.agent_runtime.api import routes as agent_runtime_view
 from aperag.domains.agent_runtime.db.models import (
+    AgentArtifactType,
     AgentEventActor,
     AgentTurnStatus,
 )
@@ -187,47 +188,143 @@ class _FakeRequest:
 
 
 @pytest.mark.asyncio
-async def test_turn_snapshot_merges_persisted_events_cached_events_and_runtime_state():
-    turn = _build_turn(answer_artifact_id="artifact-db", timeline_cursor=0)
-    persisted_event = _build_event(1, "turn.started", status="running")
-    cached_event = AgentTimelineEventEnvelope(
-        event_id="event-2",
+async def test_turn_snapshot_returns_canonical_uimessage_parts_for_completed_turn():
+    """D8.4d (#90): snapshot endpoint returns ``parts: UIMessagePart[]``
+    instead of the legacy ``{turn, timeline, artifacts}`` shape.
+
+    A completed turn with both ``answer`` and ``reference_bundle``
+    artifacts should project into a ``TextPart`` followed by
+    ``SourceUrlPart`` / ``DataCitationPart`` pairs, with the canonical
+    ``status`` and ``timeline_cursor`` mirrored from the runtime
+    state. Per D8 §2 wire/at-rest byte-equal canonical, the FE
+    consumes the same discriminated union from snapshot and live SSE.
+    """
+
+    turn = _build_turn(
+        status=AgentTurnStatus.COMPLETED,
+        answer_artifact_id="artifact-1",
+        reference_bundle_artifact_id="bundle-1",
+        timeline_cursor=2,
+    )
+    answer_artifact = SimpleNamespace(
+        id="artifact-1",
         turn_id="turn-1",
-        sequence=2,
-        timestamp=_now(),
-        type="text.delta",
-        label="Streaming Answer",
-        status="streaming",
-        actor="agent",
-        data={"delta": "hello"},
-    ).model_dump(mode="json")
-    artifact = _build_artifact()
+        artifact_type=AgentArtifactType.ANSWER,
+        summary="answer",
+        payload={"text": "Hello world"},
+        storage_ref=None,
+        gmt_created=_now(),
+        gmt_updated=_now(),
+    )
+    reference_artifact = SimpleNamespace(
+        id="bundle-1",
+        turn_id="turn-1",
+        artifact_type=AgentArtifactType.REFERENCE_BUNDLE,
+        summary="1 references",
+        payload={
+            "items": [
+                {
+                    "source_type": "web_page",
+                    "source_id": "src-1",
+                    "title": "Example",
+                    "snippet": "ApeRAG is great",
+                    "uri": "https://example.com/a",
+                    "metadata": {},
+                }
+            ]
+        },
+        storage_ref=None,
+        gmt_created=_now(),
+        gmt_updated=_now(),
+    )
 
     service = TurnService(
         db_ops=_FakeDbOps(
             turn=turn,
-            persisted_events=[persisted_event],
-            artifacts=[artifact],
+            artifacts=[answer_artifact, reference_artifact],
         ),
         redis_store=_FakeRedisStore(
-            events=[cached_event],
             runtime_state={
-                "status": "RUNNING",
-                "timeline_cursor": 1,
-                "answer_artifact_id": None,
-                "reference_bundle_artifact_id": "bundle-1",
+                "status": "COMPLETED",
+                "timeline_cursor": 2,
             },
         ),
     )
 
     snapshot = await service.get_turn_snapshot("user-1", "chat-1", "turn-1")
 
-    assert snapshot.turn.status == "RUNNING"
-    assert snapshot.turn.timeline_cursor == 2
-    assert snapshot.turn.answer_artifact_id == "artifact-db"
-    assert snapshot.turn.reference_bundle_artifact_id == "bundle-1"
-    assert [event.sequence for event in snapshot.timeline] == [1, 2]
-    assert snapshot.artifacts[0].artifact_id == "artifact-1"
+    assert snapshot.turn_id == "turn-1"
+    assert snapshot.chat_id == "chat-1"
+    assert snapshot.role == "assistant"
+    assert snapshot.status == "COMPLETED"
+    assert snapshot.timeline_cursor == 2
+    assert snapshot.error_text is None
+
+    types = [getattr(part, "type", None) for part in snapshot.parts]
+    assert types == ["text", "source-url", "data-citation"]
+    assert snapshot.parts[0].text == "Hello world"
+    assert snapshot.parts[1].source_id == "src-1"
+    assert snapshot.parts[2].data.cited_text == "ApeRAG is great"
+    assert snapshot.parts[2].data.location.url == "https://example.com/a"
+
+
+@pytest.mark.asyncio
+async def test_turn_snapshot_surfaces_error_text_for_failed_turn():
+    """D8.4d (#90): a FAILED turn's ``error_summary`` artifact surfaces
+    via the ``error_text`` field, not as a part. Mirrors the FE
+    transitional adapter (#77 huangheng ``snapshot-fallback.ts``) so
+    the BE can replace it cleanly post-merge.
+    """
+
+    turn = _build_turn(
+        status=AgentTurnStatus.FAILED,
+        error_code="agent.tool_failure",
+        error_message="upstream timeout",
+        timeline_cursor=3,
+    )
+    error_artifact = SimpleNamespace(
+        id="error-1",
+        turn_id="turn-1",
+        artifact_type=AgentArtifactType.ERROR_SUMMARY,
+        summary="upstream timeout",
+        payload={"message": "Detailed: upstream timeout after 30s"},
+        storage_ref=None,
+        gmt_created=_now(),
+        gmt_updated=_now(),
+    )
+
+    service = TurnService(
+        db_ops=_FakeDbOps(turn=turn, artifacts=[error_artifact]),
+        redis_store=_FakeRedisStore(runtime_state={"status": "FAILED"}),
+    )
+
+    snapshot = await service.get_turn_snapshot("user-1", "chat-1", "turn-1")
+
+    assert snapshot.status == "FAILED"
+    assert snapshot.error_text == "Detailed: upstream timeout after 30s"
+    # No assistant text was produced; error is not modelled as a part.
+    assert snapshot.parts == []
+
+
+@pytest.mark.asyncio
+async def test_turn_snapshot_does_not_expose_legacy_keys():
+    """Regression-guard: legacy ``{turn, timeline, artifacts}`` must
+    never reappear on the new ``AgentTurnSnapshot`` shape (D8 §2
+    wire/at-rest byte-equal canonical).
+    """
+
+    service = TurnService(
+        db_ops=_FakeDbOps(turn=_build_turn(status=AgentTurnStatus.QUEUED)),
+        redis_store=_FakeRedisStore(),
+    )
+
+    snapshot = await service.get_turn_snapshot("user-1", "chat-1", "turn-1")
+    serialised = snapshot.model_dump(mode="json")
+
+    forbidden = {"turn", "timeline", "artifacts"}
+    assert forbidden.isdisjoint(serialised.keys()), (
+        f"legacy keys leaked into AgentTurnSnapshot serialization: {forbidden & serialised.keys()}"
+    )
 
 
 @pytest.mark.asyncio
@@ -261,42 +358,30 @@ async def test_event_service_to_event_envelope_adds_user_activity_contract():
 
 
 @pytest.mark.asyncio
-async def test_turn_snapshot_backfills_user_activity_for_legacy_cached_events():
-    turn = _build_turn()
-    legacy_cached_event = {
-        "event_id": "event-3",
-        "turn_id": "turn-1",
-        "sequence": 3,
-        "timestamp": _now().isoformat(),
-        "type": "tool.finished",
-        "label": "search_collection",
-        "status": "success",
-        "actor": "tool",
-        "data": {
-            "tool_name": "search_collection",
-            "result": {
-                "items": [{"id": "doc-1"}, {"id": "doc-2"}],
-                "collection_name": "Product Docs",
-            },
-        },
-    }
+async def test_turn_snapshot_user_activity_inference_runs_via_event_service():
+    """``TurnService.get_turn_snapshot`` no longer projects timeline
+    events (D8.4d / #90 dropped the legacy timeline shape). The user
+    activity inference contract still belongs to ``EventService`` and
+    is exercised directly by
+    ``test_event_service_to_event_envelope_adds_user_activity_contract``.
 
+    This test pins the empty-timeline guarantee: snapshots no longer
+    include timeline / artifacts arrays, so the FE renderer is the
+    sole consumer of activity hints (via the live SSE
+    ``data-activity`` part).
+    """
+
+    turn = _build_turn()
     service = TurnService(
         db_ops=_FakeDbOps(turn=turn),
-        redis_store=_FakeRedisStore(events=[legacy_cached_event], runtime_state=None),
+        redis_store=_FakeRedisStore(runtime_state=None),
     )
 
     snapshot = await service.get_turn_snapshot("user-1", "chat-1", "turn-1")
 
-    assert len(snapshot.timeline) == 1
-    event = snapshot.timeline[0]
-    assert event.technical_type == "tool.finished"
-    assert event.user_activity is not None
-    assert event.user_activity.intent == UserActivityIntent.SEARCHING_KNOWLEDGE
-    assert event.user_activity.detail_key == "activity.searching_knowledge.detail.source_name"
-    assert event.user_activity.context is not None
-    assert event.user_activity.context.source_name == "Product Docs"
-    assert event.user_activity.context.count == 2
+    # Legacy timeline / artifacts fields are gone (D8.4d canonical lock).
+    assert not hasattr(snapshot, "timeline")
+    assert not hasattr(snapshot, "artifacts")
 
 
 @pytest.mark.asyncio
@@ -384,22 +469,29 @@ async def test_history_writer_builds_context_from_v3_turns_only():
 async def test_agent_runtime_views_create_stream_snapshot_cancel_and_artifact(monkeypatch):
     turn = _build_turn(status=AgentTurnStatus.RUNNING, timeline_cursor=1)
     snapshot = AgentTurnSnapshot(
-        turn=TurnService.to_turn_envelope(turn),
-        timeline=[
-            AgentTimelineEventEnvelope(
-                event_id="event-1",
-                turn_id="turn-1",
-                sequence=1,
-                timestamp=_now(),
-                type="turn.started",
-                label="Thinking",
-                status="running",
-                actor="system",
-                data={"chat_id": "chat-1"},
-            )
-        ],
-        artifacts=[],
+        turn_id="turn-1",
+        chat_id="chat-1",
+        status=AgentTurnStatus.RUNNING.value,
+        parts=[],
+        timeline_cursor=1,
+        started_at=_now(),
+        finished_at=None,
+        created_at=_now(),
+        updated_at=_now(),
     )
+    timeline_for_stream = [
+        AgentTimelineEventEnvelope(
+            event_id="event-1",
+            turn_id="turn-1",
+            sequence=1,
+            timestamp=_now(),
+            type="turn.started",
+            label="Thinking",
+            status="running",
+            actor="system",
+            data={"chat_id": "chat-1"},
+        )
+    ]
     artifact = AgentArtifactEnvelope(
         artifact_id="artifact-1",
         turn_id="turn-1",
@@ -433,11 +525,11 @@ async def test_agent_runtime_views_create_stream_snapshot_cancel_and_artifact(mo
             return snapshot
 
         def to_turn_envelope(self, _turn):
-            return snapshot.turn
+            return TurnService.to_turn_envelope(turn)
 
     class _FakeEventService:
         async def get_events_after(self, _turn_id, after_sequence=0, limit=500):
-            return snapshot.timeline if after_sequence == 0 else []
+            return timeline_for_stream if after_sequence == 0 else []
 
     class _FakeArtifactService:
         async def get_artifact_for_user(self, _user, _artifact_id):
@@ -488,7 +580,8 @@ async def test_agent_runtime_views_create_stream_snapshot_cancel_and_artifact(mo
         "turn-1",
         user=user,
     )
-    assert snapshot_response.turn.turn_id == "turn-1"
+    assert snapshot_response.turn_id == "turn-1"
+    assert snapshot_response.role == "assistant"
 
     artifact_response = await agent_runtime_view.get_artifact_view(
         "artifact-1",

--- a/tests/unit_test/agent_runtime/test_snapshot_assembler.py
+++ b/tests/unit_test/agent_runtime/test_snapshot_assembler.py
@@ -1,0 +1,171 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Snapshot assembler contract tests (Phase 8 D8.4d / #90).
+
+Pins the legacy artifact -> ``UIMessagePart`` projection that the
+snapshot endpoint relies on until the wire emitter starts persisting
+``agent_message.parts`` directly (D8.6 / #80 cleanup). Mirrors the FE
+side ``snapshot-fallback.ts`` adapter so deleting both sides post-D8.6
+is mechanical.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from aperag.domains.agent_runtime.db.models import AgentArtifactType
+from aperag.domains.agent_runtime.snapshot_assembler import (
+    assemble_parts_from_artifacts,
+    extract_error_text,
+)
+from aperag.domains.agent_runtime.uimessage import (
+    DataCitationPart,
+    SourceUrlPart,
+    TextPart,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _answer(text: str = "Hello world") -> SimpleNamespace:
+    return SimpleNamespace(
+        id="art-answer",
+        turn_id="turn-1",
+        artifact_type=AgentArtifactType.ANSWER,
+        summary=text[:200],
+        payload={"text": text, "query": "hi"},
+        storage_ref=None,
+        gmt_created=_now(),
+        gmt_updated=_now(),
+    )
+
+
+def _reference_bundle(items: list[dict]) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="art-bundle",
+        turn_id="turn-1",
+        artifact_type=AgentArtifactType.REFERENCE_BUNDLE,
+        summary=f"{len(items)} references",
+        payload={"items": items},
+        storage_ref=None,
+        gmt_created=_now(),
+        gmt_updated=_now(),
+    )
+
+
+def _error_summary(message: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="art-error",
+        turn_id="turn-1",
+        artifact_type=AgentArtifactType.ERROR_SUMMARY,
+        summary=message[:200],
+        payload={"message": message},
+        storage_ref=None,
+        gmt_created=_now(),
+        gmt_updated=_now(),
+    )
+
+
+def test_answer_artifact_projects_to_text_part():
+    parts = assemble_parts_from_artifacts([_answer("ApeRAG is great")])
+    assert len(parts) == 1
+    assert isinstance(parts[0], TextPart)
+    assert parts[0].text == "ApeRAG is great"
+
+
+def test_reference_bundle_projects_to_source_url_plus_data_citation():
+    items = [
+        {
+            "source_type": "web_page",
+            "source_id": "src-1",
+            "title": "Example",
+            "snippet": "ApeRAG is a RAG platform",
+            "uri": "https://example.com/a",
+            "metadata": {},
+        },
+        {
+            "source_type": "web_page",
+            "source_id": "src-2",
+            "title": "Second",
+            "snippet": "Second snippet",
+            "uri": "https://example.com/b",
+            "metadata": {},
+        },
+    ]
+    parts = assemble_parts_from_artifacts([_reference_bundle(items)])
+    types = [getattr(part, "type", None) for part in parts]
+    assert types == ["source-url", "data-citation", "source-url", "data-citation"]
+    assert isinstance(parts[0], SourceUrlPart)
+    assert parts[0].source_id == "src-1"
+    assert parts[0].url == "https://example.com/a"
+    assert isinstance(parts[1], DataCitationPart)
+    assert parts[1].data.cited_text == "ApeRAG is a RAG platform"
+    assert parts[1].data.location.url == "https://example.com/a"
+
+
+def test_reference_item_without_uri_emits_citation_only():
+    """Pre-D8.6 ApeRAG reference items may be document-based with no
+    URL. The citation still serialises (with empty ``url``) so the FE
+    can show snippet/title; D8.6 will replace this with the canonical
+    at-rest read where citation locations carry full doc/page info.
+    """
+
+    items = [{"source_id": "doc-1", "title": "PDF chapter", "snippet": "abc"}]
+    parts = assemble_parts_from_artifacts([_reference_bundle(items)])
+    assert [getattr(part, "type", None) for part in parts] == ["data-citation"]
+    assert parts[0].data.location.url == ""
+    assert parts[0].data.location.title == "PDF chapter"
+
+
+def test_answer_then_reference_bundle_ordering():
+    items = [{"source_id": "src-1", "uri": "https://example.com/", "title": "x", "snippet": "y"}]
+    parts = assemble_parts_from_artifacts([_reference_bundle(items), _answer("done")])
+    types = [getattr(part, "type", None) for part in parts]
+    # TextPart from answer comes first regardless of input ordering.
+    assert types == ["text", "source-url", "data-citation"]
+
+
+def test_unknown_artifact_types_are_skipped():
+    tool_summary = SimpleNamespace(
+        id="art-tool",
+        turn_id="turn-1",
+        artifact_type=AgentArtifactType.TOOL_RESULT_SUMMARY,
+        summary="tool output",
+        payload={"text": "tool output"},
+        storage_ref=None,
+        gmt_created=_now(),
+        gmt_updated=_now(),
+    )
+    parts = assemble_parts_from_artifacts([tool_summary])
+    assert parts == []
+
+
+def test_extract_error_text_prefers_payload_message():
+    text = extract_error_text([_error_summary("upstream timeout")])
+    assert text == "upstream timeout"
+
+
+def test_extract_error_text_falls_back_to_summary_when_payload_empty():
+    artifact = _error_summary("ignored")
+    artifact.payload = {}
+    artifact.summary = "from-summary"
+    assert extract_error_text([artifact]) == "from-summary"
+
+
+def test_extract_error_text_returns_none_without_error_summary():
+    assert extract_error_text([_answer()]) is None

--- a/tests/unit_test/chat/test_chat_completion_service.py
+++ b/tests/unit_test/chat/test_chat_completion_service.py
@@ -33,26 +33,24 @@ def _turn(*, turn_id="turn-1", chat_id="chat-1", status=AgentTurnStatus.COMPLETE
     )
 
 
-def _snapshot(*, turn_id="turn-1", answer_text="done", references=None):
+def _artifacts(*, answer_text="done", references=None):
+    """Phase 8 D8.4d (#90): the OpenAI-compat completion path now reads
+    raw ``AgentArtifact`` rows directly from the DB instead of through
+    ``get_turn_snapshot`` (which now returns canonical UIMessage parts
+    for the FE)."""
     references = references or [{"title": "Doc 1", "snippet": "hello"}]
-    return SimpleNamespace(
-        turn=SimpleNamespace(
-            answer_artifact_id="artifact-answer",
-            reference_bundle_artifact_id="artifact-refs",
+    return [
+        SimpleNamespace(
+            artifact_id="artifact-answer",
+            artifact_type="answer",
+            payload={"text": answer_text},
         ),
-        artifacts=[
-            SimpleNamespace(
-                artifact_id="artifact-answer",
-                artifact_type="answer",
-                payload={"text": answer_text},
-            ),
-            SimpleNamespace(
-                artifact_id="artifact-refs",
-                artifact_type="reference_bundle",
-                payload={"items": references},
-            ),
-        ],
-    )
+        SimpleNamespace(
+            artifact_id="artifact-refs",
+            artifact_type="reference_bundle",
+            payload={"items": references},
+        ),
+    ]
 
 
 class _FakeEventService:
@@ -69,14 +67,17 @@ class _FakeEventService:
 
 
 class _FakeTurnService:
-    def __init__(self, *, chat, bot, turn, snapshot, query_turns=None):
+    def __init__(self, *, chat, bot, turn, artifacts, query_turns=None):
         self.chat = chat
         self.bot = bot
         self.turn = turn
-        self.snapshot = snapshot
+        self.artifacts = list(artifacts or [])
         self.query_turns = list(query_turns or [turn])
         self.created_requests = []
-        self.db_ops = SimpleNamespace(query_agent_turn=self._query_agent_turn)
+        self.db_ops = SimpleNamespace(
+            query_agent_turn=self._query_agent_turn,
+            query_agent_artifacts_by_turn=self._query_agent_artifacts_by_turn,
+        )
 
     async def get_chat_and_bot(self, _user, _chat_id):
         return self.chat, self.bot
@@ -85,13 +86,13 @@ class _FakeTurnService:
         self.created_requests.append(request)
         return self.chat, self.bot, self.turn, True
 
-    async def get_turn_snapshot(self, _user, _chat_id, _turn_id):
-        return self.snapshot
-
     async def _query_agent_turn(self, _user, _chat_id, _turn_id):
         if len(self.query_turns) > 1:
             return self.query_turns.pop(0)
         return self.query_turns[0]
+
+    async def _query_agent_artifacts_by_turn(self, _turn_id):
+        return list(self.artifacts)
 
 
 class _FakeRuntimeManager:
@@ -133,8 +134,8 @@ async def test_openai_chat_completions_returns_openai_response_and_maps_override
     chat = SimpleNamespace(id="chat-1")
     bot = _bot()
     turn = _turn()
-    snapshot = _snapshot(answer_text="final answer")
-    fake_turn_service = _FakeTurnService(chat=chat, bot=bot, turn=turn, snapshot=snapshot)
+    artifacts = _artifacts(answer_text="final answer")
+    fake_turn_service = _FakeTurnService(chat=chat, bot=bot, turn=turn, artifacts=artifacts)
     fake_runtime_manager = _FakeRuntimeManager(turn_service=fake_turn_service, event_service=_FakeEventService())
 
     monkeypatch.setattr(completion_module, "runtime_manager", fake_runtime_manager)
@@ -172,8 +173,8 @@ async def test_openai_chat_completions_creates_and_cleans_up_ephemeral_chat(monk
     chat = SimpleNamespace(id="chat-ephemeral")
     bot = _bot()
     turn = _turn(chat_id="chat-ephemeral")
-    snapshot = _snapshot(turn_id="turn-ephemeral", answer_text="ephemeral answer")
-    fake_turn_service = _FakeTurnService(chat=chat, bot=bot, turn=turn, snapshot=snapshot)
+    artifacts = _artifacts(answer_text="ephemeral answer")
+    fake_turn_service = _FakeTurnService(chat=chat, bot=bot, turn=turn, artifacts=artifacts)
     fake_runtime_manager = _FakeRuntimeManager(turn_service=fake_turn_service, event_service=_FakeEventService())
     fake_chat_service = _FakeChatService(created_chat_id="chat-ephemeral")
 
@@ -199,12 +200,12 @@ async def test_openai_chat_completions_streams_sse_from_runtime_events(monkeypat
     bot = _bot()
     running_turn = _turn(status=AgentTurnStatus.RUNNING)
     completed_turn = _turn(status=AgentTurnStatus.COMPLETED)
-    snapshot = _snapshot(answer_text="streamed answer")
+    artifacts = _artifacts(answer_text="streamed answer")
     fake_turn_service = _FakeTurnService(
         chat=chat,
         bot=bot,
         turn=running_turn,
-        snapshot=snapshot,
+        artifacts=artifacts,
         query_turns=[running_turn, completed_turn],
     )
     fake_event_service = _FakeEventService(

--- a/web/src/components/chat/chat-messages.tsx
+++ b/web/src/components/chat/chat-messages.tsx
@@ -4,12 +4,9 @@ import type { ChatDetails, ChatMessage, Feedback } from '@/features/bot/types';
 import {
   cancelAgentTurn,
   createAgentTurn,
-  extractErrorTextFromSnapshot,
   getAgentTurnSnapshot,
   mapBackendTurnStatus,
-  synthesizePartsFromSnapshot,
   useAgentTurnStream,
-  type AgentMessagePart,
   type AgentStreamStatus,
   type AgentTurnEnvelope,
   type AgentTurnSnapshotEnvelope,
@@ -186,15 +183,43 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
 
   const seedFromSnapshot = useCallback(
     (snapshot: AgentTurnSnapshotEnvelope) => {
-      const turnId = snapshot.turn.turn_id;
-      const terminal = isTerminalStatus(snapshot.turn.status);
+      const turnId = snapshot.turn_id;
+      const terminal = isTerminalStatus(snapshot.status);
+      // Phase 8 D8.4d (#90): the snapshot endpoint now returns the flat
+      // canonical UIMessage at-rest envelope. ``AgentTurnEnvelope`` is
+      // synthesized here from the same fields so the rest of the FE
+      // can keep using its existing turn-shape contract; full
+      // ``AgentTurnEnvelope`` (including bot_id / user_id / etc.) is
+      // already provided by the ``createAgentTurn`` response on fresh
+      // turns and is not needed for reload rendering.
+      const envelope: AgentTurnEnvelope = {
+        schema_version: snapshot.schema_version,
+        turn_id: snapshot.turn_id,
+        chat_id: snapshot.chat_id,
+        user_id: '',
+        bot_id: '',
+        request_id: '',
+        client_idempotency_key: '',
+        status: snapshot.status,
+        input_text: '',
+        model_profile: {},
+        error_code: null,
+        error_message: snapshot.error_text ?? null,
+        answer_artifact_id: null,
+        reference_bundle_artifact_id: null,
+        timeline_cursor: snapshot.timeline_cursor,
+        started_at: snapshot.started_at,
+        finished_at: snapshot.finished_at,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+      };
       updateLiveTurn(turnId, () => ({
-        envelope: snapshot.turn,
+        envelope,
         baselineSnapshot: snapshot,
         streamUrl: terminal ? null : buildStreamUrl(chatId, turnId),
         pending: !terminal,
       }));
-      ensureTurnGroups(snapshot.turn, false);
+      ensureTurnGroups(envelope, false);
       if (terminal && activeTurnId === turnId) {
         updateActiveTurn(null);
       }
@@ -405,10 +430,9 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
       try {
         const snapshot = await getAgentTurnSnapshot(chatId, storedTurnId);
         if (cancelled) return;
-        ensureTurnGroups(snapshot.turn, true);
         seedFromSnapshot(snapshot);
-        if (!isTerminalStatus(snapshot.turn.status)) {
-          updateActiveTurn(snapshot.turn.turn_id);
+        if (!isTerminalStatus(snapshot.status)) {
+          updateActiveTurn(snapshot.turn_id);
         } else {
           updateActiveTurn(null);
         }
@@ -503,7 +527,7 @@ function AgentTurnStreamCard({
 }) {
   const { envelope, baselineSnapshot, streamUrl } = liveTurn;
   const initialSequence =
-    baselineSnapshot?.turn.timeline_cursor || envelope.timeline_cursor || 0;
+    baselineSnapshot?.timeline_cursor || envelope.timeline_cursor || 0;
 
   const stream = useAgentTurnStream({
     chatId,
@@ -512,36 +536,21 @@ function AgentTurnStreamCard({
     initialSequence,
   });
 
-  // dongdong msg=97336fb9 — when the hook is dormant for a terminal
-  // historical turn (`streamUrl: null`, no live frames), synthesize
-  // parts + status from the snapshot's legacy artifacts so the
-  // renderer shows the completed answer + references instead of an
-  // empty `idle` state. Read-only fallback; deletes when the BE
-  // snapshot endpoint returns UIMessages.
+  // Phase 8 D8.4d (#90): the snapshot endpoint now returns canonical
+  // UIMessage parts directly, so reload rendering for terminal
+  // historical turns reads ``baselineSnapshot.parts`` + ``error_text``
+  // without a client-side synthesizer. The previous transitional
+  // ``snapshot-fallback.ts`` adapter is gone.
   const useFallback =
     streamUrl == null && stream.parts.length === 0 && Boolean(baselineSnapshot);
-  const fallbackParts = useMemo<AgentMessagePart[]>(
-    () =>
-      useFallback && baselineSnapshot
-        ? synthesizePartsFromSnapshot(baselineSnapshot)
-        : [],
-    [useFallback, baselineSnapshot],
-  );
-  const displayParts = useFallback ? fallbackParts : stream.parts;
+  const displayParts = useFallback && baselineSnapshot ? baselineSnapshot.parts : stream.parts;
   const displayStatus: AgentStreamStatus = useFallback
     ? mapBackendTurnStatus(envelope.status)
     : stream.status;
-  const fallbackErrorText = useMemo(
-    () =>
-      useFallback && baselineSnapshot
-        ? extractErrorTextFromSnapshot(baselineSnapshot)
-        : null,
-    [useFallback, baselineSnapshot],
-  );
   const displayErrorText =
     displayStatus === 'failed'
       ? (stream.errorText ??
-        fallbackErrorText ??
+        (useFallback && baselineSnapshot ? baselineSnapshot.error_text ?? null : null) ??
         envelope.error_message ??
         null)
       : stream.errorText;

--- a/web/src/features/agent-runtime/api.ts
+++ b/web/src/features/agent-runtime/api.ts
@@ -6,7 +6,7 @@
 // only covers the JSON request/response endpoints the chat UI calls
 // alongside the stream.
 
-import type { ToolConsentData, ElicitationData } from './types';
+import type { AgentMessagePart, ToolConsentData, ElicitationData } from './types';
 
 const DEFAULT_BASE = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/agent`;
 
@@ -58,10 +58,24 @@ export type AgentArtifactEnvelope = {
   updated_at?: string | null;
 };
 
+// Phase 8 D8.4d (#90): the snapshot endpoint now returns the canonical
+// UIMessage at-rest envelope (matches `aperag.domains.agent_runtime.uimessage.AgentTurnSnapshot`).
+// Per D8 §2 wire / at-rest are byte-equal, so the FE consumes the same
+// `AgentMessagePart` discriminated union from both the live SSE stream
+// and this reload payload — no client-side converter is required.
 export type AgentTurnSnapshotEnvelope = {
-  turn: AgentTurnEnvelope;
-  timeline: AgentTimelineEventEnvelope[];
-  artifacts: AgentArtifactEnvelope[];
+  schema_version: string;
+  turn_id: string;
+  chat_id: string;
+  role: 'assistant';
+  status: string;
+  parts: AgentMessagePart[];
+  error_text?: string | null;
+  timeline_cursor: number;
+  started_at?: string | null;
+  finished_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
 };
 
 export type AgentTurnCreateInput = {

--- a/web/src/features/agent-runtime/index.ts
+++ b/web/src/features/agent-runtime/index.ts
@@ -51,8 +51,6 @@ export {
 } from './use-agent-turn-stream';
 
 export {
-  extractErrorTextFromSnapshot,
   isTerminalBackendStatus,
   mapBackendTurnStatus,
-  synthesizePartsFromSnapshot,
 } from './snapshot-fallback';

--- a/web/src/features/agent-runtime/snapshot-fallback.ts
+++ b/web/src/features/agent-runtime/snapshot-fallback.ts
@@ -1,180 +1,13 @@
 'use client';
 
-// TRANSITIONAL — TODO(#90 D8.4d): delete this file once the BE
-// snapshot endpoint returns UIMessage parts directly.
-//
-// Reload-path fallback for terminal historical turns.
-//
-// The agent runtime snapshot endpoint
-// (`GET /agent/chats/{cid}/turns/{tid}`) still returns the legacy
-// `{turn, timeline, artifacts}` envelope; D8.2 (#74) added at-rest
-// UIMessage storage but the read path that the FE calls on reload
-// has not yet been migrated to expose UIMessage parts. Until task
-// #90 (D8.4d backend snapshot endpoint UIMessage-parts return)
-// lands, terminal historical turns reload with an empty live
-// stream (`streamUrl: null` ⇒ hook never connects ⇒ `parts: []` and
-// `status: 'idle'`), which would render as an empty queued card —
-// the regression dongdong (msg=97336fb9) and Weston (msg=f8d3f102)
-// called out on PR #1703 first-cut.
-//
-// Fix: when the hook is dormant for a terminal turn, synthesize a
-// minimal `AgentMessagePart[]` from the snapshot's legacy artifacts
-// (answer text + reference bundle items) so the renderer shows the
-// completed answer + references instead of an empty idle state.
-// `error_summary` artifacts are pulled into the renderer's
-// `errorText` channel (since the wire/at-rest contract treats
-// errors as status + errorText, not as a persisted part).
-//
-// The synthesis is read-only and never feeds back into the live
-// reducer; once #90 lands, this file is a wholesale delete and
-// `chat-messages.tsx` switches to consuming the BE-returned parts
-// directly.
+// Phase 8 D8.4d (#90): the BE snapshot endpoint now returns canonical
+// UIMessage parts directly, so the artifact synthesis adapters
+// (`synthesizePartsFromSnapshot` + `extractErrorTextFromSnapshot`) are
+// gone. The remaining helpers translate the BE turn status into the
+// FE stream status enum so the renderer's status branching stays
+// consistent for reload paths.
 
-import type { AgentMessagePart, AgentStreamStatus } from './types';
-import type { AgentArtifactEnvelope, AgentTurnSnapshotEnvelope } from './api';
-
-type ReferenceBundleItem = {
-  source_id?: string | null;
-  title?: string | null;
-  snippet?: string | null;
-  uri?: string | null;
-  score?: number | null;
-  metadata?: Record<string, unknown>;
-};
-
-const ANSWER_ARTIFACT_TYPE = 'answer';
-const REFERENCE_BUNDLE_ARTIFACT_TYPE = 'reference_bundle';
-const ERROR_SUMMARY_ARTIFACT_TYPE = 'error_summary';
-
-function findArtifact(
-  artifacts: AgentArtifactEnvelope[],
-  artifactType: string,
-): AgentArtifactEnvelope | undefined {
-  return artifacts.find((a) => a.artifact_type === artifactType);
-}
-
-function extractAnswerText(artifact: AgentArtifactEnvelope): string {
-  const payload = artifact.payload || {};
-  if (typeof payload.text === 'string') return payload.text;
-  if (typeof payload.content === 'string') return payload.content;
-  return '';
-}
-
-function extractReferenceItems(
-  artifact: AgentArtifactEnvelope,
-): ReferenceBundleItem[] {
-  const items = artifact.payload?.items;
-  if (!Array.isArray(items)) return [];
-  return items.filter(
-    (item): item is ReferenceBundleItem =>
-      typeof item === 'object' && item !== null,
-  );
-}
-
-/**
- * Build a minimal `AgentMessagePart[]` from a terminal turn's legacy
- * snapshot. Currently emits at most:
- *   * one `text` part (from the `answer` artifact's payload.text /
- *     .content)
- *   * one `source-url` per reference bundle item with a usable URL
- *   * one `data-citation` per reference bundle item with a snippet
- *
- * Tool call timeline is intentionally NOT replayed — historical tool
- * calls would need lifecycle reconstruction the snapshot endpoint
- * doesn't provide cheaply. Renderer falls back to an empty activity
- * stream for these turns, which matches the legacy `agent-turn-card`
- * behaviour (it also did not show tool calls for past turns once the
- * answer artifact had landed).
- */
-export function synthesizePartsFromSnapshot(
-  snapshot: AgentTurnSnapshotEnvelope,
-): AgentMessagePart[] {
-  const parts: AgentMessagePart[] = [];
-  const turnId = snapshot.turn.turn_id;
-
-  const answerArtifact = findArtifact(snapshot.artifacts, ANSWER_ARTIFACT_TYPE);
-  if (answerArtifact) {
-    const text = extractAnswerText(answerArtifact);
-    if (text) {
-      parts.push({
-        type: 'text',
-        id: turnId,
-        text,
-        state: 'done',
-      });
-    }
-  }
-
-  const referenceArtifact = findArtifact(
-    snapshot.artifacts,
-    REFERENCE_BUNDLE_ARTIFACT_TYPE,
-  );
-  if (referenceArtifact) {
-    const items = extractReferenceItems(referenceArtifact);
-    items.forEach((item, index) => {
-      const sourceId =
-        (item.source_id ? String(item.source_id) : '') ||
-        `${turnId}-ref-${index}`;
-      const title = item.title ? String(item.title) : undefined;
-      const url = item.uri ? String(item.uri) : undefined;
-      if (url) {
-        parts.push({
-          type: 'source-url',
-          sourceId,
-          url,
-          title,
-        });
-      }
-      const snippet = item.snippet ? String(item.snippet) : '';
-      if (snippet) {
-        parts.push({
-          type: 'data-citation',
-          id: `${sourceId}-citation`,
-          data: {
-            cited_text: snippet,
-            location: {
-              type: 'url_citation',
-              url: url ?? '',
-              title,
-            },
-          },
-        });
-      }
-    });
-  }
-
-  return parts;
-}
-
-/**
- * Extract a renderer-friendly `errorText` from a snapshot's
- * `error_summary` artifact, if any. Falls back to `null` so the
- * caller can chain to `turn.error_message`.
- *
- * Per architect msg=711f8c2f: error_summary maps to the renderer's
- * status/errorText channel rather than to a part — `error` in the
- * wire/at-rest contract is a lifecycle marker (it sets
- * `status='failed'` in the reducer), not a persisted message part.
- */
-export function extractErrorTextFromSnapshot(
-  snapshot: AgentTurnSnapshotEnvelope,
-): string | null {
-  const artifact = findArtifact(snapshot.artifacts, ERROR_SUMMARY_ARTIFACT_TYPE);
-  if (!artifact) return null;
-  const payload = artifact.payload || {};
-  const candidate =
-    typeof payload.message === 'string'
-      ? payload.message
-      : typeof payload.text === 'string'
-        ? payload.text
-        : typeof payload.summary === 'string'
-          ? payload.summary
-          : artifact.summary || null;
-  if (typeof candidate === 'string' && candidate.trim().length > 0) {
-    return candidate;
-  }
-  return null;
-}
+import type { AgentStreamStatus } from './types';
 
 const TERMINAL_BACKEND_STATUSES = new Set([
   'COMPLETED',
@@ -188,10 +21,10 @@ export function isTerminalBackendStatus(status: string | undefined): boolean {
 }
 
 /**
- * Map a backend `AgentTurnEnvelope.status` string back into the
- * stream-side `AgentStreamStatus` enum so the renderer's status
- * branching (badge, answer section heading, etc.) stays consistent
- * with live-stream turns.
+ * Map a backend turn status string back into the stream-side
+ * `AgentStreamStatus` enum so the renderer's status branching (badge,
+ * answer section heading, etc.) stays consistent with live-stream
+ * turns.
  */
 export function mapBackendTurnStatus(status: string): AgentStreamStatus {
   switch (status.toUpperCase()) {


### PR DESCRIPTION
## Summary

Phase 8 task #90 (D8.4d) — replaces the agent runtime turn snapshot endpoint's legacy `{turn, timeline, artifacts}` envelope with the canonical `UIMessage`-aligned `AgentTurnSnapshot` shape. The FE renderer (#76 / #77 / #78) now consumes the same `UIMessagePart` discriminated union from both the live SSE stream and the at-rest reload path, per D8 §2 wire / at-rest byte-equal canonical (architect msg=711f8c2f canonical lock + PM scope msg=383c2e2b / msg=247f4d8e).

## What changed

### Backend
- **NEW** `aperag/domains/agent_runtime/snapshot_assembler.py` — projects legacy `AgentArtifact` rows into `UIMessagePart[]` (answer → `TextPart`, reference_bundle → `SourceUrlPart` + `DataCitationPart`, error_summary → `error_text`). Mirrors the FE-side `snapshot-fallback.ts` adapter that #77 huangheng landed as a transitional bridge so deletion was mechanical from both sides.
- `AgentTurnSnapshot` (now defined in `uimessage.py` alongside the rest of the UIMessage family; re-exported from `schemas.py` for back-compat) flips to `{schema_version, turn_id, chat_id, role, status, parts, error_text?, timeline_cursor, ...timestamps}`.
- `TurnService.get_turn_snapshot()` rewritten:
  1. **Forward-compat** — try `UIMessageStore.read(turn_id)` first (D8.6 will populate `agent_message.parts` directly via the wire emitter; today the store is optional and reads return `None`).
  2. **Fallback** — `assemble_parts_from_artifacts` projects legacy artifacts.
  3. **error_text** — `extract_error_text` pulls the `error_summary` payload (or summary), falling back to `runtime_state.error_message`.
- The 3 ownership-only callers of `get_turn_snapshot` (cancel / consent / elicit endpoints) are unaffected — they only use the call to trigger `ResourceNotFoundException`, never read the body.

### Frontend (deletes the #77 transitional adapter)
- `web/src/features/agent-runtime/api.ts` — `AgentTurnSnapshotEnvelope` flips to the new flat shape; legacy `{turn, timeline, artifacts}` types gone.
- `web/src/components/chat/chat-messages.tsx` — `seedFromSnapshot` synthesizes a minimal `AgentTurnEnvelope` from the new flat snapshot for the live-turn store; reload rendering reads `baselineSnapshot.parts` and `baselineSnapshot.error_text` directly with no client-side synthesis.
- `web/src/features/agent-runtime/snapshot-fallback.ts` — `synthesizePartsFromSnapshot` and `extractErrorTextFromSnapshot` are removed (their `TODO(#90)` trigger has fired). `mapBackendTurnStatus` / `isTerminalBackendStatus` are kept (status mapping stays useful).
- `web/src/features/agent-runtime/index.ts` — dropped exports removed from the barrel.

## Boundary discipline

- **In-scope** (per PM scope lock):
  - Snapshot endpoint shape change
  - Legacy `{turn, timeline, artifacts}` keys retired
  - OpenAPI contract preserved (schema name unchanged; fields differ)
  - Minimal regression tests
  - FE consumption updated to new shape (huangheng's transitional `snapshot-fallback.ts` adapters retired)
- **Out-of-scope** (per architect / PM):
  - Wire emitter / live SSE (#73 territory, untouched)
  - At-rest UIMessage storage main design (#74 territory, untouched)
  - Tool lifecycle / consent / elicitation (#75 territory, untouched)
  - Renderer shell (#77 territory, untouched)
  - Consent/elicitation UI body (#78 territory, untouched)
  - `legacy-snapshot-shim.ts` was already deleted by #77

## Tests

- **NEW** `tests/unit_test/agent_runtime/test_snapshot_assembler.py` — 8 contract tests pinning the artifact → UIMessagePart projection (answer text, reference-bundle fan-out with and without uri, ordering, unknown-artifact skip, error-text extraction with payload-preferred / summary fallback / none-without-error_summary).
- `tests/unit_test/agent_runtime/test_agent_runtime_v3.py` snapshot tests rewritten for the new shape:
  - `test_turn_snapshot_returns_canonical_uimessage_parts_for_completed_turn`
  - `test_turn_snapshot_surfaces_error_text_for_failed_turn`
  - `test_turn_snapshot_does_not_expose_legacy_keys` (regression-guard: `{turn, timeline, artifacts}` must not reappear)
  - `test_turn_snapshot_user_activity_inference_runs_via_event_service` pins the empty-timeline guarantee.
- `tests/e2e_http/hurl/full/15_agent_runtime_v3.hurl` snapshot assertions migrated to the new shape (`turn_id`, `chat_id`, `role`, `status`, `parts` at top level; legacy keys gone).
- `tests/unit_test/agent_runtime/test_agent_runtime_openapi_contract.py` — continues to pass (schema name unchanged).

## Test plan

- [x] `pytest tests/unit_test/agent_runtime/ -q` → **134 passed**
- [x] `pytest tests/unit_test --deselect concurrent_control flake -q` → **831 passed / 29 skipped / 0 failed**
- [x] `ruff check` → clean
- [x] `ruff format --check` → clean (446 files already formatted)
- [ ] e2e-http-smoke + e2e-http-provider — pending CI (per merge-gate rule)
- [ ] FE typed schema (`web/src/api-v2/schema.d.ts`) regen via `yarn api:v2:types` — yarn is not available in this worktree; CI / a follow-up FE-touching PR will resync if a drift is observed.
- [ ] CR — pending Weston (per architect msg=711f8c2f middle-term lane lock)

## Phase 8 Phase B / D8.4d status

| Lane | Owner | Status |
|---|---|---|
| #76 D8.4a transport | huangheng | merged `63a9d522` |
| #77 D8.4b renderer | huangheng | merged `f0351662` |
| #78 D8.4c consent/elicit body | chenyexuan | in_review (chained on #77) |
| **#90 D8.4d snapshot endpoint** | **Bryce** | **this PR** |

Per architect canonical: this PR retires `snapshot-fallback.ts` (the FE transitional adapter) end-to-end, keeping the remaining `mapBackendTurnStatus` helper. After this lands, the only remaining D8.x backend cleanup is D8.6 / #80 (drop legacy `agent_artifact` / `agent_timeline_event` tables once the wire emitter starts populating `agent_message.parts` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)