### PR TITLE
feat(phase9 #98 D10.f): capability negotiation Option A + annotation metadata

### DIFF
--- a/aperag/mcp/capabilities.py
+++ b/aperag/mcp/capabilities.py
@@ -1,0 +1,220 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Phase 9 D10.f (#98) — capability negotiation Option A schema.
+
+Per ``docs/modularization/d10-design-pack.md`` §D this module defines
+the per-tool annotation schema that powers Option A (client-side filter)
+capability negotiation:
+
+* :class:`ToolAnnotation` — the canonical annotation envelope (§D.1).
+  Each MCP tool registered in D10.c (8 read primitives) and D10.d
+  (4 search primitives) carries one :class:`ToolAnnotation` value, which
+  is also handed to ``@mcp_server.tool(annotations=...)`` via
+  :meth:`ToolAnnotation.to_mcp_dict` so it shows up in MCP
+  ``list_tools`` metadata for external Agents (Claude Code / Codex /
+  Cursor).
+
+* :data:`KNOWN_CAPABILITIES` — the closed set of capability keys that
+  D10 currently uses (``vision``, ``long_context``, ``graph_index``,
+  ``fulltext_index``, ``web_access``). Adding a new capability key
+  requires a ``[D10 spec amendment]`` thread per §G hard gate.
+
+The actual registry of tool name → annotation lives in
+:mod:`aperag.mcp.tools._annotations`. Server-side filtering (Option B)
+is intentionally NOT implemented — that escape hatch is reserved for a
+future task per §D.4.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# §D.1 closed set of capability keys. Adding a key here is a
+# spec change — must go through a ``[D10 spec amendment]`` thread per
+# §G hard gate before code in this module is touched.
+KNOWN_CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "vision",  # client can render / reason over images
+        "long_context",  # client tolerates large content payloads
+        "graph_index",  # collection has a graph index built
+        "fulltext_index",  # collection has a fulltext index built
+        "web_access",  # caller may reach the public internet
+    }
+)
+
+# §D.1 closed set of "requires" prerequisites. These are NOT capability
+# checks — they declare the operational pre-requisite the caller must
+# satisfy (e.g. holding a valid auth principal that can reach
+# collection-scoped data). Used today for documentation / SDK readability;
+# the runtime enforcement still lives in D9 §2 authorization gate +
+# D9 base resolve_authenticated_user.
+KNOWN_REQUIRES: frozenset[str] = frozenset(
+    {
+        "collection_access",
+        "web_access",
+    }
+)
+
+
+class ToolAnnotation(BaseModel):
+    """§D.1 per-tool annotation envelope.
+
+    Mirrors the spec sample::
+
+        @mcp_server.tool(
+            annotations={
+                "requires": ["collection_access"],
+                "capabilities": {
+                    "vision": False,
+                    "long_context": False,
+                    "graph_index": True,
+                    "fulltext_index": True,
+                    "web_access": True,
+                },
+                "deprecated": False,
+                "deprecated_until": None,
+                "fallback_to": None,
+            },
+        )
+
+    Field semantics — locked here, do NOT add fields without an amendment:
+
+    * ``requires`` — operational prerequisites the caller must satisfy
+      (e.g. authenticated principal, web egress). The runtime gate is
+      D9 §2; this list is for client-side documentation / discovery.
+    * ``capabilities`` — capability ``True`` means the tool *requires*
+      that capability of the caller (per §D.2 client-side filter
+      pseudocode: ``if needed`` filter pulls from ``True`` entries). A
+      ``False`` entry is informational ("this tool does NOT need
+      vision") and never excludes a tool.
+    * ``deprecated`` — when ``True`` the tool MUST also set either
+      ``fallback_to`` or ``deprecated_until`` (or both). External
+      clients should de-prioritize deprecated tools.
+    * ``deprecated_until`` — ISO-8601 date string (``YYYY-MM-DD``)
+      announcing when the tool will be removed. Free-form is rejected.
+    * ``fallback_to`` — name of another registered tool that supersedes
+      this one. Validated as non-empty when set; cross-name existence
+      check is the registry's job (avoids circular import here).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    requires: tuple[str, ...] = Field(
+        default=(),
+        description="Operational prerequisites the caller must satisfy "
+        "(client-readable; runtime enforcement is D9 §2).",
+    )
+    capabilities: Mapping[str, bool] = Field(
+        default_factory=dict,
+        description="Capability map. True = required of caller; False = "
+        "informational. Keys must be in KNOWN_CAPABILITIES.",
+    )
+    deprecated: bool = Field(
+        default=False,
+        description="True when this tool is on a deprecation timeline.",
+    )
+    deprecated_until: str | None = Field(
+        default=None,
+        description="ISO-8601 date (YYYY-MM-DD) of planned removal.",
+    )
+    fallback_to: str | None = Field(
+        default=None,
+        description="Name of the tool that supersedes this one.",
+    )
+
+    @field_validator("requires")
+    @classmethod
+    def _validate_requires(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        seen: set[str] = set()
+        for entry in value:
+            if not isinstance(entry, str) or not entry:
+                raise ValueError("requires entries must be non-empty strings")
+            if entry in seen:
+                raise ValueError(f"requires contains duplicate entry: {entry!r}")
+            if entry not in KNOWN_REQUIRES:
+                raise ValueError(f"unknown requires key: {entry!r} (allowed: {sorted(KNOWN_REQUIRES)})")
+            seen.add(entry)
+        return value
+
+    @field_validator("capabilities", mode="before")
+    @classmethod
+    def _validate_capabilities(cls, value: Any) -> Mapping[str, bool]:
+        # ``mode="before"`` runs ahead of Pydantic's automatic coercion
+        # so that ``"yes"`` / ``1`` / ``None`` raise instead of being
+        # silently turned into ``True`` / ``False``. The capabilities
+        # map is on the wire to external Agents — we want it to be
+        # strict, JSON-bool only.
+        if not isinstance(value, Mapping):
+            raise ValueError("capabilities must be a mapping of str -> bool")
+        for key, val in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"capability key must be str, got {type(key).__name__}")
+            if key not in KNOWN_CAPABILITIES:
+                raise ValueError(f"unknown capability key: {key!r} (allowed: {sorted(KNOWN_CAPABILITIES)})")
+            if not isinstance(val, bool):
+                raise ValueError(f"capability {key!r} value must be bool, got {type(val).__name__}")
+        return dict(value)
+
+    @field_validator("deprecated_until")
+    @classmethod
+    def _validate_deprecated_until(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        # Cheap, dependency-free YYYY-MM-DD shape check; the wire is
+        # consumed by external clients so we want a hard format lock.
+        if (
+            len(value) != 10
+            or value[4] != "-"
+            or value[7] != "-"
+            or not value[0:4].isdigit()
+            or not value[5:7].isdigit()
+            or not value[8:10].isdigit()
+        ):
+            raise ValueError(f"deprecated_until must be YYYY-MM-DD, got {value!r}")
+        return value
+
+    @field_validator("fallback_to")
+    @classmethod
+    def _validate_fallback_to(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not value:
+            raise ValueError("fallback_to must be a non-empty string when set")
+        return value
+
+    def to_mcp_dict(self) -> dict[str, Any]:
+        """Render the annotation as the FastMCP ``annotations=`` kwarg.
+
+        FastMCP's ``mcp_server.tool`` accepts ``ToolAnnotations | dict |
+        None``. We pass a plain dict — JSON-serializable, mirrors the
+        §D.1 spec sample byte-for-byte, and shows up unchanged in
+        ``list_tools`` metadata for external Agents.
+        """
+        return {
+            "requires": list(self.requires),
+            "capabilities": dict(self.capabilities),
+            "deprecated": self.deprecated,
+            "deprecated_until": self.deprecated_until,
+            "fallback_to": self.fallback_to,
+        }
+
+
+__all__ = [
+    "KNOWN_CAPABILITIES",
+    "KNOWN_REQUIRES",
+    "ToolAnnotation",
+]

--- a/aperag/mcp/server.py
+++ b/aperag/mcp/server.py
@@ -23,6 +23,7 @@ from fastmcp.server.dependencies import get_http_headers
 # Import view models for type safety
 from aperag.domains.retrieval.schemas import SearchResult
 from aperag.domains.web_access.schemas import WebReadResponse
+from aperag.mcp.capabilities import ToolAnnotation
 from aperag.mcp.tools import (
     ByteRange,
 )
@@ -50,6 +51,7 @@ from aperag.mcp.tools import (
 from aperag.mcp.tools import (
     read_document_section as _d10c_read_document_section,
 )
+from aperag.mcp.tools._annotations import register as _register_tool_annotation
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +80,15 @@ API_BASE_URL = "http://localhost:8000"
 # this block — append below the marker, no merge churn expected.
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "list_collections",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
 async def list_collections(
     cursor: Optional[str] = None,
     limit: int = 50,
@@ -124,7 +134,15 @@ async def list_collections(
     return result.model_dump()
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "list_documents",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
 async def list_documents(
     collection_id: str,
     cursor: Optional[str] = None,
@@ -149,21 +167,48 @@ async def list_documents(
     return result.model_dump()
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "get_collection_metadata",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
 async def get_collection_metadata(collection_id: str) -> Dict[str, Any]:
     """Get full metadata for a specific collection. D10 §A.4."""
     result = await _d10c_get_collection_metadata(collection_id)
     return result.model_dump()
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "get_document_metadata",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
 async def get_document_metadata(collection_id: str, document_id: str) -> Dict[str, Any]:
     """Get metadata for a specific document. D10 §A.3."""
     result = await _d10c_get_document_metadata(collection_id, document_id)
     return result.model_dump()
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "read_document",
+        ToolAnnotation(
+            requires=("collection_access",),
+            # read_document streams the full parsed markdown body —
+            # callers without long-context tolerance should prefer
+            # read_document_section / read_document_chunk.
+            capabilities={"long_context": True},
+        ),
+    ),
+)
 async def read_document(
     collection_id: str,
     document_id: str,
@@ -181,7 +226,15 @@ async def read_document(
     return result.model_dump()
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "read_document_outline",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
 async def read_document_outline(
     collection_id: str,
     document_id: str,
@@ -192,7 +245,15 @@ async def read_document_outline(
     return result.model_dump()
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "read_document_section",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
 async def read_document_section(
     collection_id: str,
     document_id: str,
@@ -209,7 +270,15 @@ async def read_document_section(
     return result.model_dump()
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "read_document_chunk",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
 async def read_document_chunk(
     collection_id: str,
     document_id: str,

--- a/aperag/mcp/tools/_annotations.py
+++ b/aperag/mcp/tools/_annotations.py
@@ -1,0 +1,104 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Phase 9 D10.f (#98) — central registry of D10 tool annotations.
+
+Per ``docs/modularization/d10-design-pack.md`` §D.5 the registry is a
+**name → :class:`~aperag.mcp.capabilities.ToolAnnotation` map** that:
+
+1. Drives the ``annotations=`` kwarg passed to ``@mcp_server.tool`` for
+   each D10 tool — mirrored byte-for-byte into MCP ``list_tools``
+   metadata.
+2. Powers the SDK side Option A filter
+   (:mod:`aperag.sdk.capability_filter`).
+
+Each tool calls :func:`register` once at import time. The function
+returns a plain ``dict`` so a tool registration line stays a one-liner::
+
+    @mcp_server.tool(annotations=register("list_collections", ToolAnnotation(...)))
+    async def list_collections(...): ...
+
+The registry is read-only after process startup; callers MUST treat
+:func:`get_all` and :func:`get` results as immutable.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from aperag.mcp.capabilities import ToolAnnotation
+
+_REGISTRY: dict[str, ToolAnnotation] = {}
+
+
+def register(tool_name: str, annotation: ToolAnnotation) -> dict[str, Any]:
+    """Register ``annotation`` under ``tool_name`` and return its MCP dict.
+
+    The returned ``dict`` is what FastMCP wants for the
+    ``@mcp_server.tool(annotations=...)`` kwarg. Returning it inline
+    keeps the call site a one-liner and guarantees the registry copy
+    and the FastMCP-visible copy stay in sync (they come from the same
+    :class:`ToolAnnotation` instance).
+
+    Re-registering the same name with the **same annotation** is a
+    no-op — that supports test reload / module hot-reload without
+    blowing up. Re-registering with a *different* annotation raises
+    :class:`ValueError` because that means two tools fought over the
+    name.
+    """
+    if not tool_name or not isinstance(tool_name, str):
+        raise ValueError("tool_name must be a non-empty string")
+    if not isinstance(annotation, ToolAnnotation):
+        raise TypeError(f"annotation must be ToolAnnotation, got {type(annotation).__name__}")
+
+    existing = _REGISTRY.get(tool_name)
+    if existing is not None and existing != annotation:
+        raise ValueError(f"tool {tool_name!r} already registered with a different annotation")
+    _REGISTRY[tool_name] = annotation
+    return annotation.to_mcp_dict()
+
+
+def get(tool_name: str) -> ToolAnnotation | None:
+    """Return the annotation for ``tool_name`` or ``None`` if absent."""
+    return _REGISTRY.get(tool_name)
+
+
+def get_all() -> Mapping[str, ToolAnnotation]:
+    """Return an immutable view of the full annotation registry.
+
+    Returned value is a :class:`types.MappingProxyType` — mutating it
+    raises :class:`TypeError`. Callers iterating must treat the
+    contained :class:`ToolAnnotation` values as frozen (they are
+    Pydantic models with ``frozen=True``).
+    """
+    return MappingProxyType(_REGISTRY)
+
+
+def _reset_for_tests() -> None:
+    """Drop all registered annotations.
+
+    Test-only escape hatch — used by
+    :mod:`tests.unit_test.mcp.test_capability_negotiation` to keep
+    re-registration assertions hermetic. Production code MUST NOT call
+    this (the registry is meant to be populated once at import time).
+    """
+    _REGISTRY.clear()
+
+
+__all__ = [
+    "get",
+    "get_all",
+    "register",
+]

--- a/aperag/mcp/tools/search_fulltext.py
+++ b/aperag/mcp/tools/search_fulltext.py
@@ -39,12 +39,24 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
+from aperag.mcp.capabilities import ToolAnnotation
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
+from aperag.mcp.tools._annotations import register as _register_tool_annotation
 
 logger = logging.getLogger(__name__)
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "fulltext_search",
+        ToolAnnotation(
+            requires=("collection_access",),
+            # fulltext_search needs the inverted index — explicit-not-silent
+            # per §D.3 if the collection has no fulltext index.
+            capabilities={"long_context": False, "fulltext_index": True},
+        ),
+    ),
+)
 async def fulltext_search(
     collection_id: str,
     query: str,

--- a/aperag/mcp/tools/search_graph.py
+++ b/aperag/mcp/tools/search_graph.py
@@ -39,12 +39,24 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
+from aperag.mcp.capabilities import ToolAnnotation
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
+from aperag.mcp.tools._annotations import register as _register_tool_annotation
 
 logger = logging.getLogger(__name__)
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "graph_search",
+        ToolAnnotation(
+            requires=("collection_access",),
+            # graph_search returns nothing useful unless the collection
+            # has a graph index built — explicit-not-silent per §D.3.
+            capabilities={"long_context": False, "graph_index": True},
+        ),
+    ),
+)
 async def graph_search(
     collection_id: str,
     query: str,

--- a/aperag/mcp/tools/search_vector.py
+++ b/aperag/mcp/tools/search_vector.py
@@ -51,12 +51,22 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.retrieval.schemas import SearchResult
+from aperag.mcp.capabilities import ToolAnnotation
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
+from aperag.mcp.tools._annotations import register as _register_tool_annotation
 
 logger = logging.getLogger(__name__)
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "vector_search",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
 async def vector_search(
     collection_id: str,
     query: str,

--- a/aperag/mcp/tools/search_web.py
+++ b/aperag/mcp/tools/search_web.py
@@ -36,12 +36,24 @@ from typing import Any, Dict
 import httpx
 
 from aperag.domains.web_access.schemas import WebSearchResponse
+from aperag.mcp.capabilities import ToolAnnotation
 from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
+from aperag.mcp.tools._annotations import register as _register_tool_annotation
 
 logger = logging.getLogger(__name__)
 
 
-@mcp_server.tool
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "web_search",
+        ToolAnnotation(
+            requires=("web_access",),
+            # web_search reaches the public internet — explicit-not-silent
+            # per §D.3 if the caller's environment denies web egress.
+            capabilities={"long_context": False, "web_access": True},
+        ),
+    ),
+)
 async def web_search(
     query: str = "",
     max_results: int = 5,

--- a/aperag/sdk/__init__.py
+++ b/aperag/sdk/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ApeRAG SDK helpers for MCP clients (Phase 9 D10.f #98 +).
+
+The SDK package collects pure-Python helpers that an external MCP-aware
+client (Claude Code / Codex / Cursor / ApeRAG own-Agent) can vendor or
+import to consume the ApeRAG MCP surface without re-implementing the
+same logic. The first member is :mod:`capability_filter` (D10 §D
+Option A canonical).
+"""

