### PR TITLE
docs(modularization): D10 spec amendment — back-align §G D10.e cursor error codes to §C.3 canonical

### DIFF
--- a/docs/modularization/d10-design-pack.md
+++ b/docs/modularization/d10-design-pack.md
@@ -1112,7 +1112,7 @@ Lane-to-§ mapping is one-to-one with the design pack so reviewers can locate sp
 
 #### D10.e — Pagination + cursor contract (§C)
 
-- **Deliverable**: opaque base64 cursor + `invariant_hash` field + 6 explicit error codes (`CURSOR_EXPIRED` / `CURSOR_INVARIANT_MISMATCH` / `CURSOR_MALFORMED` / `CURSOR_FOREIGN` / `CURSOR_PAGE_OUT_OF_RANGE` / `CURSOR_VERSION_MISMATCH`); cursor is **never silently reset** — explicit error always.
+- **Deliverable**: opaque base64 cursor + `invariant_hash` field + 6 explicit error codes per §C.3 canonical (`cursor_invalid` / `cursor_expired` / `cursor_filter_mismatch` / `cursor_tenant_mismatch` / `cursor_index_changed` / `cursor_schema_unsupported`); cursor is **never silently reset** — explicit error always. Wire-format casing is **snake_case** to match the rest of the API surface; client-recovery path mapping is in §C.3 body (line 567-571), not duplicated here.
 - **Owner candidate**: @Bryce (canonical caller-migration discipline from #90 round-4 fix-forward; pagination semantics are caller-sensitive) — fallback @cuiwenbo.
 - **Write-set boundary**:
   - `aperag/mcp/cursor/codec.py` + `cursor/invariants.py` + `cursor/errors.py` (new package)


### PR DESCRIPTION
## Summary

`[D10 spec amendment]` doc-only fix. Back-aligns §G D10.e Deliverable summary cursor error codes to the §C.3 canonical 6-code list.

Triggered by Bryce msg=441c5e56 in the parent channel — D10.e prep inventory found internal inconsistency between §C.3 body and §G summary. PM msg=40e98684 escalated to formal blocker; architect 双签 canonical decision is **§C.3 body wins**.

## Canonical decision (3 hard answers per PM)

1. **Wire-format casing**: `snake_case` (matches rest of ApeRAG API; client-recovery mapping in §C.3 already uses snake_case names).
2. **Final enum set**: §C.3 body 6 codes verbatim — `cursor_invalid` / `cursor_expired` / `cursor_filter_mismatch` / `cursor_tenant_mismatch` / `cursor_index_changed` / `cursor_schema_unsupported`.
3. **§G back-align**: yes (this PR). §G summary now cites §C.3 verbatim and points readers at §C.3 body for client-recovery mapping (single source of truth).

## Why §C.3 wins (not §G)

§C.3 body precedes §G summary in drafting order, has full client-recovery path mapping at line 567-571, and is the detailed contract surface. §G summary was drafting noise from the rushed §G decomposition amendment commit `36b58350`.

In particular, §G's `CURSOR_INVARIANT_MISMATCH` collapsed three §C.3 codes (`cursor_filter_mismatch` / `cursor_tenant_mismatch` / `cursor_index_changed`) into one — but §C.3 line 567-571 explicitly maps each to **different** client recovery paths:
- `cursor_filter_mismatch` → client bug, surface to user
- `cursor_tenant_mismatch` → security violation, distinct telemetry
- `cursor_index_changed` → backend ops issue, retry from null

Collapsing them would force clients to over-react and lose recovery precision. §G's `CURSOR_FOREIGN` / `CURSOR_PAGE_OUT_OF_RANGE` had no §C.3 backing and no client-recovery path — drafting noise, removed.

## Unblocks

- task #97 (D10.e) — Bryce can now land `aperag/mcp/cursor/errors.py` with the canonical 6 snake_case codes.

## Diff

1 file changed, 1 insertion(+), 1 deletion(-) — single line at `docs/modularization/d10-design-pack.md` §G D10.e Deliverable bullet (line 1115).

## Test plan

- [ ] @Bryce sanity check that the canonical 6 codes match D10.e impl plan
- [ ] No other §G or §C call site needs back-alignment (verified by full-tree grep — only the one bullet at line 1115 referred to SCREAMING_SNAKE)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — 符炫炜 (chief architect agent, dual-sign with @Bryce per §G amendment protocol)