### PR TITLE
feat(phase9 #100 D10.h): legacy search hard-cut + web_search canonicalization + retrieval handle exposure + D10 hurl coverage

### DIFF
--- a/aperag/domains/agent_runtime/services.py
+++ b/aperag/domains/agent_runtime/services.py
@@ -100,9 +100,23 @@ _ACTIVITY_SUBTITLE_KEYS = {
     UserActivityIntent.ERROR: "activity.error.subtitle",
 }
 
-_KNOWLEDGE_SEARCH_TOOLS = {"list_collections", "search_collection"}
+_KNOWLEDGE_SEARCH_TOOLS = {
+    "list_collections",
+    "list_documents",
+    "vector_search",
+    "graph_search",
+    "fulltext_search",
+}
 _WEB_SEARCH_TOOLS = {"search_web", "web_search"}
-_READING_TOOLS = {"read_document", "web_read"}
+_READING_TOOLS = {
+    "read_document",
+    "read_document_outline",
+    "read_document_section",
+    "read_document_chunk",
+    "get_collection_metadata",
+    "get_document_metadata",
+    "web_read",
+}
 
 
 def _normalize_activity_text(value: Any, *, max_length: int = 160) -> Optional[str]:

--- a/aperag/domains/retrieval/schemas.py
+++ b/aperag/domains/retrieval/schemas.py
@@ -71,6 +71,18 @@ class SearchResultMetadata(BaseModel):
     title: Optional[str] = Field(None, description="Human-readable title when available")
     collection_id: Optional[str] = Field(None, description="Collection identifier for client follow-up actions")
     document_id: Optional[str] = Field(None, description="Document identifier for client follow-up actions")
+    chunk_id: Optional[str] = Field(
+        None,
+        description="Indexing-layer chunk identifier for follow-up `read_document_chunk` calls (D10 §A.9 R1 LOCKED handle).",
+    )
+    section_path: Optional[str] = Field(
+        None,
+        description="Slash-separated section path for follow-up `read_document_section` calls (D10 §A.9 R1 LOCKED handle).",
+    )
+    heading_anchor: Optional[str] = Field(
+        None,
+        description="Slug-style heading anchor (e.g. '#chapter-2-implementation') alternative to section_path (D10 §A.9 R1 LOCKED handle).",
+    )
     asset_id: Optional[str] = Field(None, description="Asset identifier for image or binary references")
     mimetype: Optional[str] = Field(None, description="Asset MIME type when the result references an asset")
     page_idx: Optional[int] = Field(None, description="Zero-based page index when available")
@@ -104,6 +116,9 @@ class SearchResultMetadata(BaseModel):
             "title": public_str("title"),
             "collection_id": public_str("collection_id"),
             "document_id": public_str("document_id"),
+            "chunk_id": public_str("chunk_id"),
+            "section_path": public_str("section_path"),
+            "heading_anchor": public_str("heading_anchor"),
             "asset_id": public_str("asset_id"),
             "mimetype": public_str("mimetype"),
             "page_idx": page_idx,

--- a/aperag/mcp/cursor/invariants.py
+++ b/aperag/mcp/cursor/invariants.py
@@ -29,10 +29,9 @@ to remain valid:
   against; reindex bumps the id and any cursor with a stale hash
   fails ``cursor_index_changed``.
 
-The function is intentionally insulated from §C error code naming
-(pending architect canonical lock per msg=441c5e56): callers
-compute the hash here and compare; the *response* mapping into
-``cursor_filter_mismatch`` / ``cursor_tenant_mismatch`` /
+The function is intentionally insulated from §C error code naming:
+callers compute the hash here and compare; the *response* mapping
+into ``cursor_filter_mismatch`` / ``cursor_tenant_mismatch`` /
 ``cursor_index_changed`` lives in ``aperag.mcp.cursor.errors``.
 """
 

--- a/aperag/mcp/server.py
+++ b/aperag/mcp/server.py
@@ -21,7 +21,6 @@ from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_http_headers
 
 # Import view models for type safety
-from aperag.domains.retrieval.schemas import SearchResult
 from aperag.domains.web_access.schemas import WebReadResponse
 from aperag.mcp.capabilities import ToolAnnotation
 from aperag.mcp.tools import (
@@ -290,305 +289,13 @@ async def read_document_chunk(
 
 
 # === end D10.c read primitives ===
-
-
-@mcp_server.tool
-async def search_collection(
-    collection_id: str,
-    query: str,
-    use_vector_index: bool = True,
-    use_fulltext_index: bool = True,
-    use_graph_index: bool = True,
-    use_summary_index: bool = True,
-    use_vision_index: bool = True,
-    rerank: bool = True,
-    topk: int = 5,
-    query_keywords: list[str] = None,
-) -> Dict[str, Any]:
-    """[DEPRECATED] Search a persistent knowledge base for evidence relevant to the current request.
-
-    [DEPRECATED] Phase 9 D10.d (#96, ``docs/modularization/d10-design-pack.md``
-    §B.5 / §H.1): use the discrete split tools instead —
-    ``vector_search`` / ``graph_search`` / ``fulltext_search``. This
-    omnibus tool is preserved as a deprecated alias for backward
-    compatibility during the D10 migration window and will be removed in
-    D11 once telemetry confirms no remaining external callers (D10.h
-    cutover lane). Implementation is intentionally untouched.
-
-    Use this when:
-    - You already know which collection should be searched.
-    - The user asks a knowledge question that should be answered from indexed documents.
-
-    Do not use this when:
-    - The target files were uploaded only in the current chat; use search_chat_files instead.
-    - No collection has been selected or discovered yet.
-
-    What success means:
-    - You retrieved candidate evidence from the chosen collection.
-
-    What an empty result means:
-    - This collection did not return strong evidence for the current query.
-    - It does not prove the answer is false; it means this source did not support the step.
-
-    What failure may mean:
-    - auth / permission: the current user cannot access this collection.
-    - network / timeout: the search path did not complete.
-    - bad request: the collection ID or search config is invalid.
-
-    How to explain this step to the user:
-    - While running: "Searching the selected knowledge base for evidence about the request."
-    - After completion: "Reviewed results from the selected knowledge base."
-
-    Args:
-        collection_id: The ID of the collection to search in
-        query: The search query
-        query_keywords: The keywords extracted from query to use for fulltext search (optional), only effective when use_fulltext_index is True.
-        use_vector_index: Whether to use vector/semantic search (default: True)
-        use_fulltext_index: Whether to use full-text keyword search (default: True)
-        use_graph_index: Whether to use knowledge graph search (default: True)
-        use_summary_index: Whether to use summary search (default: True)
-        use_vision_index: Whether to use vision search (default: True)
-        rerank: Whether to enable reranking of search results for better relevance (default: True)
-        topk: Maximum number of results to return per search type (default: 5)
-
-    Returns:
-        Search results with relevant documents and metadata (SearchResult format)
-
-    Note:
-        Uses SearchResult view model for type-safe response parsing and validation.
-
-        ```
-        class SearchResultItem(BaseModel):
-            rank: Optional[int] = Field(None, description='Result rank')
-            score: Optional[float] = Field(None, description='Result score')
-            content: Optional[str] = Field(None, description='Result content')
-            source: Optional[str] = Field(None, description='Source document or metadata')
-            recall_type: Optional[
-                Literal['vector_search', 'graph_search', 'fulltext_search', 'summary_search']
-            ] = Field(None, description='Recall type')
-            metadata: Optional[dict[str, Any]] = Field(
-                None, description='Metadata of the result'
-            )
-
-
-        class SearchResult(BaseModel):
-            id: Optional[str] = Field(None, description='The id of the search result')
-            query: Optional[str] = None
-            vector_search: Optional[VectorSearchParams] = None
-            fulltext_search: Optional[FulltextSearchParams] = None
-            graph_search: Optional[GraphSearchParams] = None
-            summary_search: Optional[SummarySearchParams] = None
-            vision_search: Optional[VisionSearchParams] = None
-            items: Optional[list[SearchResultItem]] = None
-            created: Optional[datetime] = Field(
-                None, description='The creation time of the search result'
-            )
-        ```
-
-        The `result.items[x].metadata["page_idx"]` field indicates that the item's content is from page `page_idx` of the document (`metadata["source"]`). Note that `page_idx` is 0-indexed.
-
-        Vector search results may include images. Images are indexed in two ways:
-        1.  A multimodal embedding model converts the image into a vector. Since text and images share the same vector space, you can use text for semantic search.
-        2.  A Vision LLM generates a text description of the image, which is then converted into a vector by a text embedding model. This also enables retrieval based on vector similarity.
-
-        If `result.items[x].metadata["indexer"]` is "vision", the item is an image.
-        - If `item.content` is empty, the image was retrieved via multimodal embedding.
-        - If `item.content` is not empty, it contains a visual description of the image.
-
-        Although the LLM's Tool message interface doesn't support direct image input (meaning you can't "see" the images, even as a vision model), you can use `item.content` to understand the image and answer questions.
-        If you reference an image in your response, include its URL so the user can see it and understand your reasoning.
-
-        If your final output is in Markdown, you can display the image using an image block, like `![](<asset_url>)`. Here's how to construct the `asset_url` in Python pseudo-code:
-
-        ```python
-        m = result.items[0].metadata
-        if m.get("asset_id") and m.get("document_id") and m.get("collection_id") and m.get("mimetype"):
-            asset_url = f"asset://{m['asset_id']}?document_id={m['document_id']}&collection_id={m['collection_id']}&mime_type={m['mimetype']}"
-        ```
-
-        The `asset_url` uses a special `asset://` scheme instead of `http/https`. This helps the front-end parse and handle it. It uses `asset_id` as the path and passes `document_id`, `collection_id`, and `mimetype` as query parameters. Note that `asset_id`, `document_id`, and `collection_id` are required to display the image and must not be omitted.
-    """
-    try:
-        api_key = get_api_key()
-
-        # Build search request based on enabled search types
-        search_data = {"query": query, "rerank": rerank}
-
-        # Add search configurations for enabled types
-        if use_vector_index:
-            search_data["vector_search"] = {"topk": topk, "similarity": 0.2}
-
-        if use_fulltext_index:
-            search_data["fulltext_search"] = {"topk": topk, "keywords": query_keywords}
-
-        if use_graph_index:
-            search_data["graph_search"] = {"topk": topk}
-
-        if use_summary_index:
-            search_data["summary_search"] = {"topk": topk, "similarity": 0.2}
-
-        if use_vision_index:
-            search_data["vision_search"] = {"topk": topk, "similarity": 0.2}
-
-        # Ensure at least one search type is enabled
-        if not any([use_vector_index, use_fulltext_index, use_graph_index, use_summary_index]):
-            return {"error": "At least one search type must be enabled"}
-
-        # Use longer timeout for search operations (graph search can be time-consuming)
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.post(
-                f"{API_BASE_URL}/api/v2/collections/{collection_id}/searches",
-                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-                json=search_data,
-            )
-            if response.status_code == 200 or response.status_code == 201:
-                try:
-                    # Parse response using view model for type safety
-                    search_result = SearchResult.model_validate(response.json())
-
-                    # Ensure returned results don't exceed topk limit
-                    # This provides additional protection in case HTTP API doesn't apply global limit
-                    if search_result.items and len(search_result.items) > topk:
-                        search_result.items = search_result.items[:topk]
-                        # Update ranks if they exist
-                        for i, item in enumerate(search_result.items):
-                            if item.rank is not None:
-                                item.rank = i + 1
-
-                    return search_result.model_dump()
-                except Exception as e:
-                    logger.error(f"Failed to parse search response: {e}")
-                    return {"error": "Failed to parse search response", "details": str(e)}
-            else:
-                return {"error": f"Search failed: {response.status_code}", "details": response.text}
-    except ValueError as e:
-        return {"error": str(e)}
-
-
-@mcp_server.tool
-async def search_chat_files(
-    chat_id: str,
-    query: str,
-    use_vector_index: bool = True,
-    use_fulltext_index: bool = True,
-    rerank: bool = True,
-    topk: int = 5,
-) -> Dict[str, Any]:
-    """[DEPRECATED] Search files uploaded in the current chat for evidence relevant to this turn.
-
-    [DEPRECATED] Phase 9 D10.d (#96, ``docs/modularization/d10-design-pack.md``
-    §H.2): chat-scoped omnibus search shares the deprecation timeline of
-    ``search_collection``. The split tool surface (``vector_search`` /
-    ``graph_search`` / ``fulltext_search``) is collection-scoped today;
-    a chat-scoped equivalent will be sequenced in the D10.h cutover
-    lane. Implementation is intentionally untouched.
-
-    Use this when:
-    - The user refers to files shared in this chat session.
-    - You need evidence from temporary, chat-scoped documents.
-
-    Do not use this when:
-    - You are searching a persistent knowledge base; use search_collection instead.
-    - No files were uploaded in the current chat.
-
-    What success means:
-    - You found candidate evidence inside the current chat's uploaded files.
-
-    What an empty result means:
-    - The uploaded files did not return useful evidence for this query.
-    - It does not automatically mean the files are unreadable or the system failed.
-
-    What failure may mean:
-    - auth / permission: the current request cannot access this chat's files.
-    - network / timeout: the search path did not complete.
-
-    How to explain this step to the user:
-    - While running: "Searching files uploaded in this chat."
-    - After completion: "Reviewed results from files uploaded in this chat."
-
-    Args:
-        chat_id: The ID of the chat to search files in
-        query: The search query
-        use_vector_index: Whether to use vector/semantic search (default: True)
-        use_fulltext_index: Whether to use full-text keyword search (default: True)
-        rerank: Whether to enable reranking of search results for better relevance (default: True)
-        topk: Maximum number of results to return per search type (default: 5)
-
-    Returns:
-        Search results with relevant documents and metadata (SearchResult format)
-
-    Note:
-        Uses SearchResult view model for type-safe response parsing and validation.
-
-        SCOPE: This tool ONLY searches temporary files uploaded in the current chat.
-        It does NOT search permanent knowledge collections.
-
-        Return format follows the same structure as search_collection:
-        - rank: Result rank
-        - score: Result score
-        - content: Result content
-        - source: Source document or metadata
-        - recall_type: Type of search that found this result
-        - metadata: Additional metadata including page_idx, asset_id, etc.
-
-        Images are handled the same way as in collection search:
-        - metadata["indexer"] == "vision" indicates an image
-        - Use asset:// URLs for displaying images in markdown
-    """
-    try:
-        api_key = get_api_key()
-
-        # Build search request based on enabled search types
-        search_data = {"query": query, "rerank": rerank}
-
-        # Add search configurations for enabled types
-        if use_vector_index:
-            search_data["vector_search"] = {"topk": topk, "similarity": 0.2}
-
-        if use_fulltext_index:
-            search_data["fulltext_search"] = {"topk": topk}
-
-        # Ensure at least one search type is enabled
-        if not any([use_vector_index, use_fulltext_index]):
-            return {"error": "At least one search type must be enabled"}
-
-        # Use longer timeout for search operations
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            response = await client.post(
-                f"{API_BASE_URL}/api/v2/chats/{chat_id}/search",
-                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-                json=search_data,
-            )
-            if response.status_code == 200 or response.status_code == 201:
-                try:
-                    # Parse response using view model for type safety
-                    search_result = SearchResult.model_validate(response.json())
-
-                    # Ensure returned results don't exceed topk limit
-                    # This provides additional protection in case HTTP API doesn't apply global limit
-                    if search_result.items and len(search_result.items) > topk:
-                        search_result.items = search_result.items[:topk]
-                        # Update ranks if they exist
-                        for i, item in enumerate(search_result.items):
-                            if item.rank is not None:
-                                item.rank = i + 1
-
-                    return search_result.model_dump()
-                except Exception as e:
-                    logger.error(f"Failed to parse chat search response: {e}")
-                    return {"error": "Failed to parse chat search response", "details": str(e)}
-            else:
-                return {"error": f"Chat search failed: {response.status_code}", "details": response.text}
-    except ValueError as e:
-        return {"error": str(e)}
-
-
-# NOTE(D10.d #96 §B.4): the ``web_search`` tool implementation moved to
-# ``aperag.mcp.tools.search_web`` so all D10 search tools live in the
-# ``aperag/mcp/tools/`` subpackage. Wire signature is preserved (no
-# breaking change for external MCP callers); §B.4 spec parameter
-# canonicalization (``top_k`` / kw-only / ``source: str | None``) is
-# deferred to the D10.h cutover lane.
+# D10 search tools (vector_search / graph_search / fulltext_search /
+# web_search) live in ``aperag.mcp.tools.search_*`` per D10.d #96. The
+# legacy ``search_collection`` / ``search_chat_files`` omnibus tools
+# were removed in D10.h #100 — callers must compose the split tools
+# directly. ``web_search`` parameter canonicalization (`query`
+# required, kw-only, ``top_k``, ``source: str | None``) was applied
+# in the same cutover.
 
 
 @mcp_server.tool
@@ -696,176 +403,58 @@ async def aperag_usage_guide() -> str:
     return """
 # ApeRAG Search Guide
 
-ApeRAG provides powerful knowledge search capabilities across your collections.
+ApeRAG exposes the canonical D10 MCP tool surface (per
+``docs/modularization/d10-design-pack.md``):
 
-## Available Operations:
-1. **list_collections**: Get all available collections with essential information (ID, title, description)
-2. **search_collection**: Search within collections using multiple search methods
-3. **web_search**: Perform web search using various search engines (Google, DuckDuckGo, Bing)
-4. **web_read**: Read and extract content from web pages
+## Read primitives (D10.c §A)
+- ``list_collections`` / ``list_documents`` — paginated metadata
+- ``get_collection_metadata`` / ``get_document_metadata``
+- ``read_document`` / ``read_document_outline``
+- ``read_document_section`` / ``read_document_chunk``
 
-## Authentication:
-API authentication is handled automatically through one of these methods:
-1. **HTTP Authorization header**: `Authorization: Bearer your-api-key` (when using HTTP transport)
-2. **Environment variable**: `APERAG_API_KEY=your-api-key` (fallback method)
+## Search primitives (D10.d §B)
+- ``vector_search`` — semantic similarity over collection embeddings
+- ``graph_search`` — knowledge-graph-derived evidence
+- ``fulltext_search`` — keyword / full-text hits
+- ``web_search`` — public-internet search (independent of collections)
 
-The server will automatically try both methods in order of preference.
+The legacy ``search_collection`` / ``search_chat_files`` omnibus
+tools were removed in D10.h #100; callers compose the split tools
+directly. Pagination is opaque cursor (D10.e §C); see ``next_cursor``
+on the paginated read primitives.
 
-## Quick Start:
-1. First, get available collections with essential information: `list_collections()`
-2. Choose a collection from the list
-3. Search the collection: `search_collection(collection_id="abc123", query="your question")`
-   (By default, vector search, graph search, and reranking are enabled for optimal performance)
+## Authentication
+- HTTP transport: ``Authorization: Bearer <api-key>``
+- stdio fallback: ``APERAG_API_KEY`` environment variable
 
-## Search Types:
-You can enable/disable any combination of search methods:
-- **Vector search** (use_vector_index): Semantic similarity search using embeddings (default: True)
-- **Full-text search** (use_fulltext_index): Traditional keyword-based text search (default: True)
-- **Graph search** (use_graph_index): Knowledge graph-based search (default: True)
-- **Summary search** (use_summary_index): Search through document summaries (default: True)
-- **Reranking** (rerank): AI-powered reranking for improved result relevance (default: True)
-
-⚠️ **Important**: Full-text search can return large amounts of text content which may cause context window overflow with smaller LLM models. Use with caution and consider reducing topk when enabling fulltext search.
-
-By default, vector search, full-text search, graph search, summary search, and reranking are enabled for comprehensive search coverage.
-
-## Example Workflow:
+## Quick start
 ```
-# Step 1: Get collections with essential information
 collections = list_collections()
-
-# Step 2: Choose a collection from the list
-# (collections.items contains collection ID, title, and description)
 collection_id = collections.items[0].id
 
-# Step 3: Search with default methods (vector + fulltext + graph + summary + rerank)
-results = search_collection(
-    collection_id=collection_id,
-    query="How to deploy applications?",
-    use_vector_index=True,
-    use_fulltext_index=True,
-    use_graph_index=True,
-    use_summary_index=True,
-    rerank=True,
-    topk=5
-)
+# Pick the right primitive for your question:
+hits = vector_search(collection_id=collection_id, query="deploy app")
+graph = graph_search(collection_id=collection_id, query="deploy app")
+fts = fulltext_search(collection_id=collection_id, query="deploy app")
 
-# Or search with only specific methods
-vector_only = search_collection(
-    collection_id=collection_id,
-    query="deployment strategies",
-    use_vector_index=True,
-    use_fulltext_index=False,
-    use_graph_index=False,
-    rerank=True,  # Rerank still enabled for better results
-    topk=10
-)
-
-# Enable summary search for high-level document overviews
-summary_search = search_collection(
-    collection_id=collection_id,
-    query="project overview",
-    use_vector_index=True,
-    use_fulltext_index=True,
-    use_graph_index=True,
-    use_summary_index=True,  # Enable summary search
-    rerank=True,
-    topk=5
+# Pull the raw evidence for the top hit:
+chunk = read_document_chunk(
+    collection_id=hits.items[0].metadata.collection_id,
+    document_id=hits.items[0].metadata.document_id,
+    chunk_id=hits.items[0].metadata.chunk_id,
 )
 ```
 
-Your search results will include relevant documents with context, similarity scores, and metadata.
-
-## Web Search and Content Reading:
-You can also search the web and extract content from web pages:
-
-### Web Search Example:
+## Web search + content read
 ```
-# Basic web search
-web_results = web_search(
-    query="ApeRAG RAG system 2025",
-    max_results=5,
-    locale="zh-CN"
-)
-
-# Site-specific regular search
-site_results = web_search(
-    query="deployment documentation",
-    source="vercel.com",  # limit search to vercel.com domain
-    max_results=10
-)
-
-# Search results include URLs, titles, snippets, and domains
-for result in web_results.results:
-    print(f"Title: {result.title}")
-    print(f"URL: {result.url}")
-    print(f"Snippet: {result.snippet}")
-    print(f"Domain: {result.domain}")
+results = web_search(query="ApeRAG 2025", top_k=5, locale="zh-CN")
+content = web_read(url_list=[r.url for r in results.results])
 ```
 
-### Web Content Reading Example:
-```
-# Read content from web pages (single URL - use array with one element)
-content = web_read(
-    url_list=["https://example.com/article"],  # single URL in array
-    timeout=30
-)
-
-# Read from multiple URLs
-content = web_read(
-    url_list=["https://example.com/page1", "https://example.com/page2"],  # multiple URLs
-    max_concurrent=2
-)
-
-# Content includes extracted text, titles, word counts
-for result in content.results:
-    if result.status == "success":
-        print(f"Title: {result.title}")
-        print(f"Content: {result.content}")
-        print(f"Word Count: {result.word_count}")
-```
-
-### Combined Workflow Example:
-```
-# 1. Search web for recent information
-web_results = web_search(
-    query="latest AI developments 2025",
-    source="anthropic.com",  # limit regular search to Anthropic's content
-    max_results=3
-)
-
-# 2. Extract URLs from search results
-urls = [result.url for result in web_results.results]
-
-# 3. Read full content from those pages
-web_content = web_read(url_list=urls, max_concurrent=2)
-
-# 4. Search your internal knowledge base for related information
-collections = list_collections()
-if collections.items:
-    internal_results = search_collection(
-        collection_id=collections.items[0].id,
-        query="AI developments",
-        rerank=True,  # Default rerank for better results
-        topk=5
-    )
-
-# 5. Combine results for comprehensive analysis
-print("=== Web Results ===")
-for result in web_results.results:
-    print(f"[{result.domain}] {result.title}: {result.url}")
-
-print("\n=== Web Content ===")
-for content in web_content.results:
-    if content.status == "success":
-        print(f"📄 {content.title} ({content.word_count} words)")
-
-print("\n=== Internal Knowledge ===")
-for item in internal_results.items:
-    print(f"🔍 {item.content[:100]}...")
-
-# Now you have both web and internal knowledge base results!
-```
+Each ``SearchResultItem`` carries ``chunk_id`` / ``section_path`` /
+``heading_anchor`` (D10.h Drift #1) so the caller can navigate
+straight from a search hit into the read primitives without an
+extra resolution step.
 """
 
 

--- a/aperag/mcp/tools/search_fulltext.py
+++ b/aperag/mcp/tools/search_fulltext.py
@@ -14,21 +14,22 @@
 
 """Phase 9 D10.d (#96) — fulltext_search split MCP tool (§B.3).
 
-Replaces ``search_collection use_fulltext_index=True`` with a discrete
-tool per ``docs/modularization/d10-design-pack.md`` §B.3 (Lock #5
-split). ``search_collection`` itself remains as a deprecated alias
-(§B.5 / §H.1) until the D10.h cutover.
+The discrete keyword / full-text search primitive per
+``docs/modularization/d10-design-pack.md`` §B.3 (Lock #5 split). The
+omnibus ``search_collection`` was hard-cut in D10.h #100, so this
+file is now the only public entry point for full-text recall.
 
 Wire shape: returns the existing ``SearchResult`` dict shape with
-``recall_type = "fulltext_search"`` for produced items. §B canonical
-shape follow-up settled by the ``[D10 spec amendment]`` thread
-(msg=b9b7072a) — defer canonical SearchResultItem to D10.h cutover.
+``recall_type = "fulltext_search"`` for produced items. The retrieval
+``SearchResultMetadata`` allowlist now exposes ``chunk_id`` /
+``section_path`` / ``heading_anchor`` so callers can chain into the
+read primitives.
 
-The ``cursor`` parameter is a placeholder per the same thread (Drift
-#4 (c)): signature lands now, body raises ``NotImplementedError``
-on any non-empty value until real search pagination ships.
-``None`` and ``""`` both preserve single-page ``top_k`` behavior per
-the Weston blocker review (msg=177a1dd8).
+The ``cursor`` parameter is a placeholder: the signature lands now
+so external clients see the canonical shape, but the body raises
+``NotImplementedError`` on any non-empty value until real search
+pagination ships. ``None`` and ``""`` both preserve single-page
+``top_k`` behavior.
 """
 
 from __future__ import annotations

--- a/aperag/mcp/tools/search_graph.py
+++ b/aperag/mcp/tools/search_graph.py
@@ -14,21 +14,22 @@
 
 """Phase 9 D10.d (#96) — graph_search split MCP tool (§B.2).
 
-Replaces ``search_collection use_graph_index=True`` with a discrete tool
-per ``docs/modularization/d10-design-pack.md`` §B.2 (Lock #5 split).
-``search_collection`` itself remains as a deprecated alias (§B.5 / §H.1)
-until the D10.h cutover.
+The discrete knowledge-graph search primitive per
+``docs/modularization/d10-design-pack.md`` §B.2 (Lock #5 split). The
+omnibus ``search_collection`` was hard-cut in D10.h #100, so this
+file is now the only public entry point for graph recall.
 
 Wire shape: returns the existing ``SearchResult`` dict shape with
-``recall_type = "graph_search"`` for produced items. §B canonical
-shape follow-up settled by the ``[D10 spec amendment]`` thread
-(msg=b9b7072a) — defer canonical SearchResultItem to D10.h cutover.
+``recall_type = "graph_search"`` for produced items. The retrieval
+``SearchResultMetadata`` allowlist now exposes ``chunk_id`` /
+``section_path`` / ``heading_anchor`` so callers can chain into the
+read primitives.
 
-The ``cursor`` parameter is a placeholder per the same thread (Drift
-#4 (c)): signature lands now, body raises ``NotImplementedError``
-on any non-empty value until real search pagination ships.
-``None`` and ``""`` both preserve single-page ``top_k`` behavior per
-the Weston blocker review (msg=177a1dd8).
+The ``cursor`` parameter is a placeholder: the signature lands now
+so external clients see the canonical shape, but the body raises
+``NotImplementedError`` on any non-empty value until real search
+pagination ships. ``None`` and ``""`` both preserve single-page
+``top_k`` behavior.
 """
 
 from __future__ import annotations

--- a/aperag/mcp/tools/search_vector.py
+++ b/aperag/mcp/tools/search_vector.py
@@ -14,20 +14,18 @@
 
 """Phase 9 D10.d (#96) — vector_search split MCP tool (§B.1).
 
-Replaces ``search_collection use_vector_index=True`` with a discrete tool
-per ``docs/modularization/d10-design-pack.md`` §B.1 (Lock #5 split).
-``search_collection`` itself remains as a deprecated alias (§B.5 / §H.1)
-until the D10.h cutover.
+The discrete vector-similarity search primitive per
+``docs/modularization/d10-design-pack.md`` §B.1 (Lock #5 split). The
+omnibus ``search_collection`` was hard-cut in D10.h #100, so this
+file is now the only public entry point for vector recall.
 
 Wire shape: returns the existing ``SearchResult`` dict shape from the
 ``aperag/api/v2/collections/{id}/searches`` backend (``recall_type =
-"vector_search"`` for produced items). The §B canonical
-``SearchResult`` / ``SearchResultItem`` with ``chunk_id`` /
-``section_path`` / ``heading_anchor`` exposure was settled by the
-``[D10 spec amendment]`` thread (msg=b9b7072a) — Drift #1 resolution
-(c): defer the canonical shape to the D10.h cutover lane (one-shot
-``aperag/domains/retrieval/`` upgrade) so this lane stays focused on
-the split surface + omnibus deprecation.
+"vector_search"`` for produced items). The retrieval-domain
+``SearchResultMetadata`` allowlist gained ``chunk_id`` /
+``section_path`` / ``heading_anchor`` in the same D10.h lane so the
+caller can navigate from a search hit straight into the read
+primitives.
 
 The ``cursor`` parameter is a placeholder per the same amendment
 thread (Drift #4 resolution (c)): the signature is published now so

--- a/aperag/mcp/tools/search_web.py
+++ b/aperag/mcp/tools/search_web.py
@@ -12,26 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Phase 9 D10.d (#96) — web_search split MCP tool (§B.4).
+"""Phase 9 D10.d (#96) + D10.h (#100) — web_search split MCP tool (§B.4).
 
 Per ``docs/modularization/d10-design-pack.md`` §B.4: ``web_search``
 remains an independent tool (it does not need ``collection_id`` and
 its tenancy gate is per-user provider key, not collection access). This
 module relocates the existing ``web_search`` implementation from
 ``aperag/mcp/server.py`` into the ``aperag/mcp/tools/`` subpackage so
-all D10 search tools live in one place; the wire signature is preserved
-to avoid breaking external MCP clients (Claude Code / Codex / Cursor).
+all D10 search tools live in one place.
 
-§B.4 spec proposes a slightly different signature
-(``top_k`` keyword-only / ``source: str | None``); aligning the tool to
-the spec parameter names is a wire-breaking change for existing
-external callers and is therefore deferred to the D10.h cutover lane.
+D10.h (#100) applies the §B.4 parameter canonicalization that #96
+deferred — ``query`` is required, every other parameter is keyword-
+only, the result-count limit is named ``top_k`` (not
+``max_results``), and ``source`` is ``str | None`` so a missing
+domain filter is null rather than the empty string. The internal
+``aperag/domains/web_access`` backend still names its payload field
+``max_results``; the tool wrapper translates ``top_k`` to that field
+on the wire to keep the backend rename out of this lane.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -55,11 +58,12 @@ logger = logging.getLogger(__name__)
     ),
 )
 async def web_search(
-    query: str = "",
-    max_results: int = 5,
+    query: str,
+    *,
+    top_k: int = 5,
     timeout: int = 30,
     locale: str = "en-US",
-    source: str = "",
+    source: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Search the web for current or missing information (§B.4).
 
@@ -91,14 +95,12 @@ async def web_search(
     - After completion: "Checked web sources for supporting information."
 
     Args:
-        query: Search query for web search. Optional when using
-            source-only site browsing.
-        max_results: Maximum number of results to return (default: 5).
+        query: Search query for web search (required).
+        top_k: Maximum number of results to return (default: 5).
         timeout: Request timeout in seconds (default: 30).
         locale: Browser locale (default: ``"en-US"``).
-        source: Optional domain or URL for site-specific filtering. When
-            provided with query, limits search results to this domain
-            (e.g., ``"site:vercel.com query"``).
+        source: Optional domain or URL for site-specific filtering;
+            ``None`` means no domain restriction (default: ``None``).
 
     Returns:
         Web search results with URLs, titles, snippets, and metadata.
@@ -110,28 +112,30 @@ async def web_search(
         workflows stay stable while still distinguishing ``ok`` /
         ``empty`` / ``unavailable`` / ``disabled``.
     """
+    query = query.strip()
+    if not query:
+        raise ValueError("web_search requires a non-empty query")
+    source_value = source.strip() if source else None
     try:
         api_key = get_api_key()
         logger.info(
-            "MCP web_search request query=%s source=%s max_results=%s timeout=%s locale=%s",
-            query.strip() if query else "",
-            source.strip() if source else "",
-            max_results,
+            "MCP web_search request query=%s source=%s top_k=%s timeout=%s locale=%s",
+            query,
+            source_value or "",
+            top_k,
             timeout,
             locale,
         )
 
         search_data: Dict[str, Any] = {
-            "max_results": max_results,
+            "query": query,
+            "max_results": top_k,
             "timeout": timeout,
             "locale": locale,
         }
 
-        if query and query.strip():
-            search_data["query"] = query.strip()
-
-        if source and source.strip():
-            search_data["source"] = source.strip()
+        if source_value:
+            search_data["source"] = source_value
 
         async with httpx.AsyncClient(timeout=90.0) as client:
             response = await client.post(

--- a/tests/e2e_http/hurl/full/22_d10_read_primitives.hurl
+++ b/tests/e2e_http/hurl/full/22_d10_read_primitives.hurl
@@ -47,6 +47,7 @@ Accept: application/json, text/event-stream
   "params": {}
 }
 HTTP 200
+[Asserts]
 
 # §A.1 list_collections inputSchema markers — paginated read primitive.
 body contains "\"list_collections\""

--- a/tests/e2e_http/hurl/full/22_d10_read_primitives.hurl
+++ b/tests/e2e_http/hurl/full/22_d10_read_primitives.hurl
@@ -1,0 +1,80 @@
+# Phase 9 D10.h (#100) — D10.c §A read primitive surface contract.
+#
+# Per ``docs/modularization/d10-design-pack.md`` §A, the canonical
+# read primitive tool names + parameter names form the wire contract
+# every external Agent (Claude Code / Codex / Cursor) must see on
+# ``tools/list``. This hurl pins the parameter shape so a future
+# rename / removal / reorder fails CI loudly before merge.
+#
+# The wire is JSON-RPC framed inside an SSE event, so the assertions
+# use substring (``contains``) rather than jsonpath (which would skip
+# the SSE envelope). The unit suite covers full Pydantic round-trip;
+# this file is the cutover-time wire pin.
+
+POST {{base_url}}/api/v2/auth/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "d10-read-primitives-hurl",
+      "version": "1.0.0"
+    }
+  }
+}
+HTTP 200
+
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list",
+  "params": {}
+}
+HTTP 200
+
+# §A.1 list_collections inputSchema markers — paginated read primitive.
+body contains "\"list_collections\""
+body contains "\"cursor\""
+body contains "\"limit\""
+body contains "\"sort_by\""
+body contains "\"sort_order\""
+body contains "\"title_filter\""
+
+# §A.2 list_documents inputSchema markers — collection-scoped paginated.
+body contains "\"list_documents\""
+body contains "\"collection_id\""
+body contains "\"type_filter\""
+body contains "\"indexed_only\""
+
+# §A.5 read_document range parameters — best-effort byte range, optional.
+body contains "\"read_document\""
+body contains "\"range_start\""
+body contains "\"range_end\""
+
+# §A.7 read_document_section path/anchor handles — stable handles per §A.9.
+body contains "\"read_document_section\""
+
+# §A.8 read_document_chunk — chunk_id stable handle per §A.9 + §E.6.
+body contains "\"read_document_chunk\""
+body contains "\"chunk_id\""
+
+# §A.6 outline + §A.3/§A.4 metadata helpers all on the wire.
+body contains "\"read_document_outline\""
+body contains "\"get_collection_metadata\""
+body contains "\"get_document_metadata\""

--- a/tests/e2e_http/hurl/full/23_d10_pagination.hurl
+++ b/tests/e2e_http/hurl/full/23_d10_pagination.hurl
@@ -1,0 +1,67 @@
+# Phase 9 D10.h (#100) — D10.e §C cursor pagination wire contract.
+#
+# Per ``docs/modularization/d10-design-pack.md`` §C the paginated
+# read primitives (list_collections / list_documents) accept a
+# ``cursor`` parameter and return ``next_cursor`` / ``total_count``
+# alongside ``items``. The cursor codec lives in
+# ``aperag/mcp/cursor`` (#1712) and the wiring helper is in
+# ``aperag/service/pagination`` (#1715); this hurl pins their shape
+# on the MCP wire.
+#
+# Body is JSON-RPC framed inside SSE, so we use substring assertions
+# (mirrors 21_d10_capabilities and 22_d10_read_primitives).
+
+POST {{base_url}}/api/v2/auth/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "d10-pagination-hurl",
+      "version": "1.0.0"
+    }
+  }
+}
+HTTP 200
+
+# tools/list — assert the cursor wiring is exposed on every
+# paginated tool's inputSchema, and the result envelope is
+# discoverable via outputSchema (FastMCP includes ``returns`` /
+# ``outputSchema`` on registered tools).
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list",
+  "params": {}
+}
+HTTP 200
+
+# §C.5 PaginationParams input markers — cursor + limit on every
+# paginated read primitive.
+body contains "\"list_collections\""
+body contains "\"list_documents\""
+body contains "\"cursor\""
+body contains "\"limit\""
+
+# §C.5 PaginationResult output markers — items / next_cursor /
+# total_count on every paginated tool's outputSchema. FastMCP emits
+# the Pydantic model JSON schema, so the field names round-trip.
+body contains "\"items\""
+body contains "\"next_cursor\""
+body contains "\"total_count\""

--- a/tests/e2e_http/hurl/full/23_d10_pagination.hurl
+++ b/tests/e2e_http/hurl/full/23_d10_pagination.hurl
@@ -51,6 +51,7 @@ Accept: application/json, text/event-stream
   "params": {}
 }
 HTTP 200
+[Asserts]
 
 # §C.5 PaginationParams input markers — cursor + limit on every
 # paginated read primitive.

--- a/tests/e2e_http/hurl/full/23_d10_pagination.hurl
+++ b/tests/e2e_http/hurl/full/23_d10_pagination.hurl
@@ -54,15 +54,16 @@ HTTP 200
 [Asserts]
 
 # §C.5 PaginationParams input markers — cursor + limit on every
-# paginated read primitive.
+# paginated read primitive's ``inputSchema``. The MCP tool functions
+# in ``aperag/mcp/server.py`` are typed ``-> Dict[str, Any]`` so
+# FastMCP exposes only ``"outputSchema": {"additionalProperties":
+# true}`` — there is no on-wire pin for the
+# ``items / next_cursor / total_count`` envelope fields. Those are
+# pinned at the Pydantic schema level by
+# ``aperag/mcp/cursor/schemas.py`` and the cursor unit suite
+# (``tests/unit_test/mcp/test_cursor_contract.py`` +
+# ``tests/unit_test/service/test_pagination_helper.py``).
 body contains "\"list_collections\""
 body contains "\"list_documents\""
 body contains "\"cursor\""
 body contains "\"limit\""
-
-# §C.5 PaginationResult output markers — items / next_cursor /
-# total_count on every paginated tool's outputSchema. FastMCP emits
-# the Pydantic model JSON schema, so the field names round-trip.
-body contains "\"items\""
-body contains "\"next_cursor\""
-body contains "\"total_count\""

--- a/tests/e2e_http/hurl/full/24_d10_search_split.hurl
+++ b/tests/e2e_http/hurl/full/24_d10_search_split.hurl
@@ -48,6 +48,7 @@ Accept: application/json, text/event-stream
   "params": {}
 }
 HTTP 200
+[Asserts]
 
 # §B.1 / §B.2 / §B.3 collection-scoped split search inputSchema
 # markers — every tool keeps the per-tool ``query`` + collection

--- a/tests/e2e_http/hurl/full/24_d10_search_split.hurl
+++ b/tests/e2e_http/hurl/full/24_d10_search_split.hurl
@@ -66,14 +66,14 @@ body contains "\"web_search\""
 body contains "\"top_k\""
 body not contains "\"max_results\""
 
-# Drift #1 (amendment-#2): SearchResultItem.metadata gains the three
-# stable handles ``chunk_id`` / ``section_path`` / ``heading_anchor``
-# in this same lane. The retrieval-domain ``SearchResultMetadata``
-# Pydantic schema lands on the wire via FastMCP's outputSchema for
-# every search tool, so a substring contains is enough to pin the
-# field names. These assertions will fail until the retrieval
-# propagation block (architect-authored) is committed on this
-# branch — that is the intended cross-block gate.
-body contains "\"chunk_id\""
-body contains "\"section_path\""
-body contains "\"heading_anchor\""
+# Drift #1 (amendment-#2): SearchResultItem.metadata is meant to
+# expose the three stable handles ``chunk_id`` / ``section_path`` /
+# ``heading_anchor``. The MCP wire from FastMCP cannot prove that
+# here — the split-search tools return ``Dict[str, Any]`` so their
+# outputSchema is just ``additionalProperties: true`` and a substring
+# match against ``tools/list`` would be satisfied by unrelated read
+# primitive input schemas (Weston msg=8a691444 false-positive
+# warning). The Pydantic-level pin lives in the new
+# ``tests/unit_test/domains/retrieval/test_search_result_metadata.py``
+# alongside the schema change, which is the right level for this
+# guarantee.

--- a/tests/e2e_http/hurl/full/24_d10_search_split.hurl
+++ b/tests/e2e_http/hurl/full/24_d10_search_split.hurl
@@ -1,0 +1,79 @@
+# Phase 9 D10.h (#100) — D10.d §B split search surface contract.
+#
+# Per ``docs/modularization/d10-design-pack.md`` §B the omnibus
+# ``search_collection`` / ``search_chat_files`` tools were retired in
+# this lane; only the split surface (``vector_search`` /
+# ``graph_search`` / ``fulltext_search`` / ``web_search``) remains
+# on the MCP wire. ``web_search`` carries the §B.4 canonical
+# parameter names (``top_k`` / kw-only / ``source: str | None``)
+# applied in #100; the legacy ``max_results`` parameter must not
+# appear.
+#
+# Body is JSON-RPC framed inside SSE, so we use substring
+# assertions (mirrors 21 / 22 / 23).
+
+POST {{base_url}}/api/v2/auth/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "d10-search-split-hurl",
+      "version": "1.0.0"
+    }
+  }
+}
+HTTP 200
+
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list",
+  "params": {}
+}
+HTTP 200
+
+# §B.1 / §B.2 / §B.3 collection-scoped split search inputSchema
+# markers — every tool keeps the per-tool ``query`` + collection
+# scoping, and the cursor placeholder seam from #1717.
+body contains "\"vector_search\""
+body contains "\"graph_search\""
+body contains "\"fulltext_search\""
+body contains "\"query\""
+body contains "\"collection_id\""
+
+# §B.4 web_search canonical parameter set — D10.h #100 cutover
+# replaces ``max_results`` with ``top_k`` and switches ``source`` to
+# ``str | None``. The wire MUST carry ``top_k`` and MUST NOT carry
+# the legacy ``max_results``.
+body contains "\"web_search\""
+body contains "\"top_k\""
+body not contains "\"max_results\""
+
+# Drift #1 (amendment-#2): SearchResultItem.metadata gains the three
+# stable handles ``chunk_id`` / ``section_path`` / ``heading_anchor``
+# in this same lane. The retrieval-domain ``SearchResultMetadata``
+# Pydantic schema lands on the wire via FastMCP's outputSchema for
+# every search tool, so a substring contains is enough to pin the
+# field names. These assertions will fail until the retrieval
+# propagation block (architect-authored) is committed on this
+# branch — that is the intended cross-block gate.
+body contains "\"chunk_id\""
+body contains "\"section_path\""
+body contains "\"heading_anchor\""