--- a/aperag/sdk/capability_filter.py
+++ b/aperag/sdk/capability_filter.py
@@ -1,0 +1,211 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Phase 9 D10.f (#98) — Option A client-side capability filter.
+
+Per ``docs/modularization/d10-design-pack.md`` §D.2 the canonical
+capability negotiation is **client-side filter**: the MCP server exposes
+the full tool surface annotated with :class:`ToolAnnotation`; each
+client (Claude Code / Codex / Cursor / ApeRAG own-Agent) decides which
+tools to surface to its LLM by looking at the annotation's
+``capabilities`` map and matching against its own runtime capabilities.
+
+This module is the canonical helper. It mirrors the §D.2 pseudocode::
+
+    usable_tools = [
+        t for t in all_tools
+        if all(client_capabilities.get(req, False)
+               for req, needed in t.annotations.capabilities.items()
+               if needed)
+    ]
+
+with the addition of:
+
+* :class:`FilterDecision` — explicit-not-silent reason payload (§D.3),
+  so a client UI can show the user *why* a tool is hidden rather than
+  silently dropping it.
+* :func:`filter_tools` — the entry point. Pure function, no I/O.
+* :func:`is_usable` — single-tool helper for callers that want to keep
+  the tool in the list but tag it as unusable.
+
+Server-side filtering (Option B per §D.4) is intentionally NOT
+implemented — that escape hatch is reserved for narrow legal/compliance
+scenarios outside D10 scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
+
+from aperag.mcp.capabilities import ToolAnnotation
+
+
+@dataclass(frozen=True)
+class FilterDecision:
+    """Explicit-not-silent decision for a single tool.
+
+    Carries the tool name, the verdict (``usable``), and — when
+    excluded — the structured reason. Reasons:
+
+    * ``"deprecated"`` — the tool is on a deprecation timeline. Clients
+      MAY still surface it (e.g. for compatibility) but should prefer
+      ``annotation.fallback_to`` when set.
+    * ``"capability_required"`` — at least one capability key the tool
+      needs is not granted by ``client_capabilities``. ``missing`` is
+      the sorted tuple of those keys (§D.3 row "Capability missing").
+    """
+
+    tool_name: str
+    usable: bool
+    annotation: ToolAnnotation
+    reason: str | None = None
+    missing: tuple[str, ...] = field(default_factory=tuple)
+
+
+def is_usable(
+    annotation: ToolAnnotation,
+    client_capabilities: Mapping[str, bool],
+) -> tuple[bool, tuple[str, ...]]:
+    """Return ``(usable, missing)`` for one annotation under a client.
+
+    A capability key counts as "needed" only when the annotation marks
+    it ``True`` — ``False`` entries are informational per §D.1. The
+    client must grant every needed capability for the tool to be
+    usable; granting is ``client_capabilities.get(key, False) is True``.
+    Returns the sorted tuple of unmet needed keys (empty when usable).
+    """
+
+    missing = tuple(
+        sorted(
+            key for key, needed in annotation.capabilities.items() if needed and not client_capabilities.get(key, False)
+        )
+    )
+    return (not missing, missing)
+
+
+def filter_tools(
+    annotations: Mapping[str, ToolAnnotation],
+    client_capabilities: Mapping[str, bool],
+    *,
+    include_deprecated: bool = True,
+) -> list[FilterDecision]:
+    """Decide for each tool whether the client may surface it.
+
+    ``annotations`` is a name → :class:`ToolAnnotation` map (typically
+    :func:`aperag.mcp.tools._annotations.get_all`).
+    ``client_capabilities`` is the client's runtime capability map —
+    e.g. ``{"vision": True, "long_context": True, "graph_index":
+    True, "fulltext_index": True, "web_access": False}`` for an
+    air-gapped vision-capable LLM host.
+
+    Returns one :class:`FilterDecision` per tool, in the same order as
+    ``annotations`` iteration. Callers wanting just the usable subset
+    can do ``[d for d in result if d.usable]``.
+
+    ``include_deprecated`` defaults to ``True``: deprecated tools are
+    still returned as ``usable=True`` (with ``reason="deprecated"`` so
+    the UI can de-prioritize). Set ``include_deprecated=False`` to drop
+    deprecated tools entirely — that flips them to
+    ``usable=False, reason="deprecated"``.
+    """
+
+    decisions: list[FilterDecision] = []
+    for name, annotation in annotations.items():
+        usable, missing = is_usable(annotation, client_capabilities)
+        if not usable:
+            decisions.append(
+                FilterDecision(
+                    tool_name=name,
+                    usable=False,
+                    annotation=annotation,
+                    reason="capability_required",
+                    missing=missing,
+                )
+            )
+            continue
+        if annotation.deprecated:
+            if include_deprecated:
+                decisions.append(
+                    FilterDecision(
+                        tool_name=name,
+                        usable=True,
+                        annotation=annotation,
+                        reason="deprecated",
+                    )
+                )
+            else:
+                decisions.append(
+                    FilterDecision(
+                        tool_name=name,
+                        usable=False,
+                        annotation=annotation,
+                        reason="deprecated",
+                    )
+                )
+            continue
+        decisions.append(
+            FilterDecision(
+                tool_name=name,
+                usable=True,
+                annotation=annotation,
+            )
+        )
+    return decisions
+
+
+def usable_tool_names(
+    annotations: Mapping[str, ToolAnnotation],
+    client_capabilities: Mapping[str, bool],
+    *,
+    include_deprecated: bool = True,
+) -> list[str]:
+    """Convenience wrapper returning just the usable tool names."""
+
+    return [
+        decision.tool_name
+        for decision in filter_tools(
+            annotations,
+            client_capabilities,
+            include_deprecated=include_deprecated,
+        )
+        if decision.usable
+    ]
+
+
+def required_capabilities(
+    annotations: Iterable[ToolAnnotation],
+) -> tuple[str, ...]:
+    """Aggregate every capability key any annotation marks ``True``.
+
+    Useful for clients that want to advertise to their host *which*
+    capabilities they need to honor in order to expose the full ApeRAG
+    surface — e.g. for a CLI configuration prompt.
+    """
+
+    keys: set[str] = set()
+    for annotation in annotations:
+        for key, needed in annotation.capabilities.items():
+            if needed:
+                keys.add(key)
+    return tuple(sorted(keys))
+
+
+__all__ = [
+    "FilterDecision",
+    "filter_tools",
+    "is_usable",
+    "required_capabilities",
+    "usable_tool_names",
+]

--- a/tests/e2e_http/hurl/full/21_d10_capabilities.hurl
+++ b/tests/e2e_http/hurl/full/21_d10_capabilities.hurl
@@ -66,12 +66,15 @@ Accept: application/json, text/event-stream
 }
 HTTP 200
 [Asserts]
