### PR TITLE
docs(indexing): §G.5 amendment — index_modality field (not modality)

### DIFF
--- a/docs/modularization/indexing-redesign-design-pack.md
+++ b/docs/modularization/indexing-redesign-design-pack.md
@@ -1085,16 +1085,18 @@ Each `SearchResultItem.metadata` carries:
 class SearchResultMetadata(BaseModel):
     # ... existing fields (chunk_id / section_path / heading_anchor etc) ...
     parse_version: Optional[str] = None       # which parse_version served this hit
-    modality: Literal["vector","fulltext","graph","summary","vision"]
+    index_modality: Optional[Literal["vector","fulltext","graph","summary","vision"]] = None
     index_state_per_modality: Optional[Dict[str, Literal["ACTIVE","FAILED","NOT_ENABLED","INDEXING"]]] = None
 ```
 
+> **Naming amendment 2026-04-27 (Bryce T3.2 implementation, msg=1a02cbcb)**: the field for "which retrieval modality produced this hit" is **`index_modality`**, not `modality`. D10.h already locked `SearchResultMetadata.modality: Optional[Literal["text", "image"]]` for **content modality** (whether the hit's content is text or an image), and the two concepts are orthogonal — a hit can be `index_modality="vector"` + `modality="text"`, or `index_modality="vision"` + `modality="image"`. The `index_` prefix disambiguates and preserves the D10.h-locked field.
+
 Clients (and the agent layer) can:
 - Detect mixed-version results in one response (different modalities show different `parse_version`)
-- Skip a modality that's currently FAILED/INDEXING
+- Skip a retrieval modality that's currently FAILED/INDEXING
 - Decide whether to wait + retry vs proceed with partial coverage
 
-Schema-wise this is a small extension of the D10.h `SearchResultMetadata` allowlist (already locked at chunk_id / section_path / heading_anchor; v2 adds `parse_version` and `index_state_per_modality`).
+Schema-wise this is a small extension of the D10.h `SearchResultMetadata` allowlist (already locked at chunk_id / section_path / heading_anchor / source / title / collection_id / document_id / asset_id / mimetype / page_idx / url / modality; v3 adds `parse_version` / `index_modality` / `index_state_per_modality`).
 
 ---
 


### PR DESCRIPTION
## Summary

Architect amendment to design pack §G.5 disambiguating field name for retrieval-modality discriminator.

Bryce T3.2 implementation (Wave 3 PR #1727 commit `53257881`, msg=1a02cbcb) caught: design pack §G.5 narrative used bare `modality` field on `SearchResultMetadata`, but D10.h already locked `SearchResultMetadata.modality` as the **content modality** (Literal["text", "image"]). The narrative naming would shadow the D10.h field.

Bryce chose `index_modality` for disambiguation. Architect ack: this is the canonical name; spec amended to match.

## Changes

- §G.5: rename narrative field `modality` → `index_modality` for retrieval-modality discriminator
- §G.5: add explicit naming amendment note explaining D10.h vs §G.5 orthogonality
- §G.5: update allowlist enumeration to list all 12 D10.h-locked fields + 3 new v3 fields

## Test plan

- [x] Design pack only — no code changes
- [x] Bryce T3.2 implementation already uses `index_modality` (PR #1727 commit 53257881)
- [x] D10.h `modality` field preserved for content modality

🤖 Generated with [Claude Code](https://claude.com/claude-code)