### PR TITLE
feat(phase8 #93 D8.5-FE): consume canonical AgentTurnSnapshot history + render user bubble from input_text

### DIFF
--- a/aperag/domains/agent_runtime/api/routes.py
+++ b/aperag/domains/agent_runtime/api/routes.py
@@ -43,7 +43,6 @@ from aperag.domains.agent_runtime.db.models import AgentEventActor, AgentTurnSta
 from aperag.domains.agent_runtime.runtime import agent_runtime_manager as runtime_manager
 from aperag.domains.agent_runtime.schemas import (
     AgentArtifactEnvelope,
-    AgentTurnSnapshot,
     CancelTurnResponse,
     CreateTurnRequest,
     CreateTurnResponse,
@@ -51,6 +50,7 @@ from aperag.domains.agent_runtime.schemas import (
 from aperag.domains.agent_runtime.tools.consent import ConsentOwnershipError, ConsentService
 from aperag.domains.agent_runtime.tools.elicitation import ElicitationOwnershipError, ElicitationService
 from aperag.domains.agent_runtime.tools.lifecycle import translate_lifecycle_envelope
+from aperag.domains.agent_runtime.uimessage import AgentTurnSnapshot
 from aperag.domains.agent_runtime.wire import (
     StreamPart,
     TranslatorState,

--- a/aperag/domains/agent_runtime/db/models.py
+++ b/aperag/domains/agent_runtime/db/models.py
@@ -153,7 +153,7 @@ class AgentArtifact(Base):
 
 
 class AgentMessage(Base):
-    """At-rest UIMessage envelope (Phase 8 D8.2 first-cut).
+    """At-rest UIMessage envelope (Phase 8 D8.2 first-cut, D8.5-BE refined).
 
     One row per assistant turn (1:1 with ``AgentTurn`` for now via
     ``turn_id``). ``parts`` holds the JSON-serialised
@@ -162,6 +162,13 @@ class AgentMessage(Base):
     ChatML (``user`` / ``assistant`` / ``system``); ``schema_version``
     is the runtime contract version tag so future renderer updates
     can branch without a separate negotiation.
+
+    ``runtime_kind`` (D8.5-BE / #92) tags the runtime that produced the
+    message — ``agent_runtime`` for the agent reasoning loop (D8.x
+    Phase A), and a forward-compat enum for direct LLM (``direct_chat``)
+    or RAG-only (``rag_chat``) paths. ``role`` retains its speaker
+    semantics independent of runtime origin per Weston msg=94dac98a /
+    architect canonical lock msg=e01e9b4b.
 
     The legacy ``AgentArtifact`` / ``AgentTimelineEvent`` tables are
     retained alongside this table during D8.x rollout — they will be
@@ -179,6 +186,7 @@ class AgentMessage(Base):
     turn_id = Column(String(24), nullable=False, index=True)
     chat_id = Column(String(24), nullable=False, index=True)
     role = Column(String(16), nullable=False)
+    runtime_kind = Column(String(24), nullable=False, default="agent_runtime", server_default="agent_runtime")
     schema_version = Column(String(64), nullable=False)
     parts = Column(JSON, default=lambda: [], nullable=False)
     gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)

--- a/aperag/domains/agent_runtime/schemas.py
+++ b/aperag/domains/agent_runtime/schemas.py
@@ -44,7 +44,6 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
-from aperag.domains.conversation.schemas import File
 from aperag.domains.knowledge_base.schemas import Collection
 from aperag.schema.common import ModelSpec
 
@@ -86,6 +85,18 @@ class UserActivityEnvelope(BaseModel):
     subtitle_key: str
     detail_key: Optional[str] = None
     context: Optional[UserActivityContext] = None
+
+
+# ``File`` is imported lazily here to break the cycle introduced by D8.5-BE
+# (#92): ``conversation.schemas.ChatDetails.history`` now references
+# ``AgentTurnSnapshot`` from :mod:`aperag.domains.agent_runtime.uimessage`,
+# and ``uimessage`` in turn imports ``AGENT_RUNTIME_SCHEMA_VERSION`` and
+# ``UserActivityEnvelope`` from this module. Importing ``File`` at the
+# module top would close that cycle. By this point both symbols
+# ``uimessage`` needs are already defined, so importing ``File`` here is
+# safe and only the classes below (``CreateTurnRequest`` /
+# ``AgentMessage``) actually depend on it.
+from aperag.domains.conversation.schemas import File  # noqa: E402
 
 
 class AgentTurnEnvelope(BaseModel):
@@ -176,14 +187,14 @@ class CreateTurnResponse(BaseModel):
     stream_url: str
 
 
-# ``AgentTurnSnapshot`` is the canonical UIMessage at-rest envelope and
-# lives in :mod:`aperag.domains.agent_runtime.uimessage` next to the
-# other UIMessage classes. It is re-exported here so the existing
-# ``from aperag.domains.agent_runtime.schemas import AgentTurnSnapshot``
-# import sites continue to work without a domain-internal hop.
-from aperag.domains.agent_runtime.uimessage import (  # noqa: E402, F401
-    AgentTurnSnapshot,
-)
+# ``AgentTurnSnapshot`` lives in :mod:`aperag.domains.agent_runtime.uimessage`
+# next to the rest of the ``UIMessage`` family. The previous deferred
+# re-export from this module was retired in D8.5-BE (#92) because it
+# would close a fresh cycle between ``conversation.schemas`` (which
+# now imports ``AgentTurnSnapshot`` directly to type ``ChatDetails.history``)
+# and ``agent_runtime.schemas``. Existing call sites that still import
+# from this module are migrated to import from
+# ``aperag.domains.agent_runtime.uimessage`` directly.
 
 
 class CancelTurnResponse(BaseModel):
@@ -236,7 +247,6 @@ __all__ = [
     "AgentMessage",
     "AgentTimelineEventEnvelope",
     "AgentTurnEnvelope",
-    "AgentTurnSnapshot",
     "CancelTurnResponse",
     "CreateTurnRequest",
     "CreateTurnResponse",

--- a/aperag/domains/agent_runtime/services.py
+++ b/aperag/domains/agent_runtime/services.py
@@ -24,7 +24,6 @@ from aperag.domains.agent_runtime.schemas import (
     AgentArtifactEnvelope,
     AgentTimelineEventEnvelope,
     AgentTurnEnvelope,
-    AgentTurnSnapshot,
     CreateTurnRequest,
     ReferenceBundleItem,
     UserActivityContext,
@@ -36,6 +35,7 @@ from aperag.domains.agent_runtime.snapshot_assembler import (
     extract_error_text,
 )
 from aperag.domains.agent_runtime.storage import AgentRuntimeRedisStore
+from aperag.domains.agent_runtime.uimessage import AgentTurnSnapshot
 from aperag.domains.agent_runtime.uimessage_store import UIMessageStore
 from aperag.domains.conversation.db.models import BotType
 from aperag.domains.conversation.schemas import BotConfig
@@ -489,6 +489,7 @@ class TurnService:
         return AgentTurnSnapshot(
             turn_id=turn.id,
             chat_id=turn.chat_id,
+            runtime_kind="agent_runtime",
             status=status_str,
             parts=parts,
             error_text=error_text,
@@ -497,6 +498,7 @@ class TurnService:
             finished_at=turn.gmt_finished,
             created_at=turn.gmt_created,
             updated_at=turn.gmt_updated,
+            input_text=turn.input_text,
         )
 
     @staticmethod

--- a/aperag/domains/agent_runtime/uimessage.py
+++ b/aperag/domains/agent_runtime/uimessage.py
@@ -299,8 +299,11 @@ class UIMessage(BaseModel):
 # ---------------------------------------------------------------------
 
 
+RuntimeKind = Literal["agent_runtime", "direct_chat", "rag_chat"]
+
+
 class AgentTurnSnapshot(BaseModel):
-    """Canonical UIMessage at-rest snapshot for an agent turn (Phase 8 D8.4d / #90).
+    """Canonical UIMessage at-rest snapshot for an agent turn (Phase 8 D8.4d / #90, D8.5-BE / #92).
 
     Replaces the legacy ``{turn, timeline, artifacts}`` snapshot shape
     with the ``UIMessage``-aligned canonical that the FE renderer
@@ -309,6 +312,11 @@ class AgentTurnSnapshot(BaseModel):
     no client-side converter is required: a snapshot reload
     deserializes through the same ``UIMessagePart`` discriminated
     union the wire emits.
+
+    ``runtime_kind`` (D8.5-BE) tags the runtime that produced the
+    turn — ``agent_runtime`` for the agent reasoning loop,
+    ``direct_chat`` / ``rag_chat`` reserved for future paths. ``role``
+    keeps speaker semantics independent of runtime kind.
 
     ``parts`` is the persistable subset (transient ``data-activity``
     is stripped before write per :func:`persistable_parts`);
@@ -327,6 +335,8 @@ class AgentTurnSnapshot(BaseModel):
     schema_version: str = AGENT_RUNTIME_SCHEMA_VERSION
     turn_id: str
     chat_id: str
+    runtime_kind: RuntimeKind = "agent_runtime"
+    input_text: Optional[str] = None
     role: Literal["assistant"] = "assistant"
     status: str
     parts: list[UIMessagePart] = Field(default_factory=list)

--- a/aperag/domains/conversation/schemas.py
+++ b/aperag/domains/conversation/schemas.py
@@ -45,9 +45,18 @@ Cross-domain references kept narrow:
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from pydantic import BaseModel, Field, conint
+
+if TYPE_CHECKING:
+    # Type-only import to keep the OpenAPI schema for ``ChatDetails.history``
+    # populated without forming a runtime cycle: ``agent_runtime.uimessage``
+    # imports ``AGENT_RUNTIME_SCHEMA_VERSION`` / ``UserActivityEnvelope`` from
+    # ``agent_runtime.schemas``, which in turn imports ``File`` from this
+    # module. Pydantic resolves the forward reference via
+    # :func:`ChatDetails.model_rebuild` at the bottom of this file.
+    from aperag.domains.agent_runtime.uimessage import AgentTurnSnapshot
 
 from aperag.domains.knowledge_base.schemas import Collection as KBCollectionSchema
 from aperag.schema.common import ModelSpec, PageResult, PaginatedResponse
@@ -169,9 +178,16 @@ class ChatDetails(BaseModel):
     bot_id: Optional[str] = None
     peer_id: Optional[str] = None
     peer_type: Optional[Literal["system", "feishu", "weixin", "weixin_official", "web", "dingtalk"]] = None
-    history: Optional[list[list[ChatMessage]]] = Field(
+    history: Optional[list[AgentTurnSnapshot]] = Field(
         None,
-        description="Array of conversation turns, where each turn is an array of message parts",
+        description=(
+            "Phase 8 D8.5-BE (#92): historical conversation turns as canonical "
+            "``AgentTurnSnapshot`` envelopes — each turn carries the same "
+            "``UIMessagePart[]`` shape the FE consumes from the live SSE stream "
+            "(D8 §2 wire/at-rest byte-equal). Replaces the legacy "
+            "``list[list[ChatMessage]]`` shape; FE renders historical turns with "
+            "the same renderer used for live turns."
+        ),
     )
     status: Optional[Literal["active", "archived"]] = None
     created: Optional[datetime] = None
@@ -217,6 +233,21 @@ class Feedback(BaseModel):
 # names pointing at the same class; keep the alias here so the dual-hook
 # shim still resolves ``TurnFeedbackWrite``.
 TurnFeedbackWrite = Feedback
+
+
+# Phase 8 D8.5-BE (#92): resolve the forward reference to
+# ``AgentTurnSnapshot`` after ``conversation.schemas`` finishes loading.
+# A direct top-level import would form a cycle through
+# ``agent_runtime.uimessage`` → ``agent_runtime.schemas`` → this module.
+# The TYPE_CHECKING block at the top declares the import for static
+# checkers / OpenAPI; this rebuild wires it up at runtime.
+def _rebuild_chat_details() -> None:
+    from aperag.domains.agent_runtime.uimessage import AgentTurnSnapshot  # noqa: F401
+
+    ChatDetails.model_rebuild()
+
+
+_rebuild_chat_details()
 
 
 __all__ = [

--- a/aperag/domains/conversation/service/chat_service.py
+++ b/aperag/domains/conversation/service/chat_service.py
@@ -40,10 +40,15 @@ from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aperag.db.ops import AsyncDatabaseOps, async_db_ops
-from aperag.domains.agent_runtime.db.models import AgentArtifactType, AgentTurnStatus
+from aperag.domains.agent_runtime.db.models import AgentTurnStatus
+from aperag.domains.agent_runtime.snapshot_assembler import (
+    assemble_parts_from_artifacts,
+    extract_error_text,
+)
+from aperag.domains.agent_runtime.uimessage import AgentTurnSnapshot
 from aperag.domains.conversation.db.models import BotType, ChatStatus
 from aperag.domains.conversation.db.models import Chat as ChatRow
-from aperag.domains.conversation.schemas import Chat, ChatDetails, ChatMessage, ChatUpdate, Reference
+from aperag.domains.conversation.schemas import Chat, ChatDetails, ChatUpdate
 from aperag.exceptions import ChatNotFoundException, ResourceNotFoundException, ValidationException
 from aperag.utils.history import (
     RedisChatMessageHistory,
@@ -51,46 +56,6 @@ from aperag.utils.history import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _artifact_type_value(artifact) -> Optional[str]:
-    if not artifact:
-        return None
-    artifact_type = getattr(artifact, "artifact_type", None)
-    return artifact_type.value if hasattr(artifact_type, "value") else artifact_type
-
-
-def _extract_artifact_text(artifact) -> str:
-    if not artifact or not isinstance(getattr(artifact, "payload", None), dict):
-        return ""
-    return artifact.payload.get("text") or artifact.payload.get("content") or artifact.payload.get("message") or ""
-
-
-def _coerce_timestamp(value) -> Optional[float]:
-    return value.timestamp() if value else None
-
-
-def _map_reference_item(item: dict) -> Reference:
-    return Reference(
-        score=item.get("score"),
-        text=item.get("snippet") or "",
-        metadata={
-            **(item.get("metadata") or {}),
-            "title": item.get("title"),
-            "source_type": item.get("source_type"),
-            "source_id": item.get("source_id"),
-            "uri": item.get("uri"),
-        },
-    )
-
-
-def _extract_references(artifact) -> list[Reference]:
-    if not artifact or not isinstance(getattr(artifact, "payload", None), dict):
-        return []
-    items = artifact.payload.get("items")
-    if not isinstance(items, list):
-        return []
-    return [_map_reference_item(item) for item in items if isinstance(item, dict)]
 
 
 class ChatService:
@@ -114,97 +79,66 @@ class ChatService:
             updated=chat.gmt_updated.isoformat(),
         )
 
-    async def _build_v3_chat_history(self, user: str, chat_id: str) -> list[list[ChatMessage]]:
+    async def _build_v3_chat_history(self, user: str, chat_id: str) -> list[AgentTurnSnapshot]:
+        """Build the chat history as canonical ``AgentTurnSnapshot`` envelopes.
+
+        Phase 8 D8.5-BE (#92) flips this from the legacy
+        ``list[list[ChatMessage]]`` shape to one ``AgentTurnSnapshot``
+        per assistant turn. Each snapshot carries the same
+        ``UIMessagePart[]`` shape the FE consumes from the live SSE
+        stream, so historical and live turns render through a single
+        canonical path (D8 §2 wire/at-rest byte-equal).
+
+        The user query is exposed at ``input_text`` on the snapshot
+        envelope rather than as a separate ``role=human`` ChatMessage
+        entry; the FE renders it from there. The assistant turn's
+        ``answer`` / ``reference_bundle`` / ``error_summary``
+        artifacts are projected into ``parts`` via
+        :func:`assemble_parts_from_artifacts`, mirroring the snapshot
+        endpoint (#90 / D8.4d). FAILED / CANCELLED turns surface their
+        message via ``error_text`` (preferring an ``error_summary``
+        artifact, falling back to ``turn.error_message``), again
+        mirroring the snapshot endpoint contract.
+
+        Once the wire emitter starts populating ``agent_message.parts``
+        directly (D8.6 / #80), this method can short-circuit to
+        :meth:`UIMessageStore.read` per-turn; until then the artifact
+        projection is the single source. ``runtime_kind`` is hardcoded
+        to ``agent_runtime`` here — non-agent runtimes will write
+        ``direct_chat`` / ``rag_chat`` rows directly via the future
+        non-agent write path and this method only needs to surface
+        them when they exist (a no-op until then per architect lock
+        msg=01918929).
+        """
+
         turns = await self.db_ops.query_agent_turns(user, chat_id)
 
-        history: list[list[ChatMessage]] = []
+        history: list[AgentTurnSnapshot] = []
         for turn in turns:
-            history.append(
-                [
-                    ChatMessage(
-                        id=turn.id,
-                        type="message",
-                        role="human",
-                        data=turn.input_text,
-                        timestamp=_coerce_timestamp(turn.gmt_created),
-                    )
-                ]
-            )
-
             artifacts = await self.db_ops.query_agent_artifacts_by_turn(turn.id)
-            answer_artifact = (
-                next((artifact for artifact in artifacts if artifact.id == turn.answer_artifact_id), None)
-                if turn.answer_artifact_id
-                else None
+            parts = list(assemble_parts_from_artifacts(artifacts))
+
+            error_text: Optional[str] = None
+            if turn.status in {AgentTurnStatus.FAILED, AgentTurnStatus.CANCELLED}:
+                error_text = extract_error_text(artifacts) or turn.error_message
+
+            status_value = turn.status.value if hasattr(turn.status, "value") else str(turn.status)
+            history.append(
+                AgentTurnSnapshot(
+                    turn_id=turn.id,
+                    chat_id=turn.chat_id,
+                    runtime_kind="agent_runtime",
+                    status=status_value,
+                    parts=parts,
+                    error_text=error_text,
+                    timeline_cursor=turn.timeline_cursor or 0,
+                    started_at=turn.gmt_started,
+                    finished_at=turn.gmt_finished,
+                    created_at=turn.gmt_created,
+                    updated_at=turn.gmt_updated,
+                    input_text=turn.input_text,
+                )
             )
-            if not answer_artifact:
-                answer_artifact = next(
-                    (
-                        artifact
-                        for artifact in artifacts
-                        if _artifact_type_value(artifact) == AgentArtifactType.ANSWER.value
-                    ),
-                    None,
-                )
-
-            reference_artifact = (
-                next((artifact for artifact in artifacts if artifact.id == turn.reference_bundle_artifact_id), None)
-                if turn.reference_bundle_artifact_id
-                else None
-            )
-            if not reference_artifact:
-                reference_artifact = next(
-                    (
-                        artifact
-                        for artifact in artifacts
-                        if _artifact_type_value(artifact) == AgentArtifactType.REFERENCE_BUNDLE.value
-                    ),
-                    None,
-                )
-
-            answer_text = _extract_artifact_text(answer_artifact)
-            if not answer_text and turn.status in {
-                AgentTurnStatus.FAILED,
-                AgentTurnStatus.CANCELLED,
-            }:
-                answer_text = turn.error_message or ""
-
-            ai_parts: list[ChatMessage] = []
-            if answer_text:
-                ai_parts.append(
-                    ChatMessage(
-                        id=turn.id,
-                        type="message",
-                        role="ai",
-                        data=answer_text,
-                        timestamp=_coerce_timestamp(turn.gmt_finished) or _coerce_timestamp(turn.gmt_created),
-                    )
-                )
-            else:
-                ai_parts.append(
-                    ChatMessage(
-                        id=turn.id,
-                        type="start",
-                        role="ai",
-                        data="",
-                        timestamp=_coerce_timestamp(turn.gmt_created),
-                    )
-                )
-
-            references = _extract_references(reference_artifact)
-            if references:
-                ai_parts.append(
-                    ChatMessage(
-                        id=turn.id,
-                        type="references",
-                        role="ai",
-                        data="",
-                        references=references,
-                        timestamp=_coerce_timestamp(turn.gmt_finished) or _coerce_timestamp(turn.gmt_created),
-                    )
-                )
-
-            history.append(ai_parts)
 
         return history
 

--- a/aperag/migration/versions/20260426012000-c8f2d34a51e7_add_agent_message_runtime_kind.py
+++ b/aperag/migration/versions/20260426012000-c8f2d34a51e7_add_agent_message_runtime_kind.py
@@ -1,0 +1,54 @@
+"""add agent_message.runtime_kind discriminator (Phase 8 D8.5-BE / #92)
+
+Phase 8 task #92 — adds the ``runtime_kind`` column to ``agent_message``
+so a single canonical UIMessage table can host messages produced by
+distinct runtimes (the agent reasoning loop today; future direct-LLM
+and RAG-only chat paths). Per architect canonical lock msg=e01e9b4b
++ Weston msg=94dac98a, ``runtime_kind`` is a stable enum
+(``agent_runtime`` / ``direct_chat`` / ``rag_chat``) and ``role``
+retains its ChatML speaker semantics.
+
+Existing rows (all produced by the agent runtime to date) are
+backfilled to ``agent_runtime`` via the column ``server_default`` so
+no data migration step is required. The column is non-null going
+forward; SQLAlchemy ORM also defaults new rows to ``agent_runtime``
+when the writer doesn't supply a value (D8.5 keeps the agent runtime
+write path unchanged).
+
+Per Phase 8 destructive philosophy + earayu2 msg=f20d5034 hard-cut
+acceptance: no legacy chat-history table to drop in this migration —
+the non-agent path's previous storage was Redis-only via
+``RedisChatMessageHistory`` (kept until D8.6 / #80 cleanup post-soak
+per Weston msg=5ec539c8).
+
+Revision ID: c8f2d34a51e7
+Revises: 84fac9e3d8c2
+Create Date: 2026-04-26 01:20:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8f2d34a51e7"
+down_revision: Union[str, None] = "84fac9e3d8c2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_message",
+        sa.Column(
+            "runtime_kind",
+            sa.String(length=24),
+            nullable=False,
+            server_default="agent_runtime",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_message", "runtime_kind")

--- a/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
+++ b/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
@@ -14,11 +14,11 @@ from aperag.domains.agent_runtime.db.models import (
 from aperag.domains.agent_runtime.schemas import (
     AgentArtifactEnvelope,
     AgentTimelineEventEnvelope,
-    AgentTurnSnapshot,
     CreateTurnRequest,
     UserActivityIntent,
 )
 from aperag.domains.agent_runtime.services import EventService, HistoryWriter, TurnService
+from aperag.domains.agent_runtime.uimessage import AgentTurnSnapshot
 
 
 def _now():

--- a/tests/unit_test/chat/test_chat_service.py
+++ b/tests/unit_test/chat/test_chat_service.py
@@ -1,9 +1,28 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
 
 from aperag.domains.agent_runtime.db.models import AgentTurnStatus
+from aperag.domains.agent_runtime.uimessage import (
+    DataCitationPart,
+    SourceUrlPart,
+    TextPart,
+)
 from aperag.domains.conversation.service.chat_service import ChatService
 
 
@@ -31,17 +50,22 @@ class _FakeChatDbOps:
             answer_artifact_id="artifact-answer",
             reference_bundle_artifact_id="artifact-refs",
             error_message=None,
+            timeline_cursor=2,
             gmt_created=_now(),
+            gmt_started=_now(),
             gmt_finished=_now(),
+            gmt_updated=_now(),
         )
         self.answer_artifact = SimpleNamespace(
             id="artifact-answer",
             artifact_type="answer",
+            summary="Here is the answer.",
             payload={"text": "Here is the answer."},
         )
         self.reference_artifact = SimpleNamespace(
             id="artifact-refs",
             artifact_type="reference_bundle",
+            summary="1 references",
             payload={
                 "items": [
                     {
@@ -74,7 +98,15 @@ class _FakeChatDbOps:
 
 
 @pytest.mark.asyncio
-async def test_get_chat_projects_v3_turn_history():
+async def test_get_chat_returns_canonical_uimessage_history():
+    """Phase 8 D8.5-BE (#92): ``ChatDetails.history`` is now a list of
+    canonical ``AgentTurnSnapshot`` envelopes (one per assistant turn),
+    each carrying the same ``UIMessagePart`` shape the FE consumes from
+    the live SSE stream. Replaces the legacy
+    ``list[list[ChatMessage]]`` shape so historical and live turns
+    render through a single canonical path.
+    """
+
     service = ChatService()
     service.db_ops = _FakeChatDbOps()
 
@@ -82,18 +114,92 @@ async def test_get_chat_projects_v3_turn_history():
 
     assert chat.id == "chat-1"
     assert chat.history is not None
-    assert len(chat.history) == 2
+    assert len(chat.history) == 1
 
-    user_group, ai_group = chat.history
-    assert user_group[0].role == "human"
-    assert user_group[0].data == "What changed?"
+    snapshot = chat.history[0]
+    assert snapshot.turn_id == "turn-1"
+    assert snapshot.chat_id == "chat-1"
+    assert snapshot.runtime_kind == "agent_runtime"
+    assert snapshot.role == "assistant"
+    assert snapshot.status == "COMPLETED"
+    assert snapshot.input_text == "What changed?"
+    assert snapshot.error_text is None
+    assert snapshot.timeline_cursor == 2
 
-    assert ai_group[0].role == "ai"
-    assert ai_group[0].id == "turn-1"
-    assert ai_group[0].type == "message"
-    assert ai_group[0].data == "Here is the answer."
+    types = [getattr(part, "type", None) for part in snapshot.parts]
+    assert types == ["text", "source-url", "data-citation"]
 
-    assert ai_group[1].type == "references"
-    assert ai_group[1].references is not None
-    assert len(ai_group[1].references) == 1
-    assert "feedback" not in ai_group[1].model_dump(exclude_none=True)
+    assert isinstance(snapshot.parts[0], TextPart)
+    assert snapshot.parts[0].text == "Here is the answer."
+
+    assert isinstance(snapshot.parts[1], SourceUrlPart)
+    assert snapshot.parts[1].source_id == "doc-a"
+    assert snapshot.parts[1].url == "https://example.com/doc-a"
+
+    assert isinstance(snapshot.parts[2], DataCitationPart)
+    assert snapshot.parts[2].data.cited_text == "Reference snippet"
+    assert snapshot.parts[2].data.location.url == "https://example.com/doc-a"
+
+
+@pytest.mark.asyncio
+async def test_get_chat_history_surfaces_error_text_for_failed_turn():
+    """A FAILED turn's error_text comes from ``error_summary`` artifact
+    when present, falling back to ``turn.error_message`` (mirrors the
+    snapshot endpoint contract from #90 D8.4d)."""
+
+    service = ChatService()
+    db_ops = _FakeChatDbOps()
+    db_ops.turn = SimpleNamespace(
+        id="turn-failed",
+        chat_id="chat-1",
+        user="user-1",
+        input_text="Trigger failure",
+        status=AgentTurnStatus.FAILED,
+        answer_artifact_id=None,
+        reference_bundle_artifact_id=None,
+        error_message="upstream provider timeout",
+        timeline_cursor=1,
+        gmt_created=_now(),
+        gmt_started=_now(),
+        gmt_finished=_now(),
+        gmt_updated=_now(),
+    )
+    db_ops.answer_artifact = None
+    db_ops.reference_artifact = None
+
+    async def _empty_artifacts(turn_id):
+        return []
+
+    db_ops.query_agent_artifacts_by_turn = _empty_artifacts
+    service.db_ops = db_ops
+
+    chat = await service.get_chat("user-1", "bot-1", "chat-1")
+    assert chat.history is not None
+    assert len(chat.history) == 1
+
+    snapshot = chat.history[0]
+    assert snapshot.status == "FAILED"
+    assert snapshot.error_text == "upstream provider timeout"
+    assert snapshot.parts == []
+
+
+@pytest.mark.asyncio
+async def test_get_chat_history_does_not_expose_legacy_chatmessage_shape():
+    """Regression-guard: ``ChatDetails.history`` must not regress to the
+    legacy ``list[list[ChatMessage]]`` shape (separate human / ai
+    groups per turn). Pre-#92 callers that read ``history[i][j].role``
+    will fail loudly; that is intentional — they need to migrate to
+    the canonical snapshot shape.
+    """
+
+    service = ChatService()
+    service.db_ops = _FakeChatDbOps()
+
+    chat = await service.get_chat("user-1", "bot-1", "chat-1")
+
+    serialised = [snapshot.model_dump(mode="json") for snapshot in chat.history or []]
+    for entry in serialised:
+        assert "turn_id" in entry
+        assert "parts" in entry
+        assert "role" in entry  # but role is a string, not a list of ChatMessages
+        assert isinstance(entry["role"], str)

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -1178,6 +1178,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/agent/chats/{chat_id}/turns/{turn_id}/consent/{tool_call_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Post Consent Decision View
+         * @description Record the user's consent decision (D9 §3.2 step 4).
+         *
+         *     Tenant-bound per D9 §2 multi-tenant boundary (architect canonical
+         *     lock msg=19f2c9a9):
+         *
+         *     1. ``required_user`` enforces authentication.
+         *     2. ``turn_service.get_turn_snapshot`` enforces that the
+         *        authenticated user owns ``(chat_id, turn_id)``;
+         *        ``ResourceNotFoundException`` on miss surfaces as 404 via the
+         *        global exception handler.
+         *     3. ``ConsentService.decide(*, expected_turn_id=...)`` enforces
+         *        that the consent's stashed binding matches both
+         *        ``actor_user_id`` and ``turn_id``. Defense-in-depth so even a
+         *        misrouted request cannot resolve someone else's consent.
+         *
+         *     Returns ``404`` for unknown turn / unknown consent, ``403`` when
+         *     the consent is bound to a different user / turn, ``409`` when a
+         *     decision was already recorded.
+         */
+        post: operations["agent_runtime_post_consent_decision_view"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/agent/chats/{chat_id}/turns/{turn_id}/elicit/{elicitation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Post Elicitation Response View
+         * @description Submit an elicitation response (D9 §5.2 step 4).
+         *
+         *     Tenant-bound the same way as :func:`post_consent_decision_view`
+         *     (per D9 §2 multi-tenant boundary; architect canonical lock
+         *     msg=19f2c9a9): HTTP-layer ``turn_service.get_turn_snapshot``
+         *     ownership pre-check + service-layer
+         *     :class:`ElicitationOwnershipError` defense-in-depth.
+         *
+         *     Schema validation is handled inside
+         *     :meth:`ElicitationService.submit`; a validation failure surfaces
+         *     as ``422`` and the elicitation stays pending so the FE can
+         *     re-prompt with the corrected value.
+         */
+        post: operations["agent_runtime_post_elicitation_response_view"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/agent/chats/{chat_id}/turns/{turn_id}/events": {
         parameters: {
             query?: never;
@@ -1983,15 +2051,35 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * ActivityData
+         * @description Inner payload mirroring ``UserActivityEnvelope`` for wire/at-rest
+         *     same-schema parity. ``DataActivityPart`` is transient — never persisted —
+         *     but the wrapped shape is preserved so the live SSE stream stays
+         *     structurally identical to persisted variants.
+         */
+        ActivityData: {
+            activity: components["schemas"]["UserActivityEnvelope"];
+        };
         /** Agent */
-        Agent: {
-            completion?: components["schemas"]["ModelSpec"] | null;
+        "Agent-Input": {
+            completion?: components["schemas"]["ModelSpec-Input"] | null;
             /** System Prompt Template */
             system_prompt_template?: string | null;
             /** Query Prompt Template */
             query_prompt_template?: string | null;
             /** Collections */
-            collections?: components["schemas"]["Collection"][] | null;
+            collections?: components["schemas"]["Collection-Input"][] | null;
+        };
+        /** Agent */
+        "Agent-Output": {
+            completion?: components["schemas"]["ModelSpec-Output"] | null;
+            /** System Prompt Template */
+            system_prompt_template?: string | null;
+            /** Query Prompt Template */
+            query_prompt_template?: string | null;
+            /** Collections */
+            collections?: components["schemas"]["Collection-Output"][] | null;
         };
         /** AgentArtifactEnvelope */
         AgentArtifactEnvelope: {
@@ -2018,43 +2106,6 @@ export interface components {
             created_at?: string | null;
             /** Updated At */
             updated_at?: string | null;
-        };
-        /** AgentTimelineEventEnvelope */
-        AgentTimelineEventEnvelope: {
-            /**
-             * Schema Version
-             * @default agent-runtime-v3.1
-             */
-            schema_version: string;
-            /** Event Id */
-            event_id: string;
-            /** Turn Id */
-            turn_id: string;
-            /** Sequence */
-            sequence: number;
-            /**
-             * Timestamp
-             * Format: date-time
-             */
-            timestamp: string;
-            /** Type */
-            type: string;
-            /** Technical Type */
-            technical_type?: string | null;
-            /** Label */
-            label?: string | null;
-            /** Status */
-            status?: string | null;
-            /**
-             * Actor
-             * @enum {string}
-             */
-            actor: "agent" | "tool" | "system";
-            /** Data */
-            data?: {
-                [key: string]: unknown;
-            };
-            user_activity?: components["schemas"]["UserActivityEnvelope"] | null;
         };
         /** AgentTurnEnvelope */
         AgentTurnEnvelope: {
@@ -2105,13 +2156,79 @@ export interface components {
             /** Updated At */
             updated_at?: string | null;
         };
-        /** AgentTurnSnapshot */
+        /**
+         * AgentTurnSnapshot
+         * @description Canonical UIMessage at-rest snapshot for an agent turn (Phase 8 D8.4d / #90, D8.5-BE / #92).
+         *
+         *     Replaces the legacy ``{turn, timeline, artifacts}`` snapshot shape
+         *     with the ``UIMessage``-aligned canonical that the FE renderer
+         *     (#76 / #77 / #78) consumes from both the live SSE stream and the
+         *     at-rest reload path. Per D8 §2 wire / at-rest are byte-equal, so
+         *     no client-side converter is required: a snapshot reload
+         *     deserializes through the same ``UIMessagePart`` discriminated
+         *     union the wire emits.
+         *
+         *     ``runtime_kind`` (D8.5-BE) tags the runtime that produced the
+         *     turn — ``agent_runtime`` for the agent reasoning loop,
+         *     ``direct_chat`` / ``rag_chat`` reserved for future paths. ``role``
+         *     keeps speaker semantics independent of runtime kind.
+         *
+         *     ``parts`` is the persistable subset (transient ``data-activity``
+         *     is stripped before write per :func:`persistable_parts`);
+         *     ``status`` mirrors the runtime ``AgentTurnStatus`` enum value;
+         *     ``error_text`` surfaces an ``error_summary`` artifact's message
+         *     for failed turns. Turn-shape metadata (timestamps, ids, cursor)
+         *     is kept top-level so the FE can render without a separate
+         *     envelope round-trip.
+         *
+         *     Lives in this module rather than ``schemas`` to keep the
+         *     ``UIMessage`` family (parts + envelope) in a single source-of-truth
+         *     file; ``schemas`` re-exports the name for back-compat with
+         *     existing import sites.
+         */
         AgentTurnSnapshot: {
-            turn: components["schemas"]["AgentTurnEnvelope"];
-            /** Timeline */
-            timeline?: components["schemas"]["AgentTimelineEventEnvelope"][];
-            /** Artifacts */
-            artifacts?: components["schemas"]["AgentArtifactEnvelope"][];
+            /**
+             * Schema Version
+             * @default agent-runtime-v3.1
+             */
+            schema_version: string;
+            /** Turn Id */
+            turn_id: string;
+            /** Chat Id */
+            chat_id: string;
+            /**
+             * Runtime Kind
+             * @default agent_runtime
+             * @enum {string}
+             */
+            runtime_kind: "agent_runtime" | "direct_chat" | "rag_chat";
+            /** Input Text */
+            input_text?: string | null;
+            /**
+             * Role
+             * @default assistant
+             * @constant
+             */
+            role: "assistant";
+            /** Status */
+            status: string;
+            /** Parts */
+            parts?: (components["schemas"]["TextPart"] | components["schemas"]["ToolPart"] | components["schemas"]["SourceUrlPart"] | components["schemas"]["SourceDocumentPart"] | components["schemas"]["DataCitationPart"] | components["schemas"]["DataActivityPart"] | components["schemas"]["DataToolConsentPart"] | components["schemas"]["DataElicitationPart"])[];
+            /** Error Text */
+            error_text?: string | null;
+            /**
+             * Timeline Cursor
+             * @default 0
+             */
+            timeline_cursor: number;
+            /** Started At */
+            started_at?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Created At */
+            created_at?: string | null;
+            /** Updated At */
+            updated_at?: string | null;
         };
         /** ApiKey */
         ApiKey: {
@@ -2204,15 +2321,19 @@ export interface components {
              * @example agent
              */
             type?: ("knowledge" | "common" | "agent") | null;
-            config?: components["schemas"]["BotConfig"] | null;
+            config?: components["schemas"]["BotConfig-Output"] | null;
             /** Created */
             created?: string | null;
             /** Updated */
             updated?: string | null;
         };
         /** BotConfig */
-        BotConfig: {
-            agent?: components["schemas"]["Agent"] | null;
+        "BotConfig-Input": {
+            agent?: components["schemas"]["Agent-Input"] | null;
+        };
+        /** BotConfig */
+        "BotConfig-Output": {
+            agent?: components["schemas"]["Agent-Output"] | null;
         };
         /** BotCreate */
         BotCreate: {
@@ -2226,7 +2347,7 @@ export interface components {
              * @example agent
              */
             type?: "agent" | null;
-            config?: components["schemas"]["BotConfig"] | null;
+            config?: components["schemas"]["BotConfig-Input"] | null;
         };
         /**
          * BotList
@@ -2243,7 +2364,7 @@ export interface components {
             title?: string | null;
             /** Description */
             description?: string | null;
-            config?: components["schemas"]["BotConfig"] | null;
+            config?: components["schemas"]["BotConfig-Input"] | null;
         };
         /** CancelRunResponse */
         CancelRunResponse: {
@@ -2275,6 +2396,23 @@ export interface components {
              * @description The new password of the user
              */
             new_password?: string | null;
+        };
+        /** CharLocation */
+        CharLocation: {
+            /**
+             * Type
+             * @default char_location
+             * @constant
+             */
+            type: "char_location";
+            /** Doc Index */
+            doc_index: number;
+            /** Doc Title */
+            doc_title?: string | null;
+            /** Start Char */
+            start_char: number;
+            /** End Char */
+            end_char: number;
         };
         /** Chat */
         Chat: {
@@ -2309,9 +2447,9 @@ export interface components {
             peer_type?: ("system" | "feishu" | "weixin" | "weixin_official" | "web" | "dingtalk") | null;
             /**
              * History
-             * @description Array of conversation turns, where each turn is an array of message parts
+             * @description Phase 8 D8.5-BE (#92): historical conversation turns as canonical ``AgentTurnSnapshot`` envelopes — each turn carries the same ``UIMessagePart[]`` shape the FE consumes from the live SSE stream (D8 §2 wire/at-rest byte-equal). Replaces the legacy ``list[list[ChatMessage]]`` shape; FE renders historical turns with the same renderer used for live turns.
              */
-            history?: components["schemas"]["ChatMessage"][][] | null;
+            history?: components["schemas"]["AgentTurnSnapshot"][] | null;
             /** Status */
             status?: ("active" | "archived") | null;
             /** Created */
@@ -2363,27 +2501,6 @@ export interface components {
             /** Items */
             items?: components["schemas"]["Chat"][] | null;
         };
-        /** ChatMessage */
-        ChatMessage: {
-            /** Id */
-            id?: string | null;
-            /** Part Id */
-            part_id?: string | null;
-            /** Type */
-            type?: ("welcome" | "message" | "start" | "stop" | "error" | "tool_call_result" | "thinking" | "references") | null;
-            /** Timestamp */
-            timestamp?: number | null;
-            /** Role */
-            role?: ("human" | "ai") | null;
-            /** Data */
-            data?: string | null;
-            /** References */
-            references?: components["schemas"]["Reference"][] | null;
-            /** Urls */
-            urls?: string[] | null;
-            /** Files */
-            files?: components["schemas"]["File"][] | null;
-        };
         /** ChatUpdate */
         ChatUpdate: {
             /** Title */
@@ -2400,11 +2517,18 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
+        /** CitationData */
+        CitationData: {
+            /** Cited Text */
+            cited_text: string;
+            /** Location */
+            location: components["schemas"]["CharLocation"] | components["schemas"]["PageLocation"] | components["schemas"]["ContentBlockLocation"] | components["schemas"]["UrlCitationLocation"];
+        };
         /**
          * Collection
          * @description Collection is a collection of documents
          */
-        Collection: {
+        "Collection-Input": {
             /** Id */
             id?: string | null;
             /** Title */
@@ -2413,7 +2537,39 @@ export interface components {
             type?: string | null;
             /** Description */
             description?: string | null;
-            config?: components["schemas"]["CollectionConfig"] | null;
+            config?: components["schemas"]["CollectionConfig-Input"] | null;
+            /** Status */
+            status?: ("ACTIVE" | "INACTIVE" | "DELETED") | null;
+            /** Created */
+            created?: string | null;
+            /** Updated */
+            updated?: string | null;
+            /**
+             * Is Published
+             * @description Whether the collection is published to marketplace
+             * @default false
+             */
+            is_published: boolean | null;
+            /**
+             * Published At
+             * @description Publication time, null when not published
+             */
+            published_at?: string | null;
+        };
+        /**
+         * Collection
+         * @description Collection is a collection of documents
+         */
+        "Collection-Output": {
+            /** Id */
+            id?: string | null;
+            /** Title */
+            title?: string | null;
+            /** Type */
+            type?: string | null;
+            /** Description */
+            description?: string | null;
+            config?: components["schemas"]["CollectionConfig-Output"] | null;
             /** Status */
             status?: ("ACTIVE" | "INACTIVE" | "DELETED") | null;
             /** Created */
@@ -2433,7 +2589,7 @@ export interface components {
             published_at?: string | null;
         };
         /** CollectionConfig */
-        CollectionConfig: {
+        "CollectionConfig-Input": {
             /**
              * Source
              * @description Source system identifier. Only `system` is supported.
@@ -2480,14 +2636,65 @@ export interface components {
              * @example zh-CN
              */
             language: ("zh-CN" | "en-US" | "ja-JP" | "ko-KR") | null;
-            embedding?: components["schemas"]["ModelSpec"] | null;
-            completion?: components["schemas"]["ModelSpec"] | null;
+            embedding?: components["schemas"]["ModelSpec-Input"] | null;
+            completion?: components["schemas"]["ModelSpec-Input"] | null;
+        };
+        /** CollectionConfig */
+        "CollectionConfig-Output": {
+            /**
+             * Source
+             * @description Source system identifier. Only `system` is supported.
+             * @default system
+             * @example system
+             */
+            source: string | null;
+            /**
+             * Enable Vector
+             * @description Whether to enable vector index
+             * @default true
+             */
+            enable_vector: boolean | null;
+            /**
+             * Enable Fulltext
+             * @description Whether to enable fulltext index
+             * @default true
+             */
+            enable_fulltext: boolean | null;
+            /**
+             * Enable Knowledge Graph
+             * @description Whether to enable knowledge graph index
+             * @default true
+             */
+            enable_knowledge_graph: boolean | null;
+            /**
+             * Enable Summary
+             * @description Whether to enable summary index
+             * @default false
+             */
+            enable_summary: boolean | null;
+            /**
+             * Enable Vision
+             * @description Whether to enable vision index
+             * @default false
+             */
+            enable_vision: boolean | null;
+            knowledge_graph_config?: components["schemas"]["KnowledgeGraphConfig"] | null;
+            index_prompts?: components["schemas"]["IndexPrompts"] | null;
+            /**
+             * Language
+             * @description Language for the collection content and processing
+             * @default zh-CN
+             * @example zh-CN
+             */
+            language: ("zh-CN" | "en-US" | "ja-JP" | "ko-KR") | null;
+            embedding?: components["schemas"]["ModelSpec-Output"] | null;
+            completion?: components["schemas"]["ModelSpec-Output"] | null;
         };
         /** CollectionCreate */
         CollectionCreate: {
             /** Title */
             title?: string | null;
-            config?: components["schemas"]["CollectionConfig"] | null;
+            config?: components["schemas"]["CollectionConfig-Input"] | null;
             /** Type */
             type?: string | null;
             /** Description */
@@ -2526,7 +2733,7 @@ export interface components {
             title?: string | null;
             /** Description */
             description?: string | null;
-            config?: components["schemas"]["CollectionConfig"] | null;
+            config?: components["schemas"]["CollectionConfig-Input"] | null;
         };
         /**
          * CollectionView
@@ -2632,13 +2839,52 @@ export interface components {
              */
             failed_documents?: components["schemas"]["FailedDocument"][] | null;
         };
+        /**
+         * ConsentDecisionBody
+         * @description Body for ``POST /agent/turns/{turn_id}/consent/{tool_call_id}``.
+         *
+         *     ``decision`` is one of ``approved`` / ``denied``. The runtime
+         *     transitions ``state="expired"`` independently when the consent
+         *     times out -- not allowed as an inbound decision.
+         */
+        ConsentDecisionBody: {
+            /** Decision */
+            decision: string;
+        };
+        /**
+         * ConsentDecisionResponse
+         * @description Response for the consent POST -- echoes the resolved part.
+         */
+        ConsentDecisionResponse: {
+            /** Consent Id */
+            consent_id: string;
+            /** Decision */
+            decision: string;
+            /** State */
+            state: string;
+        };
+        /** ContentBlockLocation */
+        ContentBlockLocation: {
+            /**
+             * Type
+             * @default content_block_location
+             * @constant
+             */
+            type: "content_block_location";
+            /** Doc Index */
+            doc_index: number;
+            /** Doc Title */
+            doc_title?: string | null;
+            /** Block Index */
+            block_index: number;
+        };
         /** CreateTurnRequest */
         CreateTurnRequest: {
             /** Query */
             query: string;
-            completion?: components["schemas"]["ModelSpec"] | null;
+            completion?: components["schemas"]["ModelSpec-Input"] | null;
             /** Collections */
-            collections?: components["schemas"]["Collection"][];
+            collections?: components["schemas"]["Collection-Input"][];
             /**
              * Web Search Enabled
              * @default false
@@ -2659,6 +2905,81 @@ export interface components {
             turn: components["schemas"]["AgentTurnEnvelope"];
             /** Stream Url */
             stream_url: string;
+        };
+        /**
+         * DataActivityPart
+         * @description Ephemeral UX activity (thinking / searching / etc.).
+         *
+         *     ``transient=True`` is hard-coded — these parts are only ever
+         *     present in the live SSE stream; ``persistable_parts`` strips them
+         *     before at-rest write.
+         */
+        DataActivityPart: {
+            /**
+             * Type
+             * @default data-activity
+             * @constant
+             */
+            type: "data-activity";
+            data: components["schemas"]["ActivityData"];
+            /**
+             * Transient
+             * @default true
+             * @constant
+             */
+            transient: true;
+        };
+        /**
+         * DataCitationPart
+         * @description Anthropic-shape typed citation (D8 §2 + §2.5).
+         *
+         *     Wrapped ``data: CitationData`` shape per D8 §2 same-schema canonical
+         *     (architect lock 2026-04-25, msg=...): wire and at-rest must round-trip
+         *     byte-for-byte with no wire/at-rest converter layer.
+         */
+        DataCitationPart: {
+            /**
+             * Type
+             * @default data-citation
+             * @constant
+             */
+            type: "data-citation";
+            data: components["schemas"]["CitationData"];
+        };
+        /**
+         * DataElicitationPart
+         * @description User input request (D9 §5).
+         *
+         *     Persisted — the user's response becomes part of message history.
+         *     ``schema`` is the JSON-Schema fragment the FE should render as a
+         *     form; ``response`` is the validated submission.
+         */
+        DataElicitationPart: {
+            /**
+             * Type
+             * @default data-elicitation
+             * @constant
+             */
+            type: "data-elicitation";
+            data: components["schemas"]["ElicitationData"];
+        };
+        /**
+         * DataToolConsentPart
+         * @description Tool consent request / decision (D9 §A7).
+         *
+         *     Persisted as part of the audit trail. Raw tool args are stored
+         *     out-of-band by the runtime; only ``args_preview`` (≤ 500 chars
+         *     redacted preview) and ``args_hash`` (sha256 over canonical JSON)
+         *     appear here.
+         */
+        DataToolConsentPart: {
+            /**
+             * Type
+             * @default data-tool-consent
+             * @constant
+             */
+            type: "data-tool-consent";
+            data: components["schemas"]["ToolConsentData"];
         };
         /** DeleteDocumentsRequest */
         DeleteDocumentsRequest: {
@@ -2826,6 +3147,45 @@ export interface components {
             /** Vision Chunks */
             vision_chunks?: components["schemas"]["VisionChunk"][] | null;
         };
+        /** ElicitationData */
+        ElicitationData: {
+            /** Elicitationid */
+            elicitationId: string;
+            /** Servername */
+            serverName: string;
+            /** Prompt */
+            prompt: string;
+            /** Schema */
+            schema?: {
+                [key: string]: unknown;
+            };
+            /** Response */
+            response?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "pending" | "answered" | "cancelled";
+        };
+        /**
+         * ElicitationSubmitBody
+         * @description Body for ``POST /agent/turns/{turn_id}/elicit/{elicitation_id}``.
+         */
+        ElicitationSubmitBody: {
+            /** Response */
+            response: {
+                [key: string]: unknown;
+            };
+        };
+        /** ElicitationSubmitResponse */
+        ElicitationSubmitResponse: {
+            /** Elicitation Id */
+            elicitation_id: string;
+            /** State */
+            state: string;
+        };
         /** EmbeddingData */
         EmbeddingData: {
             /**
@@ -2838,15 +3198,43 @@ export interface components {
             /** Index */
             index: number;
         };
-        /** EmbeddingRequest */
+        /**
+         * EmbeddingRequest
+         * @description OpenAI-compatible embedding request.
+         *
+         *     Accepts either the new ``{model_id}`` shape *or* the legacy
+         *     ``{model, model_service_provider, custom_llm_provider}`` triple
+         *     that pre-#1697 callers (provider hurl, external clients) still
+         *     send. ``/api/v1/embeddings`` is permanent OpenAI-compat allowlist
+         *     surface — see Weston msg=80e873c1 / PR #1697 Blocker A. The
+         *     triple is resolved to a ``model_id`` server-side via
+         *     ``resolve_legacy_model_id`` before the runtime lookup runs.
+         *     Routes that are post-#1697-only (``/api/v3/...``) require
+         *     ``model_id`` and never accept the triple.
+         */
         EmbeddingRequest: {
             /**
              * Model Id
              * @description ApeRAG model id
              */
-            model_id: string;
+            model_id?: string | null;
             /** Input */
             input: string | string[];
+            /**
+             * Model
+             * @description Legacy provider-model name (pre-#1697 compat). Resolved to ``model_id`` server-side.
+             */
+            model?: string | null;
+            /**
+             * Model Service Provider
+             * @description Legacy provider name (pre-#1697 compat). Resolved to ``model_id`` server-side.
+             */
+            model_service_provider?: string | null;
+            /**
+             * Custom Llm Provider
+             * @description Legacy provider dialect (pre-#1697 compat). Ignored once ``model_id`` is resolved.
+             */
+            custom_llm_provider?: string | null;
         };
         /** EmbeddingResponse */
         EmbeddingResponse: {
@@ -4045,8 +4433,92 @@ export interface components {
             items?: components["schemas"]["ModelProvider"][];
             pageResult?: components["schemas"]["PageResult"] | null;
         };
-        /** ModelSpec */
-        ModelSpec: {
+        /**
+         * ModelSpec
+         * @description Inline model spec embedded in collection / bot config blobs.
+         *
+         *     Post-#1697 the canonical shape is ``{model_id}``. Pre-#1697 callers
+         *     (collections / bots already in the DB, plus any external clients
+         *     that hand-build the JSON) wrote ``{model, model_service_provider,
+         *     custom_llm_provider}`` instead. Pydantic silently dropped those
+         *     extras after the schema cut, so existing rows would parse with
+         *     ``model_id=None`` and the runtime resolver would 404. Per Weston
+         *     msg=80e873c1 / Blocker C we keep parsing both shapes — when the
+         *     legacy triple is present, it is stashed on the private
+         *     ``__legacy_*__`` slots and a ``ModelPlatformService`` lookup at
+         *     runtime resolves it to a real ``model_id`` (see
+         *     :func:`aperag.schema.utils.resolve_model_spec_legacy`).
+         */
+        "ModelSpec-Input": {
+            /**
+             * Model Id
+             * @description ApeRAG model id to use
+             * @example mdl_default_chat
+             */
+            model_id?: string | null;
+            /**
+             * Temperature
+             * @description Controls randomness in the output. Values between 0 and 2. Lower values make output more focused and deterministic
+             * @default 0.1
+             * @example 0.1
+             */
+            temperature: number | null;
+            /**
+             * Max Tokens
+             * @description Maximum number of tokens to generate
+             * @example 4096
+             */
+            max_tokens?: number | null;
+            /**
+             * Max Completion Tokens
+             * @description Upper bound for generated completion tokens, including visible and reasoning tokens
+             * @example 4096
+             */
+            max_completion_tokens?: number | null;
+            /**
+             * Timeout
+             * @description Maximum execution time in seconds for the API request
+             */
+            timeout?: number | null;
+            /**
+             * Top N
+             * @description Number of top results to return when reranking documents
+             */
+            top_n?: number | null;
+            /**
+             * Tags
+             * @description Tags for model categorization
+             * @default []
+             * @example [
+             *       "free",
+             *       "recommend"
+             *     ]
+             */
+            tags: string[] | null;
+            /** Legacy Model */
+            legacy_model?: string | null;
+            /** Legacy Provider */
+            legacy_provider?: string | null;
+            /** Legacy Custom Llm Provider */
+            legacy_custom_llm_provider?: string | null;
+        };
+        /**
+         * ModelSpec
+         * @description Inline model spec embedded in collection / bot config blobs.
+         *
+         *     Post-#1697 the canonical shape is ``{model_id}``. Pre-#1697 callers
+         *     (collections / bots already in the DB, plus any external clients
+         *     that hand-build the JSON) wrote ``{model, model_service_provider,
+         *     custom_llm_provider}`` instead. Pydantic silently dropped those
+         *     extras after the schema cut, so existing rows would parse with
+         *     ``model_id=None`` and the runtime resolver would 404. Per Weston
+         *     msg=80e873c1 / Blocker C we keep parsing both shapes — when the
+         *     legacy triple is present, it is stashed on the private
+         *     ``__legacy_*__`` slots and a ``ModelPlatformService`` lookup at
+         *     runtime resolves it to a real ``model_id`` (see
+         *     :func:`aperag.schema.utils.resolve_model_spec_legacy`).
+         */
+        "ModelSpec-Output": {
             /**
              * Model Id
              * @description ApeRAG model id to use
@@ -4248,6 +4720,21 @@ export interface components {
         /** OpenAIErrorResponse */
         OpenAIErrorResponse: {
             error: components["schemas"]["OpenAIErrorDetail"];
+        };
+        /** PageLocation */
+        PageLocation: {
+            /**
+             * Type
+             * @default page_location
+             * @constant
+             */
+            type: "page_location";
+            /** Doc Index */
+            doc_index: number;
+            /** Doc Title */
+            doc_title?: string | null;
+            /** Page Index */
+            page_index: number;
         };
         /**
          * PageResult
@@ -4477,19 +4964,6 @@ export interface components {
              */
             affected_documents?: number | null;
         };
-        /** Reference */
-        Reference: {
-            /** Score */
-            score?: number | null;
-            /** Text */
-            text?: string | null;
-            /** Image Uri */
-            image_uri?: string | null;
-            /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
-        };
         /**
          * Register
          * @description The email of the user
@@ -4524,13 +4998,17 @@ export interface components {
             relevance_score: number;
             document?: components["schemas"]["Document2"] | null;
         };
-        /** RerankRequest */
+        /**
+         * RerankRequest
+         * @description OpenAI-compatible rerank request — same legacy/new shape duality
+         *     as :class:`EmbeddingRequest`. See its docstring for the rationale.
+         */
         RerankRequest: {
             /**
              * Model Id
              * @description ApeRAG rerank model id
              */
-            model_id: string;
+            model_id?: string | null;
             /** Query */
             query: string;
             /** Documents */
@@ -4545,6 +5023,21 @@ export interface components {
              * @default true
              */
             return_documents: boolean | null;
+            /**
+             * Model
+             * @description Legacy provider-model name (pre-#1697 compat). Resolved to ``model_id`` server-side.
+             */
+            model?: string | null;
+            /**
+             * Model Service Provider
+             * @description Legacy provider name (pre-#1697 compat). Resolved to ``model_id`` server-side.
+             */
+            model_service_provider?: string | null;
+            /**
+             * Custom Llm Provider
+             * @description Legacy provider dialect (pre-#1697 compat). Ignored once ``model_id`` is resolved.
+             */
+            custom_llm_provider?: string | null;
         };
         /** RerankResponse */
         RerankResponse: {
@@ -4861,6 +5354,36 @@ export interface components {
              */
             published_at?: string | null;
         };
+        /** SourceDocumentPart */
+        SourceDocumentPart: {
+            /**
+             * Type
+             * @default source-document
+             * @constant
+             */
+            type: "source-document";
+            /** Sourceid */
+            sourceId: string;
+            /** Mediatype */
+            mediaType: string;
+            /** Title */
+            title: string;
+        };
+        /** SourceUrlPart */
+        SourceUrlPart: {
+            /**
+             * Type
+             * @default source-url
+             * @constant
+             */
+            type: "source-url";
+            /** Sourceid */
+            sourceId: string;
+            /** Url */
+            url: string;
+            /** Title */
+            title?: string | null;
+        };
         /** StagedDocumentsResponse */
         StagedDocumentsResponse: {
             /**
@@ -4963,6 +5486,20 @@ export interface components {
             message: string;
             quotas: components["schemas"]["SystemDefaultQuotas"];
         };
+        /**
+         * TextPart
+         * @description Plain assistant / user text content.
+         */
+        TextPart: {
+            /**
+             * Type
+             * @default text
+             * @constant
+             */
+            type: "text";
+            /** Text */
+            text: string;
+        };
         /** TitleGenerateRequest */
         TitleGenerateRequest: {
             /**
@@ -4991,6 +5528,71 @@ export interface components {
              * @description Generated title string
              */
             title: string;
+        };
+        /** ToolConsentData */
+        ToolConsentData: {
+            /** Toolcallid */
+            toolCallId: string;
+            /** Toolname */
+            toolName: string;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /** Argspreview */
+            argsPreview: string;
+            /** Argshash */
+            argsHash: string;
+            /**
+             * Risk
+             * @enum {string}
+             */
+            risk: "writes_user_data" | "calls_external_api" | "modifies_system" | "admin_only";
+            /** Requestedat */
+            requestedAt: string;
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "pending" | "approved" | "denied" | "expired";
+        };
+        /**
+         * ToolPart
+         * @description AI SDK v5 consolidated tool-call part (D8 §2.4 / D9 §A1+§A6).
+         *
+         *     The ``type`` discriminator carries the ``SafeToolName`` directly
+         *     (e.g. ``tool-aperag_knowledge_base_search_collection``); MCP server /
+         *     tool identity lives in ``metadata``. This matches the AI SDK v5
+         *     *at-rest* shape (one consolidated tool part per call, lifecycle
+         *     captured in ``state``) — not the *wire* shape, which is a sequence
+         *     of ``tool-input-*`` / ``tool-output-*`` events emitted by #73 and
+         *     collapsed by the FE consumer into this consolidated form.
+         *
+         *     SafeToolName resolution (raw MCP name → ``tool-<safeName>``) is
+         *     #75's responsibility (``aperag.domains.agent_runtime.tools``);
+         *     storage only enforces that the caller has already produced a
+         *     canonical ``type`` string.
+         */
+        ToolPart: {
+            /** Type */
+            type: string;
+            /** Toolcallid */
+            toolCallId: string;
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "input-streaming" | "input-available" | "output-available" | "output-error";
+            /** Input */
+            input?: unknown | null;
+            /** Output */
+            output?: unknown | null;
+            /** Errortext */
+            errorText?: string | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
         };
         /** TurnFeedback */
         TurnFeedback: {
@@ -5064,6 +5666,19 @@ export interface components {
              * @enum {string}
              */
             status: "UPLOADED" | "PENDING" | "RUNNING" | "COMPLETE" | "FAILED" | "DELETED" | "EXPIRED";
+        };
+        /** UrlCitationLocation */
+        UrlCitationLocation: {
+            /**
+             * Type
+             * @default url_citation
+             * @constant
+             */
+            type: "url_citation";
+            /** Url */
+            url: string;
+            /** Title */
+            title?: string | null;
         };
         /** User */
         User: {
@@ -7812,6 +8427,84 @@ export interface operations {
             };
         };
     };
+    agent_runtime_post_consent_decision_view: {
+        parameters: {
+            query?: {
+                engine?: unknown;
+            };
+            header?: never;
+            path: {
+                chat_id: string;
+                turn_id: string;
+                tool_call_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConsentDecisionBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsentDecisionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    agent_runtime_post_elicitation_response_view: {
+        parameters: {
+            query?: {
+                engine?: unknown;
+            };
+            header?: never;
+            path: {
+                chat_id: string;
+                turn_id: string;
+                elicitation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ElicitationSubmitBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ElicitationSubmitResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     agent_runtime_stream_turn_events_view: {
         parameters: {
             query?: {
@@ -9321,7 +10014,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Collection"];
+                    "application/json": components["schemas"]["Collection-Output"];
                 };
             };
             /** @description Validation Error */
@@ -9354,7 +10047,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Collection"];
+                    "application/json": components["schemas"]["Collection-Output"];
                 };
             };
             /** @description Validation Error */
@@ -9391,7 +10084,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Collection"];
+                    "application/json": components["schemas"]["Collection-Output"];
                 };
             };
             /** @description Validation Error */

--- a/web/src/components/chat/chat-messages.tsx
+++ b/web/src/components/chat/chat-messages.tsx
@@ -27,7 +27,6 @@ import { AgentTurnRenderer } from './agent-turn-renderer';
 import { ConsentPrompt } from './consent-prompt';
 import { ElicitationForm } from './elicitation-form';
 import { ChatInput, ChatInputSubmitParams } from './chat-input';
-import { MessagePartsAi } from './message-parts-ai';
 import { MessagePartsUser } from './message-parts-user';
 
 const API_BASE_PATH = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2`;
@@ -38,6 +37,12 @@ type LiveTurn = {
   baselineSnapshot?: AgentTurnSnapshotEnvelope;
   streamUrl: string | null; // null = no live connection (terminal / paused)
   pending: boolean;
+};
+
+type PendingUserMessage = {
+  key: string;
+  query: string;
+  timestamp: number;
 };
 
 type TurnFeedbackListResponse = {
@@ -57,53 +62,135 @@ function getActiveTurnStorageKey(chatId?: string) {
   return `${ACTIVE_TURN_STORAGE_PREFIX}${chatId || 'unknown'}`;
 }
 
-function createUserParts(query: string): ChatMessage[] {
-  return [
-    {
-      type: 'message',
-      role: 'human',
-      data: query,
-      timestamp: Math.floor(Date.now() / 1000),
-    },
-  ];
-}
-
-function createAiPlaceholder(turnId: string): ChatMessage[] {
-  return [
-    {
-      id: turnId,
-      type: 'start',
-      role: 'ai',
-      data: '',
-    },
-  ];
-}
-
-function getAiGroupId(parts: ChatMessage[]) {
-  const aiIds = [
-    ...new Set(
-      parts
-        .filter((part) => part.role === 'ai' && part.id)
-        .map((part) => part.id as string),
-    ),
-  ];
-  return aiIds.length === 1 ? aiIds[0] : undefined;
-}
-
 function getErrorMessage(error: unknown, fallback: string) {
   if (error instanceof Error) return error.message;
   return fallback;
 }
 
-function cloneMessages(messages: ChatMessage[][]) {
-  return messages.map((parts) => [...parts]);
+function buildStreamUrl(
+  chatId: string | undefined,
+  turnId: string,
+): string | null {
+  if (!chatId) return null;
+  const base = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/agent`;
+  return `${base}/chats/${chatId}/turns/${turnId}/events`;
+}
+
+/**
+ * Phase 8 D8.5-FE (#93): synthesize an `AgentTurnEnvelope` from the
+ * canonical `AgentTurnSnapshot` returned by `getBotChat()` /
+ * `getAgentTurnSnapshot()`. Reload-side fields the renderer needs
+ * (status / timestamps / error_message / timeline_cursor) come from
+ * the snapshot directly; turn-shape fields the renderer does NOT
+ * consume on reload (`bot_id` / `user_id` / `request_id` /
+ * `client_idempotency_key` / `model_profile`) are filled with empty
+ * placeholders. Live turn submissions still hand the renderer the
+ * full envelope returned by `createAgentTurn`.
+ */
+function envelopeFromSnapshot(
+  snapshot: AgentTurnSnapshotEnvelope,
+): AgentTurnEnvelope {
+  return {
+    schema_version: snapshot.schema_version,
+    turn_id: snapshot.turn_id,
+    chat_id: snapshot.chat_id,
+    user_id: '',
+    bot_id: '',
+    request_id: '',
+    client_idempotency_key: '',
+    status: snapshot.status,
+    input_text: snapshot.input_text ?? '',
+    model_profile: {},
+    error_code: null,
+    error_message: snapshot.error_text ?? null,
+    answer_artifact_id: null,
+    reference_bundle_artifact_id: null,
+    timeline_cursor: snapshot.timeline_cursor,
+    started_at: snapshot.started_at,
+    finished_at: snapshot.finished_at,
+    created_at: snapshot.created_at,
+    updated_at: snapshot.updated_at,
+  };
+}
+
+function liveTurnFromSnapshot(
+  chatId: string | undefined,
+  snapshot: AgentTurnSnapshotEnvelope,
+): LiveTurn {
+  const terminal = isTerminalStatus(snapshot.status);
+  return {
+    envelope: envelopeFromSnapshot(snapshot),
+    baselineSnapshot: snapshot,
+    streamUrl: terminal ? null : buildStreamUrl(chatId, snapshot.turn_id),
+    pending: !terminal,
+  };
+}
+
+function seedFromHistory(
+  chatId: string | undefined,
+  history: AgentTurnSnapshotEnvelope[] | null | undefined,
+): { liveTurns: Record<string, LiveTurn>; turnOrder: string[] } {
+  const liveTurns: Record<string, LiveTurn> = {};
+  const turnOrder: string[] = [];
+  for (const snapshot of history ?? []) {
+    if (!snapshot?.turn_id) continue;
+    liveTurns[snapshot.turn_id] = liveTurnFromSnapshot(chatId, snapshot);
+    turnOrder.push(snapshot.turn_id);
+  }
+  return { liveTurns, turnOrder };
+}
+
+function userMessagePartsFromText(
+  text: string | null | undefined,
+  timestamp: number | null | undefined,
+): ChatMessage[] {
+  if (!text) return [];
+  return [
+    {
+      type: 'message',
+      role: 'human',
+      data: text,
+      timestamp:
+        typeof timestamp === 'number' && Number.isFinite(timestamp)
+          ? timestamp
+          : Math.floor(Date.now() / 1000),
+    },
+  ];
 }
 
 export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
   const { chatRename } = useBotContext();
   const { chatId } = useParams<{ chatId: string }>();
-  const [messages, setMessages] = useState<ChatMessage[][]>(chat.history || []);
-  const [liveTurns, setLiveTurns] = useState<Record<string, LiveTurn>>({});
+
+  // Phase 8 D8.5-FE (#93): `chat.history` now ships canonical
+  // `AgentTurnSnapshot[]`; seed `liveTurns` directly from it, no
+  // separate per-turn snapshot fetch on first render.
+  //
+  // The OpenAPI-generated `ChatDetails.history` shape and the
+  // FE-curated `AgentTurnSnapshotEnvelope` shape carry the same
+  // wire bytes (D8 §2 byte-equal canonical) but are nominally
+  // distinct TypeScript types — the OpenAPI union for `parts`
+  // references generated `TextPart` / `ToolPart` / etc. while the
+  // FE renderer consumes the SDK-aligned `AgentMessagePart` union
+  // (with its compile-time `_AgentMessagePartIsSDKCompatible`
+  // assertion). The `unknown` cast bridges the two without losing
+  // run-time safety; this seam disappears whenever the FE part
+  // union is regenerated from the OpenAPI schema.
+  const historicalTurns = (chat.history ?? null) as
+    | AgentTurnSnapshotEnvelope[]
+    | null;
+  const initialSeed = useMemo(
+    () => seedFromHistory(chatId, historicalTurns),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const [liveTurns, setLiveTurns] = useState<Record<string, LiveTurn>>(
+    initialSeed.liveTurns,
+  );
+  const [turnOrder, setTurnOrder] = useState<string[]>(initialSeed.turnOrder);
+  const [pendingUserMessages, setPendingUserMessages] = useState<
+    PendingUserMessage[]
+  >([]);
   const [feedbackByTurnId, setFeedbackByTurnId] = useState<
     Record<string, Feedback>
   >({});
@@ -118,12 +205,17 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
   );
 
   const loading = useMemo(
-    () => Object.values(liveTurns).some((turn) => turn.pending),
-    [liveTurns],
+    () =>
+      pendingUserMessages.length > 0 ||
+      Object.values(liveTurns).some((turn) => turn.pending),
+    [liveTurns, pendingUserMessages.length],
   );
 
   const updateLiveTurn = useCallback(
-    (turnId: string, updater: (previous: LiveTurn | undefined) => LiveTurn | undefined) => {
+    (
+      turnId: string,
+      updater: (previous: LiveTurn | undefined) => LiveTurn | undefined,
+    ) => {
       setLiveTurns((previous) => {
         const next = updater(previous[turnId]);
         if (!next) {
@@ -134,6 +226,16 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
         }
         return { ...previous, [turnId]: next };
       });
+    },
+    [],
+  );
+
+  const recordTurn = useCallback(
+    (turnId: string, liveTurn: LiveTurn) => {
+      setLiveTurns((previous) => ({ ...previous, [turnId]: liveTurn }));
+      setTurnOrder((previous) =>
+        previous.includes(turnId) ? previous : [...previous, turnId],
+      );
     },
     [],
   );
@@ -149,84 +251,6 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
       }
     },
     [activeTurnStorageKey],
-  );
-
-  const ensureTurnGroups = useCallback(
-    (turn: AgentTurnEnvelope, includeUserQuery: boolean) => {
-      setMessages((previous) => {
-        const next = cloneMessages(previous);
-        const aiIndex = next.findIndex(
-          (parts) => getAiGroupId(parts) === turn.turn_id,
-        );
-
-        if (includeUserQuery) {
-          const hasUserMessage = next.some((parts) =>
-            parts.some(
-              (part) =>
-                part.role === 'human' &&
-                part.type === 'message' &&
-                part.data === turn.input_text,
-            ),
-          );
-          if (!hasUserMessage && turn.input_text) {
-            next.push(createUserParts(turn.input_text));
-          }
-        }
-
-        if (aiIndex === -1) {
-          next.push(createAiPlaceholder(turn.turn_id));
-        }
-
-        return next;
-      });
-    },
-    [],
-  );
-
-  const seedFromSnapshot = useCallback(
-    (snapshot: AgentTurnSnapshotEnvelope) => {
-      const turnId = snapshot.turn_id;
-      const terminal = isTerminalStatus(snapshot.status);
-      // Phase 8 D8.4d (#90): the snapshot endpoint now returns the flat
-      // canonical UIMessage at-rest envelope. ``AgentTurnEnvelope`` is
-      // synthesized here from the same fields so the rest of the FE
-      // can keep using its existing turn-shape contract; full
-      // ``AgentTurnEnvelope`` (including bot_id / user_id / etc.) is
-      // already provided by the ``createAgentTurn`` response on fresh
-      // turns and is not needed for reload rendering.
-      const envelope: AgentTurnEnvelope = {
-        schema_version: snapshot.schema_version,
-        turn_id: snapshot.turn_id,
-        chat_id: snapshot.chat_id,
-        user_id: '',
-        bot_id: '',
-        request_id: '',
-        client_idempotency_key: '',
-        status: snapshot.status,
-        input_text: '',
-        model_profile: {},
-        error_code: null,
-        error_message: snapshot.error_text ?? null,
-        answer_artifact_id: null,
-        reference_bundle_artifact_id: null,
-        timeline_cursor: snapshot.timeline_cursor,
-        started_at: snapshot.started_at,
-        finished_at: snapshot.finished_at,
-        created_at: snapshot.created_at,
-        updated_at: snapshot.updated_at,
-      };
-      updateLiveTurn(turnId, () => ({
-        envelope,
-        baselineSnapshot: snapshot,
-        streamUrl: terminal ? null : buildStreamUrl(chatId, turnId),
-        pending: !terminal,
-      }));
-      ensureTurnGroups(envelope, false);
-      if (terminal && activeTurnId === turnId) {
-        updateActiveTurn(null);
-      }
-    },
-    [activeTurnId, chatId, ensureTurnGroups, updateActiveTurn, updateLiveTurn],
   );
 
   const fetchTurnFeedbacks = useCallback(
@@ -247,30 +271,40 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     async (params: ChatInputSubmitParams) => {
       if (!chatId) return;
 
-      setMessages((previous) => [
-        ...cloneMessages(previous),
-        createUserParts(params.query),
-      ]);
+      const pendingKey = `pending-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+      const optimistic: PendingUserMessage = {
+        key: pendingKey,
+        query: params.query,
+        timestamp: Math.floor(Date.now() / 1000),
+      };
+      setPendingUserMessages((previous) => [...previous, optimistic]);
 
       try {
-        const response = await createAgentTurn(chatId, {
-          ...params,
-        });
+        const response = await createAgentTurn(chatId, { ...params });
         const turnId = response.turn.turn_id;
-        ensureTurnGroups(response.turn, false);
         const terminal = isTerminalStatus(response.turn.status);
-        updateLiveTurn(turnId, () => ({
+        recordTurn(turnId, {
           envelope: response.turn,
           streamUrl: terminal ? null : response.stream_url,
           pending: !terminal,
-        }));
+        });
+        setPendingUserMessages((previous) =>
+          previous.filter((m) => m.key !== pendingKey),
+        );
         updateActiveTurn(terminal ? null : turnId);
       } catch (error) {
         console.error('Failed to create agent turn', error);
-        toast.error(getErrorMessage(error, 'Failed to create a new agent turn.'));
+        setPendingUserMessages((previous) =>
+          previous.filter((m) => m.key !== pendingKey),
+        );
+        toast.error(
+          getErrorMessage(error, 'Failed to create a new agent turn.'),
+        );
       }
     },
-    [chatId, ensureTurnGroups, updateActiveTurn, updateLiveTurn],
+    [chatId, recordTurn, updateActiveTurn],
   );
 
   const handleCancel = useCallback(async () => {
@@ -311,7 +345,9 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
       const init: RequestInit = {
         method: feedback.type ? 'POST' : 'DELETE',
         credentials: 'same-origin',
-        headers: feedback.type ? { 'Content-Type': 'application/json' } : undefined,
+        headers: feedback.type
+          ? { 'Content-Type': 'application/json' }
+          : undefined,
         body: feedback.type ? JSON.stringify(feedback) : undefined,
       };
 
@@ -324,7 +360,10 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
       }
 
       if (feedback.type) {
-        setFeedbackByTurnId((previous) => ({ ...previous, [turnId]: feedback }));
+        setFeedbackByTurnId((previous) => ({
+          ...previous,
+          [turnId]: feedback,
+        }));
       } else {
         setFeedbackByTurnId((previous) => {
           const next = { ...previous };
@@ -336,18 +375,16 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     [chatId],
   );
 
+  const isEmpty = turnOrder.length === 0 && pendingUserMessages.length === 0;
+
   useEffect(() => {
-    if (!messages.length && !Object.keys(liveTurns).length) return;
+    if (isEmpty) return;
     scroll.scrollToBottom({ duration: 0 });
-  }, [messages, liveTurns]);
+  }, [isEmpty, liveTurns, pendingUserMessages, turnOrder]);
 
   useEffect(() => {
     scroll.scrollToBottom({ duration: 0 });
   }, []);
-
-  useEffect(() => {
-    setMessages(chat.history || []);
-  }, [chat.history]);
 
   useEffect(() => {
     if (!chatId) return;
@@ -382,45 +419,11 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     };
   }, [chatId, fetchTurnFeedbacks]);
 
-  useEffect(() => {
-    if (!chatId) return;
-
-    const storedActiveTurnId =
-      typeof window === 'undefined'
-        ? null
-        : window.sessionStorage.getItem(activeTurnStorageKey);
-
-    const potentialTurnIds = [
-      ...new Set(
-        (chat.history || [])
-          .map((parts) => getAiGroupId(parts))
-          .filter(
-            (value): value is string =>
-              Boolean(value) && value !== storedActiveTurnId,
-          ),
-      ),
-    ];
-
-    if (!potentialTurnIds.length) return;
-
-    let cancelled = false;
-    const loadSnapshots = async () => {
-      for (const turnId of potentialTurnIds) {
-        if (cancelled || liveTurnsRef.current[turnId]) continue;
-        try {
-          const snapshot = await getAgentTurnSnapshot(chatId, turnId);
-          if (!cancelled) seedFromSnapshot(snapshot);
-        } catch (error) {
-          console.error('Failed to load historical turn snapshot', turnId, error);
-        }
-      }
-    };
-    void loadSnapshots();
-    return () => {
-      cancelled = true;
-    };
-  }, [activeTurnStorageKey, chat.history, chatId, seedFromSnapshot]);
-
+  // Phase 8 D8.5-FE (#93): historical turns now arrive populated in
+  // `chat.history` (canonical `AgentTurnSnapshot[]`). The
+  // `recoverActiveTurn` effect below still re-fetches the snapshot for
+  // the session-storage active turn id so a mid-stream reload picks up
+  // any timeline_cursor / status drift since the page load.
   useEffect(() => {
     if (typeof window === 'undefined' || !chat.id || !chatId) return;
 
@@ -432,7 +435,7 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
       try {
         const snapshot = await getAgentTurnSnapshot(chatId, storedTurnId);
         if (cancelled) return;
-        seedFromSnapshot(snapshot);
+        recordTurn(storedTurnId, liveTurnFromSnapshot(chatId, snapshot));
         if (!isTerminalStatus(snapshot.status)) {
           updateActiveTurn(snapshot.turn_id);
         } else {
@@ -450,47 +453,35 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
     activeTurnStorageKey,
     chat.id,
     chatId,
-    ensureTurnGroups,
-    seedFromSnapshot,
+    recordTurn,
     updateActiveTurn,
   ]);
 
   return (
     <div className="flex flex-col gap-6 pb-70">
-      {messages.map((parts, index) => {
-        const isAI = parts.some((part) => part.role === 'ai');
-        const turnId = isAI ? getAiGroupId(parts) : undefined;
-        const liveTurn = turnId ? liveTurns[turnId] : undefined;
-
+      {turnOrder.map((turnId) => {
+        const liveTurn = liveTurns[turnId];
+        if (!liveTurn) return null;
         return (
-          <div key={`${turnId || parts[0]?.timestamp || index}-${index}`}>
-            {isAI ? (
-              liveTurn ? (
-                <AgentTurnStreamCard
-                  chatId={chatId || ''}
-                  liveTurn={liveTurn}
-                  feedback={turnId ? feedbackByTurnId[turnId] : undefined}
-                  onFeedback={handleMessageFeedback}
-                  onTerminal={handleStreamTerminal}
-                />
-              ) : (
-                <MessagePartsAi
-                  pending={false}
-                  loading={false}
-                  parts={parts}
-                  feedback={turnId ? feedbackByTurnId[turnId] : undefined}
-                  onFeedback={handleMessageFeedback}
-                />
-              )
-            ) : (
-              <MessagePartsUser parts={parts} />
-            )}
-          </div>
+          <AgentTurnStreamCard
+            key={turnId}
+            chatId={chatId || ''}
+            liveTurn={liveTurn}
+            feedback={feedbackByTurnId[turnId]}
+            onFeedback={handleMessageFeedback}
+            onTerminal={handleStreamTerminal}
+          />
         );
       })}
+      {pendingUserMessages.map((msg) => (
+        <MessagePartsUser
+          key={msg.key}
+          parts={userMessagePartsFromText(msg.query, msg.timestamp)}
+        />
+      ))}
       <ChatInput
         chat={chat}
-        welcome={_.isEmpty(messages)}
+        welcome={_.isEmpty(turnOrder) && _.isEmpty(pendingUserMessages)}
         onSubmit={handleSendMessage}
         disabled={false}
         loading={loading}
@@ -500,18 +491,17 @@ export const ChatMessages = ({ chat }: { chat: ChatDetails }) => {
   );
 };
 
-function buildStreamUrl(chatId: string | undefined, turnId: string): string | null {
-  if (!chatId) return null;
-  const base = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/v2/agent`;
-  return `${base}/chats/${chatId}/turns/${turnId}/events`;
-}
-
 // ---------------------------------------------------------------------------
-// AgentTurnStreamCard — child component that owns one live
-// `useAgentTurnStream` hook per turn and feeds the result straight into
-// the new parts renderer. The hook seam is the contract; #78 plugs
-// interactive consent / elicitation slots in via the renderer's
-// `ConsentSlot` / `ElicitationSlot` props.
+// AgentTurnStreamCard — renders one turn (historical or live). Owns one
+// `useAgentTurnStream` hook per turn; for terminal historical turns the
+// hook stays dormant (`streamUrl: null`) and the card falls back to
+// `baselineSnapshot.parts` directly.
+//
+// User input bubble (`MessagePartsUser` driven by `envelope.input_text`)
+// is rendered inline above the AI card so historical and live turns
+// share one render path. The legacy `MessagePartsAi` branch is gone —
+// historical turns now consume canonical UIMessage parts the same way
+// live turns do.
 // ---------------------------------------------------------------------------
 
 function AgentTurnStreamCard({
@@ -538,21 +528,25 @@ function AgentTurnStreamCard({
     initialSequence,
   });
 
-  // Phase 8 D8.4d (#90): the snapshot endpoint now returns canonical
-  // UIMessage parts directly, so reload rendering for terminal
-  // historical turns reads ``baselineSnapshot.parts`` + ``error_text``
-  // without a client-side synthesizer. The previous transitional
-  // ``snapshot-fallback.ts`` adapter is gone.
+  // Phase 8 D8.4d (#90) + D8.5-FE (#93): for dormant terminal turns
+  // (`streamUrl == null` and live stream produced nothing), fall back
+  // to `baselineSnapshot.parts` and the snapshot's status / error_text
+  // so the renderer reads canonical UIMessage parts uniformly.
   const useFallback =
-    streamUrl == null && stream.parts.length === 0 && Boolean(baselineSnapshot);
-  const displayParts = useFallback && baselineSnapshot ? baselineSnapshot.parts : stream.parts;
+    streamUrl == null &&
+    stream.parts.length === 0 &&
+    Boolean(baselineSnapshot);
+  const displayParts =
+    useFallback && baselineSnapshot ? baselineSnapshot.parts : stream.parts;
   const displayStatus: AgentStreamStatus = useFallback
     ? mapBackendTurnStatus(envelope.status)
     : stream.status;
   const displayErrorText =
     displayStatus === 'failed'
       ? (stream.errorText ??
-        (useFallback && baselineSnapshot ? baselineSnapshot.error_text ?? null : null) ??
+        (useFallback && baselineSnapshot
+          ? (baselineSnapshot.error_text ?? null)
+          : null) ??
         envelope.error_message ??
         null)
       : stream.errorText;
@@ -572,18 +566,32 @@ function AgentTurnStreamCard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stream.status, envelope.turn_id]);
 
+  const userParts = useMemo(
+    () =>
+      userMessagePartsFromText(
+        envelope.input_text,
+        envelope.created_at
+          ? Math.floor(new Date(envelope.created_at).getTime() / 1000)
+          : null,
+      ),
+    [envelope.created_at, envelope.input_text],
+  );
+
   return (
-    <AgentTurnRenderer
-      chatId={chatId}
-      turn={envelope}
-      parts={displayParts}
-      transientActivity={stream.transientActivity}
-      status={displayStatus}
-      errorText={displayErrorText}
-      feedback={feedback}
-      onFeedback={onFeedback}
-      ConsentSlot={ConsentPrompt}
-      ElicitationSlot={ElicitationForm}
-    />
+    <div className="flex flex-col gap-4">
+      {userParts.length > 0 && <MessagePartsUser parts={userParts} />}
+      <AgentTurnRenderer
+        chatId={chatId}
+        turn={envelope}
+        parts={displayParts}
+        transientActivity={stream.transientActivity}
+        status={displayStatus}
+        errorText={displayErrorText}
+        feedback={feedback}
+        onFeedback={onFeedback}
+        ConsentSlot={ConsentPrompt}
+        ElicitationSlot={ElicitationForm}
+      />
+    </div>
   );
 }

--- a/web/src/features/agent-runtime/api.ts
+++ b/web/src/features/agent-runtime/api.ts
@@ -58,15 +58,30 @@ export type AgentArtifactEnvelope = {
   updated_at?: string | null;
 };
 
-// Phase 8 D8.4d (#90): the snapshot endpoint now returns the canonical
-// UIMessage at-rest envelope (matches `aperag.domains.agent_runtime.uimessage.AgentTurnSnapshot`).
+// Phase 8 D8.4d (#90) + D8.5-BE (#92): the snapshot endpoint and
+// `getBotChat()` history payload both return the canonical UIMessage
+// at-rest envelope (matches
+// `aperag.domains.agent_runtime.uimessage.AgentTurnSnapshot`).
 // Per D8 §2 wire / at-rest are byte-equal, so the FE consumes the same
 // `AgentMessagePart` discriminated union from both the live SSE stream
 // and this reload payload — no client-side converter is required.
+//
+// `runtime_kind` (D8.5-BE) is a forward-compat discriminator for
+// future direct/RAG chat paths; today's production code only emits
+// `agent_runtime`. The FE does NOT branch on it (per PM lock
+// msg=38e116e5 — kept BE-internal).
+//
+// `input_text` is the user-side bubble content; the FE renders it as
+// the `MessagePartsUser` paired with the AI card so historical and
+// live turns share one render path.
+export type AgentRuntimeKind = 'agent_runtime' | 'direct_chat' | 'rag_chat';
+
 export type AgentTurnSnapshotEnvelope = {
   schema_version: string;
   turn_id: string;
   chat_id: string;
+  runtime_kind: AgentRuntimeKind;
+  input_text?: string | null;
   role: 'assistant';
   status: string;
   parts: AgentMessagePart[];

--- a/web/src/features/agent-runtime/index.ts
+++ b/web/src/features/agent-runtime/index.ts
@@ -28,6 +28,7 @@ export {
 
 export type {
   AgentArtifactEnvelope,
+  AgentRuntimeKind,
   AgentTimelineEventEnvelope,
   AgentTurnCreateInput,
   AgentTurnCreateResponse,


### PR DESCRIPTION
## Summary

D8.5-FE first-cut. Chained on @Bryce's #92 PR #1706 (`bryce/phase8-task92-d85-be-non-agent-uimessage`).

`ChatDetails.history` flips from `list[list[ChatMessage]]` → `list[AgentTurnSnapshot]`. The FE consumes the canonical UIMessage at-rest envelope directly: historical turns share the live-turn render path; user bubbles come from `snapshot.input_text`. Legacy `MessagePartsAi` rendering branch is gone.

## What changed (FE)

| File | Change |
|---|---|
| `web/src/components/chat/chat-messages.tsx` | Full per-turn render rewrite: `liveTurns` map + `turnOrder` + `pendingUserMessages` (optimistic). Seeds `liveTurns` directly from `chat.history`. `AgentTurnStreamCard` now renders `<MessagePartsUser>` from `envelope.input_text` inline above the AI card. |
| `web/src/features/agent-runtime/api.ts` | `AgentTurnSnapshotEnvelope` extended with `runtime_kind: AgentRuntimeKind` + `input_text`. `AgentRuntimeKind` exported. |
| `web/src/features/agent-runtime/index.ts` | Re-export `AgentRuntimeKind`. |
| `web/src/api-v2/schema.d.ts` | Regenerated via `yarn api:v2:types` against post-#92 OpenAPI. |

## Boundary held (per PM lock msg=38e116e5)

* **No new `chat-runtime/` feature module** — `agent-runtime/` covers the historical render path 1:1.
* **`runtime_kind` is BE-internal** — FE does not branch on it.
* **No `MessagePartsAi` / `StoredChatMessagePart` deletion** — Python-side schema/storage delete is #80 territory; the FE legacy files have no callers after this PR but stay on disk for the #80 sweep.
* **No new non-agent SSE / live path** — production code already routes everything through `agent_runtime`; per Bryce msg=27e8ec6d D defer + PM acceptance.

## D8.5-BE / D8.5-FE handoff contract

* Wire shape (architect lock): `ChatDetails.history: list[AgentTurnSnapshot]` — done in BE PR #1706.
* User bubble: `snapshot.input_text` paired with `AgentTurnRenderer(parts, status, error_text)`.
* No transport changes; `useAgentTurnStream` hook contract unchanged.

## Verification

* `yarn lint` clean (one pre-existing `no-explicit-any` warning in `features/providers/server-api.ts` unrelated).
* `tsc --noEmit` clean for touched files (pre-existing main-branch errors in `chat-input.tsx` unchanged).
* `yarn dev` boots in 2.6s on port 3014; `GET /`, `/auth/signin`, `/workspace/collections`, `/workspace` all return 200.

## Test plan

- [ ] Symphony architect canonical drift quick check on the canonical-history → renderer mapping
- [ ] Optional FE seam re-check (any reviewer): historical render + optimistic user bubble + recoverActiveTurn path
- [ ] Manual smoke once a fresh tenant is up: load a chat with history → confirm historical user bubbles + AI cards render from canonical parts; submit a new turn → confirm pending bubble → live stream → terminal closure all work

## Note on chained base

This PR's base is `bryce/phase8-task92-d85-be-non-agent-uimessage` (PR #1706). Once #1706 lands on main, GitHub will auto-rebase this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)