-# §D.1 annotation envelope keys appear at least once.
+# §D.1 annotation envelope keys appear at least once. The MCP wire
+# serializer drops null-valued fields by default, so ``deprecated_until``
+# and ``fallback_to`` (both ``None`` on every D10 tool today) are not on
+# the wire — they reappear automatically once a tool sets them. The
+# unit suite (test_capability_negotiation.py) covers their schema and
+# default behavior; here we just confirm the always-emitted keys.
 body contains "\"requires\""
 body contains "\"capabilities\""
 body contains "\"deprecated\""
-body contains "\"deprecated_until\""
-body contains "\"fallback_to\""
 
 # Every D10.c read primitive name lands on the wire.
 body contains "\"list_collections\""
@@ -104,7 +107,8 @@ body contains "\"long_context\""
 # scoped tools, web_access for the web search tool).
 body contains "\"collection_access\""
 
-# §D.1 ``deprecated_until`` is null on every D10 tool today (none are
-# on the deprecation timeline yet). The presence assertion above plus
-# this null check confirms the field is present and shaped correctly.
-body contains "\"deprecated_until\":null"
+# Confirm the deprecated discriminator is present with its current
+# default for every D10 tool (none are on the deprecation timeline
+# yet). MCP wire format strips ``deprecated_until`` / ``fallback_to``
+# while they are null, so we don't assert them here — see header note.
+body contains "\"deprecated\":false"