--- a/tests/e2e_http/hurl/full/25_d10_cutover.hurl
+++ b/tests/e2e_http/hurl/full/25_d10_cutover.hurl
@@ -1,0 +1,78 @@
+# Phase 9 D10.h (#100) — legacy search tool cutover wire-shape contract.
+#
+# Per ``docs/modularization/d10-design-pack.md`` §H + amendment-#2
+# Drift #2/#3, D10.h hard-cuts the omnibus
+# ``search_collection`` / ``search_chat_files`` tools and keeps only
+# the canonical D10.c read + D10.d split-search surface. This hurl
+# pins the cutover on the wire so a future regression that
+# accidentally re-registers either legacy tool fails CI loudly.
+#
+# We use substring assertions on the SSE-framed JSON-RPC body for
+# the same reason 21_d10_capabilities.hurl does — the wire is
+# ``event: message\ndata: {...}`` and jsonpath against the unframed
+# JSON would skip the SSE envelope entirely.
+
+POST {{base_url}}/api/v2/auth/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+HTTP 200
+
+# 1. MCP initialize handshake — needed before tools/list will emit
+# any annotation metadata, even on a stateless mount.
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "d10-cutover-hurl",
+      "version": "1.0.0"
+    }
+  }
+}
+HTTP 200
+
+# 2. tools/list — the cutover assertion battery. Each canonical D10
+# tool name MUST still be present; the two legacy omnibus tools
+# MUST NOT be present.
+POST {{base_url}}/mcp/
+Content-Type: application/json
+Accept: application/json, text/event-stream
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list",
+  "params": {}
+}
+HTTP 200
+
+# Canonical surface still on the wire — these are the names a
+# post-cutover external Agent should discover.
+body contains "\"list_collections\""
+body contains "\"list_documents\""
+body contains "\"get_collection_metadata\""
+body contains "\"get_document_metadata\""
+body contains "\"read_document\""
+body contains "\"read_document_outline\""
+body contains "\"read_document_section\""
+body contains "\"read_document_chunk\""
+body contains "\"vector_search\""
+body contains "\"graph_search\""
+body contains "\"fulltext_search\""
+body contains "\"web_search\""
+body contains "\"web_read\""
+
+# Hard-cut guard — both legacy omnibus tools were removed in #100.
+# A future regression that accidentally re-registers either tool
+# (e.g., a copy/paste from history, a revert PR) will fail this
+# substring assertion and surface the issue in CI before merge.
+body not contains "\"search_collection\""
+body not contains "\"search_chat_files\""

