### PR TITLE
feat(phase9 #96 D10.d): cursor placeholder + kw-only sentinel on split search tools

### DIFF
--- a/aperag/mcp/tools/search_fulltext.py
+++ b/aperag/mcp/tools/search_fulltext.py
@@ -25,8 +25,10 @@ shape follow-up settled by the ``[D10 spec amendment]`` thread
 (msg=b9b7072a) — defer canonical SearchResultItem to D10.h cutover.
 
 The ``cursor`` parameter is a placeholder per the same thread (Drift
-#4 (c)): signature lands now, body raises ``CursorError`` on any
-non-null value until real search pagination ships.
+#4 (c)): signature lands now, body raises ``NotImplementedError``
+on any non-empty value until real search pagination ships.
+``None`` and ``""`` both preserve single-page ``top_k`` behavior per
+the Weston blocker review (msg=177a1dd8).
 """
 
 from __future__ import annotations
@@ -37,7 +39,6 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
-from aperag.mcp.cursor.errors import CursorError
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
 
 logger = logging.getLogger(__name__)
@@ -87,20 +88,19 @@ async def fulltext_search(
         rerank: Whether to apply reranker on returned candidates
             (default: True).
         cursor: Pagination cursor placeholder (§B.3 / amendment
-            msg=b9b7072a Drift #4 (c)). ``None`` returns first page;
-            non-null raises ``CursorError("cursor_invalid")`` until
-            real search pagination ships.
+            msg=b9b7072a Drift #4 (c)). ``None`` and ``""`` return
+            first page; any non-empty value raises
+            ``NotImplementedError`` with a clear "not implemented"
+            message until real search pagination ships.
 
     Returns:
         Search results with ``items`` carrying ``recall_type =
         "fulltext_search"``. Highlight snippets / matched terms are
         surfaced via ``items[*].metadata``.
     """
-    if cursor is not None:
-        raise CursorError(
-            "cursor_invalid",
-            "search pagination cursor is not yet implemented",
-            details={"reason": "search_not_paginated", "tool": "fulltext_search"},
+    if cursor:
+        raise NotImplementedError(
+            "search pagination is not yet implemented (tool=fulltext_search, reason=search_not_paginated)"
         )
     try:
         api_key = get_api_key()

--- a/aperag/mcp/tools/search_fulltext.py
+++ b/aperag/mcp/tools/search_fulltext.py
@@ -21,8 +21,12 @@ split). ``search_collection`` itself remains as a deprecated alias
 
 Wire shape: returns the existing ``SearchResult`` dict shape with
 ``recall_type = "fulltext_search"`` for produced items. §B canonical
-shape follow-up gated on the chunk_id propagation amendment thread —
-see ``search_vector.py`` module docstring.
+shape follow-up settled by the ``[D10 spec amendment]`` thread
+(msg=b9b7072a) — defer canonical SearchResultItem to D10.h cutover.
+
+The ``cursor`` parameter is a placeholder per the same thread (Drift
+#4 (c)): signature lands now, body raises ``CursorError`` on any
+non-null value until real search pagination ships.
 """
 
 from __future__ import annotations
@@ -33,6 +37,7 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
+from aperag.mcp.cursor.errors import CursorError
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
 
 logger = logging.getLogger(__name__)
@@ -42,8 +47,11 @@ logger = logging.getLogger(__name__)
 async def fulltext_search(
     collection_id: str,
     query: str,
+    *,
     top_k: int = 5,
     keywords: list[str] | None = None,
+    rerank: bool = True,
+    cursor: str | None = None,
 ) -> Dict[str, Any]:
     """Full-text keyword search within a collection (§B.3).
 
@@ -76,12 +84,24 @@ async def fulltext_search(
         top_k: Maximum number of results to return (default: 5).
         keywords: Optional explicit keyword list overriding the
             auto-extracted keywords from the query.
+        rerank: Whether to apply reranker on returned candidates
+            (default: True).
+        cursor: Pagination cursor placeholder (§B.3 / amendment
+            msg=b9b7072a Drift #4 (c)). ``None`` returns first page;
+            non-null raises ``CursorError("cursor_invalid")`` until
+            real search pagination ships.
 
     Returns:
         Search results with ``items`` carrying ``recall_type =
         "fulltext_search"``. Highlight snippets / matched terms are
         surfaced via ``items[*].metadata``.
     """
+    if cursor is not None:
+        raise CursorError(
+            "cursor_invalid",
+            "search pagination cursor is not yet implemented",
+            details={"reason": "search_not_paginated", "tool": "fulltext_search"},
+        )
     try:
         api_key = get_api_key()
 
@@ -91,6 +111,7 @@ async def fulltext_search(
 
         search_data: Dict[str, Any] = {
             "query": query,
+            "rerank": rerank,
             "fulltext_search": fulltext_payload,
         }
 

--- a/aperag/mcp/tools/search_graph.py
+++ b/aperag/mcp/tools/search_graph.py
@@ -25,8 +25,10 @@ shape follow-up settled by the ``[D10 spec amendment]`` thread
 (msg=b9b7072a) — defer canonical SearchResultItem to D10.h cutover.
 
 The ``cursor`` parameter is a placeholder per the same thread (Drift
-#4 (c)): signature lands now, body raises ``CursorError`` on any
-non-null value until real search pagination ships.
+#4 (c)): signature lands now, body raises ``NotImplementedError``
+on any non-empty value until real search pagination ships.
+``None`` and ``""`` both preserve single-page ``top_k`` behavior per
+the Weston blocker review (msg=177a1dd8).
 """
 
 from __future__ import annotations
@@ -37,7 +39,6 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
-from aperag.mcp.cursor.errors import CursorError
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
 
 logger = logging.getLogger(__name__)
@@ -82,20 +83,19 @@ async def graph_search(
         query: The natural-language search query.
         top_k: Maximum number of results to return (default: 5).
         cursor: Pagination cursor placeholder (§B.2 / amendment
-            msg=b9b7072a Drift #4 (c)). ``None`` returns first page;
-            non-null raises ``CursorError("cursor_invalid")`` until
-            real search pagination ships.
+            msg=b9b7072a Drift #4 (c)). ``None`` and ``""`` return
+            first page; any non-empty value raises
+            ``NotImplementedError`` with a clear "not implemented"
+            message until real search pagination ships.
 
     Returns:
         Search results with ``items`` carrying ``recall_type =
         "graph_search"``. Graph-specific fields (entity / relation / path)
         are surfaced via ``items[*].metadata``.
     """
-    if cursor is not None:
-        raise CursorError(
-            "cursor_invalid",
-            "search pagination cursor is not yet implemented",
-            details={"reason": "search_not_paginated", "tool": "graph_search"},
+    if cursor:
+        raise NotImplementedError(
+            "search pagination is not yet implemented (tool=graph_search, reason=search_not_paginated)"
         )
     try:
         api_key = get_api_key()

--- a/aperag/mcp/tools/search_graph.py
+++ b/aperag/mcp/tools/search_graph.py
@@ -20,9 +20,13 @@ per ``docs/modularization/d10-design-pack.md`` §B.2 (Lock #5 split).
 until the D10.h cutover.
 
 Wire shape: returns the existing ``SearchResult`` dict shape with
-``recall_type = "graph_search"`` for produced items. §B canonical shape
-follow-up gated on the chunk_id propagation amendment thread — see
-``search_vector.py`` module docstring.
+``recall_type = "graph_search"`` for produced items. §B canonical
+shape follow-up settled by the ``[D10 spec amendment]`` thread
+(msg=b9b7072a) — defer canonical SearchResultItem to D10.h cutover.
+
+The ``cursor`` parameter is a placeholder per the same thread (Drift
+#4 (c)): signature lands now, body raises ``CursorError`` on any
+non-null value until real search pagination ships.
 """
 
 from __future__ import annotations
@@ -33,6 +37,7 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
+from aperag.mcp.cursor.errors import CursorError
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
 
 logger = logging.getLogger(__name__)
@@ -42,7 +47,9 @@ logger = logging.getLogger(__name__)
 async def graph_search(
     collection_id: str,
     query: str,
+    *,
     top_k: int = 5,
+    cursor: str | None = None,
 ) -> Dict[str, Any]:
     """Knowledge-graph search within a collection (§B.2).
 
@@ -74,12 +81,22 @@ async def graph_search(
         collection_id: The ID of the collection to search.
         query: The natural-language search query.
         top_k: Maximum number of results to return (default: 5).
+        cursor: Pagination cursor placeholder (§B.2 / amendment
+            msg=b9b7072a Drift #4 (c)). ``None`` returns first page;
+            non-null raises ``CursorError("cursor_invalid")`` until
+            real search pagination ships.
 
     Returns:
         Search results with ``items`` carrying ``recall_type =
         "graph_search"``. Graph-specific fields (entity / relation / path)
         are surfaced via ``items[*].metadata``.
     """
+    if cursor is not None:
+        raise CursorError(
+            "cursor_invalid",
+            "search pagination cursor is not yet implemented",
+            details={"reason": "search_not_paginated", "tool": "graph_search"},
+        )
     try:
         api_key = get_api_key()
 

--- a/aperag/mcp/tools/search_vector.py
+++ b/aperag/mcp/tools/search_vector.py
@@ -32,9 +32,15 @@ the split surface + omnibus deprecation.
 The ``cursor`` parameter is a placeholder per the same amendment
 thread (Drift #4 resolution (c)): the signature is published now so
 external MCP clients see the canonical shape, but the body explicitly
-fails with ``CursorError("cursor_invalid", ...)`` on any non-null
-input until real search pagination lands. ``None`` continues to mean
-"first page" (current behavior).
+raises ``NotImplementedError("search pagination is not yet
+implemented")`` on any **non-empty** value. The architect sign-off
+(msg=ebfcdabe) plus Weston's blocker review (msg=177a1dd8) explicitly
+forbid reusing the canonical ``CursorError("cursor_invalid", ...)``
+malformed-wire semantic for this "feature not implemented" case —
+that would camouflage missing capability as a client-side cursor bug.
+``cursor=None`` and ``cursor=""`` both keep the existing single-page
+``top_k`` behavior (Weston msg=177a1dd8 lock); only truthy /
+non-empty cursor values trigger the loud-fail.
 """
 
 from __future__ import annotations
@@ -45,7 +51,6 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
-from aperag.mcp.cursor.errors import CursorError
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
 
 logger = logging.getLogger(__name__)
@@ -94,23 +99,25 @@ async def vector_search(
         similarity_threshold: Minimum similarity score [0, 1]; ``None``
             uses the collection's default threshold.
         rerank: Whether to apply reranker on returned candidates (default: True).
-        cursor: Pagination cursor placeholder (§B.1). ``None`` returns
-            the first page (current behavior). Any non-null value
-            raises ``CursorError("cursor_invalid")`` per the
-            ``[D10 spec amendment]`` (msg=b9b7072a) Drift #4 (c)
-            resolution — real search pagination requires a backend
-            capability that is not yet available and will land in a
-            dedicated D11+ upgrade.
+        cursor: Pagination cursor placeholder (§B.1). ``None`` and
+            ``""`` both return the first page (current behavior); any
+            non-empty value raises ``NotImplementedError`` with a
+            ``"search pagination is not yet implemented"`` message per
+            the ``[D10 spec amendment]`` (msg=b9b7072a + sign-off
+            msg=ebfcdabe + Weston msg=177a1dd8). Real search
+            pagination requires a backend capability that is not yet
+            available and will land in a dedicated D11+ upgrade.
 
     Returns:
         Search results with ``items`` ranked by vector similarity. Each
         item carries ``recall_type = "vector_search"``.
     """
-    if cursor is not None:
-        raise CursorError(
-            "cursor_invalid",
-            "search pagination cursor is not yet implemented",
-            details={"reason": "search_not_paginated", "tool": "vector_search"},
+    if cursor:
+        # ``cursor`` is truthy iff non-None and non-empty (Weston
+        # msg=177a1dd8 lock: ``None`` and ``""`` both preserve
+        # single-page ``top_k`` behavior).
+        raise NotImplementedError(
+            "search pagination is not yet implemented (tool=vector_search, reason=search_not_paginated)"
         )
     try:
         api_key = get_api_key()

--- a/aperag/mcp/tools/search_vector.py
+++ b/aperag/mcp/tools/search_vector.py
@@ -23,10 +23,18 @@ Wire shape: returns the existing ``SearchResult`` dict shape from the
 ``aperag/api/v2/collections/{id}/searches`` backend (``recall_type =
 "vector_search"`` for produced items). The §B canonical
 ``SearchResult`` / ``SearchResultItem`` with ``chunk_id`` /
-``section_path`` / ``heading_anchor`` is deferred to a D10.d follow-up
-PR after the chunk_id propagation question is resolved via a
-``[D10 spec amendment]`` thread (current backend does not surface
-``chunk_id`` in the public response shape — see PR description).
+``section_path`` / ``heading_anchor`` exposure was settled by the
+``[D10 spec amendment]`` thread (msg=b9b7072a) — Drift #1 resolution
+(c): defer the canonical shape to the D10.h cutover lane (one-shot
+``aperag/domains/retrieval/`` upgrade) so this lane stays focused on
+the split surface + omnibus deprecation.
+
+The ``cursor`` parameter is a placeholder per the same amendment
+thread (Drift #4 resolution (c)): the signature is published now so
+external MCP clients see the canonical shape, but the body explicitly
+fails with ``CursorError("cursor_invalid", ...)`` on any non-null
+input until real search pagination lands. ``None`` continues to mean
+"first page" (current behavior).
 """
 
 from __future__ import annotations
@@ -37,6 +45,7 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
+from aperag.mcp.cursor.errors import CursorError
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
 
 logger = logging.getLogger(__name__)
@@ -46,9 +55,11 @@ logger = logging.getLogger(__name__)
 async def vector_search(
     collection_id: str,
     query: str,
+    *,
     top_k: int = 5,
     similarity_threshold: float | None = None,
     rerank: bool = True,
+    cursor: str | None = None,
 ) -> Dict[str, Any]:
     """Vector similarity search within a collection (§B.1).
 
@@ -83,11 +94,24 @@ async def vector_search(
         similarity_threshold: Minimum similarity score [0, 1]; ``None``
             uses the collection's default threshold.
         rerank: Whether to apply reranker on returned candidates (default: True).
+        cursor: Pagination cursor placeholder (§B.1). ``None`` returns
+            the first page (current behavior). Any non-null value
+            raises ``CursorError("cursor_invalid")`` per the
+            ``[D10 spec amendment]`` (msg=b9b7072a) Drift #4 (c)
+            resolution — real search pagination requires a backend
+            capability that is not yet available and will land in a
+            dedicated D11+ upgrade.
 
     Returns:
         Search results with ``items`` ranked by vector similarity. Each
         item carries ``recall_type = "vector_search"``.
     """
+    if cursor is not None:
+        raise CursorError(
+            "cursor_invalid",
+            "search pagination cursor is not yet implemented",
+            details={"reason": "search_not_paginated", "tool": "vector_search"},
+        )
     try:
         api_key = get_api_key()
 

--- a/tests/unit_test/mcp/test_search_split.py
+++ b/tests/unit_test/mcp/test_search_split.py
@@ -39,6 +39,8 @@ import ast
 import inspect
 from pathlib import Path
 
+import pytest
+
 # Importing ``aperag.mcp.server`` triggers the bottom-of-module
 # registration block which loads ``aperag.mcp.tools.search_*`` and
 # triggers ``@mcp_server.tool`` decorators. The tool functions are
@@ -48,6 +50,7 @@ from pathlib import Path
 # would otherwise occur if the search modules were imported via
 # ``aperag.mcp.tools`` package's ``__init__``.
 from aperag.mcp import server as mcp_server_module
+from aperag.mcp.cursor.errors import CursorError
 from aperag.mcp.server import (
     fulltext_search,
     graph_search,
@@ -88,41 +91,68 @@ def _params(func) -> dict[str, inspect.Parameter]:
     return dict(inspect.signature(func).parameters)
 
 
+def _kw_only_params(func) -> set[str]:
+    return {
+        name
+        for name, param in inspect.signature(func).parameters.items()
+        if param.kind is inspect.Parameter.KEYWORD_ONLY
+    }
+
+
 def test_vector_search_signature_matches_b1_lock():
-    """``vector_search`` signature follows §B.1: collection_id + query
-    positional, then keyword-tunable top_k / similarity_threshold /
-    rerank.
+    """``vector_search`` signature follows §B.1: ``collection_id`` +
+    ``query`` positional, then a ``*,`` kw-only barrier with
+    ``top_k`` / ``similarity_threshold`` / ``rerank`` / ``cursor``.
+    The kw-only enforcement aligns with the D10.c precedent (per
+    `[D10 spec amendment]` msg=b9b7072a Drift #5 resolution).
     """
     params = _params(vector_search)
     assert list(params)[:2] == ["collection_id", "query"]
-    for name in ("top_k", "similarity_threshold", "rerank"):
-        assert name in params, f"§B.1 requires `{name}` parameter"
+    assert _kw_only_params(vector_search) == {
+        "top_k",
+        "similarity_threshold",
+        "rerank",
+        "cursor",
+    }, "§B.1 requires kw-only `top_k / similarity_threshold / rerank / cursor`."
     assert params["top_k"].default == 5
     # similarity_threshold defaults to None to mean "use collection default".
     assert params["similarity_threshold"].default is None
     assert params["rerank"].default is True
+    # cursor placeholder per amendment msg=b9b7072a Drift #4 (c).
+    assert params["cursor"].default is None
 
 
 def test_graph_search_signature_matches_b2_lock():
-    """``graph_search`` signature follows §B.2: collection_id + query +
-    top_k. The §B.2 spec mentions ``depth`` / ``entity_types`` as
+    """``graph_search`` signature follows §B.2 + amendment msg=b9b7072a:
+    collection_id + query positional then kw-only top_k + cursor.
+    The §B.2 spec mentions ``depth`` / ``entity_types`` as
     forward-looking knobs; first-cut keeps them out until the backend
     surface for graph traversal is wired (deferred to D10.d follow-up).
     """
     params = _params(graph_search)
     assert list(params)[:2] == ["collection_id", "query"]
-    assert "top_k" in params
+    assert _kw_only_params(graph_search) == {"top_k", "cursor"}, "§B.2 requires kw-only `top_k / cursor`."
     assert params["top_k"].default == 5
+    assert params["cursor"].default is None
 
 
 def test_fulltext_search_signature_matches_b3_lock():
-    """``fulltext_search`` signature follows §B.3: collection_id +
-    query + top_k + optional keyword override.
+    """``fulltext_search`` signature follows §B.3 + amendment
+    msg=b9b7072a: collection_id + query positional then kw-only
+    top_k + keywords + rerank + cursor.
     """
     params = _params(fulltext_search)
     assert list(params)[:2] == ["collection_id", "query"]
-    assert "top_k" in params and params["top_k"].default == 5
-    assert "keywords" in params and params["keywords"].default is None
+    assert _kw_only_params(fulltext_search) == {
+        "top_k",
+        "keywords",
+        "rerank",
+        "cursor",
+    }, "§B.3 requires kw-only `top_k / keywords / rerank / cursor`."
+    assert params["top_k"].default == 5
+    assert params["keywords"].default is None
+    assert params["rerank"].default is True
+    assert params["cursor"].default is None
 
 
 def test_web_search_signature_preserves_existing_wire_for_b4():
@@ -137,6 +167,61 @@ def test_web_search_signature_preserves_existing_wire_for_b4():
     assert "timeout" in params and params["timeout"].default == 30
     assert "locale" in params and params["locale"].default == "en-US"
     assert "source" in params and params["source"].default == ""
+
+
+# --- 2b. Cursor placeholder explicit-not-silent (§B / amendment Drift #4) ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool",
+    [vector_search, graph_search, fulltext_search],
+    ids=["vector_search", "graph_search", "fulltext_search"],
+)
+@pytest.mark.parametrize(
+    "bad_cursor",
+    ["", "garbage", "AAAA", "{}"],
+    ids=["empty_string", "garbage", "base64_no_payload", "empty_json"],
+)
+async def test_collection_scoped_split_tools_reject_non_null_cursor(tool, bad_cursor):
+    """Per `[D10 spec amendment]` msg=b9b7072a Drift #4 (c): the
+    ``cursor`` parameter on ``vector_search`` / ``graph_search`` /
+    ``fulltext_search`` is published as a placeholder; any non-null
+    value must raise ``CursorError("cursor_invalid")`` until real
+    search pagination ships. Silent reset to first page is
+    explicitly forbidden (§C explicit-not-silent invariant).
+
+    ``cursor=None`` is exercised by the existing happy-path suite.
+    """
+
+    with pytest.raises(CursorError) as excinfo:
+        await tool("collection-id", "query", cursor=bad_cursor)
+
+    err = excinfo.value
+    assert err.code == "cursor_invalid", (
+        f"{tool.__name__} must produce canonical `cursor_invalid` for non-null cursor; got {err.code!r}."
+    )
+    assert err.details.get("reason") == "search_not_paginated", (
+        "Error envelope must surface the deferred-pagination reason "
+        "so clients understand they should not retry the cursor."
+    )
+    assert err.details.get("tool") == tool.__name__, (
+        "Error envelope must identify the originating tool so logs can attribute the rejection."
+    )
+
+
+@pytest.mark.asyncio
+async def test_web_search_does_not_carry_cursor_param():
+    """``web_search`` is intentionally cursor-less — its provider
+    chain (Jina / DDG) is provider-bounded, not paginated, per §B.4.
+    The amendment thread (msg=b9b7072a Drift #4) only added cursor
+    placeholders to the 3 collection-scoped split tools.
+    """
+
+    params = _params(web_search)
+    assert "cursor" not in params, (
+        "web_search must not carry a cursor parameter — its scope is provider-bounded per §B.4 (no pagination)."
+    )
 
 
 # --- 3. Deprecation banner on omnibus aliases ------------------------

--- a/tests/unit_test/mcp/test_search_split.py
+++ b/tests/unit_test/mcp/test_search_split.py
@@ -50,7 +50,6 @@ import pytest
 # would otherwise occur if the search modules were imported via
 # ``aperag.mcp.tools`` package's ``__init__``.
 from aperag.mcp import server as mcp_server_module
-from aperag.mcp.cursor.errors import CursorError
 from aperag.mcp.server import (
     fulltext_search,
     graph_search,
@@ -180,33 +179,100 @@ def test_web_search_signature_preserves_existing_wire_for_b4():
 )
 @pytest.mark.parametrize(
     "bad_cursor",
-    ["", "garbage", "AAAA", "{}"],
-    ids=["empty_string", "garbage", "base64_no_payload", "empty_json"],
+    ["garbage", "AAAA", "{}", "0"],
+    ids=["garbage", "base64_no_payload", "empty_json", "single_zero"],
 )
-async def test_collection_scoped_split_tools_reject_non_null_cursor(tool, bad_cursor):
-    """Per `[D10 spec amendment]` msg=b9b7072a Drift #4 (c): the
-    ``cursor`` parameter on ``vector_search`` / ``graph_search`` /
-    ``fulltext_search`` is published as a placeholder; any non-null
-    value must raise ``CursorError("cursor_invalid")`` until real
-    search pagination ships. Silent reset to first page is
-    explicitly forbidden (§C explicit-not-silent invariant).
+async def test_collection_scoped_split_tools_reject_non_empty_cursor(tool, bad_cursor):
+    """Per `[D10 spec amendment]` msg=b9b7072a Drift #4 (c) +
+    architect sign-off msg=ebfcdabe + Weston blocker msg=177a1dd8:
+    any non-empty cursor must loud-fail with ``NotImplementedError``
+    bearing a "search pagination is not yet implemented" message.
 
-    ``cursor=None`` is exercised by the existing happy-path suite.
+    The sign-off explicitly forbids reusing
+    ``CursorError("cursor_invalid", ...)`` for this case — the canonical
+    cursor codes describe wire-level malformed / expired / drifted
+    cursors, and the "feature not implemented yet" semantic must not
+    be camouflaged as a malformed-cursor error.
+
+    ``cursor=None`` and ``cursor=""`` are covered by the
+    happy-path-passthrough test below; this case only exercises the
+    truthy-cursor loud-fail path.
     """
 
-    with pytest.raises(CursorError) as excinfo:
+    with pytest.raises(NotImplementedError) as excinfo:
         await tool("collection-id", "query", cursor=bad_cursor)
 
-    err = excinfo.value
-    assert err.code == "cursor_invalid", (
-        f"{tool.__name__} must produce canonical `cursor_invalid` for non-null cursor; got {err.code!r}."
+    message = str(excinfo.value)
+    assert "search pagination is not yet implemented" in message, (
+        f"{tool.__name__} loud-fail message must clearly state that "
+        f"search pagination is not implemented (got {message!r})."
     )
-    assert err.details.get("reason") == "search_not_paginated", (
-        "Error envelope must surface the deferred-pagination reason "
-        "so clients understand they should not retry the cursor."
+    assert tool.__name__ in message, (
+        "Loud-fail message must identify the originating tool so logs can attribute the rejection."
     )
-    assert err.details.get("tool") == tool.__name__, (
-        "Error envelope must identify the originating tool so logs can attribute the rejection."
+    assert "search_not_paginated" in message, (
+        "Loud-fail message must surface the deferred-pagination reason so clients understand they should not retry."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool",
+    [vector_search, graph_search, fulltext_search],
+    ids=["vector_search", "graph_search", "fulltext_search"],
+)
+@pytest.mark.parametrize(
+    "noop_cursor",
+    [None, ""],
+    ids=["none", "empty_string"],
+)
+async def test_collection_scoped_split_tools_treat_none_and_empty_cursor_as_first_page(tool, noop_cursor, monkeypatch):
+    """Weston blocker msg=177a1dd8 lock: ``None`` *and* ``""`` cursor
+    must both preserve the existing single-page ``top_k`` behavior
+    (``""`` is **not** a malformed cursor; it is the canonical
+    "no pagination requested" wire value).
+
+    We stub ``get_api_key()`` and the outbound httpx call so the test
+    only validates that the cursor guard does **not** raise — it does
+    not exercise the backend search path itself.
+    """
+
+    import aperag.mcp.tools.search_fulltext as sft
+    import aperag.mcp.tools.search_graph as sg
+    import aperag.mcp.tools.search_vector as sv
+
+    monkeypatch.setattr(sv, "get_api_key", lambda: "test-token")
+    monkeypatch.setattr(sg, "get_api_key", lambda: "test-token")
+    monkeypatch.setattr(sft, "get_api_key", lambda: "test-token")
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"items": []}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, headers=None, json=None):
+            return _FakeResponse()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+    # No exception expected — the cursor guard must not raise on
+    # ``None`` or ``""``.
+    result = await tool("collection-id", "query", cursor=noop_cursor)
+    assert isinstance(result, dict), (
+        f"{tool.__name__} must return the SearchResult dict for None/empty cursor (got {type(result).__name__})."
     )
 
 


### PR DESCRIPTION
## Summary

D10.d task #96 same-lane follow-up per `[D10 spec amendment]` thread (msg=b9b7072a) PM canonical decisions. Closes the cursor + kw-only drift items so the §B canonical signature lands on `vector_search` / `graph_search` / `fulltext_search` and the lane is ready to be marked Done.

## What changed

- **Drift #5 (kw-only `*,` sentinel)** — Added to `vector_search` / `graph_search` / `fulltext_search` after the `query` parameter, aligning with the D10.c read-primitive precedent established in #1714. `web_search` keeps its existing wire signature per §B.4 / amendment (parameter canonicalization deferred to D10.h cutover).
- **Drift #4 (c): cursor placeholder** — Published `cursor: str | None = None` on the same 3 tools so external MCP clients see the canonical §B surface. Body explicitly fails with `CursorError("cursor_invalid", "search pagination cursor is not yet implemented", details={"reason": "search_not_paginated", "tool": ...})` on any non-null value. `cursor=None` continues to mean "first page". Real search pagination requires a backend capability that will land in a dedicated D11+ upgrade.
- **`fulltext_search.rerank`** — Surfaced `rerank: bool = True` on the split tool to match §B.3 spec; previously the rerank flag was reachable only via the omnibus `search_collection`.

## Diff

4 files / +168 / -21
- MOD `aperag/mcp/tools/search_vector.py` (+32/-7)
- MOD `aperag/mcp/tools/search_graph.py` (+23/-5)
- MOD `aperag/mcp/tools/search_fulltext.py` (+25/-6)
- MOD `tests/unit_test/mcp/test_search_split.py` (+109/-3)

## NOT in this PR (per amendment thread)

- **Drift #1** (`SearchResultItem` with `chunk_id` / `section_path` / `heading_anchor`) — deferred to D10.h cutover (touches `aperag/domains/retrieval/` + indexing exposure; out of D10.d follow-up scope).
- **Drift #2** (`web_search` parameter canonicalization, `top_k` / kw-only / `source: str | None`) — deferred to D10.h cutover (wire-breaking change for external MCP clients).
- **Drift #3** (R3 Option A capability annotations) — D10.f territory (task #98).

## §G hard-gate self-check

- ✅ **Hard gate #1 contract shape change**: full 3-root grep (`tests/e2e_http/hurl/` + `tests/unit_test/` + `tests/e2e_http/scripts/`) confirms no caller references the old positional-friendly signatures of vector/graph/fulltext_search outside the test file (which I updated). The kw-only barrier breaks any caller that passed `top_k` / `keywords` / etc. positionally — none found.
- ✅ **Hard gate #4 caller migration → preserve original assertion semantics**: `cursor=None` continues to mean "first page" identically to pre-PR behavior. Non-null cursor was previously not accepted at all (silently ignored as the parameter didn't exist). The amendment thread explicitly chose loud-fail over silent-ignore (Drift #4 (c)).
- ✅ **Hard gate #5 cross-stack design boundary**: writes confined to `aperag/mcp/tools/search_*.py` + tests; no cross-lane import surface change. `aperag.mcp.cursor.errors.CursorError` import is read-only consumption of the D10.e canonical (#1712 / #1715) — same one-way dependency direction Bryce confirmed in his amendment-thread reply.

## Verification

- `uvx ruff check --no-fix aperag/mcp/tools/search_*.py tests/unit_test/mcp/test_search_split.py` → All checks passed
- `uvx ruff format --check ...` → 5 files already formatted
- Local pytest blocked by the same `aperag.mcp.__init__ -> fastmcp` collection issue Bryce reported on #1712 (msg=54e9b17b) and observed on #1713; CI is the gate.

## Reviewers per RR2

- @符炫炜 architect canonical drift quick-check
- @Weston 二线 sanity on the cursor explicit-not-silent contract (matches #1715 / #1716 same-pattern enforcement)

## Test plan

- [ ] `lint-and-unit` CI green (incl. new `test_collection_scoped_split_tools_reject_non_null_cursor` parametrized over 3 tools × 4 bad cursors = 12 regression cases + new kw-only signature lock tests + existing happy-path / deprecation / Forbidden tests)
- [ ] `e2e-http-smoke` / `e2e-http-provider` / `provider-preflight` CI green
- [ ] Architect spec line-by-line diff — including dataflow trace per amendment-thread Drift #4 / #5 resolution

## Closes the lane

Once this merges, task #96 has no remaining deferred items in this lane (Drifts #1 / #2 / #3 are in other lanes' scope). PM can move task #96 to Done after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)