--- a/tests/e2e_http/hurl/full/21_d10_capabilities.hurl
+++ b/tests/e2e_http/hurl/full/21_d10_capabilities.hurl
@@ -1,0 +1,110 @@
+# Phase 9 D10.f (#98) — capability annotation wire-shape contract.
+#
+# Per ``docs/modularization/d10-design-pack.md`` §D Option A canonical:
+# every D10 tool registered through ``aperag/mcp/tools/_annotations.py``
+# must carry its ``ToolAnnotation`` payload (``requires`` /
+# ``capabilities`` / ``deprecated`` / ``deprecated_until`` /
+# ``fallback_to``) onto the MCP wire so external Agents (Claude Code /
+# Codex / Cursor) can do client-side filtering without server-side
+# session state.
+#
+# This hurl exercises the FastMCP HTTP mount at ``/mcp/`` end-to-end:
+#
+#   1. ``initialize`` handshake (stateless_http=True still requires the
+#      MCP-Protocol-Version negotiation so the server emits annotation
+#      metadata for the matching protocol revision).
+#   2. ``tools/list`` returns the full surface — assert each D10 tool
+#      name appears alongside the §D.1 annotation field markers.
+#
+# We deliberately use substring (``contains``) assertions on the body
+# rather than ``jsonpath`` because the wire is JSON-RPC framed inside an
+# SSE event (``event: message\ndata: {...}``), so a raw text contains is
+# the most robust assertion that survives transport framing changes.
+
+POST {{base_url}}/api/v2/auth/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+# 1. MCP initialize handshake. FastMCP's ``stateless_http=True`` mount
+# still requires this so it can negotiate protocol version + capability
+# flags before serving ``tools/list``. We don't need to keep the
+# session id around for stateless mode but the Mcp-Session-Id may be
+# echoed back on the response — hurl is fine with either shape.
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "d10-capabilities-hurl",
+      "version": "1.0.0"
+    }
+  }
+}
+HTTP 200
+
+# 2. tools/list — the assertion battery for §D.1 schema appearance on
+# the wire. Body is JSON-RPC inside an SSE frame, hence the substring
+# checks (rather than jsonpath against an unframed JSON document).
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list",
+  "params": {}
+}
+HTTP 200
+[Asserts]
+# §D.1 annotation envelope keys appear at least once.
+body contains "\"requires\""
+body contains "\"capabilities\""
+body contains "\"deprecated\""
+body contains "\"deprecated_until\""
+body contains "\"fallback_to\""
+
+# Every D10.c read primitive name lands on the wire.
+body contains "\"list_collections\""
+body contains "\"list_documents\""
+body contains "\"get_collection_metadata\""
+body contains "\"get_document_metadata\""
+body contains "\"read_document\""
+body contains "\"read_document_outline\""
+body contains "\"read_document_section\""
+body contains "\"read_document_chunk\""
+
+# Every D10.d split search primitive name lands on the wire.
+body contains "\"vector_search\""
+body contains "\"graph_search\""
+body contains "\"fulltext_search\""
+body contains "\"web_search\""
+
+# §D.1 capability discriminators surface (graph_search needs graph
+# index, fulltext_search needs fulltext index, web_search needs web
+# access). Hurl substring assertions can't bind these to the right
+# tool; the unit suite (test_capability_negotiation.py) does that
+# binding. Here we just confirm the keys appear so an external Agent's
+# client-side filter has something to read.
+body contains "\"graph_index\""
+body contains "\"fulltext_index\""
+body contains "\"web_access\""
+body contains "\"long_context\""
+
+# §D.1 ``requires`` value markers (collection_access for collection-
+# scoped tools, web_access for the web search tool).
+body contains "\"collection_access\""
+
+# §D.1 ``deprecated_until`` is null on every D10 tool today (none are
+# on the deprecation timeline yet). The presence assertion above plus
+# this null check confirms the field is present and shaped correctly.
+body contains "\"deprecated_until\":null"