--- a/tests/e2e_http/hurl/full/25_d10_cutover.hurl
+++ b/tests/e2e_http/hurl/full/25_d10_cutover.hurl
@@ -53,6 +53,7 @@ Accept: application/json, text/event-stream
   "params": {}
 }
 HTTP 200
+[Asserts]
 
 # Canonical surface still on the wire — these are the names a
 # post-cutover external Agent should discover.

--- a/tests/fixtures/mcp_agent.py
+++ b/tests/fixtures/mcp_agent.py
@@ -113,9 +113,16 @@ async def interactive_chat():
                 name="searcher",
                 instruction="""You are a knowledge searcher. Your job is to:
 1. List available collections using list_collections() when asked about collections
-2. Search relevant collections using search_collection() with appropriate parameters
-3. Use hybrid search method for best results (use_vector_index=true, use_fulltext_index=true, use_graph_index=true)
-4. Return search results with proper formatting and source attribution""",
+2. For each candidate collection, run the relevant D10 split-search tools
+   directly: vector_search() for semantic similarity, fulltext_search()
+   for keyword precision, and graph_search() for entity / relationship
+   recall. Compose multiple split tools when one mode is insufficient —
+   the legacy search_collection() omnibus is no longer available
+   post-D10.h cutover.
+3. Each search result item carries chunk_id / section_path /
+   heading_anchor on its metadata; use them with read_document_chunk()
+   or read_document_section() to fetch the underlying evidence.
+4. Return search results with proper formatting and source attribution.""",
                 server_names=["aperag"],
             )
 

--- a/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
+++ b/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
@@ -332,10 +332,14 @@ async def test_event_service_to_event_envelope_adds_user_activity_contract():
     event = _build_event(
         3,
         "tool.started",
-        label="search_collection",
+        label="vector_search",
         status="started",
         data={
-            "tool_name": "search_collection",
+            # Post D10.h cutover the omnibus ``search_collection`` is
+            # gone; ``_KNOWLEDGE_SEARCH_TOOLS`` (services.py) now keys
+            # off the canonical D10.d split tools, so the activity
+            # inference contract is exercised against ``vector_search``.
+            "tool_name": "vector_search",
             "args": {
                 "query": "OpenAI API key",
                 "collection_name": "Product Docs",

--- a/tests/unit_test/domains/retrieval/test_search_result_metadata.py
+++ b/tests/unit_test/domains/retrieval/test_search_result_metadata.py
@@ -1,0 +1,109 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""D10.h cutover (#100) — SearchResultMetadata chunk_id / section_path /
+heading_anchor exposure tests (per amendment-#2 Drift #1).
+
+Locks the retrieval-domain public allowlist:
+
+* The 3 D10 §A.9 stable handle fields are part of the
+  ``SearchResultMetadata`` Pydantic model (so callers can read them
+  off ``SearchResultItem.metadata``).
+* ``SearchResultMetadata.from_raw()`` extracts each of the 3 fields
+  from a raw upstream metadata dict.
+* The model still ``extra="forbid"``s unknown keys — adding the 3
+  fields does NOT relax the allowlist.
+
+These are static contract guards — wire propagation behavior is exercised
+in the search-pipeline tests + e2e hurl. The point of this file is to
+prevent a future refactor from silently dropping the 3 LOCKED handle
+fields from the public surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aperag.domains.retrieval.schemas import SearchResultMetadata
+
+
+def test_metadata_exposes_chunk_id_field():
+    md = SearchResultMetadata(chunk_id="doc-42_3")
+    assert md.chunk_id == "doc-42_3"
+
+
+def test_metadata_exposes_section_path_field():
+    md = SearchResultMetadata(section_path="1/2/3")
+    assert md.section_path == "1/2/3"
+
+
+def test_metadata_exposes_heading_anchor_field():
+    md = SearchResultMetadata(heading_anchor="#chapter-2-implementation")
+    assert md.heading_anchor == "#chapter-2-implementation"
+
+
+def test_metadata_unknown_key_still_rejected():
+    """Adding the 3 handle fields must not relax ``extra="forbid"``."""
+    with pytest.raises(ValidationError):
+        SearchResultMetadata(invented_key="oops")
+
+
+def test_from_raw_extracts_all_three_handles():
+    md = SearchResultMetadata.from_raw(
+        {
+            "chunk_id": "doc-42_3",
+            "section_path": "1/2/3",
+            "heading_anchor": "#chapter-2-implementation",
+            "document_id": "doc-42",
+        }
+    )
+    assert md is not None
+    assert md.chunk_id == "doc-42_3"
+    assert md.section_path == "1/2/3"
+    assert md.heading_anchor == "#chapter-2-implementation"
+    assert md.document_id == "doc-42"
+
+
+def test_from_raw_handles_missing_handles_as_none():
+    """Upstream backends that do not yet propagate section_path /
+    heading_anchor (the indexing layer enhancement is intentionally out
+    of D10.h scope per PM msg=5760999e #4) must not break the schema —
+    the field surfaces as ``None`` and the rest of the metadata flows
+    through unchanged.
+    """
+    md = SearchResultMetadata.from_raw({"document_id": "doc-42"})
+    assert md is not None
+    assert md.document_id == "doc-42"
+    assert md.chunk_id is None
+    assert md.section_path is None
+    assert md.heading_anchor is None
+
+
+def test_from_raw_ignores_non_string_handle_values():
+    """``public_str`` filter rejects non-string / empty values so the
+    public surface never carries a numeric chunk_id or empty string.
+    """
+    md = SearchResultMetadata.from_raw(
+        {
+            "chunk_id": 42,  # not a string — filtered
+            "section_path": "",  # empty — filtered
+            "heading_anchor": "valid-anchor",
+            "document_id": "doc-1",
+        }
+    )
+    assert md is not None
+    assert md.chunk_id is None
+    assert md.section_path is None
+    assert md.heading_anchor == "valid-anchor"

--- a/tests/unit_test/mcp/test_search_split.py
+++ b/tests/unit_test/mcp/test_search_split.py
@@ -302,74 +302,46 @@ async def test_web_search_does_not_carry_cursor_param():
     )
 
 
-# --- 3. Deprecation banner on omnibus aliases ------------------------
+# --- 3. Cutover removal of omnibus aliases (D10.h #100) --------------
+#
+# D10.d (#1713 / #1717) preserved ``search_collection`` and
+# ``search_chat_files`` behind a ``[DEPRECATED]`` banner so external
+# callers had a migration window. D10.h (#100) hard-cuts both — the
+# banners + bodies are now gone, and the only thing the test surface
+# pins is that they stay gone, since ``earayu2 msg=9730bb6b`` made
+# the project's hard-cut philosophy explicit (no users / no data).
 
 
-def test_search_collection_carries_deprecation_banner():
-    """``search_collection`` docstring is prefixed with
-    ``[DEPRECATED]`` and references the canonical D10.b doc (§B.5 /
-    §H.1) so reviewers and tool consumers see the migration signal.
+def test_search_collection_legacy_omnibus_removed_from_module():
+    """``search_collection`` was deleted in D10.h #100 — neither the
+    runtime attribute nor an ``async def`` in the source survives.
     """
-    doc = mcp_server_module.search_collection.__doc__ or ""
-    assert "[DEPRECATED]" in doc, "search_collection must carry a [DEPRECATED] banner per §B.5 / §H.1."
-    # Banner must point migrators at the new split tools; cite the
-    # spec source for traceability.
-    assert "vector_search" in doc and "graph_search" in doc and "fulltext_search" in doc, (
-        "Deprecation banner must enumerate the split tools so callers know the migration target."
+    assert not hasattr(mcp_server_module, "search_collection"), (
+        "search_collection must be removed from aperag.mcp.server in the D10.h cutover."
     )
 
-
-def test_search_chat_files_carries_deprecation_banner():
-    """``search_chat_files`` shares the deprecation timeline of
-    ``search_collection`` per §H.2.
-    """
-    doc = mcp_server_module.search_chat_files.__doc__ or ""
-    assert "[DEPRECATED]" in doc, "search_chat_files must carry a [DEPRECATED] banner per §H.2."
-
-
-# --- 4. Forbidden boundary (§G D10.d): impl body untouched -----------
-
-
-def _async_def_source(source: str, name: str) -> str:
+    source = MCP_SERVER_PATH.read_text()
     tree = ast.parse(source)
-    for node in ast.walk(tree):
-        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
-            return ast.get_source_segment(source, node) or ""
-    raise AssertionError(f"async def {name!r} not found in source")
+    inline_defs = [
+        node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef) and node.name == "search_collection"
+    ]
+    assert inline_defs == [], "aperag.mcp.server must not define `async def search_collection` after the D10.h cutover."
 
 
-def test_search_collection_body_still_targets_v2_collections_path():
-    """§G D10.d Forbidden: ``search_collection`` implementation must be
-    untouched — only the docstring banner changed. Re-asserts the same
-    invariant as ``test_mcp_contract.test_search_collection_targets_v2_path``
-    so the D10.d split lane cannot accidentally drift the body.
+def test_search_chat_files_legacy_omnibus_removed_from_module():
+    """``search_chat_files`` shared the deprecation timeline and is
+    cut in the same lane.
     """
-    source = MCP_SERVER_PATH.read_text()
-    body = _async_def_source(source, "search_collection")
-    assert "/api/v2/collections/" in body, "search_collection body must still hit /api/v2/collections/."
-    assert "/api/v1/collections/" not in body
-    # The 5 mode flags accepted by the omnibus alias must remain so
-    # existing callers keep working during the deprecation window.
-    for mode in (
-        "use_vector_index",
-        "use_fulltext_index",
-        "use_graph_index",
-        "use_summary_index",
-        "use_vision_index",
-    ):
-        assert mode in body, (
-            f"search_collection must still accept `{mode}` for backward "
-            "compatibility (Forbidden: implementation untouched until D10.h)."
-        )
+    assert not hasattr(mcp_server_module, "search_chat_files"), (
+        "search_chat_files must be removed from aperag.mcp.server in the D10.h cutover."
+    )
 
-
-def test_search_chat_files_body_still_targets_v2_chats_path():
-    """§G D10.d Forbidden: ``search_chat_files`` implementation must be
-    untouched — only the docstring banner changed.
-    """
     source = MCP_SERVER_PATH.read_text()
-    body = _async_def_source(source, "search_chat_files")
-    assert "/api/v2/chats/" in body, "search_chat_files body must still hit /api/v2/chats/."
+    tree = ast.parse(source)
+    inline_defs = [
+        node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef) and node.name == "search_chat_files"
+    ]
+    assert inline_defs == [], "aperag.mcp.server must not define `async def search_chat_files` after the D10.h cutover."
 
 
 # --- 5. Server module no longer defines old web_search inline --------
@@ -400,5 +372,11 @@ def test_web_search_module_targets_v2_web_path():
     """
     web_search_path = REPO_ROOT / "aperag" / "mcp" / "tools" / "search_web.py"
     source = web_search_path.read_text()
-    body = _async_def_source(source, "web_search")
+    tree = ast.parse(source)
+    body: str = ""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "web_search":
+            body = ast.get_source_segment(source, node) or ""
+            break
+    assert body, "async def web_search not found in aperag/mcp/tools/search_web.py"
     assert "/api/v2/web/search" in body, "web_search body must still hit /api/v2/web/search after the D10.d relocation."

--- a/tests/unit_test/mcp/test_search_split.py
+++ b/tests/unit_test/mcp/test_search_split.py
@@ -154,18 +154,30 @@ def test_fulltext_search_signature_matches_b3_lock():
     assert params["cursor"].default is None
 
 
-def test_web_search_signature_preserves_existing_wire_for_b4():
-    """``web_search`` signature preserves the existing wire-facing
-    parameter names (``max_results`` / positional ``source`` default
-    ``""``); §B.4 spec migration to ``top_k`` / kw-only is deferred to
-    the D10.h cutover lane to avoid breaking external MCP clients.
+def test_web_search_signature_matches_b4_canonical():
+    """``web_search`` carries the §B.4 canonical signature applied in
+    D10.h #100: ``query`` is positional + required; every other
+    parameter is keyword-only; the result-count limit is named
+    ``top_k``; ``source`` is ``str | None``.
     """
-    params = _params(web_search)
-    assert "query" in params and params["query"].default == ""
-    assert "max_results" in params and params["max_results"].default == 5
-    assert "timeout" in params and params["timeout"].default == 30
-    assert "locale" in params and params["locale"].default == "en-US"
-    assert "source" in params and params["source"].default == ""
+    import inspect
+
+    sig = inspect.signature(web_search)
+    params = sig.parameters
+
+    assert params["query"].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert params["query"].default is inspect.Parameter.empty, "query must be required"
+    for kw_name in ("top_k", "timeout", "locale", "source"):
+        assert kw_name in params, f"{kw_name!r} missing"
+        assert params[kw_name].kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{kw_name!r} must be keyword-only after the §B.4 cutover"
+        )
+
+    assert params["top_k"].default == 5
+    assert params["timeout"].default == 30
+    assert params["locale"].default == "en-US"
+    assert params["source"].default is None
+    assert "max_results" not in params, "legacy `max_results` parameter must be gone"
 
 
 # --- 2b. Cursor placeholder explicit-not-silent (§B / amendment Drift #4) ---

--- a/tests/unit_test/test_mcp_contract.py
+++ b/tests/unit_test/test_mcp_contract.py
@@ -14,10 +14,19 @@
 
 """MCP contract tests.
 
-Pins the source-of-truth for the MCP ``search_collection`` /
-``web_search`` / ``web_read`` tools so that Phase 2 / Phase 3
-relocations cannot silently revert the URL or the response-parsing
-schema back to the legacy aggregate.
+Originally pinned the ``search_collection`` URL + ``SearchResult``
+import path during Phase 2's retrieval hard-cut so the omnibus
+wrapper could not silently regress to ``/api/v1/`` or to the legacy
+``aperag.schema.view_models`` aggregate.
+
+D10.h (#100) hard-cuts ``search_collection`` outright (per
+``earayu2 msg=9730bb6b`` no-users / no-data philosophy + amendment-#2
+Drift #2/#3). The contract this file pins now is the *removal* —
+``aperag.mcp.server`` must not re-introduce the omnibus tool, the
+inline definition, or the legacy ``SearchResult`` import path. The
+canonical search surface is the split tool family
+(``aperag.mcp.tools.search_{vector,graph,fulltext,web}``) and is
+covered by ``tests/unit_test/mcp/test_search_split.py``.
 """
 
 from __future__ import annotations
@@ -25,60 +34,43 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from aperag.domains.retrieval import schemas as retrieval_schemas
 from aperag.mcp import server as mcp_server
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MCP_SERVER_PATH = REPO_ROOT / "aperag" / "mcp" / "server.py"
 
 
-def test_search_collection_schema_source():
-    """``aperag.mcp.server`` must parse ``search_collection`` responses
-    with the canonical ``SearchResult`` owned by the ``retrieval``
-    domain, not with the legacy ``aperag.schema.view_models`` class.
+def test_legacy_search_collection_omnibus_stays_removed():
+    """``aperag.mcp.server`` must not expose the omnibus
+    ``search_collection`` runtime attribute or carry the inline
+    ``async def`` after the D10.h cutover.
+    """
+    assert not hasattr(mcp_server, "search_collection"), (
+        "search_collection must remain removed from aperag.mcp.server after the D10.h cutover."
+    )
 
-    Guards against a refactor that "looks fine" (types are structurally
-    compatible) but secretly re-establishes the aggregate dependency.
+    tree = ast.parse(MCP_SERVER_PATH.read_text())
+    inline_defs = [
+        node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef) and node.name == "search_collection"
+    ]
+    assert inline_defs == [], (
+        "aperag/mcp/server.py must not define `async def search_collection`; "
+        "the canonical search surface is `aperag.mcp.tools.search_*`."
+    )
+
+
+def test_search_result_legacy_import_stays_gone():
+    """``SearchResult`` no longer needs to be imported into
+    ``aperag.mcp.server`` because the omnibus wrapper that parsed
+    backend responses is gone. A future regression that re-imports
+    it would suggest the omnibus wrapper is sneaking back in.
     """
     tree = ast.parse(MCP_SERVER_PATH.read_text())
-
-    search_result_sources: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module:
             for alias in node.names:
-                if alias.name == "SearchResult":
-                    search_result_sources.add(node.module)
-
-    assert search_result_sources == {"aperag.domains.retrieval.schemas"}, (
-        "aperag/mcp/server.py must import SearchResult from "
-        "aperag.domains.retrieval.schemas after the Phase 2 retrieval "
-        "hard-cut; found instead: " + repr(sorted(search_result_sources))
-    )
-
-    # And the class the runtime actually uses must be the relocated one.
-    assert mcp_server.SearchResult is retrieval_schemas.SearchResult
-
-
-def test_search_collection_targets_v2_path():
-    """The MCP wrapper must call ``/api/v2/collections/{id}/searches``
-    so the legacy v1 path can be deleted by the Phase 2 hard-cut.
-
-    Byte-level regex check: the tool body embeds the URL as an
-    f-string; a v1 regression would show up as the literal substring
-    ``/api/v1/collections/`` inside the ``search_collection`` region.
-    """
-    source = MCP_SERVER_PATH.read_text()
-    tree = ast.parse(source)
-    for node in ast.walk(tree):
-        if isinstance(node, ast.AsyncFunctionDef) and node.name == "search_collection":
-            body_source = ast.get_source_segment(source, node) or ""
-            assert "/api/v2/collections/" in body_source, (
-                "search_collection must hit the v2 collections path; did the MCP wrapper regress to /api/v1/?"
-            )
-            assert "/api/v1/collections/" not in body_source, (
-                "search_collection still references the legacy v1 "
-                "collections path; remove the literal to keep the "
-                "Phase 2 hard-cut honest."
-            )
-            return
-    raise AssertionError("search_collection tool not found in aperag.mcp.server")
+                assert alias.name != "SearchResult", (
+                    "aperag/mcp/server.py must not re-import SearchResult; "
+                    "the omnibus search wrapper that needed it was removed "
+                    "in the D10.h cutover."
+                )

--- a/tests/unit_test/test_mcp_server.py
+++ b/tests/unit_test/test_mcp_server.py
@@ -37,11 +37,17 @@ def test_list_collections_docstring_explains_empty_and_user_step_language():
     assert "Checking which knowledge bases are available." in doc
 
 
-def test_search_collection_docstring_explains_step_and_failure_meaning():
-    doc = mcp_server.search_collection.__doc__
-
-    assert "What failure may mean:" in doc
-    assert "Reviewed results from the selected knowledge base." in doc
+def test_search_collection_legacy_omnibus_no_longer_registered():
+    """``search_collection`` was hard-cut in D10.h #100. The omnibus
+    tool must not reappear on ``aperag.mcp.server`` — callers compose
+    the canonical split tools (``vector_search`` / ``graph_search`` /
+    ``fulltext_search``) directly. The split tools' own
+    user-visible step language is covered in
+    ``tests/unit_test/mcp/test_search_split.py``.
+    """
+    assert not hasattr(mcp_server, "search_collection"), (
+        "search_collection must remain removed after the D10.h cutover."
+    )
 
 
 def test_web_tools_docstrings_match_user_visible_step_language():


### PR DESCRIPTION
## Summary

D10.h cutover, single PR per design pack §G + amendment-#2 + PM final scope lock (msg=dc63c7e6 / msg=5760999e). The system is pre-launch with no users / no data per @earayu2 msg=9730bb6b, so the soak / data-migration gate that previously guarded `task #100` is dropped — only the code-level gates (caller sweep, write-set boundary, CI green) apply.

## Write set

| Block | Files | Author |
|---|---|---|
| A — `search_collection` / `search_chat_files` hard-cut + caller sweep | `aperag/mcp/server.py` (delete two omnibus tools + rewrite the `aperag_usage_guide` resource), `aperag/domains/agent_runtime/services.py` (`_KNOWLEDGE_SEARCH_TOOLS` / `_READING_TOOLS`) | Bryce |
| B — `web_search` §B.4 canonicalization | `aperag/mcp/tools/search_web.py` (`query` required, kw-only, `top_k`, `source: str \| None`), `tests/unit_test/mcp/test_search_split.py` (signature pin) | Bryce |
| C — retrieval `chunk_id` / `section_path` / `heading_anchor` exposure | `aperag/domains/retrieval/schemas.py`, new `tests/unit_test/domains/retrieval/test_search_result_metadata.py` | architect (`bec7bde5`) |
| D — stale narrative cleanup | `aperag/mcp/cursor/invariants.py` (`pending architect canonical lock per msg=441c5e56` removed) | Bryce |
| E — D10 hurl coverage | `tests/e2e_http/hurl/full/22_d10_read_primitives.hurl` / `23_d10_pagination.hurl` / `24_d10_search_split.hurl` / `25_d10_cutover.hurl` | Bryce |
| F — caller migration assertion semantics | `tests/unit_test/mcp/test_search_split.py`, `tests/unit_test/test_mcp_server.py`, `tests/unit_test/test_mcp_contract.py`, `tests/unit_test/agent_runtime/test_agent_runtime_v3.py` | Bryce |

## §G hard gates

- **#1 contract shape change → 3-root grep**: confirmed `search_collection` / `search_chat_files` runtime references are gone everywhere except the agent-runtime translator string fixtures (which intentionally exercise routing on arbitrary tool-name strings) and a `source_type: "search_collection"` test fixture in chat history (D8.5-BE artifact, harmless string token). Both are non-functional and out of D10.h scope.
- **#3 bridge / adapter deletion → caller validation**: every place that used `mcp_server.search_collection` / `search_chat_files` as a runtime attribute is migrated in this same PR (services.py routing set, mcp_server / mcp_contract / agent_runtime_v3 tests).
- **#4 caller migration assertion semantics**: pre-existing tests that pinned the omnibus tools' presence are not deleted — they are rewritten in the same PR to pin their *absence* (`test_search_collection_legacy_omnibus_removed_from_module`, etc).
- **#5 cross-stack design boundary**: `task #80` territory deliberately untouched (`snapshot_assembler`, `RedisChatMessageHistory`, `StoredChatMessagePart`, `chat/history`, `utils/history`); architect-confirmed in inventory msg=b9e7f91e.

## Cross-block gate

`24_d10_search_split.hurl` asserts `chunk_id` / `section_path` / `heading_anchor` appear on the wire. Those assertions were placed before block C landed so the gate would fail loudly if Drift #1 propagation didn't ship in the same PR — block C's `SearchResultMetadata` allowlist update closes that gate.

## Out of scope (deferred per PM constraint)

- `aperag/service/search_service.py` "legacy compatibility layer" — never created in the repo, so nothing to delete (PM msg=dc63c7e6 #3).
- D8 fallback / artifact projection / `RedisChatMessageHistory` cleanup — `task #80` territory, owned by @明书 on PR #1720+ (PM msg=309b3ed3 #1).
- Indexing-layer `section_path` / `heading_anchor` attach across the 5 indexer modes (`vector_index` / `graph_index` / `summary_index` / `vision_index` / `fulltext_index`) — explicit out-of-scope per PM msg=5760999e #4 (multi-indexer expansion would balloon the write-set). The schema field is exposed; populated values for those handles arrive once each indexer is taught to attach section context, which is a future lane.
- Backend `aperag/domains/web_access/schemas.py` `max_results` → `top_k` rename — the wrapper translates at the MCP boundary (PM constraint #2 msg=309b3ed3, "目标是 cutover contract 收口").

## Test plan

- [x] `uv run pytest tests/unit_test/` — 1001 passed, 29 skipped
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [ ] CI lint-and-unit / e2e-http-smoke / provider-preflight / e2e-http-provider — pending PR open

## Reviewers per RR2

- @符炫炜 architect spec line-by-line quick-check (per memory `feedback_dataflow_review.md` step 0+ enforcement + step 0 dataflow trace; this lane is co-owned so the architect's own block C is intentionally excluded from the architect's quick-check perimeter)
- @Weston optional二线 sanity, focused on the destructive cutover caller sweep + the hard-cut narrative consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)