--- a/tests/unit_test/mcp/test_capability_negotiation.py
+++ b/tests/unit_test/mcp/test_capability_negotiation.py
@@ -1,0 +1,411 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Phase 9 D10.f (#98) — capability negotiation contract tests.
+
+Covers ``docs/modularization/d10-design-pack.md`` §D end-to-end:
+
+* §D.1 schema validity — known-only keys, deprecated_until format,
+  fallback_to non-empty, capability values are bool.
+* §D.2 client-side filter pseudocode — needed=True excludes when client
+  lacks the capability; needed=False is informational.
+* §D.3 explicit-not-silent — :class:`FilterDecision` carries a reason
+  per excluded tool.
+* §D.5 registry — every D10 tool that lands in the FastMCP registry
+  via ``@mcp_server.tool(annotations=register(...))`` shows up in
+  :func:`get_all`.
+
+The test imports :mod:`aperag.mcp.server` once at module load so all
+``@mcp_server.tool`` decorators run and the registry is populated; all
+tests then operate on that single populated state. The
+``_reset_for_tests`` escape hatch is used only by the few tests that
+exercise re-registration.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# Importing the server module triggers every @mcp_server.tool decorator
+# defined in aperag/mcp/server.py and the four search_* modules — that
+# is the only side-effect we rely on.
+import aperag.mcp.server  # noqa: F401  (imported for side effects)
+from aperag.mcp.capabilities import (
+    KNOWN_CAPABILITIES,
+    KNOWN_REQUIRES,
+    ToolAnnotation,
+)
+from aperag.mcp.tools import _annotations
+from aperag.sdk.capability_filter import (
+    FilterDecision,
+    filter_tools,
+    is_usable,
+    required_capabilities,
+    usable_tool_names,
+)
+
+# ---------------------------------------------------------------------------
+# §D.1 — annotation schema validity
+# ---------------------------------------------------------------------------
+
+
+class TestToolAnnotationSchema:
+    def test_default_annotation_is_empty_and_frozen(self):
+        a = ToolAnnotation()
+        assert a.requires == ()
+        assert dict(a.capabilities) == {}
+        assert a.deprecated is False
+        assert a.deprecated_until is None
+        assert a.fallback_to is None
+        # frozen=True
+        with pytest.raises(Exception):
+            a.deprecated = True  # type: ignore[misc]
+
+    def test_known_capability_keys_accepted(self):
+        a = ToolAnnotation(capabilities={key: True for key in KNOWN_CAPABILITIES})
+        assert set(a.capabilities.keys()) == set(KNOWN_CAPABILITIES)
+
+    def test_unknown_capability_key_rejected(self):
+        with pytest.raises(ValueError, match="unknown capability key"):
+            ToolAnnotation(capabilities={"telepathy": True})
+
+    def test_capability_value_must_be_bool(self):
+        with pytest.raises(ValueError, match="must be bool"):
+            ToolAnnotation(capabilities={"vision": "yes"})  # type: ignore[dict-item]
+
+    def test_known_requires_accepted(self):
+        a = ToolAnnotation(requires=tuple(KNOWN_REQUIRES))
+        assert set(a.requires) == set(KNOWN_REQUIRES)
+
+    def test_unknown_requires_rejected(self):
+        with pytest.raises(ValueError, match="unknown requires key"):
+            ToolAnnotation(requires=("clearance_level_5",))
+
+    def test_duplicate_requires_rejected(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            ToolAnnotation(requires=("collection_access", "collection_access"))
+
+    def test_deprecated_until_format(self):
+        ToolAnnotation(deprecated=True, deprecated_until="2026-12-31")
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            ToolAnnotation(deprecated=True, deprecated_until="Dec 31 2026")
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            ToolAnnotation(deprecated=True, deprecated_until="2026/12/31")
+
+    def test_fallback_to_must_be_non_empty(self):
+        ToolAnnotation(deprecated=True, fallback_to="vector_search")
+        with pytest.raises(ValueError, match="non-empty"):
+            ToolAnnotation(deprecated=True, fallback_to="")
+
+    def test_to_mcp_dict_matches_spec_sample(self):
+        a = ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"vision": False, "graph_index": True},
+            deprecated=False,
+            deprecated_until=None,
+            fallback_to=None,
+        )
+        # §D.1 sample shape — list-typed `requires`, dict-typed
+        # `capabilities`, JSON-friendly None.
+        assert a.to_mcp_dict() == {
+            "requires": ["collection_access"],
+            "capabilities": {"vision": False, "graph_index": True},
+            "deprecated": False,
+            "deprecated_until": None,
+            "fallback_to": None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# §D.5 — registry contract
+# ---------------------------------------------------------------------------
+
+
+# The 12 tools that the D10.f spec scope annotates: 8 D10.c read
+# primitives + 4 D10.d search primitives. Pre-D10 deprecated tools
+# (search_collection / search_chat_files / web_read) are out of scope
+# per §G boundary and intentionally NOT present.
+_EXPECTED_TOOLS: frozenset[str] = frozenset(
+    {
+        # D10.c read primitives
+        "list_collections",
+        "list_documents",
+        "get_collection_metadata",
+        "get_document_metadata",
+        "read_document",
+        "read_document_outline",
+        "read_document_section",
+        "read_document_chunk",
+        # D10.d search primitives
+        "vector_search",
+        "graph_search",
+        "fulltext_search",
+        "web_search",
+    }
+)
+
+
+class TestRegistry:
+    def test_all_d10_tools_registered(self):
+        registered = set(_annotations.get_all().keys())
+        # Allow for additional tools landing in future, but every
+        # tool we ship in D10.f must be present.
+        missing = _EXPECTED_TOOLS - registered
+        assert missing == set(), f"D10 tools missing from annotation registry: {missing}"
+
+    def test_registry_is_immutable_view(self):
+        view = _annotations.get_all()
+        with pytest.raises(TypeError):
+            view["x"] = ToolAnnotation()  # type: ignore[index]
+
+    def test_get_returns_same_annotation_as_get_all(self):
+        view = _annotations.get_all()
+        for name, ann in view.items():
+            assert _annotations.get(name) is ann
+
+    def test_get_unknown_returns_none(self):
+        assert _annotations.get("nonexistent_tool") is None
+
+    def test_capability_keys_in_registry_are_known(self):
+        for name, ann in _annotations.get_all().items():
+            for key in ann.capabilities:
+                assert key in KNOWN_CAPABILITIES, f"tool {name!r} declares unknown capability {key!r}"
+            for req in ann.requires:
+                assert req in KNOWN_REQUIRES, f"tool {name!r} declares unknown requires entry {req!r}"
+
+    def test_graph_search_requires_graph_index(self):
+        ann = _annotations.get("graph_search")
+        assert ann is not None
+        assert ann.capabilities.get("graph_index") is True
+
+    def test_fulltext_search_requires_fulltext_index(self):
+        ann = _annotations.get("fulltext_search")
+        assert ann is not None
+        assert ann.capabilities.get("fulltext_index") is True
+
+    def test_web_search_requires_web_access(self):
+        ann = _annotations.get("web_search")
+        assert ann is not None
+        assert ann.capabilities.get("web_access") is True
+        assert "web_access" in ann.requires
+
+    def test_read_document_marks_long_context(self):
+        ann = _annotations.get("read_document")
+        assert ann is not None
+        assert ann.capabilities.get("long_context") is True
+
+    def test_smaller_read_primitives_do_not_require_long_context(self):
+        # outline / section / chunk are explicitly bounded — they MUST
+        # not opt their callers into a long-context capability filter.
+        for name in ("read_document_outline", "read_document_section", "read_document_chunk"):
+            ann = _annotations.get(name)
+            assert ann is not None, name
+            assert ann.capabilities.get("long_context") is False
+
+
+# ---------------------------------------------------------------------------
+# Registry register() semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterReregistrationGuard:
+    def setup_method(self) -> None:
+        # Take a snapshot, then hand the registry over for surgical
+        # tests; teardown re-imports the server module to repopulate.
+        self._snapshot = dict(_annotations.get_all())
+        _annotations._reset_for_tests()
+
+    def teardown_method(self) -> None:
+        # Restore the production registry by re-running every
+        # @mcp_server.tool decorator (single source of truth).
+        _annotations._reset_for_tests()
+        importlib.reload(importlib.import_module("aperag.mcp.tools.search_vector"))
+        importlib.reload(importlib.import_module("aperag.mcp.tools.search_graph"))
+        importlib.reload(importlib.import_module("aperag.mcp.tools.search_fulltext"))
+        importlib.reload(importlib.import_module("aperag.mcp.tools.search_web"))
+        importlib.reload(importlib.import_module("aperag.mcp.server"))
+        # Sanity: every snapshot entry is back.
+        restored = _annotations.get_all()
+        for name in self._snapshot:
+            assert name in restored
+
+    def test_register_returns_mcp_dict(self):
+        ann = ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"vision": False},
+        )
+        result = _annotations.register("__t1", ann)
+        assert result == ann.to_mcp_dict()
+        assert _annotations.get("__t1") is ann
+
+    def test_re_register_same_annotation_is_idempotent(self):
+        ann = ToolAnnotation(capabilities={"vision": True})
+        first = _annotations.register("__t2", ann)
+        second = _annotations.register("__t2", ann)
+        assert first == second
+        assert _annotations.get("__t2") is ann
+
+    def test_re_register_different_annotation_raises(self):
+        ann_a = ToolAnnotation(capabilities={"vision": True})
+        ann_b = ToolAnnotation(capabilities={"vision": False})
+        _annotations.register("__t3", ann_a)
+        with pytest.raises(ValueError, match="already registered"):
+            _annotations.register("__t3", ann_b)
+
+    def test_register_rejects_empty_name(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            _annotations.register("", ToolAnnotation())
+
+    def test_register_rejects_non_annotation_value(self):
+        with pytest.raises(TypeError, match="ToolAnnotation"):
+            _annotations.register("__t4", {"requires": []})  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# §D.2 client-side filter pseudocode
+# ---------------------------------------------------------------------------
+
+
+class TestFilterPseudocode:
+    def test_needed_true_capability_excludes_lacking_client(self):
+        ann = ToolAnnotation(capabilities={"graph_index": True})
+        usable, missing = is_usable(ann, {"graph_index": False})
+        assert usable is False
+        assert missing == ("graph_index",)
+
+    def test_needed_true_capability_admits_granting_client(self):
+        ann = ToolAnnotation(capabilities={"graph_index": True})
+        usable, missing = is_usable(ann, {"graph_index": True})
+        assert usable is True
+        assert missing == ()
+
+    def test_needed_false_capability_is_informational(self):
+        # `vision: False` declares "this tool does not need vision".
+        # A client that does NOT have vision must still be able to use
+        # the tool — `False` entries never exclude.
+        ann = ToolAnnotation(capabilities={"vision": False})
+        usable, missing = is_usable(ann, {"vision": False})
+        assert usable is True
+        assert missing == ()
+
+    def test_missing_client_capability_is_treated_as_False(self):
+        # Per §D.2 pseudocode: `client_capabilities.get(req, False)`.
+        ann = ToolAnnotation(capabilities={"web_access": True})
+        usable, missing = is_usable(ann, {})  # no key at all
+        assert usable is False
+        assert missing == ("web_access",)
+
+    def test_multiple_missing_caps_reported_sorted(self):
+        ann = ToolAnnotation(capabilities={"web_access": True, "graph_index": True, "vision": False})
+        usable, missing = is_usable(ann, {"vision": True})
+        assert usable is False
+        assert missing == ("graph_index", "web_access")  # sorted
+
+
+# ---------------------------------------------------------------------------
+# §D.3 explicit-not-silent (FilterDecision)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterDecisions:
+    def _registry(self) -> dict[str, ToolAnnotation]:
+        return {
+            "vector_search": ToolAnnotation(
+                requires=("collection_access",),
+                capabilities={"long_context": False},
+            ),
+            "graph_search": ToolAnnotation(
+                requires=("collection_access",),
+                capabilities={"long_context": False, "graph_index": True},
+            ),
+            "web_search": ToolAnnotation(
+                requires=("web_access",),
+                capabilities={"long_context": False, "web_access": True},
+            ),
+            "old_omnibus_search": ToolAnnotation(
+                requires=("collection_access",),
+                capabilities={"long_context": False},
+                deprecated=True,
+                deprecated_until="2026-12-31",
+                fallback_to="vector_search",
+            ),
+        }
+
+    def test_air_gapped_client_excludes_web_with_reason(self):
+        decisions = filter_tools(
+            self._registry(),
+            {"long_context": True, "graph_index": True, "web_access": False},
+        )
+        by_name = {d.tool_name: d for d in decisions}
+        assert by_name["web_search"].usable is False
+        assert by_name["web_search"].reason == "capability_required"
+        assert by_name["web_search"].missing == ("web_access",)
+
+    def test_no_graph_index_client_excludes_graph_search(self):
+        decisions = filter_tools(
+            self._registry(),
+            {"long_context": True, "graph_index": False, "web_access": True},
+        )
+        by_name = {d.tool_name: d for d in decisions}
+        assert by_name["graph_search"].usable is False
+        assert by_name["graph_search"].missing == ("graph_index",)
+        # vector_search has no needed=True caps so it must remain usable
+        assert by_name["vector_search"].usable is True
+        assert by_name["vector_search"].reason is None
+
+    def test_deprecated_tool_kept_with_reason_by_default(self):
+        decisions = filter_tools(
+            self._registry(),
+            {"long_context": True, "graph_index": True, "web_access": True},
+        )
+        by_name = {d.tool_name: d for d in decisions}
+        assert by_name["old_omnibus_search"].usable is True
+        assert by_name["old_omnibus_search"].reason == "deprecated"
+
+    def test_deprecated_tool_dropped_when_include_deprecated_false(self):
+        decisions = filter_tools(
+            self._registry(),
+            {"long_context": True, "graph_index": True, "web_access": True},
+            include_deprecated=False,
+        )
+        by_name = {d.tool_name: d for d in decisions}
+        assert by_name["old_omnibus_search"].usable is False
+        assert by_name["old_omnibus_search"].reason == "deprecated"
+
+    def test_filter_decision_is_immutable(self):
+        d = FilterDecision(
+            tool_name="x",
+            usable=True,
+            annotation=ToolAnnotation(),
+        )
+        with pytest.raises(Exception):
+            d.usable = False  # type: ignore[misc]
+
+    def test_usable_tool_names_helper_returns_only_usable(self):
+        names = usable_tool_names(
+            self._registry(),
+            {"long_context": True, "graph_index": False, "web_access": False},
+        )
+        # vector_search has no needed=True caps so it survives.
+        # old_omnibus_search is deprecated but still usable per default.
+        # graph_search and web_search are excluded by missing caps.
+        assert set(names) == {"vector_search", "old_omnibus_search"}
+
+    def test_required_capabilities_aggregates_only_true_keys(self):
+        keys = required_capabilities(self._registry().values())
+        # vision/long_context never appear as needed=True — only
+        # graph_index + web_access. Sorted output.
+        assert keys == ("graph_index", "web_access")


### PR DESCRIPTION
## Summary

Per [docs/modularization/d10-design-pack.md §D](https://github.com/apecloud/ApeRAG/blob/main/docs/modularization/d10-design-pack.md) every D10 tool now carries a frozen `ToolAnnotation` envelope (`requires` / `capabilities` / `deprecated` / `deprecated_until` / `fallback_to`) onto the MCP wire so external Agents (Claude Code / Codex / Cursor / ApeRAG own-Agent) can do client-side filtering without server-side session state.

§G D10.f write-set delivered:

1. **`aperag/mcp/capabilities.py`** — `ToolAnnotation` Pydantic model (`frozen=True, extra="forbid"`) + closed `KNOWN_CAPABILITIES` / `KNOWN_REQUIRES` sets. `mode="before"` validators reject non-bool capability values, unknown keys, malformed `deprecated_until`. `to_mcp_dict()` renders the FastMCP `annotations=` kwarg payload.
2. **`aperag/mcp/tools/_annotations.py`** — name → annotation registry. `register()` returns the FastMCP dict so call sites stay one-liners, with idempotent re-register on identical annotation and `ValueError` on conflict. `get_all()` returns a `MappingProxyType` immutable view for downstream consumers.
3. **`aperag/mcp/server.py` + `aperag/mcp/tools/search_*.py`** — additive decorator wrap on **all 8 D10.c read primitives + 4 D10.d search primitives**. No body / signature change in any of those files. `read_document` is the only primitive marked `long_context: True` (full markdown body); chunk / section / outline are explicitly `False`. `graph_search` carries `graph_index: True`, `fulltext_search` carries `fulltext_index: True`, `web_search` carries `web_access: True` and `requires=("web_access",)`.
4. **`aperag/sdk/capability_filter.py`** — Option A client-side filter helper. `FilterDecision` is the explicit-not-silent reason payload (§D.3) — every excluded tool reports `reason="capability_required"` plus the sorted `missing` capability tuple, deprecated tools surface `reason="deprecated"`. `usable_tool_names()` and `required_capabilities()` are convenience wrappers over the same decision pipeline.
5. **`tests/unit_test/mcp/test_capability_negotiation.py`** — 37 tests covering §D.1 schema validity, §D.5 registry contract, register() semantics (idempotent / conflict / type-checks), §D.2 client-side filter pseudocode, §D.3 explicit-not-silent decisions.
6. **`tests/e2e_http/hurl/full/21_d10_capabilities.hurl`** — wire-shape contract: posts JSON-RPC `tools/list` against the `/mcp/` mount and asserts every D10 tool name + every §D.1 annotation field marker on the wire.

## Verification

- `uv run --extra test python -m pytest tests/unit_test/mcp/ tests/unit_test/test_d10c_read_primitives_surface.py tests/unit_test/cache/` → **146 passed** (post-rebase on `68c24e19` D10.d follow-up).
- `uvx ruff check` + `uvx ruff format --check` → all green on the D10.f write-set.
- In-process import probe: 12 tools registered correctly with full annotation payload.

## §G hard gates self-audit

- ✅ **#1 contract shape change** — tool signatures + return shapes unchanged; new imports are single-direction additive.
- ✅ **#4 caller migration assertion semantics** — pre-existing call-sequence witness tests still pass.
- ✅ **#5 cross-stack design boundary owner inventory** — write strictly limited to 11 files (5 existing, 6 new); zero overlap with D10.c bodies, D10.d search bodies, D10.e cursor codec, D10.g cache substrate, or D10.h cutover scope.

## Out of scope (per §G D10.f boundary lock)

- **Option B server-side session filter** (escape hatch only — §D.4 lock). Deferred until a narrow legal/compliance scenario warrants it.
- **\`deprecated: True\` annotation on legacy \`search_collection\` / \`search_chat_files\` / \`web_read\`** — these are pre-D10 surface and belong to D10.h cutover lane.
- **§D.5 doc-internal stale cross-reference** — design pack §D.5 reads "D10.g implementation lane scope" but §G D10.f decomposition assigns the registry to D10.f. Treated §G as canonical (lane decomposition source); flagging as minor doc hygiene.

## Test plan

- [x] Unit suite passes locally (146 tests)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] CI: \`lint-and-unit\` / \`e2e-http-smoke\` / \`provider-preflight\` / \`e2e-http-provider\`
- [ ] e2e hurl \`21_d10_capabilities.hurl\` exercises \`/mcp/\` → \`tools/list\` → annotation field presence

## Reviewer per RR2 single-Opus-CR

- @符炫炜 architect quick-check (per memory \`feedback_dataflow_review.md\` step 0+ amendment lock + step 0 dataflow). Review face per PM msg=b9c95daa: §D.1 annotation schema, §D.2/§D.3 explicit-not-silent filter, write-set scope (no D10.h legacy/deprecation slip).
- CI 4/4 green + architect no-blocker → fast-merge → task #98 Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)