### PR TITLE
feat(celery Wave 4): real backends + 11 production-readiness items

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -337,11 +337,17 @@ async def combined_lifespan(app: FastAPI):
                 )
             )
         )
+        # Wave 4 T2: cleanup loop now consumes a per-row worker
+        # factory so each ``DocumentIndex`` row is cleaned against the
+        # right per-(collection, modality) backend. Without this the
+        # cleanup loop ran with ``workers={}`` and silently skipped
+        # every backend delete (Qdrant points / ES docs / graph
+        # entities leaked forever after document or collection delete).
         indexing_runtime_tasks.append(
             asyncio.create_task(
                 run_cleanup_loop(
                     engine=engine,
-                    workers={},  # T3.3 follow-up: pass concrete worker registry
+                    worker_factory=worker_factory.build_for_cleanup_row,
                     shutdown=indexing_shutdown,
                 )
             )
@@ -366,6 +372,7 @@ async def combined_lifespan(app: FastAPI):
                 queue=queue,
                 workers={},
                 metrics_emitter=metrics_emitter,
+                cleanup_worker_factory=worker_factory.build_for_cleanup_row,
             )
         )
     else:

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -295,7 +295,7 @@ async def combined_lifespan(app: FastAPI):
             except ImportError as exc:  # pragma: no cover — redis is a base dep
                 raise RuntimeError("INDEXING_QUOTA_BACKEND=redis but redis package not installed") from exc
             quota_redis = redis_asyncio.from_url(
-                settings.indexing_queue_redis_url,
+                settings.indexing_quota_redis_url,
                 encoding="utf-8",
                 decode_responses=False,
             )

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -239,6 +239,7 @@ async def combined_lifespan(app: FastAPI):
             run_cleanup_loop,
             run_fulltext_worker,
             run_graph_worker,
+            run_parse_worker,
             run_reconcile_loop,
             run_summary_worker,
             run_vector_worker,
@@ -301,6 +302,32 @@ async def combined_lifespan(app: FastAPI):
         indexing_runtime_tasks.append(asyncio.create_task(run_graph_worker(**worker_kwargs)))
         indexing_runtime_tasks.append(asyncio.create_task(run_summary_worker(**worker_kwargs)))
         indexing_runtime_tasks.append(asyncio.create_task(run_vision_worker(**worker_kwargs)))
+
+        # Wave 4 T3 chunk 2: parse worker reads ``q:parse``, runs
+        # :class:`DocParser`, and dispatches the per-modality jobs.
+        # Without this, the upload handler's :func:`push_parse` call
+        # would land in Redis with no consumer — the per-modality
+        # rows would never get inserted and documents would stay
+        # PENDING forever. The object store factory is async per the
+        # production resolver signature; this closure adapts the
+        # synchronous ``get_object_store`` helper into the
+        # ``ObjectStoreFactory`` shape :func:`run_parse_worker`
+        # expects.
+        from aperag.objectstore.base import get_object_store
+
+        async def _resolve_object_store():
+            return await asyncio.to_thread(get_object_store)
+
+        indexing_runtime_tasks.append(
+            asyncio.create_task(
+                run_parse_worker(
+                    engine=engine,
+                    queue=queue,
+                    object_store_factory=_resolve_object_store,
+                    shutdown=indexing_shutdown,
+                )
+            )
+        )
         indexing_runtime_tasks.append(
             asyncio.create_task(
                 run_reconcile_loop(

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -273,6 +273,37 @@ async def combined_lifespan(app: FastAPI):
         else:
             metrics_emitter = NoopMetricsEmitter()
 
+        # Wave 4 T5: dispatch on ``INDEXING_QUOTA_BACKEND`` setting
+        # (default ``inmemory`` for backward-compat single-pod
+        # deployments; production multi-pod sets ``redis`` so worker
+        # processes share §H.5 token-bucket state via Redis logical
+        # db=3 per §H.5.1 amendment). InMemoryQuotaBackend is process-
+        # local — multi-pod deployments running ``inmemory`` would
+        # have each pod's worker independently exhaust its tenant
+        # quota, which silently breaks the per-tenant rate limit
+        # invariant (§H.5).
+        from aperag.indexing.quota import (
+            InMemoryQuotaBackend,
+            QuotaPolicyRegistry,
+            RedisQuotaBackend,
+        )
+
+        quota_registry = QuotaPolicyRegistry()
+        if settings.indexing_quota_backend.lower() == "redis":
+            try:
+                from redis import asyncio as redis_asyncio
+            except ImportError as exc:  # pragma: no cover — redis is a base dep
+                raise RuntimeError("INDEXING_QUOTA_BACKEND=redis but redis package not installed") from exc
+            quota_redis = redis_asyncio.from_url(
+                settings.indexing_queue_redis_url,
+                encoding="utf-8",
+                decode_responses=False,
+            )
+            quota_backend = RedisQuotaBackend(quota_redis, quota_registry)
+        else:
+            quota_redis = None
+            quota_backend = InMemoryQuotaBackend(quota_registry)
+
         # Worker factory — per-task lazy construction. The async
         # worker entrypoints (``run_*_worker``) call this closure on
         # every BLPOP'd payload to materialise the concrete
@@ -358,6 +389,12 @@ async def combined_lifespan(app: FastAPI):
         app.state.indexing_queue = queue
         app.state.indexing_engine = engine
         app.state.indexing_metrics_emitter = metrics_emitter
+        app.state.indexing_quota_backend = quota_backend
+        # Wave 4 T5: stash the underlying Redis client (only when
+        # ``INDEXING_QUOTA_BACKEND=redis``) so the lifespan finally
+        # block can close it on shutdown — mirrors the T4 RedisWorkQueue
+        # close lifecycle.
+        app.state.indexing_quota_redis = quota_redis
 
         # Service-layer callers (aperag/domains/**) consume the same
         # triple through the process-wide IndexingRuntime singleton —
@@ -373,6 +410,7 @@ async def combined_lifespan(app: FastAPI):
                 workers={},
                 metrics_emitter=metrics_emitter,
                 cleanup_worker_factory=worker_factory.build_for_cleanup_row,
+                quota_backend=quota_backend,
             )
         )
     else:
@@ -400,6 +438,13 @@ async def combined_lifespan(app: FastAPI):
         if queue_obj is not None and hasattr(queue_obj, "close"):
             with contextlib.suppress(Exception):
                 await queue_obj.close()
+        # Wave 4 T5: release the quota Redis client (only present when
+        # ``INDEXING_QUOTA_BACKEND=redis`` was selected at startup).
+        # ``InMemoryQuotaBackend`` has no underlying client.
+        quota_redis_obj = getattr(app.state, "indexing_quota_redis", None)
+        if quota_redis_obj is not None:
+            with contextlib.suppress(Exception):
+                await quota_redis_obj.aclose()
         # Wave 4 T6: flush + shut down the OTLP MeterProvider so the
         # PeriodicExportingMetricReader drains any pending metric
         # samples before the process exits. Mirrors the T4 graceful

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -233,6 +233,8 @@ async def combined_lifespan(app: FastAPI):
         from aperag.config import sync_engine
         from aperag.indexing import (
             InMemoryWorkQueue,
+            NoopMetricsEmitter,
+            OTLPMetricsEmitter,
             RedisWorkQueue,
             run_cleanup_loop,
             run_fulltext_worker,
@@ -256,6 +258,19 @@ async def combined_lifespan(app: FastAPI):
         else:
             queue = InMemoryWorkQueue()
         engine = sync_engine
+
+        # Wave 4 T6: dispatch on ``INDEXING_METRICS_EMITTER`` setting
+        # (default ``noop`` for backward-compat; production multi-pod
+        # sets ``otlp`` to wire the four §J.1 SLIs onto the
+        # ``MeterProvider`` configured by ``aperag.observability``).
+        # NoopMetricsEmitter silently drops every sample, so operators
+        # running Tier 2/3 production must explicitly opt into ``otlp``
+        # — otherwise queue-backlog / failure-rate alerts on the
+        # collector side never receive data.
+        if settings.indexing_metrics_emitter.lower() == "otlp":
+            metrics_emitter = OTLPMetricsEmitter()
+        else:
+            metrics_emitter = NoopMetricsEmitter()
 
         # Worker factory — per-task lazy construction. The async
         # worker entrypoints (``run_*_worker``) call this closure on
@@ -309,6 +324,7 @@ async def combined_lifespan(app: FastAPI):
         # same queue / engine the workers consume.
         app.state.indexing_queue = queue
         app.state.indexing_engine = engine
+        app.state.indexing_metrics_emitter = metrics_emitter
 
         # Service-layer callers (aperag/domains/**) consume the same
         # triple through the process-wide IndexingRuntime singleton —
@@ -317,10 +333,18 @@ async def combined_lifespan(app: FastAPI):
         # populates concrete factories per modality.
         from aperag.indexing.runtime import IndexingRuntime, set_runtime
 
-        set_runtime(IndexingRuntime(engine=engine, queue=queue, workers={}))
+        set_runtime(
+            IndexingRuntime(
+                engine=engine,
+                queue=queue,
+                workers={},
+                metrics_emitter=metrics_emitter,
+            )
+        )
     else:
         app.state.indexing_queue = None
         app.state.indexing_engine = None
+        app.state.indexing_metrics_emitter = None
         from aperag.indexing.runtime import set_runtime
 
         set_runtime(None)

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -366,6 +366,17 @@ async def combined_lifespan(app: FastAPI):
         if queue_obj is not None and hasattr(queue_obj, "close"):
             with contextlib.suppress(Exception):
                 await queue_obj.close()
+        # Wave 4 T6: flush + shut down the OTLP MeterProvider so the
+        # PeriodicExportingMetricReader drains any pending metric
+        # samples before the process exits. Mirrors the T4 graceful
+        # shutdown pattern and addresses huangheng pass-1 observation A
+        # (msg=5d450300). ``shutdown_metrics_provider`` is a no-op when
+        # the SDK MeterProvider was never installed (default
+        # ``noop`` emitter / OTLP endpoint missing).
+        from aperag.observability.metrics import shutdown_metrics_provider
+
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(shutdown_metrics_provider)
 
 
 # Create the main FastAPI app with combined lifespan

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import asyncio  # noqa: E402
+import contextlib  # noqa: E402
 
 from aperag.config import settings
 from aperag.observability import (
@@ -232,6 +233,7 @@ async def combined_lifespan(app: FastAPI):
         from aperag.config import sync_engine
         from aperag.indexing import (
             InMemoryWorkQueue,
+            RedisWorkQueue,
             run_cleanup_loop,
             run_fulltext_worker,
             run_graph_worker,
@@ -242,11 +244,17 @@ async def combined_lifespan(app: FastAPI):
         )
 
         indexing_shutdown = asyncio.Event()
-        # Single process-local InMemoryWorkQueue is the default
-        # transport for the in-process topology. Tier-3 production
-        # swaps this for a Redis-backed WorkQueue (RPUSH / BLPOP) by
-        # injecting via app state at deploy time — Wave 3 follow-up.
-        queue = InMemoryWorkQueue()
+        # Wave 4 T4: dispatch on ``INDEXING_QUEUE_BACKEND`` setting
+        # (default ``inmemory`` for backward-compat single-pod
+        # deployments; production multi-pod sets ``redis`` to enable
+        # BLPOP transport per design pack §E.2). InMemoryWorkQueue is
+        # process-local — multi-pod deployments lose tasks pushed to
+        # one process and BLPOP'd by another, so production must run
+        # ``INDEXING_QUEUE_BACKEND=redis`` for correctness.
+        if settings.indexing_queue_backend.lower() == "redis":
+            queue = RedisWorkQueue(redis_url=settings.indexing_queue_redis_url)
+        else:
+            queue = InMemoryWorkQueue()
         engine = sync_engine
 
         # Worker factory — per-task lazy construction. The async
@@ -327,6 +335,13 @@ async def combined_lifespan(app: FastAPI):
             # Drain in-flight worker / reconciler / cleanup loops with
             # a short grace window so a SIGTERM does not abort mid-task.
             await asyncio.gather(*indexing_runtime_tasks, return_exceptions=True)
+        # Wave 4 T4: release the indexing queue's underlying connection
+        # pool (Redis client owns one); InMemoryWorkQueue has no
+        # ``close`` so guard with hasattr.
+        queue_obj = getattr(app.state, "indexing_queue", None)
+        if queue_obj is not None and hasattr(queue_obj, "close"):
+            with contextlib.suppress(Exception):
+                await queue_obj.close()
 
 
 # Create the main FastAPI app with combined lifespan

--- a/aperag/config.py
+++ b/aperag/config.py
@@ -175,6 +175,13 @@ class Config(BaseSettings):
     #                exhausting capacity independently).
     indexing_quota_backend: str = Field("inmemory", alias="INDEXING_QUOTA_BACKEND")
 
+    # Indexing quota / EntityLock Redis URL (chunk 4e §H.5.1 lock: db=3
+    # for `quota:<class>:<tenant>:tokens` + `indexing:graph:entity:<slot>`
+    # — separate from broker (db=0) / memory (db=1) / WorkQueue (db=2)).
+    # When unset the default-derive chain in ``_apply_defaults`` builds
+    # `redis://USER:PASS@HOST:PORT/3` from the same Redis credentials.
+    indexing_quota_redis_url: Optional[str] = Field(None, alias="INDEXING_QUOTA_REDIS_URL")
+
     # Model configs
     model_configs: Dict[str, Any] = {}
 
@@ -331,6 +338,13 @@ class Config(BaseSettings):
         if not self.indexing_queue_redis_url:
             self.indexing_queue_redis_url = (
                 f"redis://{self.redis_user}:{self.redis_password}@{self.redis_host}:{self.redis_port}/2"
+            )
+        # INDEXING_QUOTA_REDIS_URL — chunk 4e §H.5.1 lock: separate
+        # logical DB (db=3) for quota token-bucket + EntityLock keyspace
+        # (broker=0 / memory=1 / WorkQueue=2 / Quota+EntityLock=3).
+        if not self.indexing_quota_redis_url:
+            self.indexing_quota_redis_url = (
+                f"redis://{self.redis_user}:{self.redis_password}@{self.redis_host}:{self.redis_port}/3"
             )
         # ES_HOST
         if not self.es_host:

--- a/aperag/config.py
+++ b/aperag/config.py
@@ -119,6 +119,25 @@ class Config(BaseSettings):
     #              per design pack §L.
     indexing_mode: str = Field("async", alias="INDEXING_MODE")
 
+    # Indexing queue backend (Wave 4 T4 — replaces InMemoryWorkQueue
+    # default with Redis BLPOP for multi-process scale-out per design
+    # pack §E.2). Values:
+    #
+    # ``inmemory`` → ``aperag.indexing.InMemoryWorkQueue`` (Wave 1+2
+    #                default, single-process, asyncio.Queue per modality;
+    #                multi-pod deployments lose tasks pushed to one
+    #                process and BLPOP'd by another — TEST / SINGLE-POD
+    #                ONLY).
+    # ``redis``    → ``aperag.indexing.RedisWorkQueue`` (production
+    #                BLPOP transport keyed ``q:indexing:<modality>``
+    #                on the URL ``INDEXING_QUEUE_REDIS_URL`` if set,
+    #                else derived from ``REDIS_HOST`` / ``REDIS_PORT``
+    #                / ``REDIS_USER`` / ``REDIS_PASSWORD`` on a
+    #                separate logical DB (db=2) from the cache /
+    #                memory backends).
+    indexing_queue_backend: str = Field("inmemory", alias="INDEXING_QUEUE_BACKEND")
+    indexing_queue_redis_url: Optional[str] = Field(None, alias="INDEXING_QUEUE_REDIS_URL")
+
     # Model configs
     model_configs: Dict[str, Any] = {}
 
@@ -268,6 +287,13 @@ class Config(BaseSettings):
         if not self.memory_redis_url:
             self.memory_redis_url = (
                 f"redis://{self.redis_user}:{self.redis_password}@{self.redis_host}:{self.redis_port}/1"
+            )
+        # INDEXING_QUEUE_REDIS_URL — separate logical DB (db=2) from
+        # broker (db=0) and memory (db=1) so BLPOP queues never collide
+        # with cache or memory backends.
+        if not self.indexing_queue_redis_url:
+            self.indexing_queue_redis_url = (
+                f"redis://{self.redis_user}:{self.redis_password}@{self.redis_host}:{self.redis_port}/2"
             )
         # ES_HOST
         if not self.es_host:

--- a/aperag/config.py
+++ b/aperag/config.py
@@ -138,6 +138,28 @@ class Config(BaseSettings):
     indexing_queue_backend: str = Field("inmemory", alias="INDEXING_QUEUE_BACKEND")
     indexing_queue_redis_url: Optional[str] = Field(None, alias="INDEXING_QUEUE_REDIS_URL")
 
+    # Indexing metrics emitter (Wave 4 T6 — replaces NoopMetricsEmitter
+    # default with OTLP wire-in for §J.1 SLIs per design pack §J).
+    # Values:
+    #
+    # ``noop`` → ``aperag.indexing.NoopMetricsEmitter`` (default,
+    #            metrics silently dropped — TEST / dev / single-machine
+    #            deployments without observability infra). Operators
+    #            running production multi-pod deployments MUST set
+    #            ``INDEXING_METRICS_EMITTER=otlp`` to ship the four
+    #            §J.1 SLIs (``index_lag_seconds`` / ``queue_depth`` /
+    #            ``index_success_total`` / ``index_failure_total`` /
+    #            ``worker_utilization``) to the OTLP collector.
+    # ``otlp`` → ``aperag.indexing.OTLPMetricsEmitter`` (production —
+    #            instruments materialised on the OpenTelemetry SDK
+    #            ``MeterProvider`` configured by
+    #            ``aperag.observability``; requires
+    #            ``APERAG_OBSERVABILITY_MODE`` ∈ {``otlp``, ``collector``}
+    #            with a populated ``OTEL_EXPORTER_OTLP_ENDPOINT`` —
+    #            without those the OTLP exporter falls back to no-op
+    #            even though the emitter dispatch path is taken).
+    indexing_metrics_emitter: str = Field("noop", alias="INDEXING_METRICS_EMITTER")
+
     # Model configs
     model_configs: Dict[str, Any] = {}
 

--- a/aperag/config.py
+++ b/aperag/config.py
@@ -160,6 +160,21 @@ class Config(BaseSettings):
     #            even though the emitter dispatch path is taken).
     indexing_metrics_emitter: str = Field("noop", alias="INDEXING_METRICS_EMITTER")
 
+    # Indexing quota backend (Wave 4 T5 — wires the Redis token-bucket
+    # quota across LLM / embedding callsites). Values:
+    #
+    # ``inmemory`` → ``aperag.indexing.quota.InMemoryQuotaBackend``
+    #                (default; per-process token state, suitable for
+    #                tests / single-pod deployments).
+    # ``redis``    → ``aperag.indexing.quota.RedisQuotaBackend`` (Lua-
+    #                atomic token bucket on shared Redis at
+    #                ``indexing_queue_redis_url`` logical db=3 per
+    #                §H.5.1 amendment; multi-pod production MUST set
+    #                ``INDEXING_QUOTA_BACKEND=redis`` so worker
+    #                processes share token state instead of each pod
+    #                exhausting capacity independently).
+    indexing_quota_backend: str = Field("inmemory", alias="INDEXING_QUOTA_BACKEND")
+
     # Model configs
     model_configs: Dict[str, Any] = {}
 

--- a/aperag/domains/knowledge_base/service/document_service.py
+++ b/aperag/domains/knowledge_base/service/document_service.py
@@ -203,12 +203,17 @@ async def _create_or_update_document_indexes(
 
     source_bytes = await asyncio.to_thread(_read_source_bytes)
 
+    # Wave 4 T3 chunk 1: pass the upload's filename so ``parse_document``
+    # dispatches to the real ``DocParser`` chain on PDF / Office /
+    # image inputs instead of falling through the simulator's UTF-8
+    # markdown decode (which would raise on binary bytes).
     parsed = await asyncio.to_thread(
         parse_document,
         store=object_store,
         collection_id=document.collection_id,
         document_id=document.id,
         source_bytes=source_bytes,
+        source_filename=object_path,
         config=ParseConfig(),
     )
     parse_version = parsed.parse_version

--- a/aperag/domains/knowledge_base/service/document_service.py
+++ b/aperag/domains/knowledge_base/service/document_service.py
@@ -266,6 +266,7 @@ async def _delete_document_indexes(*, document_id: str) -> None:
     await cleanup_for_deleted_documents(
         engine=runtime.engine,
         workers=runtime.workers,
+        worker_factory=runtime.cleanup_worker_factory,
         document_ids=[document_id],
     )
 

--- a/aperag/domains/knowledge_base/service/document_service.py
+++ b/aperag/domains/knowledge_base/service/document_service.py
@@ -33,7 +33,6 @@ the same G1 boundary pass Step 5b2b applied to ``collection_service``:
   continue to resolve via the ``view_models`` dual-hook re-export shim.
 """
 
-import asyncio
 import json
 import logging
 import mimetypes
@@ -126,46 +125,45 @@ async def _create_or_update_document_indexes(
     """Replacement for legacy ``document_index_manager.
     create_or_update_document_indexes``.
 
-    Wave 3 T3.1 chunk 3 + post-pass-8 parser-wiring fix
-    (architect msg=c605037e ruling on the chunks.jsonl-never-written
-    gap): dispatches via the new
-    :func:`aperag.indexing.dispatcher.dispatch_indexing` ASYNC mode.
+    Wave 4 T3 chunk 2 (q:parse async promotion): the upload handler
+    no longer blocks on :func:`aperag.indexing.parse_document` (a 30s+
+    DocParser run for PDF / Word / image inputs would freeze the HTTP
+    request). Instead, this adapter pushes a :class:`ParseDispatchPayload`
+    onto ``q:parse`` and returns immediately; the parse worker pool
+    (``aperag.indexing.parse_orchestrator.run_parse_worker``) consumes
+    the payload, runs DocParser, then fans out the 5 per-modality
+    PENDING rows + queue payloads via :func:`dispatch_indexing`.
 
-    Parsing runs **synchronously inside this dispatch** (option 1
-    minimal scope per architect). Celery used to spin a separate
-    ``process_document_task`` that wrote the canonical
-    ``derived/parse_<version>/{markdown.md,outline.json,chunks.jsonl}``
-    artifacts; chunk 2 deleted that task layer but no replacement
-    caller invoked :func:`aperag.indexing.parse_document`, so every
-    modality worker hit ``derive-incomplete`` and rescheduled
-    forever — the symptom that broke
-    e2e-http-provider's ``wait_for_document_indexes`` assertion.
+    Net effect: the upload route becomes a 202-equivalent (pending
+    state visible via ``document.status``) instead of a 30s+ blocked
+    request. The async roundtrip — upload → parse worker → modality
+    workers → ``ACTIVE`` — is exercised by
+    ``tests/integration/test_parse_async_roundtrip.py``.
 
-    Sync parse here keeps the §E.2 "parse-as-first-stage" data flow
-    intact; the parse step happens inside the request task instead of
-    a separate ``parse_worker`` queue. Wave 4 follow-up may promote
-    parse to ``q:parse`` once parse latency starts blocking HTTP
-    requests; the sync path is acceptable for current latencies.
-
-    The dispatcher's ``source_path`` is now ``parsed.chunks_path`` —
-    the canonical location modality workers read chunks from. The
-    parse_version returned by the parser pins ``(parser, content,
-    chunking)`` per the §C.3 idempotency contract; we use it
-    verbatim instead of recomputing locally.
+    The rebuild path (``rebuild_indexes``) sets ``purge_existing_triples=True``
+    on the payload so the parse worker can DELETE any prior
+    ``(document_id, parse_version, modality)`` rows immediately
+    before dispatch. Without this, a same-content rebuild (parse_version
+    unchanged) would trip ``uq_document_index_triple`` mid-INSERT.
     """
     if not index_types:
         return
 
-    from aperag.indexing import DispatchRequest, IndexingMode, dispatch_indexing
-    from aperag.indexing.parser import ParseConfig, parse_document
+    from aperag.indexing.parse_orchestrator import ParseDispatchPayload
     from aperag.indexing.runtime import get_runtime
-    from aperag.objectstore.base import get_object_store
 
     runtime = get_runtime()
     if runtime is None:
         logger.warning(
             "_create_or_update_document_indexes(document=%s): IndexingRuntime not installed "
             "(INDEXING_MODE != async or pre-startup); skipping dispatch",
+            document_id,
+        )
+        return
+    if runtime.queue is None:
+        logger.warning(
+            "_create_or_update_document_indexes(document=%s): runtime.queue is None "
+            "(INLINE mode does not run a parse worker); skipping dispatch",
             document_id,
         )
         return
@@ -179,9 +177,7 @@ async def _create_or_update_document_indexes(
         return
 
     # Resolve the upload object path (``user-<u>/<col>/<doc>/original<ext>``)
-    # from the document metadata the upload handler stashed there. The
-    # base path alone is a directory prefix, not the file we need to
-    # parse.
+    # from the document metadata the upload handler stashed there.
     metadata = json.loads(document.doc_metadata) if document.doc_metadata else {}
     object_path = metadata.get("object_path")
     if not object_path:
@@ -192,77 +188,59 @@ async def _create_or_update_document_indexes(
         )
         return
 
-    object_store = get_object_store()
+    parser_config = await _resolve_parser_config_for_collection(document.collection_id, session)
 
-    def _read_source_bytes() -> bytes:
-        stream = object_store.get(object_path)
-        if stream is None:
-            raise FileNotFoundError(f"document source not found in object store: {object_path}")
-        with stream:
-            return stream.read()
-
-    source_bytes = await asyncio.to_thread(_read_source_bytes)
-
-    # Wave 4 T3 chunk 1: pass the upload's filename so ``parse_document``
-    # dispatches to the real ``DocParser`` chain on PDF / Office /
-    # image inputs instead of falling through the simulator's UTF-8
-    # markdown decode (which would raise on binary bytes).
-    parsed = await asyncio.to_thread(
-        parse_document,
-        store=object_store,
-        collection_id=document.collection_id,
+    payload = ParseDispatchPayload(
         document_id=document.id,
-        source_bytes=source_bytes,
-        source_filename=object_path,
-        config=ParseConfig(),
+        collection_id=document.collection_id,
+        object_path=object_path,
+        tenant_scope_key=f"user:{document.user}",
+        modalities=tuple(m.value for m in index_types),
+        parser_config=parser_config,
+        purge_existing_triples=True,
     )
-    parse_version = parsed.parse_version
-    source_path = parsed.chunks_path
-    tenant_scope_key = f"user:{document.user}"
-
-    # Wave 3 T3.1 chunk 3 fix-forward: ``rebuild_indexes`` re-invokes
-    # this adapter with the same ``(document_id, parse_version,
-    # modality)`` triple that already exists (content unchanged →
-    # parse_version unchanged). The §F.1 ``uq_document_index_triple``
-    # UNIQUE constraint then fails the dispatcher's INSERT with an
-    # IntegrityError → 500 DATABASE_ERROR. Pre-DELETE matching rows
-    # (any status / serving state) so the INSERT lands cleanly. The
-    # cutover-on-sync-completion (§F.3) re-establishes the serving
-    # state once the new dispatch's worker finishes; brief
-    # unavailability between DELETE and cutover is acceptable for an
-    # explicit rebuild op.
-    from sqlalchemy import delete as sa_delete
-
-    from aperag.indexing.models import DocumentIndex
-
-    def _purge_existing_triples() -> None:
-        from sqlalchemy.orm import Session
-
-        with Session(runtime.engine) as sync_session, sync_session.begin():
-            sync_session.execute(
-                sa_delete(DocumentIndex).where(
-                    DocumentIndex.document_id == document.id,
-                    DocumentIndex.parse_version == parse_version,
-                    DocumentIndex.modality.in_([m.value for m in index_types]),
-                )
-            )
-
-    await asyncio.to_thread(_purge_existing_triples)
-
-    await dispatch_indexing(
-        engine=runtime.engine,
-        queue=runtime.queue,
-        workers=runtime.workers,
-        request=DispatchRequest(
-            collection_id=document.collection_id,
-            document_id=document.id,
-            parse_version=parse_version,
-            source_path=source_path,
-            tenant_scope_key=tenant_scope_key,
-            modalities=tuple(index_types),
-        ),
-        mode=IndexingMode.ASYNC,
+    await runtime.queue.push_parse(payload=payload.to_dict())
+    logger.info(
+        "parse-queue dispatch document=%s collection=%s modalities=%d object_path=%s",
+        document.id,
+        document.collection_id,
+        len(index_types),
+        object_path,
     )
+
+
+async def _resolve_parser_config_for_collection(collection_id: str, session: AsyncSession) -> dict | None:
+    """Look up the optional collection-level ``parser_config`` dict.
+
+    The upload handler hands it to the parse worker through the
+    :class:`ParseDispatchPayload`. The parse worker forwards it to
+    :class:`DocParser` so a collection can opt into MinerU / a
+    specific OCR engine without a code change.
+
+    Returns ``None`` when the collection's config does not surface
+    one — :class:`DocParser` falls back to env vars in that case
+    (matching the legacy behaviour).
+    """
+    collection = await session.get(Collection, collection_id)
+    if collection is None or not collection.config:
+        return None
+    try:
+        config_dict = json.loads(collection.config)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(config_dict, dict):
+        return None
+    parser_config = config_dict.get("parser_config")
+    if parser_config is None:
+        return None
+    if not isinstance(parser_config, dict):
+        logger.warning(
+            "collection=%s collection.config.parser_config is not a dict (got %s); ignoring",
+            collection_id,
+            type(parser_config).__name__,
+        )
+        return None
+    return parser_config
 
 
 async def _delete_document_indexes(*, document_id: str) -> None:

--- a/aperag/indexing/__init__.py
+++ b/aperag/indexing/__init__.py
@@ -114,6 +114,7 @@ from aperag.indexing.orchestrator import (
     InMemoryWorkQueue,
     ModalityWorkerFactory,
     OrchestratorConfig,
+    RedisWorkQueue,
     WorkQueue,
     drain_queue_sync,
     process_one_task,
@@ -239,6 +240,7 @@ __all__ = [
     # Orchestrator (T2.1)
     "DispatchPayload",
     "InMemoryWorkQueue",
+    "RedisWorkQueue",
     "WorkQueue",
     "OrchestratorConfig",
     "ModalityWorkerFactory",

--- a/aperag/indexing/__init__.py
+++ b/aperag/indexing/__init__.py
@@ -126,6 +126,16 @@ from aperag.indexing.orchestrator import (
     run_vision_worker,
     run_worker_loop,
 )
+from aperag.indexing.parse_orchestrator import (
+    DEFAULT_PARSE_CONCURRENCY,
+    DEFAULT_POLL_TIMEOUT_SECONDS,
+    ObjectStoreFactory,
+    ParseDispatchPayload,
+    ParseOrchestratorConfig,
+    process_one_parse_task,
+    run_parse_worker,
+    run_parse_worker_loop,
+)
 from aperag.indexing.parser import (
     DEFAULT_CHUNK_OVERLAP,
     DEFAULT_CHUNK_SIZE,
@@ -257,6 +267,15 @@ __all__ = [
     "run_summary_worker",
     "run_vision_worker",
     "drain_queue_sync",
+    # Parse orchestrator (Wave 4 T3 chunk 2)
+    "DEFAULT_PARSE_CONCURRENCY",
+    "DEFAULT_POLL_TIMEOUT_SECONDS",
+    "ObjectStoreFactory",
+    "ParseDispatchPayload",
+    "ParseOrchestratorConfig",
+    "process_one_parse_task",
+    "run_parse_worker",
+    "run_parse_worker_loop",
     # Reconciler (T2.1)
     "RECONCILE_INTERVAL_SECONDS",
     "RECONCILE_BATCH_SIZE",

--- a/aperag/indexing/__init__.py
+++ b/aperag/indexing/__init__.py
@@ -100,6 +100,7 @@ from aperag.indexing.observability import (
     InMemoryMetricsEmitter,
     MetricsEmitter,
     NoopMetricsEmitter,
+    OTLPMetricsEmitter,
     emit_index_failure,
     emit_index_lag,
     emit_index_success,
@@ -226,6 +227,7 @@ __all__ = [
     # Observability (T1.5)
     "MetricsEmitter",
     "NoopMetricsEmitter",
+    "OTLPMetricsEmitter",
     "InMemoryMetricsEmitter",
     "INDEX_LAG_METRIC",
     "INDEX_FAILURE_METRIC",

--- a/aperag/indexing/cleanup.py
+++ b/aperag/indexing/cleanup.py
@@ -85,7 +85,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, Mapping
+from typing import Any, Awaitable, Callable, Mapping, Optional
 
 from sqlalchemy import Engine, and_, delete, func, select
 from sqlalchemy.orm import Session
@@ -94,6 +94,18 @@ from aperag.indexing.base import ModalityWorker
 from aperag.indexing.models import DocumentIndex, Modality
 
 logger = logging.getLogger(__name__)
+
+
+# Wave 4 T2: per-row worker factory shape. Production wires
+# :meth:`aperag.indexing.worker_factory.ProductionWorkerFactory.build_for_cleanup_row`;
+# tests inject a closure that returns the right cleanup view per
+# ``(row.collection_id, row.modality)`` against InMemory backends.
+# A factory may raise :class:`WorkerFactoryError` for a row whose
+# backend is intentionally gated (Wave 4 #9 vision multimodal /
+# Wave 4 #2 graph extractor): the cleanup loop catches that and
+# counts the row as ``backend_skipped`` while still dropping the DB
+# row so the index does not grow unboundedly.
+WorkerFactoryForRow = Callable[[DocumentIndex], Awaitable[ModalityWorker]]
 
 
 # §F.5 cleanup cycle interval. Production runs every 5 minutes;
@@ -150,6 +162,47 @@ def _is_graph_worker(worker: ModalityWorker) -> bool:
     LineageGraphStore) AND ``_entity_lock``.
     """
     return getattr(worker, "modality", None) is Modality.GRAPH
+
+
+async def _resolve_cleanup_worker(
+    *,
+    workers: Optional[Mapping[Modality, ModalityWorker]],
+    worker_factory: Optional[WorkerFactoryForRow],
+    row: DocumentIndex,
+) -> Optional[ModalityWorker]:
+    """Resolve the cleanup worker for a row from factory or static map.
+
+    Wave 4 T2: production wires the factory (per-(collection, modality)
+    lazy materialisation); tests typically pass a pre-built ``workers``
+    mapping. When both are provided the factory wins — production
+    deployments override the legacy mapping with the per-row factory.
+
+    Returns ``None`` when neither source can supply a worker; the
+    caller logs + counts the row as ``backend_skipped``. A factory
+    that raises :class:`WorkerFactoryError` (Wave 4 vision multimodal
+    gate / partial config) also returns ``None`` so the cleanup cycle
+    drops the DB row even when the backend is unreachable, matching
+    the existing "skip backend, drop row" semantics.
+    """
+    if worker_factory is not None:
+        try:
+            return await worker_factory(row)
+        except Exception as exc:  # noqa: BLE001 — surface via log, count as skip
+            logger.warning(
+                "cleanup worker_factory failed modality=%s row id=%d collection=%s: %s — counting as backend_skipped",
+                row.modality,
+                row.id,
+                row.collection_id,
+                exc,
+            )
+            return None
+    if workers is None:
+        return None
+    try:
+        modality = Modality(row.modality)
+    except ValueError:
+        return None
+    return workers.get(modality)
 
 
 # ---------------------------------------------------------------------
@@ -215,16 +268,19 @@ def find_orphan_parse_versions(
 async def cleanup_orphan_parse_versions(
     *,
     engine: Engine,
-    workers: Mapping[Modality, ModalityWorker],
+    workers: Optional[Mapping[Modality, ModalityWorker]] = None,
+    worker_factory: Optional[WorkerFactoryForRow] = None,
     cooldown_seconds: int = ORPHAN_COOLDOWN_SECONDS,
     batch_size: int = CLEANUP_BATCH_SIZE,
 ) -> dict[str, int]:
     """Garbage-collect every orphan triple visible right now (path A).
 
-    ``workers`` is the per-modality registry the orchestrator already
-    uses; cleanup looks up each row's modality to find the worker.
-    Returns a dict ``{"backend_deleted": N, "rows_deleted": N,
-    "graph_noop": N, "backend_skipped": N}`` for telemetry / tests.
+    Wave 4 T2: ``worker_factory`` is the per-row lazy resolver
+    production lifespan installs; ``workers`` is the legacy per-modality
+    static map kept for backward-compat with existing tests. When both
+    are passed the factory wins. Returns a dict ``{"backend_deleted":
+    N, "rows_deleted": N, "graph_noop": N, "backend_skipped": N}``
+    for telemetry / tests.
 
     **Graph behaviour** (per architect ruling msg=492315e8 Ruling 3):
     the §D.3.6 sync supersede semantic already removed the old
@@ -250,7 +306,7 @@ async def cleanup_orphan_parse_versions(
     delete_ids: list[int] = []
     for row in rows:
         try:
-            modality = Modality(row.modality)
+            Modality(row.modality)
         except ValueError:
             logger.error(
                 "cleanup unknown modality %r on row id=%d — skipping",
@@ -259,7 +315,11 @@ async def cleanup_orphan_parse_versions(
             )
             continue
 
-        worker = workers.get(modality)
+        worker = await _resolve_cleanup_worker(
+            workers=workers,
+            worker_factory=worker_factory,
+            row=row,
+        )
         if worker is None:
             logger.warning(
                 "cleanup no worker registered for modality=%s row id=%d — skipping backend delete",
@@ -320,7 +380,8 @@ async def cleanup_orphan_parse_versions(
 async def cleanup_for_deleted_documents(
     *,
     engine: Engine,
-    workers: Mapping[Modality, ModalityWorker],
+    workers: Optional[Mapping[Modality, ModalityWorker]] = None,
+    worker_factory: Optional[WorkerFactoryForRow] = None,
     document_ids: list[str],
 ) -> dict[str, int]:
     """Garbage-collect every triple for the given deleted documents (path B).
@@ -335,6 +396,11 @@ async def cleanup_for_deleted_documents(
       delete via :class:`LineageGraphStore` per architect ruling
       msg=492315e8 Ruling 3. Each entity is removed under its
       :class:`EntityLock` so a concurrent graph sync cannot race.
+
+    Wave 4 T2: ``worker_factory`` resolves the worker per-row from the
+    persisted ``DocumentIndex`` (collection_id + modality); ``workers``
+    is the legacy static map kept for tests. When both are passed the
+    factory wins.
 
     All ``document_index_v2`` rows for the requested documents are
     dropped at the end (one batched DELETE).
@@ -368,7 +434,7 @@ async def cleanup_for_deleted_documents(
 
     for row in rows:
         try:
-            modality = Modality(row.modality)
+            Modality(row.modality)
         except ValueError:
             logger.error(
                 "cleanup unknown modality %r on row id=%d (document=%s) — skipping",
@@ -378,7 +444,11 @@ async def cleanup_for_deleted_documents(
             )
             continue
 
-        worker = workers.get(modality)
+        worker = await _resolve_cleanup_worker(
+            workers=workers,
+            worker_factory=worker_factory,
+            row=row,
+        )
         if worker is None:
             logger.warning(
                 "cleanup no worker for modality=%s row id=%d document=%s — skipping backend",
@@ -510,7 +580,8 @@ def _delete_rows(engine: Engine, ids: list[int]) -> None:
 async def cleanup_for_deleted_collections(
     *,
     engine: Engine,
-    workers: Mapping[Modality, ModalityWorker],
+    workers: Optional[Mapping[Modality, ModalityWorker]] = None,
+    worker_factory: Optional[WorkerFactoryForRow] = None,
     collection_ids: list[str],
 ) -> dict[str, int]:
     """Cascade-cleanup every triple for the given deleted collections (path C).
@@ -567,6 +638,7 @@ async def cleanup_for_deleted_collections(
         sub_counts = await cleanup_for_deleted_documents(
             engine=engine,
             workers=workers,
+            worker_factory=worker_factory,
             document_ids=document_ids,
         )
         for key in ("backend_deleted", "graph_lineage_cleaned", "rows_deleted", "backend_skipped"):
@@ -603,7 +675,8 @@ def _delete_rows_for_collections(engine: Engine, collection_ids: list[str]) -> i
 async def run_cleanup_loop(
     *,
     engine: Engine,
-    workers: Mapping[Modality, ModalityWorker],
+    workers: Optional[Mapping[Modality, ModalityWorker]] = None,
+    worker_factory: Optional[WorkerFactoryForRow] = None,
     shutdown: asyncio.Event,
     interval_seconds: int = CLEANUP_INTERVAL_SECONDS,
     cooldown_seconds: int = ORPHAN_COOLDOWN_SECONDS,
@@ -618,6 +691,11 @@ async def run_cleanup_loop(
       stuck in UPLOADED status > 1 day (replaces legacy
       ``cleanup_expired_documents_task`` Celery beat schedule)
 
+    Wave 4 T2: production lifespan injects ``worker_factory`` (per-row
+    lazy resolver against the existing ``ProductionWorkerFactory``);
+    tests typically inject a static ``workers`` map. When both are
+    given the factory wins.
+
     A cycle that throws is logged and the loop continues — DB
     unreachable / Redis blip should not crash the cleanup process.
     """
@@ -626,6 +704,7 @@ async def run_cleanup_loop(
             counts = await cleanup_orphan_parse_versions(
                 engine=engine,
                 workers=workers,
+                worker_factory=worker_factory,
                 cooldown_seconds=cooldown_seconds,
             )
             if any(counts.values()):
@@ -665,6 +744,7 @@ __all__ = [
     "CLEANUP_BATCH_SIZE",
     "CLEANUP_INTERVAL_SECONDS",
     "ORPHAN_COOLDOWN_SECONDS",
+    "WorkerFactoryForRow",
     "cleanup_expired_documents_hook",
     "cleanup_for_deleted_collections",
     "cleanup_for_deleted_documents",

--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -1,0 +1,354 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real LLM-driven graph extractor — Wave 4 T1.
+
+Replaces the chunk 4b ``_no_op_extractor`` placeholder with an actual
+LightRAG-style entity/relation extractor that calls the collection's
+configured completion model for each chunk and parses the JSON output
+into the new ``aperag.indexing.graph.EntityRecord`` /
+``RelationRecord`` shapes.
+
+The extractor is built per-collection so the LLM callable is closure-
+bound to the collection's completion config (provider / model / api
+key). The factory function returns an async closure with the
+``GraphExtractor`` Protocol shape — the same shape
+:class:`GraphModalityWorker` already accepts.
+
+Failure semantics (per Wave 3 lesson #10 ship-incomplete-but-don't-
+silently-lie):
+
+* No completion model configured for the collection → factory raises
+  :class:`aperag.indexing.worker_factory.WorkerFactoryError` so the
+  graph row finalises FAILED with operator-facing diagnostics. Without
+  this, the extractor would build but every dispatch would emit a
+  cryptic LLM-side error.
+* Per-chunk LLM call failures (malformed JSON, transient backend
+  errors, etc.) log a warning and skip the chunk's entities/relations.
+  The other chunks still contribute. This matches the legacy LightRAG
+  extractor's failure semantics — one bad chunk does not poison the
+  whole document.
+
+Wave 5 follow-up (per architect msg=87e2b187 chunk 4d Option C
+ruling): the legacy ``aperag/domains/knowledge_graph/graphindex/``
+package is slated for elimination. The current implementation
+imports ``render_extraction_prompt`` from the legacy ``prompts``
+module + ``build_collection_llm_callable`` from the legacy
+``integration`` module — these dependencies are intentional bridge
+points and will be relocated to ``aperag/indexing/llm.py`` when the
+Wave 5 cross-cutting refactor lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any, Awaitable, Callable, Mapping, Sequence
+
+from aperag.indexing.graph import (
+    EntityRecord,
+    GraphExtractor,
+    RelationRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_ENTITY_TYPES: tuple[str, ...] = (
+    "organization",
+    "person",
+    "geo",
+    "event",
+    "product",
+    "technology",
+    "date",
+    "category",
+)
+_DEFAULT_LANGUAGE = "en-US"
+_DEFAULT_MAX_ENTITIES_PER_CHUNK = 32
+_DEFAULT_MAX_RELATIONS_PER_CHUNK = 32
+_DEFAULT_PER_CHUNK_TIMEOUT_SECONDS = 60.0
+
+
+def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
+    """Construct a :class:`GraphExtractor` closure bound to
+    ``collection``'s completion model.
+
+    Read by :func:`aperag.indexing.worker_factory._build_graph_worker`
+    when constructing a graph modality worker for an indexing dispatch.
+    The closure is async and matches the
+    ``Sequence[dict] -> Awaitable[(entities, relations)]`` shape
+    :class:`aperag.indexing.graph.GraphModalityWorker` expects.
+
+    Raises :class:`aperag.indexing.worker_factory.WorkerFactoryError`
+    if the collection has no completion model configured (no LLM
+    callable can be built) — the orchestrator finalises the graph row
+    FAILED with the message rather than silently building a worker
+    that will fail at dispatch time.
+    """
+    from aperag.domains.knowledge_graph.graphindex.integration import (
+        build_collection_llm_callable,
+    )
+    from aperag.indexing.worker_factory import WorkerFactoryError
+
+    try:
+        llm = build_collection_llm_callable(collection)
+    except Exception as exc:  # noqa: BLE001 — wrap for orchestrator
+        raise WorkerFactoryError(
+            f"graph extractor: completion model not configured for collection "
+            f"{getattr(collection, 'id', '<unknown>')}: {exc!r}; "
+            f"set collection.config.enable_knowledge_graph=false or configure "
+            f"the collection's completion model"
+        ) from exc
+
+    entity_types = tuple(_resolve_entity_types(collection))
+    language = _resolve_language(collection)
+    max_entities = _DEFAULT_MAX_ENTITIES_PER_CHUNK
+    max_relations = _DEFAULT_MAX_RELATIONS_PER_CHUNK
+
+    async def _extractor(chunks: Sequence[dict[str, Any]]) -> tuple[list[EntityRecord], list[RelationRecord]]:
+        """Run the LLM extractor over every chunk in the dispatch."""
+        if not chunks:
+            return ([], [])
+
+        entities: list[EntityRecord] = []
+        relations: list[RelationRecord] = []
+        for chunk in chunks:
+            chunk_id = str(chunk.get("chunk_id") or chunk.get("id") or "")
+            text = str(chunk.get("text") or "")
+            if not text.strip():
+                continue
+            try:
+                ents, rels = await _extract_one_chunk(
+                    llm=llm,
+                    text=text,
+                    chunk_id=chunk_id,
+                    entity_types=entity_types,
+                    language=language,
+                    max_entities=max_entities,
+                    max_relations=max_relations,
+                )
+            except Exception:  # noqa: BLE001 — per-chunk failure isolation
+                logger.exception(
+                    "graph extractor: LLM call failed for chunk_id=%s in collection=%s; "
+                    "skipping chunk's entities/relations",
+                    chunk_id,
+                    getattr(collection, "id", "<unknown>"),
+                )
+                continue
+            entities.extend(ents)
+            relations.extend(rels)
+        return entities, relations
+
+    return _extractor
+
+
+# ---------------------------------------------------------------------
+# Per-chunk extraction.
+# ---------------------------------------------------------------------
+
+
+async def _extract_one_chunk(
+    *,
+    llm: Callable[[str], Awaitable[str]],
+    text: str,
+    chunk_id: str,
+    entity_types: tuple[str, ...],
+    language: str,
+    max_entities: int,
+    max_relations: int,
+) -> tuple[list[EntityRecord], list[RelationRecord]]:
+    """Single-chunk extraction: render the prompt, call the LLM, parse
+    the JSON response, return record lists.
+
+    Wraps the LLM call in :func:`asyncio.wait_for` with the per-chunk
+    timeout so a stuck LLM does not block the worker forever; on
+    timeout we propagate :class:`asyncio.TimeoutError` to the caller
+    which already logs + skips the chunk.
+    """
+    from aperag.domains.knowledge_graph.graphindex.prompts import (
+        render_extraction_prompt,
+    )
+
+    prompt = render_extraction_prompt(
+        input_text=text,
+        entity_types=list(entity_types),
+        language=language,
+        max_entities=max_entities,
+        max_relations=max_relations,
+    )
+    raw = await asyncio.wait_for(llm(prompt), timeout=_DEFAULT_PER_CHUNK_TIMEOUT_SECONDS)
+    return _parse_extraction_response(raw=raw, chunk_id=chunk_id)
+
+
+def _parse_extraction_response(
+    *,
+    raw: str,
+    chunk_id: str,
+) -> tuple[list[EntityRecord], list[RelationRecord]]:
+    """Parse the LLM's JSON response into entity / relation records.
+
+    The prompt asks for strict JSON with ``entities`` + ``relations``
+    arrays; we accept either a fenced `````json ... ````` block or a bare JSON
+    object so deployments that strip code-fences in their LLM
+    middleware still work. Malformed payloads return ``([], [])``;
+    individual records that fail to parse are logged + skipped so a
+    single bad row does not drop the rest.
+    """
+    payload = _strip_code_fence(raw)
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        logger.warning(
+            "graph extractor: chunk_id=%s response is not valid JSON; skipping entities/relations from this chunk",
+            chunk_id,
+        )
+        return ([], [])
+
+    if not isinstance(parsed, Mapping):
+        logger.warning(
+            "graph extractor: chunk_id=%s response is JSON but not an object; got %s",
+            chunk_id,
+            type(parsed).__name__,
+        )
+        return ([], [])
+
+    entities: list[EntityRecord] = []
+    for raw_entity in parsed.get("entities", []) or []:
+        if not isinstance(raw_entity, Mapping):
+            continue
+        try:
+            entities.append(_entity_from_dict(raw_entity, chunk_id=chunk_id))
+        except (KeyError, ValueError, TypeError) as exc:
+            logger.warning(
+                "graph extractor: chunk_id=%s skipping malformed entity %r: %s",
+                chunk_id,
+                raw_entity,
+                exc,
+            )
+
+    relations: list[RelationRecord] = []
+    for raw_relation in parsed.get("relations", []) or []:
+        if not isinstance(raw_relation, Mapping):
+            continue
+        try:
+            relations.append(_relation_from_dict(raw_relation, chunk_id=chunk_id))
+        except (KeyError, ValueError, TypeError) as exc:
+            logger.warning(
+                "graph extractor: chunk_id=%s skipping malformed relation %r: %s",
+                chunk_id,
+                raw_relation,
+                exc,
+            )
+
+    return entities, relations
+
+
+_FENCE_RE = re.compile(r"^\s*```(?:json|JSON)?\s*\n(.*)\n```\s*$", re.DOTALL)
+
+
+def _strip_code_fence(raw: str) -> str:
+    """Remove a wrapping markdown code fence if present so
+    ``json.loads`` sees the inner JSON directly. Idempotent on bare
+    JSON."""
+    match = _FENCE_RE.match(raw)
+    if match:
+        return match.group(1)
+    return raw.strip()
+
+
+def _entity_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> EntityRecord:
+    name = str(raw["name"]).strip()
+    if not name:
+        raise ValueError("entity name cannot be empty")
+    entity_type = str(raw.get("type") or "")
+    description = str(raw.get("description") or "")
+    return EntityRecord(
+        name=name,
+        type=entity_type,
+        description=description,
+        source_chunk_ids=(chunk_id,) if chunk_id else (),
+    )
+
+
+def _relation_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> RelationRecord:
+    source = str(raw["source"]).strip()
+    target = str(raw["target"]).strip()
+    if not source or not target:
+        raise ValueError("relation source/target cannot be empty")
+    rel_type = str(raw.get("type") or "")
+    description = str(raw.get("description") or "")
+    return RelationRecord(
+        source=source,
+        target=target,
+        type=rel_type,
+        description=description,
+        source_chunk_ids=(chunk_id,) if chunk_id else (),
+    )
+
+
+# ---------------------------------------------------------------------
+# Collection config readers — tolerant of the dict / pydantic-attr /
+# JSON-string shapes ``Collection.config`` may take in the DB.
+# ---------------------------------------------------------------------
+
+
+def _resolve_entity_types(collection: Any) -> Sequence[str]:
+    cfg = _resolve_config(collection)
+    if cfg is None:
+        return _DEFAULT_ENTITY_TYPES
+    kg_config: Any = None
+    if hasattr(cfg, "knowledge_graph_config"):
+        kg_config = cfg.knowledge_graph_config
+    elif isinstance(cfg, Mapping):
+        kg_config = cfg.get("knowledge_graph_config")
+    if kg_config is None:
+        return _DEFAULT_ENTITY_TYPES
+    if hasattr(kg_config, "entity_types"):
+        types = kg_config.entity_types
+    elif isinstance(kg_config, Mapping):
+        types = kg_config.get("entity_types")
+    else:
+        types = None
+    if not types:
+        return _DEFAULT_ENTITY_TYPES
+    return [str(t) for t in types]
+
+
+def _resolve_language(collection: Any) -> str:
+    cfg = _resolve_config(collection)
+    if cfg is None:
+        return _DEFAULT_LANGUAGE
+    if hasattr(cfg, "language"):
+        return str(cfg.language or _DEFAULT_LANGUAGE)
+    if isinstance(cfg, Mapping):
+        return str(cfg.get("language") or _DEFAULT_LANGUAGE)
+    return _DEFAULT_LANGUAGE
+
+
+def _resolve_config(collection: Any) -> Any:
+    cfg = getattr(collection, "config", None)
+    if cfg is None:
+        return None
+    if isinstance(cfg, str):
+        try:
+            return json.loads(cfg)
+        except (TypeError, ValueError):
+            return None
+    return cfg
+
+
+__all__ = ["build_collection_graph_extractor"]

--- a/aperag/indexing/graph_storage/__init__.py
+++ b/aperag/indexing/graph_storage/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""§D.3.5 :class:`LineageGraphStore` adapters — Wave 4 T8.
+
+Wave 3 shipped the lineage-aware graph modality with only the
+in-memory reference store; :func:`aperag.indexing.worker_factory.
+_build_graph_worker` raises a ``WorkerFactoryError`` for any
+collection that opts into graph indexing because the placeholder
+is non-durable and silent-broken in production. Wave 4 lifts that
+gate by wiring the three real backends ApeRAG already supports for
+the legacy ``GraphStore`` Protocol — PostgreSQL / Neo4j / Nebula —
+to the new lineage-SET-level Protocol.
+
+The adapters live in this package (one module per backend) plus a
+``factory`` helper that picks the right implementation based on
+``collection.config.graph_backend_type``. The legacy
+``aperag/domains/knowledge_graph/graphindex/storage/`` subpackage
+is hard-cut deleted in the same PR so the codebase keeps exactly
+one graph backend abstraction (architect msg=0aea9edf "no dual
+store abstraction long-term").
+
+The Postgres adapter is the reference implementation; Neo4j and
+Nebula mirror its shape with per-backend storage primitives
+(Cypher list-of-MAP property / nGQL JSON STRING tag respectively).
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/aperag/indexing/graph_storage/nebula.py
+++ b/aperag/indexing/graph_storage/nebula.py
@@ -347,7 +347,6 @@ class NebulaLineageGraphStore:
                 f"gmt_created datetime, gmt_updated datetime)",
                 f"CREATE TAG IF NOT EXISTS `{_RELATION_TAG}`("
                 f"source string, target string, type string, "
-                f"description string, "
                 f"evidence_lineage_json string, description_parts_json string, "
                 f"gmt_created datetime, gmt_updated datetime)",
                 f"CREATE TAG INDEX IF NOT EXISTS `idx_{_ENTITY_TAG}_name` ON `{_ENTITY_TAG}`(name(256))",
@@ -403,22 +402,20 @@ class NebulaLineageGraphStore:
 
     def _read_relation_lineage(
         self, source: str, target: str, type: str
-    ) -> tuple[str, list[LineageMember], list[DescriptionPart]] | None:
+    ) -> tuple[list[LineageMember], list[DescriptionPart]] | None:
         vid = _relation_vid(source, target, type)
         stmt = (
             f'FETCH PROP ON `{_RELATION_TAG}` "{_escape_str(vid)}" '
-            f"YIELD `{_RELATION_TAG}`.description AS description, "
-            f"`{_RELATION_TAG}`.evidence_lineage_json AS el, "
+            f"YIELD `{_RELATION_TAG}`.evidence_lineage_json AS el, "
             f"`{_RELATION_TAG}`.description_parts_json AS dp"
         )
         result = self._execute_with_schema_retry(self._space, stmt)
         if result.row_size() == 0:
             return None
         row = result.row_values(0)
-        description = row[0].as_string() if row[0].is_string() else ""
-        el_raw = row[1].as_string() if row[1].is_string() else ""
-        dp_raw = row[2].as_string() if row[2].is_string() else ""
-        return description, _members_from_json(el_raw), _parts_from_json(dp_raw)
+        el_raw = row[0].as_string() if row[0].is_string() else ""
+        dp_raw = row[1].as_string() if row[1].is_string() else ""
+        return _members_from_json(el_raw), _parts_from_json(dp_raw)
 
     def _list_all_entity_vids(self) -> list[str]:
         """Return all VIDs tagged with ``lineage_entity`` in the
@@ -490,18 +487,16 @@ class NebulaLineageGraphStore:
         source: str,
         target: str,
         type_value: str,
-        description: str,
         evidence_lineage: list[LineageMember],
         description_parts: list[DescriptionPart],
     ) -> None:
         vid = _relation_vid(source, target, type_value)
         stmt = (
             f"INSERT VERTEX `{_RELATION_TAG}`"
-            f"(source, target, type, description, "
+            f"(source, target, type, "
             f"evidence_lineage_json, description_parts_json, gmt_created, gmt_updated) "
             f'VALUES "{_escape_str(vid)}":('
             f'"{_escape_str(source)}", "{_escape_str(target)}", "{_escape_str(type_value)}", '
-            f'"{_escape_str(description)}", '
             f'"{_escape_str(_members_to_json(evidence_lineage))}", '
             f'"{_escape_str(_parts_to_json(description_parts))}", '
             f"datetime(), datetime())"
@@ -545,7 +540,7 @@ class NebulaLineageGraphStore:
                 row = self._read_relation_lineage_by_vid(vid)
                 if row is None:
                     continue
-                source, target, type_value, _description, members, _parts = row
+                source, target, type_value, members, _parts = row
                 if any(m.document_id == document_id for m in members):
                     keys.append((source, target, type_value))
             return keys
@@ -576,13 +571,12 @@ class NebulaLineageGraphStore:
 
     def _read_relation_lineage_by_vid(
         self, vid: str
-    ) -> tuple[str, str, str, str, list[LineageMember], list[DescriptionPart]] | None:
+    ) -> tuple[str, str, str, list[LineageMember], list[DescriptionPart]] | None:
         stmt = (
             f'FETCH PROP ON `{_RELATION_TAG}` "{_escape_str(vid)}" '
             f"YIELD `{_RELATION_TAG}`.source AS source, "
             f"`{_RELATION_TAG}`.target AS target, "
             f"`{_RELATION_TAG}`.type AS type, "
-            f"`{_RELATION_TAG}`.description AS description, "
             f"`{_RELATION_TAG}`.evidence_lineage_json AS el, "
             f"`{_RELATION_TAG}`.description_parts_json AS dp"
         )
@@ -593,14 +587,12 @@ class NebulaLineageGraphStore:
         source = row[0].as_string() if row[0].is_string() else ""
         target = row[1].as_string() if row[1].is_string() else ""
         type_value = row[2].as_string() if row[2].is_string() else ""
-        description = row[3].as_string() if row[3].is_string() else ""
-        el_raw = row[4].as_string() if row[4].is_string() else ""
-        dp_raw = row[5].as_string() if row[5].is_string() else ""
+        el_raw = row[3].as_string() if row[3].is_string() else ""
+        dp_raw = row[4].as_string() if row[4].is_string() else ""
         return (
             source,
             target,
             type_value,
-            description,
             _members_from_json(el_raw),
             _parts_from_json(dp_raw),
         )
@@ -637,7 +629,7 @@ class NebulaLineageGraphStore:
                 row = self._read_relation_lineage(source, target, type)
                 if row is None:
                     return
-                description, members, parts = row
+                members, parts = row
                 new_members = [m for m in members if m.document_id != document_id]
                 new_parts = [p for p in parts if p.document_id != document_id]
                 if len(new_members) == len(members) and len(new_parts) == len(parts):
@@ -646,7 +638,6 @@ class NebulaLineageGraphStore:
                     source=source,
                     target=target,
                     type_value=type,
-                    description=description,
                     evidence_lineage=new_members,
                     description_parts=new_parts,
                 )
@@ -679,7 +670,7 @@ class NebulaLineageGraphStore:
                 row = self._read_relation_lineage(source, target, type)
                 if row is None:
                     return False
-                _description, members, _parts = row
+                members, _parts = row
                 if members:
                     return False
                 self._delete_relation_vertex(source, target, type)
@@ -740,14 +731,13 @@ class NebulaLineageGraphStore:
                     new_members = [lineage]
                     new_parts = [new_part]
                 else:
-                    _existing_description, members, parts = row
+                    members, parts = row
                     new_members = [m for m in members if m.key() != lineage.key()] + [lineage]
                     new_parts = [p for p in parts if p.key() != new_part.key()] + [new_part]
                 self._write_relation_vertex(
                     source=record.source,
                     target=record.target,
                     type_value=record.type,
-                    description=record.description,
                     evidence_lineage=new_members,
                     description_parts=new_parts,
                 )
@@ -780,7 +770,7 @@ class NebulaLineageGraphStore:
             row = self._read_relation_lineage(source, target, type)
             if row is None:
                 return None
-            _description, members, parts = row
+            members, parts = row
             return RelationWithLineage(
                 source=source,
                 target=target,

--- a/aperag/indexing/graph_storage/nebula.py
+++ b/aperag/indexing/graph_storage/nebula.py
@@ -143,6 +143,13 @@ _SCHEMA_VISIBILITY_ERROR_FRAGMENTS = (
     "TagNotFound",
     "EdgeNotFound",
     "SpaceNotFound",
+    # Storage-side variant (text spelling differs from metad's): the
+    # storaged process emits ``Storage Error: Tag not found`` /
+    # ``Edge not found`` while metad emits the camelCased forms above.
+    # Wave 4 chunk 4c surfaced this on rapid space-drop/recreate
+    # cycles (cross-backend contract fixture's per-test SPACE setup).
+    "Tag not found",
+    "Edge not found",
 )
 
 

--- a/aperag/indexing/graph_storage/nebula.py
+++ b/aperag/indexing/graph_storage/nebula.py
@@ -1,0 +1,797 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nebula Graph implementation of :class:`LineageGraphStore` — Wave 4 T8 chunk 3.
+
+Mirrors :class:`PostgresLineageGraphStore` (chunk 1 reference) and
+:class:`Neo4jLineageGraphStore` (chunk 2) over Nebula 3.x. The §D.3.5
+lineage SET dedup-by-``(document_id, parse_version)`` semantic ports
+to Nebula via a **JSON STRING property** encoding because Nebula's
+property model does not support list-of-MAP and has only limited
+list ops (per architect msg=95179f2a). Each lineage SET is serialised
+into a single ``string`` column holding a JSON array; reads parse the
+JSON, writes mutate in Python and write the new JSON back.
+
+That round-trip is **inherently a read-modify-write loop** — two
+concurrent ``upsert_*_with_lineage`` against the same row will race
+unless serialised. Per architect msg=f2921ae0, the Nebula backend
+**must** acquire an :class:`EntityLock` keyed by entity name (or
+relation triple) for every read-modify-write; the Postgres / Neo4j
+backends don't need this because they have native single-statement
+strip-then-append. The :class:`EntityLock` is injected at construction
+time so callers control the lock scope (``InMemoryEntityLock`` for
+single-process tests, ``RedisEntityLock`` for multi-process production
+worker pools).
+
+Storage layout — one Nebula SPACE per ``collection_id`` (the natural
+Nebula tenancy boundary, mirroring how the legacy ``NebulaGraphStore``
+isolates collections; cheap and cleaner than a per-row collection_id
+filter on a single space):
+
+    SPACE ``{space_prefix}_{collection_id}``
+        TAG ``lineage_entity(
+            name string,
+            type string,
+            source_lineage_json string,
+            description_parts_json string,
+            gmt_created datetime,
+            gmt_updated datetime
+        )``
+        TAG ``lineage_relation(
+            source string,
+            target string,
+            type string,
+            description string,
+            evidence_lineage_json string,
+            description_parts_json string,
+            gmt_created datetime,
+            gmt_updated datetime
+        )``
+
+Vertex VID convention (Nebula needs every vertex to have a string VID
+that fits ``FIXED_STRING(N)``):
+
+* entity vertex VID = ``"e|" + name``
+* relation vertex VID = ``"r|" + source + "|" + target + "|" + type``
+
+The ``|`` separator is escaped in inputs (URL-encode style) so the VID
+parse is unambiguous. ``r|`` and ``e|`` prefixes guarantee no VID
+collision between entity and relation rows even when an entity
+happens to share its name with a relation triple component.
+
+Every public method is async to honour the Protocol; the underlying
+``nebula3-python`` SDK is sync and CPU/IO blocking, so each method
+funnels its work through ``asyncio.to_thread`` (matching the legacy
+adapter pattern). The :class:`EntityLock` acquisition is async so it
+composes correctly across the thread boundary.
+
+§D.3.5 Protocol semantics → nGQL:
+
+* ``find_entity_ids_with_lineage(document_id)`` → ``LOOKUP ON
+  lineage_entity`` to enumerate all entities, then in-Python filter
+  on JSON for the ``document_id`` match. Without a JSON containment
+  index, this is O(N) over the entity tag — acceptable for the
+  lineage SET cardinality the §D.3 design pack describes (typically
+  < 100 docs/entity); high-cardinality entities are a Wave 5 perf
+  optimisation candidate.
+* ``remove_entity_lineage_member(name, document_id)`` → FETCH PROP
+  + JSON parse + filter members where ``document_id != X`` + UPDATE
+  VERTEX with the new JSON. The whole block is wrapped in
+  ``EntityLock.acquire(name)`` so two concurrent strips on the same
+  row serialise.
+* ``upsert_entity_with_lineage`` → MERGE-style: FETCH (or initialise
+  empty) + remove any existing member with same
+  ``(document_id, parse_version)`` key + append new member +
+  INSERT/UPDATE VERTEX. Lock-protected.
+* ``gc_*_if_orphan`` → FETCH lineage; if empty list, ``DELETE
+  VERTEX``. Returns True if the delete actually happened. Also
+  lock-protected so a concurrent re-upsert on the same key does not
+  resurrect-then-delete.
+
+Hard-cut second round: this module is the new Nebula adapter. The
+legacy ``aperag/domains/knowledge_graph/graphindex/storage/nebula.py``
+is deleted in chunk 4 of the same Wave 4 PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import threading
+import time
+from typing import Any
+
+from aperag.indexing.graph import (
+    DescriptionPart,
+    EntityLock,
+    EntityRecord,
+    EntityWithLineage,
+    LineageMember,
+    RelationRecord,
+    RelationWithLineage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_ENTITY_TAG = "lineage_entity"
+_RELATION_TAG = "lineage_relation"
+_ENTITY_VID_PREFIX = "e|"
+_RELATION_VID_PREFIX = "r|"
+
+# Schema-visibility retry settings: Nebula metad propagates new tags /
+# spaces to storaged on a heartbeat; freshly-created tag/space writes
+# can briefly raise ``SpaceNotFound`` / ``No schema found for`` /
+# ``TagNotFound`` before the heartbeat catches up.
+_SCHEMA_VISIBILITY_RETRIES = 30
+_SCHEMA_VISIBILITY_DELAY_SECONDS = 1.0
+_SCHEMA_VISIBILITY_ERROR_FRAGMENTS = (
+    "No schema found for",
+    "TagNotFound",
+    "EdgeNotFound",
+    "SpaceNotFound",
+)
+
+
+def _is_schema_visibility_error(exc: BaseException) -> bool:
+    msg = str(exc)
+    return any(fragment in msg for fragment in _SCHEMA_VISIBILITY_ERROR_FRAGMENTS)
+
+
+# ---------------------------------------------------------------------
+# Helpers — VID encoding, JSON SET manipulation, escaping.
+# ---------------------------------------------------------------------
+
+
+def _escape_str(s: str) -> str:
+    """Escape a Python string for embedding inside an nGQL string
+    literal. Uses ``json.dumps`` and strips the surrounding quotes so
+    the embedded backslash / quote / unicode handling matches what the
+    Nebula parser expects."""
+    return json.dumps(s, ensure_ascii=False)[1:-1]
+
+
+def _vid_escape_segment(s: str) -> str:
+    """Escape ``|`` and backslash inside a VID segment so the
+    ``r|<source>|<target>|<type>`` decomposition is unambiguous."""
+    return s.replace("\\", "\\\\").replace("|", "\\p")
+
+
+def _entity_vid(name: str) -> str:
+    return _ENTITY_VID_PREFIX + _vid_escape_segment(name)
+
+
+def _relation_vid(source: str, target: str, type: str) -> str:
+    return (
+        _RELATION_VID_PREFIX
+        + _vid_escape_segment(source)
+        + "|"
+        + _vid_escape_segment(target)
+        + "|"
+        + _vid_escape_segment(type)
+    )
+
+
+def _space_name(prefix: str, collection_id: str) -> str:
+    """Sanitise the collection_id so it can be embedded in a Nebula
+    SPACE name (Nebula identifiers must match ``[a-zA-Z0-9_]``)."""
+    safe_id = re.sub(r"[^a-zA-Z0-9_]", "_", collection_id)
+    return f"{prefix}_{safe_id}"
+
+
+def _members_to_json(members: list[LineageMember]) -> str:
+    return json.dumps([m.to_dict() for m in members])
+
+
+def _parts_to_json(parts: list[DescriptionPart]) -> str:
+    return json.dumps([p.to_dict() for p in parts])
+
+
+def _members_from_json(raw: str) -> list[LineageMember]:
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return [LineageMember.from_dict(item) for item in data if isinstance(item, dict)]
+
+
+def _parts_from_json(raw: str) -> list[DescriptionPart]:
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return [DescriptionPart.from_dict(item) for item in data if isinstance(item, dict)]
+
+
+# ---------------------------------------------------------------------
+# Public adapter.
+# ---------------------------------------------------------------------
+
+
+class NebulaLineageGraphStore:
+    """:class:`LineageGraphStore` implementation backed by Nebula 3.x.
+
+    Key design decisions (per architect msg=95179f2a + msg=f2921ae0):
+
+    1. **JSON STRING property** for the lineage SET — Nebula property
+       types are scalars + ``string``; no list-of-map. Each SET is one
+       ``string`` column holding a JSON array.
+    2. **Per-entity / per-relation lock for read-modify-write** — JSON
+       round-trip is inherently racy across concurrent syncs;
+       :class:`EntityLock` makes the serialisation explicit.
+    3. **One SPACE per collection_id** — natural Nebula tenancy
+       (cheap; ``DROP SPACE`` is the fastest way to wipe a collection).
+       The store-instance binds to a ``collection_id`` at construction
+       time, mirroring the per-store-instance binding pattern used by
+       :class:`PostgresLineageGraphStore` and
+       :class:`Neo4jLineageGraphStore` (per architect msg=95179f2a
+       Design point 2).
+
+    The constructor accepts a Nebula 3.x ``ConnectionPool`` (the
+    caller — typically the worker_factory — controls pool lifecycle)
+    plus username / password / collection_id / entity_lock. Production
+    deployments inject a :class:`RedisEntityLock` so the lock
+    serialises across worker processes; tests inject the
+    :class:`InMemoryEntityLock` reference impl.
+    """
+
+    def __init__(
+        self,
+        *,
+        pool: Any,
+        username: str,
+        password: str,
+        collection_id: str,
+        entity_lock: EntityLock,
+        space_prefix: str = "aperag_lineage",
+    ) -> None:
+        self._pool = pool
+        self._username = username
+        self._password = password
+        self._collection_id = collection_id
+        self._entity_lock = entity_lock
+        self._space_prefix = space_prefix
+        self._space = _space_name(space_prefix, collection_id)
+        self._schema_init_lock = threading.Lock()
+        self._schema_initialised = False
+
+    # -- low-level session execution ----------------------------------
+
+    def _execute(self, space: str, stmt: str) -> Any:
+        """Run a single nGQL statement in a sync session. Raises
+        ``RuntimeError`` on Nebula-side failure; the caller is
+        responsible for translating known transient errors (e.g.
+        schema-visibility) into retries."""
+        session = self._pool.get_session(self._username, self._password)
+        try:
+            if space:
+                use_result = session.execute(f"USE `{space}`")
+                if not use_result.is_succeeded():
+                    raise RuntimeError(f"Nebula USE failed: {use_result.error_msg()}")
+            result = session.execute(stmt)
+            if not result.is_succeeded():
+                raise RuntimeError(f"Nebula query failed: {result.error_msg()}\nStatement: {stmt}")
+            return result
+        finally:
+            session.release()
+
+    def _execute_with_schema_retry(self, space: str, stmt: str) -> Any:
+        last_error: RuntimeError | None = None
+        for _ in range(_SCHEMA_VISIBILITY_RETRIES):
+            try:
+                return self._execute(space, stmt)
+            except RuntimeError as exc:
+                if not _is_schema_visibility_error(exc):
+                    raise
+                last_error = exc
+                time.sleep(_SCHEMA_VISIBILITY_DELAY_SECONDS)
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("Nebula schema retry loop exited without a result")
+
+    def _space_exists(self, space: str) -> bool:
+        try:
+            result = self._execute("", "SHOW SPACES")
+        except Exception:
+            return False
+        for i in range(result.row_size()):
+            row = result.row_values(i)
+            if row and row[0].is_string() and row[0].as_string() == space:
+                return True
+        return False
+
+    # -- schema -------------------------------------------------------
+
+    def _ensure_schema_sync(self) -> None:
+        """Create SPACE + TAGs if absent. Idempotent; uses a process
+        lock so concurrent `__init__`-then-`upsert` from multiple
+        coroutines don't double-create.
+        """
+        if self._schema_initialised:
+            return
+        with self._schema_init_lock:
+            if self._schema_initialised:
+                return
+
+            self._execute(
+                "",
+                f"CREATE SPACE IF NOT EXISTS `{self._space}` "
+                f"(vid_type=FIXED_STRING(256), partition_num=1, replica_factor=1)",
+            )
+
+            tag_stmts = [
+                f"CREATE TAG IF NOT EXISTS `{_ENTITY_TAG}`("
+                f"name string, type string, "
+                f"source_lineage_json string, description_parts_json string, "
+                f"gmt_created datetime, gmt_updated datetime)",
+                f"CREATE TAG IF NOT EXISTS `{_RELATION_TAG}`("
+                f"source string, target string, type string, "
+                f"description string, "
+                f"evidence_lineage_json string, description_parts_json string, "
+                f"gmt_created datetime, gmt_updated datetime)",
+                f"CREATE TAG INDEX IF NOT EXISTS `idx_{_ENTITY_TAG}_name` ON `{_ENTITY_TAG}`(name(256))",
+                f"CREATE TAG INDEX IF NOT EXISTS `idx_{_RELATION_TAG}_source` ON `{_RELATION_TAG}`(source(256))",
+            ]
+            last_error: RuntimeError | None = None
+            for _ in range(_SCHEMA_VISIBILITY_RETRIES):
+                try:
+                    if not self._space_exists(self._space):
+                        time.sleep(_SCHEMA_VISIBILITY_DELAY_SECONDS)
+                        continue
+                    for stmt in tag_stmts:
+                        self._execute(self._space, stmt)
+                    # Allow heartbeat to propagate the new tags before
+                    # any caller writes; otherwise the first INSERT
+                    # races schema visibility.
+                    time.sleep(_SCHEMA_VISIBILITY_DELAY_SECONDS)
+                    self._schema_initialised = True
+                    return
+                except RuntimeError as exc:
+                    if not _is_schema_visibility_error(exc):
+                        raise
+                    last_error = exc
+                    time.sleep(_SCHEMA_VISIBILITY_DELAY_SECONDS)
+
+            if last_error is not None:
+                raise last_error
+            raise RuntimeError("Nebula schema visibility never converged for space %s" % self._space)
+
+    async def ensure_schema(self) -> None:
+        await asyncio.to_thread(self._ensure_schema_sync)
+
+    # -- read helpers (sync-blocking, called via to_thread) -----------
+
+    def _read_entity_lineage(self, entity_name: str) -> tuple[str, list[LineageMember], list[DescriptionPart]] | None:
+        """Return ``(type, source_lineage, description_parts)`` for the
+        entity, or ``None`` if the vertex doesn't exist yet."""
+        vid = _entity_vid(entity_name)
+        stmt = (
+            f'FETCH PROP ON `{_ENTITY_TAG}` "{_escape_str(vid)}" '
+            f"YIELD `{_ENTITY_TAG}`.type AS type, "
+            f"`{_ENTITY_TAG}`.source_lineage_json AS sl, "
+            f"`{_ENTITY_TAG}`.description_parts_json AS dp"
+        )
+        result = self._execute_with_schema_retry(self._space, stmt)
+        if result.row_size() == 0:
+            return None
+        row = result.row_values(0)
+        type_value = row[0].as_string() if row[0].is_string() else ""
+        sl_raw = row[1].as_string() if row[1].is_string() else ""
+        dp_raw = row[2].as_string() if row[2].is_string() else ""
+        return type_value, _members_from_json(sl_raw), _parts_from_json(dp_raw)
+
+    def _read_relation_lineage(
+        self, source: str, target: str, type: str
+    ) -> tuple[str, list[LineageMember], list[DescriptionPart]] | None:
+        vid = _relation_vid(source, target, type)
+        stmt = (
+            f'FETCH PROP ON `{_RELATION_TAG}` "{_escape_str(vid)}" '
+            f"YIELD `{_RELATION_TAG}`.description AS description, "
+            f"`{_RELATION_TAG}`.evidence_lineage_json AS el, "
+            f"`{_RELATION_TAG}`.description_parts_json AS dp"
+        )
+        result = self._execute_with_schema_retry(self._space, stmt)
+        if result.row_size() == 0:
+            return None
+        row = result.row_values(0)
+        description = row[0].as_string() if row[0].is_string() else ""
+        el_raw = row[1].as_string() if row[1].is_string() else ""
+        dp_raw = row[2].as_string() if row[2].is_string() else ""
+        return description, _members_from_json(el_raw), _parts_from_json(dp_raw)
+
+    def _list_all_entity_vids(self) -> list[str]:
+        """Return all VIDs tagged with ``lineage_entity`` in the
+        bound space. Used by the doc-id scan in
+        ``find_entity_ids_with_lineage`` — Nebula has no JSON
+        containment index, so we enumerate then filter in Python.
+        """
+        # ``LOOKUP ON tag YIELD id(vertex)`` returns the VID of every
+        # vertex that carries the tag — independent of the property
+        # values. The ``WHERE`` clause filtering by JSON content
+        # would need a column index Nebula can't build for a string,
+        # so we paginate-via-LIMIT-only to keep the query simple.
+        stmt = f"LOOKUP ON `{_ENTITY_TAG}` YIELD id(vertex) AS vid | LIMIT 100000"
+        try:
+            result = self._execute_with_schema_retry(self._space, stmt)
+        except RuntimeError as exc:
+            # Empty space / no vertices yet → some Nebula versions
+            # raise instead of returning 0 rows. Treat as empty.
+            if "not exist" in str(exc).lower() or "no vertex" in str(exc).lower():
+                return []
+            raise
+        out = []
+        for i in range(result.row_size()):
+            row = result.row_values(i)
+            if row and row[0].is_string():
+                out.append(row[0].as_string())
+        return out
+
+    def _list_all_relation_vids(self) -> list[str]:
+        stmt = f"LOOKUP ON `{_RELATION_TAG}` YIELD id(vertex) AS vid | LIMIT 100000"
+        try:
+            result = self._execute_with_schema_retry(self._space, stmt)
+        except RuntimeError as exc:
+            if "not exist" in str(exc).lower() or "no vertex" in str(exc).lower():
+                return []
+            raise
+        out = []
+        for i in range(result.row_size()):
+            row = result.row_values(i)
+            if row and row[0].is_string():
+                out.append(row[0].as_string())
+        return out
+
+    # -- write helpers ------------------------------------------------
+
+    def _write_entity_vertex(
+        self,
+        *,
+        name: str,
+        type_value: str,
+        source_lineage: list[LineageMember],
+        description_parts: list[DescriptionPart],
+    ) -> None:
+        vid = _entity_vid(name)
+        stmt = (
+            f"INSERT VERTEX `{_ENTITY_TAG}`"
+            f"(name, type, source_lineage_json, description_parts_json, gmt_created, gmt_updated) "
+            f'VALUES "{_escape_str(vid)}":('
+            f'"{_escape_str(name)}", "{_escape_str(type_value)}", '
+            f'"{_escape_str(_members_to_json(source_lineage))}", '
+            f'"{_escape_str(_parts_to_json(description_parts))}", '
+            f"datetime(), datetime())"
+        )
+        self._execute_with_schema_retry(self._space, stmt)
+
+    def _write_relation_vertex(
+        self,
+        *,
+        source: str,
+        target: str,
+        type_value: str,
+        description: str,
+        evidence_lineage: list[LineageMember],
+        description_parts: list[DescriptionPart],
+    ) -> None:
+        vid = _relation_vid(source, target, type_value)
+        stmt = (
+            f"INSERT VERTEX `{_RELATION_TAG}`"
+            f"(source, target, type, description, "
+            f"evidence_lineage_json, description_parts_json, gmt_created, gmt_updated) "
+            f'VALUES "{_escape_str(vid)}":('
+            f'"{_escape_str(source)}", "{_escape_str(target)}", "{_escape_str(type_value)}", '
+            f'"{_escape_str(description)}", '
+            f'"{_escape_str(_members_to_json(evidence_lineage))}", '
+            f'"{_escape_str(_parts_to_json(description_parts))}", '
+            f"datetime(), datetime())"
+        )
+        self._execute_with_schema_retry(self._space, stmt)
+
+    def _delete_entity_vertex(self, name: str) -> None:
+        vid = _entity_vid(name)
+        stmt = f'DELETE VERTEX "{_escape_str(vid)}" WITH EDGE'
+        self._execute_with_schema_retry(self._space, stmt)
+
+    def _delete_relation_vertex(self, source: str, target: str, type: str) -> None:
+        vid = _relation_vid(source, target, type)
+        stmt = f'DELETE VERTEX "{_escape_str(vid)}" WITH EDGE'
+        self._execute_with_schema_retry(self._space, stmt)
+
+    # -- find-by-document scans (pre-rebuild phase) -------------------
+
+    async def find_entity_ids_with_lineage(self, *, document_id: str) -> list[str]:
+        await self.ensure_schema()
+
+        def _scan() -> list[str]:
+            names: list[str] = []
+            for vid in self._list_all_entity_vids():
+                row = self._read_entity_lineage_by_vid(vid)
+                if row is None:
+                    continue
+                name, _type, members, _parts = row
+                if any(m.document_id == document_id for m in members):
+                    names.append(name)
+            return names
+
+        return await asyncio.to_thread(_scan)
+
+    async def find_relation_keys_with_lineage(self, *, document_id: str) -> list[tuple[str, str, str]]:
+        await self.ensure_schema()
+
+        def _scan() -> list[tuple[str, str, str]]:
+            keys: list[tuple[str, str, str]] = []
+            for vid in self._list_all_relation_vids():
+                row = self._read_relation_lineage_by_vid(vid)
+                if row is None:
+                    continue
+                source, target, type_value, _description, members, _parts = row
+                if any(m.document_id == document_id for m in members):
+                    keys.append((source, target, type_value))
+            return keys
+
+        return await asyncio.to_thread(_scan)
+
+    # Variants that return the natural-key columns alongside the
+    # lineage so the doc-scan helpers don't have to re-parse the VID.
+    def _read_entity_lineage_by_vid(
+        self, vid: str
+    ) -> tuple[str, str, list[LineageMember], list[DescriptionPart]] | None:
+        stmt = (
+            f'FETCH PROP ON `{_ENTITY_TAG}` "{_escape_str(vid)}" '
+            f"YIELD `{_ENTITY_TAG}`.name AS name, "
+            f"`{_ENTITY_TAG}`.type AS type, "
+            f"`{_ENTITY_TAG}`.source_lineage_json AS sl, "
+            f"`{_ENTITY_TAG}`.description_parts_json AS dp"
+        )
+        result = self._execute_with_schema_retry(self._space, stmt)
+        if result.row_size() == 0:
+            return None
+        row = result.row_values(0)
+        name = row[0].as_string() if row[0].is_string() else ""
+        type_value = row[1].as_string() if row[1].is_string() else ""
+        sl_raw = row[2].as_string() if row[2].is_string() else ""
+        dp_raw = row[3].as_string() if row[3].is_string() else ""
+        return name, type_value, _members_from_json(sl_raw), _parts_from_json(dp_raw)
+
+    def _read_relation_lineage_by_vid(
+        self, vid: str
+    ) -> tuple[str, str, str, str, list[LineageMember], list[DescriptionPart]] | None:
+        stmt = (
+            f'FETCH PROP ON `{_RELATION_TAG}` "{_escape_str(vid)}" '
+            f"YIELD `{_RELATION_TAG}`.source AS source, "
+            f"`{_RELATION_TAG}`.target AS target, "
+            f"`{_RELATION_TAG}`.type AS type, "
+            f"`{_RELATION_TAG}`.description AS description, "
+            f"`{_RELATION_TAG}`.evidence_lineage_json AS el, "
+            f"`{_RELATION_TAG}`.description_parts_json AS dp"
+        )
+        result = self._execute_with_schema_retry(self._space, stmt)
+        if result.row_size() == 0:
+            return None
+        row = result.row_values(0)
+        source = row[0].as_string() if row[0].is_string() else ""
+        target = row[1].as_string() if row[1].is_string() else ""
+        type_value = row[2].as_string() if row[2].is_string() else ""
+        description = row[3].as_string() if row[3].is_string() else ""
+        el_raw = row[4].as_string() if row[4].is_string() else ""
+        dp_raw = row[5].as_string() if row[5].is_string() else ""
+        return (
+            source,
+            target,
+            type_value,
+            description,
+            _members_from_json(el_raw),
+            _parts_from_json(dp_raw),
+        )
+
+    # -- strip-by-document (pre-rebuild phase) ------------------------
+
+    async def remove_entity_lineage_member(self, *, entity_name: str, document_id: str) -> None:
+        await self.ensure_schema()
+        async with self._entity_lock.acquire(entity_name):
+
+            def _strip() -> None:
+                row = self._read_entity_lineage(entity_name)
+                if row is None:
+                    return
+                type_value, members, parts = row
+                new_members = [m for m in members if m.document_id != document_id]
+                new_parts = [p for p in parts if p.document_id != document_id]
+                if len(new_members) == len(members) and len(new_parts) == len(parts):
+                    return
+                self._write_entity_vertex(
+                    name=entity_name,
+                    type_value=type_value,
+                    source_lineage=new_members,
+                    description_parts=new_parts,
+                )
+
+            await asyncio.to_thread(_strip)
+
+    async def remove_relation_lineage_member(self, *, source: str, target: str, type: str, document_id: str) -> None:
+        await self.ensure_schema()
+        async with self._entity_lock.acquire(_relation_vid(source, target, type)):
+
+            def _strip() -> None:
+                row = self._read_relation_lineage(source, target, type)
+                if row is None:
+                    return
+                description, members, parts = row
+                new_members = [m for m in members if m.document_id != document_id]
+                new_parts = [p for p in parts if p.document_id != document_id]
+                if len(new_members) == len(members) and len(new_parts) == len(parts):
+                    return
+                self._write_relation_vertex(
+                    source=source,
+                    target=target,
+                    type_value=type,
+                    description=description,
+                    evidence_lineage=new_members,
+                    description_parts=new_parts,
+                )
+
+            await asyncio.to_thread(_strip)
+
+    # -- GC (post-rebuild) --------------------------------------------
+
+    async def gc_entity_if_orphan(self, entity_name: str) -> bool:
+        await self.ensure_schema()
+        async with self._entity_lock.acquire(entity_name):
+
+            def _gc() -> bool:
+                row = self._read_entity_lineage(entity_name)
+                if row is None:
+                    return False
+                _type_value, members, _parts = row
+                if members:
+                    return False
+                self._delete_entity_vertex(entity_name)
+                return True
+
+            return await asyncio.to_thread(_gc)
+
+    async def gc_relation_if_orphan(self, source: str, target: str, type: str) -> bool:
+        await self.ensure_schema()
+        async with self._entity_lock.acquire(_relation_vid(source, target, type)):
+
+            def _gc() -> bool:
+                row = self._read_relation_lineage(source, target, type)
+                if row is None:
+                    return False
+                _description, members, _parts = row
+                if members:
+                    return False
+                self._delete_relation_vertex(source, target, type)
+                return True
+
+            return await asyncio.to_thread(_gc)
+
+    # -- upserts (rebuild phase) --------------------------------------
+
+    async def upsert_entity_with_lineage(self, *, record: EntityRecord, lineage: LineageMember) -> None:
+        """Add (or replace by ``(document_id, parse_version)`` key) the
+        lineage member + corresponding description part.
+
+        The whole read-modify-write is wrapped in
+        ``EntityLock.acquire(name)`` so two concurrent rebuilds for the
+        same entity serialise. Without this serialisation, Nebula's
+        property-update semantics (no native list ops) would race —
+        per architect msg=f2921ae0.
+        """
+        await self.ensure_schema()
+        new_part = DescriptionPart(
+            document_id=lineage.document_id,
+            parse_version=lineage.parse_version,
+            text=record.description,
+        )
+        async with self._entity_lock.acquire(record.name):
+
+            def _upsert() -> None:
+                row = self._read_entity_lineage(record.name)
+                if row is None:
+                    new_members = [lineage]
+                    new_parts = [new_part]
+                else:
+                    _existing_type, members, parts = row
+                    new_members = [m for m in members if m.key() != lineage.key()] + [lineage]
+                    new_parts = [p for p in parts if p.key() != new_part.key()] + [new_part]
+                self._write_entity_vertex(
+                    name=record.name,
+                    type_value=record.type,
+                    source_lineage=new_members,
+                    description_parts=new_parts,
+                )
+
+            await asyncio.to_thread(_upsert)
+
+    async def upsert_relation_with_lineage(self, *, record: RelationRecord, lineage: LineageMember) -> None:
+        await self.ensure_schema()
+        new_part = DescriptionPart(
+            document_id=lineage.document_id,
+            parse_version=lineage.parse_version,
+            text=record.description,
+        )
+        async with self._entity_lock.acquire(_relation_vid(record.source, record.target, record.type)):
+
+            def _upsert() -> None:
+                row = self._read_relation_lineage(record.source, record.target, record.type)
+                if row is None:
+                    new_members = [lineage]
+                    new_parts = [new_part]
+                else:
+                    _existing_description, members, parts = row
+                    new_members = [m for m in members if m.key() != lineage.key()] + [lineage]
+                    new_parts = [p for p in parts if p.key() != new_part.key()] + [new_part]
+                self._write_relation_vertex(
+                    source=record.source,
+                    target=record.target,
+                    type_value=record.type,
+                    description=record.description,
+                    evidence_lineage=new_members,
+                    description_parts=new_parts,
+                )
+
+            await asyncio.to_thread(_upsert)
+
+    # -- read-path ----------------------------------------------------
+
+    async def get_entity(self, entity_name: str) -> EntityWithLineage | None:
+        await self.ensure_schema()
+
+        def _read() -> EntityWithLineage | None:
+            row = self._read_entity_lineage(entity_name)
+            if row is None:
+                return None
+            type_value, members, parts = row
+            return EntityWithLineage(
+                name=entity_name,
+                type=type_value,
+                source_lineage=tuple(members),
+                description_parts=tuple(parts),
+            )
+
+        return await asyncio.to_thread(_read)
+
+    async def get_relation(self, source: str, target: str, type: str) -> RelationWithLineage | None:
+        await self.ensure_schema()
+
+        def _read() -> RelationWithLineage | None:
+            row = self._read_relation_lineage(source, target, type)
+            if row is None:
+                return None
+            _description, members, parts = row
+            return RelationWithLineage(
+                source=source,
+                target=target,
+                type=type,
+                evidence_lineage=tuple(members),
+                description_parts=tuple(parts),
+            )
+
+        return await asyncio.to_thread(_read)
+
+
+__all__ = [
+    "NebulaLineageGraphStore",
+]

--- a/aperag/indexing/graph_storage/neo4j.py
+++ b/aperag/indexing/graph_storage/neo4j.py
@@ -44,7 +44,6 @@ two-table schema exactly):
 
     (:LineageRelation {
         collection_id, source, target, type,
-        description,                     -- legacy column, chunk 4 audit candidate (per architect msg=95179f2a Design point 3)
         evidence_lineage,
         evidence_lineage_doc_ids,
         evidence_lineage_parse_versions,
@@ -53,6 +52,13 @@ two-table schema exactly):
         description_parts_parse_versions,
         gmt_created, gmt_updated
     })
+
+Wave 4 chunk 4 dropped the legacy ``description`` property — the
+per-document fragments in ``description_parts`` are the canonical
+source. The standalone overwritten-on-every-upsert ``description``
+property had no consumer on the §D.3 / §G.5 read path
+(``RelationWithLineage`` does not expose it), so dropping it
+cross-backend keeps "ORM 100% mirror" with the Postgres adapter.
 
 Rationale for parallel lists: Cypher list comprehensions can filter by
 index (``[i IN range(0, size(L)-1) WHERE L[i] <> $key]``) but a list of
@@ -386,7 +392,6 @@ class Neo4jLineageGraphStore:
             f"MERGE (r:{_RELATION_LABEL} "
             f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
             f"ON CREATE SET "
-            f"  r.description = '', "
             f"  r.evidence_lineage = [], "
             f"  r.evidence_lineage_doc_ids = [], "
             f"  r.evidence_lineage_parse_versions = [], "
@@ -401,8 +406,7 @@ class Neo4jLineageGraphStore:
             f"  [i IN range(0, size(r.description_parts_doc_ids) - 1) "
             f"   WHERE NOT (r.description_parts_doc_ids[i] = $document_id "
             f"              AND r.description_parts_parse_versions[i] = $parse_version)] AS dp_keep "
-            f"SET r.description = $description, "
-            f"    r.evidence_lineage = [i IN el_keep | r.evidence_lineage[i]] + [$member_json], "
+            f"SET r.evidence_lineage = [i IN el_keep | r.evidence_lineage[i]] + [$member_json], "
             f"    r.evidence_lineage_doc_ids = "
             f"      [i IN el_keep | r.evidence_lineage_doc_ids[i]] + [$document_id], "
             f"    r.evidence_lineage_parse_versions = "
@@ -421,7 +425,6 @@ class Neo4jLineageGraphStore:
                 source=record.source,
                 target=record.target,
                 type=record.type,
-                description=record.description,
                 document_id=lineage.document_id,
                 parse_version=lineage.parse_version,
                 member_json=member_json,

--- a/aperag/indexing/graph_storage/neo4j.py
+++ b/aperag/indexing/graph_storage/neo4j.py
@@ -1,0 +1,486 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Neo4j implementation of :class:`LineageGraphStore` — Wave 4 T8 chunk 2.
+
+Mirrors :class:`PostgresLineageGraphStore` (chunk 1 reference impl) over
+Neo4j 5.x. Both backends realise the §D.3.5 lineage SET semantics; the
+Postgres adapter expresses each SET as a JSONB array, here we use the
+**parallel-list** encoding because Neo4j node properties cannot hold
+``LIST<MAP>`` directly (only homogeneous lists of primitives are
+allowed). Per architect ratify msg=95179f2a, the dedup key
+``(document_id, parse_version)`` and the strip-by-document_id semantics
+must port cross-backend; this module realises both purely in Cypher
+without requiring APOC.
+
+Storage layout — one row per entity / relation, modelled as a label
+``LineageEntity`` / ``LineageRelation`` node (relations are NOT modelled
+as edges here because the §D.3 Protocol does not require traversal —
+that is a separate retrieval concern owned by the legacy ``GraphStore``;
+keeping relations as their own labelled nodes mirrors the Postgres
+two-table schema exactly):
+
+    (:LineageEntity {
+        collection_id, name, type,
+        source_lineage,                  -- list<string>, JSON-encoded LineageMember
+        source_lineage_doc_ids,          -- list<string>, parallel index, dedup + strip-by-doc filter
+        source_lineage_parse_versions,   -- list<string>, parallel index, dedup composite key
+        description_parts,               -- list<string>, JSON-encoded DescriptionPart
+        description_parts_doc_ids,
+        description_parts_parse_versions,
+        gmt_created, gmt_updated
+    })
+
+    (:LineageRelation {
+        collection_id, source, target, type,
+        description,                     -- legacy column, chunk 4 audit candidate (per architect msg=95179f2a Design point 3)
+        evidence_lineage,
+        evidence_lineage_doc_ids,
+        evidence_lineage_parse_versions,
+        description_parts,
+        description_parts_doc_ids,
+        description_parts_parse_versions,
+        gmt_created, gmt_updated
+    })
+
+Rationale for parallel lists: Cypher list comprehensions can filter by
+index (``[i IN range(0, size(L)-1) WHERE L[i] <> $key]``) but a list of
+maps is not a valid property type. Storing the dedup key fields in
+parallel ``list<string>`` properties keeps the strip-then-append a
+single Cypher statement (and therefore atomic under Neo4j MERGE's
+write-lock on the row) while preserving the full JSON serialisation of
+each member alongside.
+
+§D.3.5 Protocol semantics → Cypher:
+
+* ``find_entity_ids_with_lineage(document_id)`` →
+  ``MATCH (n:LineageEntity {collection_id:$cid}) WHERE $document_id IN
+  n.source_lineage_doc_ids RETURN n.name``. Pure list membership; no
+  containment-style index but Neo4j scans the entity label, which the
+  per-collection ``collection_id`` index narrows.
+* ``remove_entity_lineage_member(entity_name, document_id)`` →
+  one ``MATCH … SET …`` statement that filters BOTH lineage and
+  description-part lists by ``doc_id != $d``. Single statement so two
+  concurrent syncs cannot race on the read-modify-write.
+* ``upsert_entity_with_lineage`` → ``MERGE`` plus a strip-then-append
+  ``SET`` that drops the existing ``(doc_id, parse_v)`` element (if
+  any) and re-appends with the new payload. Replaces semantics, single
+  statement.
+* ``gc_*_if_orphan`` → ``MATCH … WHERE size(...) = 0 DELETE`` returns
+  the count for the boolean.
+
+Concurrency: Neo4j MERGE issues an exclusive lock on the merged node /
+constraint key for the duration of the statement, so the
+strip-then-append SET that follows cannot interleave with another
+upsert against the same row. ``EntityLock`` is therefore unnecessary
+for this backend (per architect msg=f2921ae0 — Neo4j with native list
+ops doesn't need the per-entity Redis lock that Nebula's
+read-modify-write loop requires).
+
+Hard-cut second round: this module is the new Neo4j adapter. The
+legacy ``aperag/domains/knowledge_graph/graphindex/storage/neo4j.py``
+is deleted in chunk 4 of the same Wave 4 PR.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from aperag.indexing.graph import (
+    DescriptionPart,
+    EntityRecord,
+    EntityWithLineage,
+    LineageMember,
+    RelationRecord,
+    RelationWithLineage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_ENTITY_LABEL = "LineageEntity"
+_RELATION_LABEL = "LineageRelation"
+
+_ENTITY_CONSTRAINT_NAME = "lineage_entity_collection_name_unique"
+_RELATION_CONSTRAINT_NAME = "lineage_relation_collection_triple_unique"
+
+
+# ---------------------------------------------------------------------
+# JSON serialisation helpers — kept module-private so the dedup-key
+# and parallel-list encoding stays in one place.
+# ---------------------------------------------------------------------
+
+
+def _lineage_member_json(member: LineageMember) -> str:
+    return json.dumps(member.to_dict())
+
+
+def _description_part_json(part: DescriptionPart) -> str:
+    return json.dumps(part.to_dict())
+
+
+# ---------------------------------------------------------------------
+# Public adapter.
+# ---------------------------------------------------------------------
+
+
+class Neo4jLineageGraphStore:
+    """:class:`LineageGraphStore` backed by Neo4j (5.x async driver).
+
+    One instance per ``collection_id``. The ``worker_factory`` (chunk 4)
+    caches one instance per collection, mirroring the
+    :class:`PostgresLineageGraphStore` pattern. The adapter owns no
+    schema-creation responsibility in production; :meth:`ensure_schema`
+    is the test / dev convenience for spinning up the constraints when
+    a fresh Neo4j instance is involved.
+    """
+
+    def __init__(
+        self,
+        *,
+        driver: Any,
+        collection_id: str,
+        database: str | None = None,
+    ) -> None:
+        """Construct the adapter.
+
+        ``driver`` is a ``neo4j.AsyncDriver`` (typed as ``Any`` so this
+        module does not import ``neo4j`` at top level — keeps optional-
+        dep handling consistent with the legacy ``Neo4jGraphStore``).
+        ``database`` is forwarded to ``driver.session(database=...)``;
+        ``None`` defers to the driver default.
+        """
+        self._driver = driver
+        self._collection_id = collection_id
+        self._database = database
+
+    def _session(self):
+        if self._database is None:
+            return self._driver.session()
+        return self._driver.session(database=self._database)
+
+    # -- schema -------------------------------------------------------
+
+    async def ensure_schema(self) -> None:
+        """Create the composite unique constraints if missing.
+
+        Neo4j 5.x uses node property uniqueness constraints; the
+        ``IF NOT EXISTS`` clause makes this idempotent so production
+        rollouts that already created the constraints (via terraform /
+        a cluster admin script) just no-op.
+        """
+        async with self._session() as session:
+            await session.run(
+                f"CREATE CONSTRAINT {_ENTITY_CONSTRAINT_NAME} IF NOT EXISTS "
+                f"FOR (n:{_ENTITY_LABEL}) REQUIRE (n.collection_id, n.name) IS UNIQUE"
+            )
+            await session.run(
+                f"CREATE CONSTRAINT {_RELATION_CONSTRAINT_NAME} IF NOT EXISTS "
+                f"FOR (r:{_RELATION_LABEL}) "
+                f"REQUIRE (r.collection_id, r.source, r.target, r.type) IS UNIQUE"
+            )
+
+    # -- find-by-document scans (pre-rebuild phase) -------------------
+
+    async def find_entity_ids_with_lineage(self, *, document_id: str) -> list[str]:
+        query = (
+            f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $collection_id}}) "
+            f"WHERE $document_id IN n.source_lineage_doc_ids "
+            f"RETURN n.name AS name"
+        )
+        async with self._session() as session:
+            result = await session.run(
+                query,
+                collection_id=self._collection_id,
+                document_id=document_id,
+            )
+            return [rec["name"] async for rec in result]
+
+    async def find_relation_keys_with_lineage(self, *, document_id: str) -> list[tuple[str, str, str]]:
+        query = (
+            f"MATCH (r:{_RELATION_LABEL} {{collection_id: $collection_id}}) "
+            f"WHERE $document_id IN r.evidence_lineage_doc_ids "
+            f"RETURN r.source AS source, r.target AS target, r.type AS type"
+        )
+        async with self._session() as session:
+            result = await session.run(
+                query,
+                collection_id=self._collection_id,
+                document_id=document_id,
+            )
+            return [(rec["source"], rec["target"], rec["type"]) async for rec in result]
+
+    # -- strip-by-document (pre-rebuild phase) ------------------------
+
+    async def remove_entity_lineage_member(self, *, entity_name: str, document_id: str) -> None:
+        # Single MATCH … SET statement: list-comprehension filters keep
+        # the indices that don't match $document_id and projects every
+        # parallel list onto those indices. Two concurrent syncs cannot
+        # race because Neo4j locks the row for the SET.
+        query = (
+            f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $collection_id, name: $name}}) "
+            f"WITH n, "
+            f"  [i IN range(0, size(n.source_lineage_doc_ids) - 1) "
+            f"   WHERE n.source_lineage_doc_ids[i] <> $document_id] AS sl_keep, "
+            f"  [i IN range(0, size(n.description_parts_doc_ids) - 1) "
+            f"   WHERE n.description_parts_doc_ids[i] <> $document_id] AS dp_keep "
+            f"SET n.source_lineage = [i IN sl_keep | n.source_lineage[i]], "
+            f"    n.source_lineage_doc_ids = [i IN sl_keep | n.source_lineage_doc_ids[i]], "
+            f"    n.source_lineage_parse_versions = [i IN sl_keep | n.source_lineage_parse_versions[i]], "
+            f"    n.description_parts = [i IN dp_keep | n.description_parts[i]], "
+            f"    n.description_parts_doc_ids = [i IN dp_keep | n.description_parts_doc_ids[i]], "
+            f"    n.description_parts_parse_versions = [i IN dp_keep | n.description_parts_parse_versions[i]], "
+            f"    n.gmt_updated = datetime()"
+        )
+        async with self._session() as session:
+            await session.run(
+                query,
+                collection_id=self._collection_id,
+                name=entity_name,
+                document_id=document_id,
+            )
+
+    async def remove_relation_lineage_member(self, *, source: str, target: str, type: str, document_id: str) -> None:
+        query = (
+            f"MATCH (r:{_RELATION_LABEL} "
+            f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
+            f"WITH r, "
+            f"  [i IN range(0, size(r.evidence_lineage_doc_ids) - 1) "
+            f"   WHERE r.evidence_lineage_doc_ids[i] <> $document_id] AS el_keep, "
+            f"  [i IN range(0, size(r.description_parts_doc_ids) - 1) "
+            f"   WHERE r.description_parts_doc_ids[i] <> $document_id] AS dp_keep "
+            f"SET r.evidence_lineage = [i IN el_keep | r.evidence_lineage[i]], "
+            f"    r.evidence_lineage_doc_ids = [i IN el_keep | r.evidence_lineage_doc_ids[i]], "
+            f"    r.evidence_lineage_parse_versions = [i IN el_keep | r.evidence_lineage_parse_versions[i]], "
+            f"    r.description_parts = [i IN dp_keep | r.description_parts[i]], "
+            f"    r.description_parts_doc_ids = [i IN dp_keep | r.description_parts_doc_ids[i]], "
+            f"    r.description_parts_parse_versions = [i IN dp_keep | r.description_parts_parse_versions[i]], "
+            f"    r.gmt_updated = datetime()"
+        )
+        async with self._session() as session:
+            await session.run(
+                query,
+                collection_id=self._collection_id,
+                source=source,
+                target=target,
+                type=type,
+                document_id=document_id,
+            )
+
+    # -- GC (post-rebuild) --------------------------------------------
+
+    async def gc_entity_if_orphan(self, entity_name: str) -> bool:
+        query = (
+            f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $collection_id, name: $name}}) "
+            f"WHERE size(n.source_lineage) = 0 "
+            f"DELETE n "
+            f"RETURN count(n) AS deleted"
+        )
+        async with self._session() as session:
+            result = await session.run(query, collection_id=self._collection_id, name=entity_name)
+            rec = await result.single()
+            return bool(rec and rec["deleted"] > 0)
+
+    async def gc_relation_if_orphan(self, source: str, target: str, type: str) -> bool:
+        query = (
+            f"MATCH (r:{_RELATION_LABEL} "
+            f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
+            f"WHERE size(r.evidence_lineage) = 0 "
+            f"DELETE r "
+            f"RETURN count(r) AS deleted"
+        )
+        async with self._session() as session:
+            result = await session.run(
+                query,
+                collection_id=self._collection_id,
+                source=source,
+                target=target,
+                type=type,
+            )
+            rec = await result.single()
+            return bool(rec and rec["deleted"] > 0)
+
+    # -- upserts (rebuild phase) --------------------------------------
+
+    async def upsert_entity_with_lineage(self, *, record: EntityRecord, lineage: LineageMember) -> None:
+        """Add (or replace by ``(document_id, parse_version)`` key) the
+        lineage member + its description part. Single Cypher statement
+        so two concurrent rebuilds against the same entity cannot race
+        on read-modify-write — Neo4j MERGE locks the merged row for the
+        duration of the trailing SET.
+        """
+        member_json = _lineage_member_json(lineage)
+        part_json = _description_part_json(
+            DescriptionPart(
+                document_id=lineage.document_id,
+                parse_version=lineage.parse_version,
+                text=record.description,
+            )
+        )
+        query = (
+            f"MERGE (n:{_ENTITY_LABEL} {{collection_id: $collection_id, name: $name}}) "
+            # initialise on create — start with empty parallel lists so
+            # the strip-then-append below has a defined input list.
+            f"ON CREATE SET "
+            f"  n.source_lineage = [], "
+            f"  n.source_lineage_doc_ids = [], "
+            f"  n.source_lineage_parse_versions = [], "
+            f"  n.description_parts = [], "
+            f"  n.description_parts_doc_ids = [], "
+            f"  n.description_parts_parse_versions = [], "
+            f"  n.gmt_created = datetime() "
+            f"WITH n, "
+            f"  [i IN range(0, size(n.source_lineage_doc_ids) - 1) "
+            f"   WHERE NOT (n.source_lineage_doc_ids[i] = $document_id "
+            f"              AND n.source_lineage_parse_versions[i] = $parse_version)] AS sl_keep, "
+            f"  [i IN range(0, size(n.description_parts_doc_ids) - 1) "
+            f"   WHERE NOT (n.description_parts_doc_ids[i] = $document_id "
+            f"              AND n.description_parts_parse_versions[i] = $parse_version)] AS dp_keep "
+            f"SET n.type = $type, "
+            f"    n.source_lineage = [i IN sl_keep | n.source_lineage[i]] + [$member_json], "
+            f"    n.source_lineage_doc_ids = [i IN sl_keep | n.source_lineage_doc_ids[i]] + [$document_id], "
+            f"    n.source_lineage_parse_versions = "
+            f"      [i IN sl_keep | n.source_lineage_parse_versions[i]] + [$parse_version], "
+            f"    n.description_parts = [i IN dp_keep | n.description_parts[i]] + [$part_json], "
+            f"    n.description_parts_doc_ids = "
+            f"      [i IN dp_keep | n.description_parts_doc_ids[i]] + [$document_id], "
+            f"    n.description_parts_parse_versions = "
+            f"      [i IN dp_keep | n.description_parts_parse_versions[i]] + [$parse_version], "
+            f"    n.gmt_updated = datetime()"
+        )
+        async with self._session() as session:
+            await session.run(
+                query,
+                collection_id=self._collection_id,
+                name=record.name,
+                type=record.type,
+                document_id=lineage.document_id,
+                parse_version=lineage.parse_version,
+                member_json=member_json,
+                part_json=part_json,
+            )
+
+    async def upsert_relation_with_lineage(self, *, record: RelationRecord, lineage: LineageMember) -> None:
+        member_json = _lineage_member_json(lineage)
+        part_json = _description_part_json(
+            DescriptionPart(
+                document_id=lineage.document_id,
+                parse_version=lineage.parse_version,
+                text=record.description,
+            )
+        )
+        query = (
+            f"MERGE (r:{_RELATION_LABEL} "
+            f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
+            f"ON CREATE SET "
+            f"  r.description = '', "
+            f"  r.evidence_lineage = [], "
+            f"  r.evidence_lineage_doc_ids = [], "
+            f"  r.evidence_lineage_parse_versions = [], "
+            f"  r.description_parts = [], "
+            f"  r.description_parts_doc_ids = [], "
+            f"  r.description_parts_parse_versions = [], "
+            f"  r.gmt_created = datetime() "
+            f"WITH r, "
+            f"  [i IN range(0, size(r.evidence_lineage_doc_ids) - 1) "
+            f"   WHERE NOT (r.evidence_lineage_doc_ids[i] = $document_id "
+            f"              AND r.evidence_lineage_parse_versions[i] = $parse_version)] AS el_keep, "
+            f"  [i IN range(0, size(r.description_parts_doc_ids) - 1) "
+            f"   WHERE NOT (r.description_parts_doc_ids[i] = $document_id "
+            f"              AND r.description_parts_parse_versions[i] = $parse_version)] AS dp_keep "
+            f"SET r.description = $description, "
+            f"    r.evidence_lineage = [i IN el_keep | r.evidence_lineage[i]] + [$member_json], "
+            f"    r.evidence_lineage_doc_ids = "
+            f"      [i IN el_keep | r.evidence_lineage_doc_ids[i]] + [$document_id], "
+            f"    r.evidence_lineage_parse_versions = "
+            f"      [i IN el_keep | r.evidence_lineage_parse_versions[i]] + [$parse_version], "
+            f"    r.description_parts = [i IN dp_keep | r.description_parts[i]] + [$part_json], "
+            f"    r.description_parts_doc_ids = "
+            f"      [i IN dp_keep | r.description_parts_doc_ids[i]] + [$document_id], "
+            f"    r.description_parts_parse_versions = "
+            f"      [i IN dp_keep | r.description_parts_parse_versions[i]] + [$parse_version], "
+            f"    r.gmt_updated = datetime()"
+        )
+        async with self._session() as session:
+            await session.run(
+                query,
+                collection_id=self._collection_id,
+                source=record.source,
+                target=record.target,
+                type=record.type,
+                description=record.description,
+                document_id=lineage.document_id,
+                parse_version=lineage.parse_version,
+                member_json=member_json,
+                part_json=part_json,
+            )
+
+    # -- read-path ----------------------------------------------------
+
+    async def get_entity(self, entity_name: str) -> EntityWithLineage | None:
+        query = (
+            f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $collection_id, name: $name}}) "
+            f"RETURN n.name AS name, n.type AS type, "
+            f"       n.source_lineage AS source_lineage, "
+            f"       n.description_parts AS description_parts"
+        )
+        async with self._session() as session:
+            result = await session.run(query, collection_id=self._collection_id, name=entity_name)
+            rec = await result.single()
+            if rec is None:
+                return None
+            return EntityWithLineage(
+                name=rec["name"],
+                type=rec["type"] or "",
+                source_lineage=tuple(LineageMember.from_dict(json.loads(s)) for s in (rec["source_lineage"] or [])),
+                description_parts=tuple(
+                    DescriptionPart.from_dict(json.loads(s)) for s in (rec["description_parts"] or [])
+                ),
+            )
+
+    async def get_relation(self, source: str, target: str, type: str) -> RelationWithLineage | None:
+        query = (
+            f"MATCH (r:{_RELATION_LABEL} "
+            f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
+            f"RETURN r.source AS source, r.target AS target, r.type AS type, "
+            f"       r.evidence_lineage AS evidence_lineage, "
+            f"       r.description_parts AS description_parts"
+        )
+        async with self._session() as session:
+            result = await session.run(
+                query,
+                collection_id=self._collection_id,
+                source=source,
+                target=target,
+                type=type,
+            )
+            rec = await result.single()
+            if rec is None:
+                return None
+            return RelationWithLineage(
+                source=rec["source"],
+                target=rec["target"],
+                type=rec["type"],
+                evidence_lineage=tuple(LineageMember.from_dict(json.loads(s)) for s in (rec["evidence_lineage"] or [])),
+                description_parts=tuple(
+                    DescriptionPart.from_dict(json.loads(s)) for s in (rec["description_parts"] or [])
+                ),
+            )
+
+
+__all__ = [
+    "Neo4jLineageGraphStore",
+]

--- a/aperag/indexing/graph_storage/postgres.py
+++ b/aperag/indexing/graph_storage/postgres.py
@@ -1,0 +1,504 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PostgreSQL implementation of :class:`LineageGraphStore` — Wave 4 T8 chunk 1.
+
+Stores entities and relations as two tables (``aperag_lineage_entity``
+and ``aperag_lineage_relation``) with JSONB columns for the
+``source_lineage`` / ``evidence_lineage`` SETs and the
+``description_parts`` lists. Both tables include a
+``collection_id`` column so a process-wide store instance handles
+all collections; the SQLAlchemy queries always filter on
+``collection_id`` to keep tenants isolated. Each store instance is
+constructed with the ``collection_id`` it serves; the worker_factory
+caches one instance per collection.
+
+§D.3.5 Protocol semantics mapped to SQL:
+
+* ``find_entity_ids_with_lineage(document_id)`` → SELECT name FROM
+  entity WHERE collection_id=$c AND source_lineage @>
+  '[{"document_id": "$d"}]' (JSONB containment filter).
+* ``remove_entity_lineage_member(entity_name, document_id)`` →
+  UPDATE entity SET source_lineage = (SELECT jsonb_agg(elem) FROM
+  jsonb_array_elements(source_lineage) elem WHERE elem->>'document_id'
+  != $d), description_parts = (same shape) WHERE collection_id=$c AND
+  name=$n. Single statement so concurrent syncs cannot race on the
+  read-modify-write.
+* ``upsert_entity_with_lineage`` → INSERT … ON CONFLICT DO UPDATE
+  with a ``COALESCE`` + ``jsonb_build_object`` expression that
+  inserts the new ``LineageMember`` if the
+  ``(document_id, parse_version)`` key is absent, replaces the
+  matching element otherwise. Same shape for ``DescriptionPart``.
+* ``gc_*_if_orphan`` → DELETE … WHERE jsonb_array_length(...) = 0.
+
+Every method opens its own ``engine.begin()`` transaction so a
+caller that wants to batch must do that at a higher layer; the
+adapter keeps the boundary crisp (per legacy ``Postgres.GraphStore``
+convention).
+
+Hard-cut second round: this module replaces
+``aperag/domains/knowledge_graph/graphindex/storage/postgres.py``;
+the legacy file is deleted in the same PR (chunk 4).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    String,
+    Text,
+    UniqueConstraint,
+    select,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.orm import declarative_base
+
+from aperag.indexing.graph import (
+    DescriptionPart,
+    EntityRecord,
+    EntityWithLineage,
+    LineageMember,
+    RelationRecord,
+    RelationWithLineage,
+)
+from aperag.utils.utils import utc_now
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------
+# ORM models — declared on a private ``Base`` so the adapter can own
+# its own metadata without colliding with the application's main
+# ``aperag.db.base.Base``. Alembic migration owns the actual DDL; the
+# ``ensure_schema`` method below is a fallback for tests / dev.
+# ---------------------------------------------------------------------
+
+
+_LineageGraphBase = declarative_base()
+
+ENTITY_TABLE = "aperag_lineage_entity"
+RELATION_TABLE = "aperag_lineage_relation"
+
+
+class _LineageEntityRow(_LineageGraphBase):
+    __tablename__ = ENTITY_TABLE
+    __table_args__ = (UniqueConstraint("collection_id", "name", name="uq_lineage_entity_collection_name"),)
+
+    # composite primary key kept on the UniqueConstraint above so
+    # SQLAlchemy can issue UPSERTs (PostgreSQL ON CONFLICT requires a
+    # named constraint or a column list).
+    collection_id = Column(String(64), primary_key=True)
+    name = Column(String(512), primary_key=True)
+    type = Column(String(64), nullable=False)
+    source_lineage = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    description_parts = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+
+
+class _LineageRelationRow(_LineageGraphBase):
+    __tablename__ = RELATION_TABLE
+    __table_args__ = (
+        UniqueConstraint(
+            "collection_id",
+            "source",
+            "target",
+            "type",
+            name="uq_lineage_relation_collection_triple",
+        ),
+    )
+
+    collection_id = Column(String(64), primary_key=True)
+    source = Column(String(512), primary_key=True)
+    target = Column(String(512), primary_key=True)
+    type = Column(String(64), primary_key=True)
+    description = Column(Text, nullable=False, server_default="")
+    evidence_lineage = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    description_parts = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+
+
+# ---------------------------------------------------------------------
+# Helpers — JSONB SET-element manipulation. Centralised so the SQL
+# expressions are inspectable and tests can call them directly.
+# ---------------------------------------------------------------------
+
+
+def _lineage_to_json_array(lineage: LineageMember) -> str:
+    """Serialise one :class:`LineageMember` to the canonical JSON
+    fragment stored in the ``source_lineage`` / ``evidence_lineage``
+    JSONB array. The key for SET-element dedup is
+    ``(document_id, parse_version)``."""
+    return json.dumps(lineage.to_dict())
+
+
+def _description_part_to_json(part: DescriptionPart) -> str:
+    return json.dumps(part.to_dict())
+
+
+# ---------------------------------------------------------------------
+# Public adapter.
+# ---------------------------------------------------------------------
+
+
+class PostgresLineageGraphStore:
+    """:class:`LineageGraphStore` implementation backed by PostgreSQL.
+
+    One instance per ``collection_id``; the
+    ``worker_factory`` caches instances. The adapter owns no
+    schema-creation responsibility in production — alembic migration
+    ``aperag_lineage_graph_postgres`` (Wave 4 T8) creates the tables.
+    The :meth:`ensure_schema` helper is for tests + dev.
+    """
+
+    def __init__(self, *, engine: AsyncEngine, collection_id: str) -> None:
+        self._engine = engine
+        self._collection_id = collection_id
+
+    # -- schema -------------------------------------------------------
+
+    async def ensure_schema(self) -> None:
+        """Create tables if missing. Idempotent. Production uses
+        alembic; this is the test / dev convenience.
+        """
+        async with self._engine.begin() as conn:
+            await conn.run_sync(_LineageGraphBase.metadata.create_all)
+
+    # -- find-by-document scans (pre-rebuild phase) -------------------
+
+    async def find_entity_ids_with_lineage(self, *, document_id: str) -> list[str]:
+        """Return entity names with a lineage member matching
+        ``document_id`` (any parse_version)."""
+        # JSONB containment ``@>`` matches when the right side is a
+        # subset of the left; we wrap the document_id object in a
+        # one-element array so the operator scans the lineage SET.
+        sql = text(
+            f"""
+            SELECT name
+            FROM {ENTITY_TABLE}
+            WHERE collection_id = :collection_id
+              AND source_lineage @> jsonb_build_array(jsonb_build_object('document_id', :document_id))
+            """
+        )
+        async with self._engine.connect() as conn:
+            result = await conn.execute(sql, {"collection_id": self._collection_id, "document_id": document_id})
+            return [row.name for row in result]
+
+    async def find_relation_keys_with_lineage(self, *, document_id: str) -> list[tuple[str, str, str]]:
+        sql = text(
+            f"""
+            SELECT source, target, type
+            FROM {RELATION_TABLE}
+            WHERE collection_id = :collection_id
+              AND evidence_lineage @> jsonb_build_array(jsonb_build_object('document_id', :document_id))
+            """
+        )
+        async with self._engine.connect() as conn:
+            result = await conn.execute(sql, {"collection_id": self._collection_id, "document_id": document_id})
+            return [(row.source, row.target, row.type) for row in result]
+
+    # -- strip-by-document (pre-rebuild phase) ------------------------
+
+    async def remove_entity_lineage_member(self, *, entity_name: str, document_id: str) -> None:
+        """Strip every ``LineageMember`` and ``DescriptionPart`` whose
+        document_id matches. Single SQL statement so concurrent syncs
+        do not race on read-modify-write."""
+        sql = text(
+            f"""
+            UPDATE {ENTITY_TABLE}
+            SET source_lineage = COALESCE(
+                    (SELECT jsonb_agg(elem) FROM jsonb_array_elements(source_lineage) elem
+                     WHERE elem->>'document_id' != :document_id),
+                    '[]'::jsonb
+                ),
+                description_parts = COALESCE(
+                    (SELECT jsonb_agg(part) FROM jsonb_array_elements(description_parts) part
+                     WHERE part->>'document_id' != :document_id),
+                    '[]'::jsonb
+                ),
+                gmt_updated = NOW()
+            WHERE collection_id = :collection_id AND name = :name
+            """
+        )
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                sql,
+                {
+                    "collection_id": self._collection_id,
+                    "name": entity_name,
+                    "document_id": document_id,
+                },
+            )
+
+    async def remove_relation_lineage_member(self, *, source: str, target: str, type: str, document_id: str) -> None:
+        sql = text(
+            f"""
+            UPDATE {RELATION_TABLE}
+            SET evidence_lineage = COALESCE(
+                    (SELECT jsonb_agg(elem) FROM jsonb_array_elements(evidence_lineage) elem
+                     WHERE elem->>'document_id' != :document_id),
+                    '[]'::jsonb
+                ),
+                description_parts = COALESCE(
+                    (SELECT jsonb_agg(part) FROM jsonb_array_elements(description_parts) part
+                     WHERE part->>'document_id' != :document_id),
+                    '[]'::jsonb
+                ),
+                gmt_updated = NOW()
+            WHERE collection_id = :collection_id
+              AND source = :source AND target = :target AND type = :type
+            """
+        )
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                sql,
+                {
+                    "collection_id": self._collection_id,
+                    "source": source,
+                    "target": target,
+                    "type": type,
+                    "document_id": document_id,
+                },
+            )
+
+    # -- GC (post-rebuild) --------------------------------------------
+
+    async def gc_entity_if_orphan(self, entity_name: str) -> bool:
+        sql = text(
+            f"""
+            DELETE FROM {ENTITY_TABLE}
+            WHERE collection_id = :collection_id
+              AND name = :name
+              AND jsonb_array_length(source_lineage) = 0
+            """
+        )
+        async with self._engine.begin() as conn:
+            result = await conn.execute(sql, {"collection_id": self._collection_id, "name": entity_name})
+            return (result.rowcount or 0) > 0
+
+    async def gc_relation_if_orphan(self, source: str, target: str, type: str) -> bool:
+        sql = text(
+            f"""
+            DELETE FROM {RELATION_TABLE}
+            WHERE collection_id = :collection_id
+              AND source = :source AND target = :target AND type = :type
+              AND jsonb_array_length(evidence_lineage) = 0
+            """
+        )
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                sql,
+                {
+                    "collection_id": self._collection_id,
+                    "source": source,
+                    "target": target,
+                    "type": type,
+                },
+            )
+            return (result.rowcount or 0) > 0
+
+    # -- upserts (rebuild phase) --------------------------------------
+
+    async def upsert_entity_with_lineage(self, *, record: EntityRecord, lineage: LineageMember) -> None:
+        """Add (or replace by `(document_id, parse_version)` key)
+        the lineage member + a corresponding description part. Single
+        statement so concurrent rebuilds do not race."""
+        member_json = _lineage_to_json_array(lineage)
+        part_json = _description_part_to_json(
+            DescriptionPart(
+                document_id=lineage.document_id,
+                parse_version=lineage.parse_version,
+                text=record.description,
+            )
+        )
+        sql = text(
+            f"""
+            INSERT INTO {ENTITY_TABLE} (
+                collection_id, name, type, source_lineage, description_parts,
+                gmt_created, gmt_updated
+            )
+            VALUES (
+                :collection_id, :name, :type,
+                jsonb_build_array(CAST(:member_json AS jsonb)),
+                jsonb_build_array(CAST(:part_json AS jsonb)),
+                NOW(), NOW()
+            )
+            ON CONFLICT ON CONSTRAINT uq_lineage_entity_collection_name DO UPDATE
+            SET type = EXCLUDED.type,
+                source_lineage = (
+                    -- strip any existing element with the same
+                    -- (document_id, parse_version) key, then append
+                    -- the new one.
+                    COALESCE(
+                        (SELECT jsonb_agg(elem) FROM jsonb_array_elements({ENTITY_TABLE}.source_lineage) elem
+                         WHERE NOT (elem->>'document_id' = :document_id AND elem->>'parse_version' = :parse_version)),
+                        '[]'::jsonb
+                    ) || jsonb_build_array(CAST(:member_json AS jsonb))
+                ),
+                description_parts = (
+                    COALESCE(
+                        (SELECT jsonb_agg(part) FROM jsonb_array_elements({ENTITY_TABLE}.description_parts) part
+                         WHERE NOT (part->>'document_id' = :document_id AND part->>'parse_version' = :parse_version)),
+                        '[]'::jsonb
+                    ) || jsonb_build_array(CAST(:part_json AS jsonb))
+                ),
+                gmt_updated = NOW()
+            """
+        )
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                sql,
+                {
+                    "collection_id": self._collection_id,
+                    "name": record.name,
+                    "type": record.type,
+                    "document_id": lineage.document_id,
+                    "parse_version": lineage.parse_version,
+                    "member_json": member_json,
+                    "part_json": part_json,
+                },
+            )
+
+    async def upsert_relation_with_lineage(self, *, record: RelationRecord, lineage: LineageMember) -> None:
+        member_json = _lineage_to_json_array(lineage)
+        part_json = _description_part_to_json(
+            DescriptionPart(
+                document_id=lineage.document_id,
+                parse_version=lineage.parse_version,
+                text=record.description,
+            )
+        )
+        sql = text(
+            f"""
+            INSERT INTO {RELATION_TABLE} (
+                collection_id, source, target, type,
+                description, evidence_lineage, description_parts,
+                gmt_created, gmt_updated
+            )
+            VALUES (
+                :collection_id, :source, :target, :type,
+                :description,
+                jsonb_build_array(CAST(:member_json AS jsonb)),
+                jsonb_build_array(CAST(:part_json AS jsonb)),
+                NOW(), NOW()
+            )
+            ON CONFLICT ON CONSTRAINT uq_lineage_relation_collection_triple DO UPDATE
+            SET description = EXCLUDED.description,
+                evidence_lineage = (
+                    COALESCE(
+                        (SELECT jsonb_agg(elem) FROM jsonb_array_elements({RELATION_TABLE}.evidence_lineage) elem
+                         WHERE NOT (elem->>'document_id' = :document_id AND elem->>'parse_version' = :parse_version)),
+                        '[]'::jsonb
+                    ) || jsonb_build_array(CAST(:member_json AS jsonb))
+                ),
+                description_parts = (
+                    COALESCE(
+                        (SELECT jsonb_agg(part) FROM jsonb_array_elements({RELATION_TABLE}.description_parts) part
+                         WHERE NOT (part->>'document_id' = :document_id AND part->>'parse_version' = :parse_version)),
+                        '[]'::jsonb
+                    ) || jsonb_build_array(CAST(:part_json AS jsonb))
+                ),
+                gmt_updated = NOW()
+            """
+        )
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                sql,
+                {
+                    "collection_id": self._collection_id,
+                    "source": record.source,
+                    "target": record.target,
+                    "type": record.type,
+                    "description": record.description,
+                    "document_id": lineage.document_id,
+                    "parse_version": lineage.parse_version,
+                    "member_json": member_json,
+                    "part_json": part_json,
+                },
+            )
+
+    # -- read-path ----------------------------------------------------
+
+    async def get_entity(self, entity_name: str) -> EntityWithLineage | None:
+        async with self._engine.connect() as conn:
+            result = await conn.execute(
+                select(_LineageEntityRow).where(
+                    _LineageEntityRow.collection_id == self._collection_id,
+                    _LineageEntityRow.name == entity_name,
+                )
+            )
+            row = result.first()
+            if row is None:
+                return None
+            mapping = row._mapping
+            return _row_to_entity_with_lineage(mapping)
+
+    async def get_relation(self, source: str, target: str, type: str) -> RelationWithLineage | None:
+        async with self._engine.connect() as conn:
+            result = await conn.execute(
+                select(_LineageRelationRow).where(
+                    _LineageRelationRow.collection_id == self._collection_id,
+                    _LineageRelationRow.source == source,
+                    _LineageRelationRow.target == target,
+                    _LineageRelationRow.type == type,
+                )
+            )
+            row = result.first()
+            if row is None:
+                return None
+            mapping = row._mapping
+            return _row_to_relation_with_lineage(mapping)
+
+
+# ---------------------------------------------------------------------
+# Row → dataclass materialisation. Centralised so the JSONB shape
+# decisions live in one place.
+# ---------------------------------------------------------------------
+
+
+def _row_to_entity_with_lineage(row: Any) -> EntityWithLineage:
+    raw_lineage = row[_LineageEntityRow.source_lineage] or []
+    raw_parts = row[_LineageEntityRow.description_parts] or []
+    return EntityWithLineage(
+        name=row[_LineageEntityRow.name],
+        type=row[_LineageEntityRow.type],
+        source_lineage=tuple(LineageMember.from_dict(elem) for elem in raw_lineage),
+        description_parts=tuple(DescriptionPart.from_dict(part) for part in raw_parts),
+    )
+
+
+def _row_to_relation_with_lineage(row: Any) -> RelationWithLineage:
+    raw_lineage = row[_LineageRelationRow.evidence_lineage] or []
+    raw_parts = row[_LineageRelationRow.description_parts] or []
+    return RelationWithLineage(
+        source=row[_LineageRelationRow.source],
+        target=row[_LineageRelationRow.target],
+        type=row[_LineageRelationRow.type],
+        evidence_lineage=tuple(LineageMember.from_dict(elem) for elem in raw_lineage),
+        description_parts=tuple(DescriptionPart.from_dict(part) for part in raw_parts),
+    )
+
+
+__all__ = [
+    "ENTITY_TABLE",
+    "PostgresLineageGraphStore",
+    "RELATION_TABLE",
+]

--- a/aperag/indexing/graph_storage/postgres.py
+++ b/aperag/indexing/graph_storage/postgres.py
@@ -56,14 +56,12 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 from sqlalchemy import (
     Column,
     DateTime,
+    Index,
     String,
-    Text,
-    UniqueConstraint,
     select,
     text,
 )
@@ -99,11 +97,20 @@ RELATION_TABLE = "aperag_lineage_relation"
 
 class _LineageEntityRow(_LineageGraphBase):
     __tablename__ = ENTITY_TABLE
-    __table_args__ = (UniqueConstraint("collection_id", "name", name="uq_lineage_entity_collection_name"),)
+    # The ``(collection_id, name)`` composite primary key already
+    # enforces uniqueness; the upsert SQL uses the column-list
+    # ``ON CONFLICT (collection_id, name)`` form so no separate
+    # named UniqueConstraint is required. The GIN index accelerates
+    # the JSONB ``@>`` containment scan in
+    # ``find_entity_ids_with_lineage`` against multi-tenant tables.
+    __table_args__ = (
+        Index(
+            "idx_lineage_entity_source_lineage_gin",
+            "source_lineage",
+            postgresql_using="gin",
+        ),
+    )
 
-    # composite primary key kept on the UniqueConstraint above so
-    # SQLAlchemy can issue UPSERTs (PostgreSQL ON CONFLICT requires a
-    # named constraint or a column list).
     collection_id = Column(String(64), primary_key=True)
     name = Column(String(512), primary_key=True)
     type = Column(String(64), nullable=False)
@@ -116,12 +123,10 @@ class _LineageEntityRow(_LineageGraphBase):
 class _LineageRelationRow(_LineageGraphBase):
     __tablename__ = RELATION_TABLE
     __table_args__ = (
-        UniqueConstraint(
-            "collection_id",
-            "source",
-            "target",
-            "type",
-            name="uq_lineage_relation_collection_triple",
+        Index(
+            "idx_lineage_relation_evidence_lineage_gin",
+            "evidence_lineage",
+            postgresql_using="gin",
         ),
     )
 
@@ -129,7 +134,10 @@ class _LineageRelationRow(_LineageGraphBase):
     source = Column(String(512), primary_key=True)
     target = Column(String(512), primary_key=True)
     type = Column(String(64), primary_key=True)
-    description = Column(Text, nullable=False, server_default="")
+    # Wave 4 chunk 4 dropped the legacy ``description`` Text column —
+    # the per-document fragments in ``description_parts`` are the
+    # canonical source. ``RelationWithLineage`` does not expose a
+    # standalone ``description`` field so the column had no consumer.
     evidence_lineage = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     description_parts = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
@@ -190,12 +198,18 @@ class PostgresLineageGraphStore:
         # JSONB containment ``@>`` matches when the right side is a
         # subset of the left; we wrap the document_id object in a
         # one-element array so the operator scans the lineage SET.
+        # ``CAST(:document_id AS TEXT)`` makes the asyncpg adapter
+        # infer the parameter type — without the cast asyncpg sees
+        # an indeterminate datatype because the parameter sits inside
+        # ``jsonb_build_object`` (which accepts ``ANY``).
         sql = text(
             f"""
             SELECT name
             FROM {ENTITY_TABLE}
             WHERE collection_id = :collection_id
-              AND source_lineage @> jsonb_build_array(jsonb_build_object('document_id', :document_id))
+              AND source_lineage @> jsonb_build_array(
+                    jsonb_build_object('document_id', CAST(:document_id AS TEXT))
+                  )
             """
         )
         async with self._engine.connect() as conn:
@@ -208,7 +222,9 @@ class PostgresLineageGraphStore:
             SELECT source, target, type
             FROM {RELATION_TABLE}
             WHERE collection_id = :collection_id
-              AND evidence_lineage @> jsonb_build_array(jsonb_build_object('document_id', :document_id))
+              AND evidence_lineage @> jsonb_build_array(
+                    jsonb_build_object('document_id', CAST(:document_id AS TEXT))
+                  )
             """
         )
         async with self._engine.connect() as conn:
@@ -341,7 +357,7 @@ class PostgresLineageGraphStore:
                 jsonb_build_array(CAST(:part_json AS jsonb)),
                 NOW(), NOW()
             )
-            ON CONFLICT ON CONSTRAINT uq_lineage_entity_collection_name DO UPDATE
+            ON CONFLICT (collection_id, name) DO UPDATE
             SET type = EXCLUDED.type,
                 source_lineage = (
                     -- strip any existing element with the same
@@ -390,19 +406,17 @@ class PostgresLineageGraphStore:
             f"""
             INSERT INTO {RELATION_TABLE} (
                 collection_id, source, target, type,
-                description, evidence_lineage, description_parts,
+                evidence_lineage, description_parts,
                 gmt_created, gmt_updated
             )
             VALUES (
                 :collection_id, :source, :target, :type,
-                :description,
                 jsonb_build_array(CAST(:member_json AS jsonb)),
                 jsonb_build_array(CAST(:part_json AS jsonb)),
                 NOW(), NOW()
             )
-            ON CONFLICT ON CONSTRAINT uq_lineage_relation_collection_triple DO UPDATE
-            SET description = EXCLUDED.description,
-                evidence_lineage = (
+            ON CONFLICT (collection_id, source, target, type) DO UPDATE
+            SET evidence_lineage = (
                     COALESCE(
                         (SELECT jsonb_agg(elem) FROM jsonb_array_elements({RELATION_TABLE}.evidence_lineage) elem
                          WHERE NOT (elem->>'document_id' = :document_id AND elem->>'parse_version' = :parse_version)),
@@ -427,7 +441,6 @@ class PostgresLineageGraphStore:
                     "source": record.source,
                     "target": record.target,
                     "type": record.type,
-                    "description": record.description,
                     "document_id": lineage.document_id,
                     "parse_version": lineage.parse_version,
                     "member_json": member_json,
@@ -440,7 +453,12 @@ class PostgresLineageGraphStore:
     async def get_entity(self, entity_name: str) -> EntityWithLineage | None:
         async with self._engine.connect() as conn:
             result = await conn.execute(
-                select(_LineageEntityRow).where(
+                select(
+                    _LineageEntityRow.name,
+                    _LineageEntityRow.type,
+                    _LineageEntityRow.source_lineage,
+                    _LineageEntityRow.description_parts,
+                ).where(
                     _LineageEntityRow.collection_id == self._collection_id,
                     _LineageEntityRow.name == entity_name,
                 )
@@ -448,13 +466,23 @@ class PostgresLineageGraphStore:
             row = result.first()
             if row is None:
                 return None
-            mapping = row._mapping
-            return _row_to_entity_with_lineage(mapping)
+            return EntityWithLineage(
+                name=row.name,
+                type=row.type,
+                source_lineage=tuple(LineageMember.from_dict(elem) for elem in (row.source_lineage or [])),
+                description_parts=tuple(DescriptionPart.from_dict(part) for part in (row.description_parts or [])),
+            )
 
     async def get_relation(self, source: str, target: str, type: str) -> RelationWithLineage | None:
         async with self._engine.connect() as conn:
             result = await conn.execute(
-                select(_LineageRelationRow).where(
+                select(
+                    _LineageRelationRow.source,
+                    _LineageRelationRow.target,
+                    _LineageRelationRow.type,
+                    _LineageRelationRow.evidence_lineage,
+                    _LineageRelationRow.description_parts,
+                ).where(
                     _LineageRelationRow.collection_id == self._collection_id,
                     _LineageRelationRow.source == source,
                     _LineageRelationRow.target == target,
@@ -464,37 +492,13 @@ class PostgresLineageGraphStore:
             row = result.first()
             if row is None:
                 return None
-            mapping = row._mapping
-            return _row_to_relation_with_lineage(mapping)
-
-
-# ---------------------------------------------------------------------
-# Row → dataclass materialisation. Centralised so the JSONB shape
-# decisions live in one place.
-# ---------------------------------------------------------------------
-
-
-def _row_to_entity_with_lineage(row: Any) -> EntityWithLineage:
-    raw_lineage = row[_LineageEntityRow.source_lineage] or []
-    raw_parts = row[_LineageEntityRow.description_parts] or []
-    return EntityWithLineage(
-        name=row[_LineageEntityRow.name],
-        type=row[_LineageEntityRow.type],
-        source_lineage=tuple(LineageMember.from_dict(elem) for elem in raw_lineage),
-        description_parts=tuple(DescriptionPart.from_dict(part) for part in raw_parts),
-    )
-
-
-def _row_to_relation_with_lineage(row: Any) -> RelationWithLineage:
-    raw_lineage = row[_LineageRelationRow.evidence_lineage] or []
-    raw_parts = row[_LineageRelationRow.description_parts] or []
-    return RelationWithLineage(
-        source=row[_LineageRelationRow.source],
-        target=row[_LineageRelationRow.target],
-        type=row[_LineageRelationRow.type],
-        evidence_lineage=tuple(LineageMember.from_dict(elem) for elem in raw_lineage),
-        description_parts=tuple(DescriptionPart.from_dict(part) for part in raw_parts),
-    )
+            return RelationWithLineage(
+                source=row.source,
+                target=row.target,
+                type=row.type,
+                evidence_lineage=tuple(LineageMember.from_dict(elem) for elem in (row.evidence_lineage or [])),
+                description_parts=tuple(DescriptionPart.from_dict(part) for part in (row.description_parts or [])),
+            )
 
 
 __all__ = [

--- a/aperag/indexing/observability.py
+++ b/aperag/indexing/observability.py
@@ -28,13 +28,12 @@ operators alert on:
   slots currently running a task.
 
 This module defines a minimal :class:`MetricsEmitter` protocol plus a
-process-local :class:`InMemoryMetricsEmitter` (test fixture) and a
-no-op :class:`NoopMetricsEmitter` (Tier 1 single-machine deploy where
-OTLP is not wired). Production wiring (T2.x) instantiates the OTLP
-adapter from ``aperag.observability`` (PR #1702 if that infra has
-already landed; otherwise a stub that satisfies the protocol so the
-modality / orchestrator code does not need to branch on whether
-OTLP is up).
+process-local :class:`InMemoryMetricsEmitter` (test fixture), a no-op
+:class:`NoopMetricsEmitter` (default for ``INDEXING_METRICS_EMITTER=noop``
+single-machine deployments where OTLP is not wired), and the production
+:class:`OTLPMetricsEmitter` (wires the four §J.1 SLIs onto the SDK
+``MeterProvider`` configured by :mod:`aperag.observability.metrics`,
+selected by ``INDEXING_METRICS_EMITTER=otlp``).
 
 The emit helpers (``emit_index_lag`` / ``emit_index_failure`` /
 ``emit_queue_depth`` / ``emit_worker_utilization``) are the canonical
@@ -77,7 +76,16 @@ class MetricsEmitter(Protocol):
 
 
 class NoopMetricsEmitter:
-    """No-op emitter for deployments without OTLP wired (Tier 1 §L)."""
+    """No-op emitter — the default ``INDEXING_METRICS_EMITTER=noop`` binding.
+
+    Suitable for single-machine deployments without an OTLP collector
+    (Tier 1 §L) and for unit tests that don't care about metric output.
+    Production multi-pod deployments **must** opt into
+    :class:`OTLPMetricsEmitter` via ``INDEXING_METRICS_EMITTER=otlp`` so
+    the §J.1 SLIs reach the collector — silently dropping metrics on
+    Tier 2/3 means operators lose the queue-backlog / failure-rate
+    signals they alert on.
+    """
 
     def gauge(
         self,
@@ -96,6 +104,92 @@ class NoopMetricsEmitter:
         attributes: dict[str, str] | None = None,
     ) -> None:  # pragma: no cover - trivial
         return None
+
+
+class OTLPMetricsEmitter:
+    """Production emitter — materialises SDK instruments on the global
+    OpenTelemetry ``MeterProvider`` and forwards every ``gauge`` /
+    ``counter`` call to that provider's exporter.
+
+    The constructor pulls ``opentelemetry.metrics.get_meter`` lazily so
+    importing this module never forces an OTLP install. When the SDK
+    packages or :func:`aperag.observability.metrics.init_metrics_provider`
+    have not run, the global provider is the no-op
+    ``ProxyMeterProvider`` and every call here is silently dropped —
+    the operator-facing diagnosis is therefore "your OTLP endpoint is
+    not configured" rather than a crash, which matches how the rest of
+    :mod:`aperag.observability` degrades.
+
+    Instruments are cached on the instance so repeated emits for the
+    same metric name share one ``Counter`` / ``Gauge`` instrument
+    handle (mirrors the pattern in
+    :mod:`aperag.observability.metrics.record_counter`).
+    """
+
+    def __init__(
+        self,
+        meter_name: str = "aperag.indexing",
+        *,
+        meter: object | None = None,
+    ) -> None:
+        if meter is not None:
+            # Tests pass a meter sourced from an isolated SDK
+            # ``MeterProvider`` (with an :class:`InMemoryMetricReader`)
+            # so they don't have to mutate the process-global provider
+            # — ``opentelemetry.metrics.set_meter_provider`` only takes
+            # effect once per process and cannot be reset between tests.
+            self._meter = meter
+        else:
+            try:
+                from opentelemetry import metrics as otel_metrics
+            except ImportError as exc:  # pragma: no cover - depends on runtime install
+                raise RuntimeError(
+                    "OTLPMetricsEmitter requires the opentelemetry-api package; "
+                    "fall back to NoopMetricsEmitter when OTLP is not installed."
+                ) from exc
+            self._meter = otel_metrics.get_meter(meter_name)
+        self._gauges: dict[str, object] = {}
+        self._counters: dict[str, object] = {}
+
+    def gauge(
+        self,
+        *,
+        name: str,
+        value: float,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        instrument = self._gauges.get(name)
+        if instrument is None:
+            try:
+                instrument = self._meter.create_gauge(name)
+            except Exception:
+                logger.debug("OTLP gauge create failed for %s", name, exc_info=True)
+                return
+            self._gauges[name] = instrument
+        try:
+            instrument.set(float(value), dict(attributes or {}))
+        except Exception:
+            logger.debug("OTLP gauge set failed for %s", name, exc_info=True)
+
+    def counter(
+        self,
+        *,
+        name: str,
+        value: float = 1.0,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        instrument = self._counters.get(name)
+        if instrument is None:
+            try:
+                instrument = self._meter.create_counter(name)
+            except Exception:
+                logger.debug("OTLP counter create failed for %s", name, exc_info=True)
+                return
+            self._counters[name] = instrument
+        try:
+            instrument.add(float(value), dict(attributes or {}))
+        except Exception:
+            logger.debug("OTLP counter add failed for %s", name, exc_info=True)
 
 
 class InMemoryMetricsEmitter:
@@ -242,6 +336,7 @@ def emit_worker_utilization(
 __all__ = [
     "MetricsEmitter",
     "NoopMetricsEmitter",
+    "OTLPMetricsEmitter",
     "InMemoryMetricsEmitter",
     "INDEX_LAG_METRIC",
     "INDEX_FAILURE_METRIC",

--- a/aperag/indexing/orchestrator.py
+++ b/aperag/indexing/orchestrator.py
@@ -109,6 +109,21 @@ class WorkQueue(Protocol):
     Production wires this to a Redis-backed queue (``RPUSH`` enqueue +
     ``BLPOP`` dequeue keyed by ``q:<modality>``). Tests inject
     :class:`InMemoryWorkQueue` for synchronous deterministic dispatch.
+
+    The protocol covers two queue families:
+
+    * **Per-modality queues** (``push`` / ``pop``) — keyed by
+      :class:`Modality`. The 5 modality worker pools (vector / fulltext
+      / graph / summary / vision) consume these. Backed by Redis lists
+      named ``q:indexing:<modality>``.
+
+    * **Parse queue** (``push_parse`` / ``pop_parse``) — un-keyed
+      single queue feeding the parse worker pool (Wave 4 T3 chunk 2,
+      design pack §E.2). Parse jobs are dispatched here by the upload
+      handler so the HTTP request returns 202 immediately instead of
+      blocking on a 30s+ DocParser run; the parse worker pops, parses,
+      and then fans out to the per-modality queues. Backed by a Redis
+      list named ``q:parse``.
     """
 
     async def pop(self, *, modality: Modality, timeout_seconds: float) -> dict[str, Any] | None:
@@ -120,16 +135,34 @@ class WorkQueue(Protocol):
     async def push(self, *, modality: Modality, payload: Mapping[str, Any]) -> None:
         """Enqueue a payload for the given modality (reconciler dispatch path)."""
 
+    async def push_parse(self, *, payload: Mapping[str, Any]) -> None:
+        """Enqueue a parse payload onto ``q:parse`` (Wave 4 T3 chunk 2).
+
+        Called from the upload handler (``_create_or_update_document_indexes``)
+        to hand the document off to the parse worker pool without
+        blocking the HTTP request on parse latency.
+        """
+
+    async def pop_parse(self, *, timeout_seconds: float) -> dict[str, Any] | None:
+        """Block up to ``timeout_seconds`` for the next parse payload.
+
+        Consumed by the parse worker run loop. Returns the deserialised
+        payload dict (matching :class:`ParseDispatchPayload.to_dict`) or
+        ``None`` on timeout.
+        """
+
 
 class InMemoryWorkQueue:
     """Process-local asyncio queue mirror of the :class:`WorkQueue` protocol.
 
-    One ``asyncio.Queue`` per modality. Suitable for unit / contract
-    tests that want to drive the orchestrator without standing up Redis.
+    One ``asyncio.Queue`` per modality plus a single un-keyed parse
+    queue. Suitable for unit / contract tests that want to drive the
+    orchestrator without standing up Redis.
     """
 
     def __init__(self) -> None:
         self._queues: dict[Modality, asyncio.Queue[dict[str, Any]]] = {}
+        self._parse_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
 
     def _q(self, modality: Modality) -> asyncio.Queue[dict[str, Any]]:
         if modality not in self._queues:
@@ -145,10 +178,22 @@ class InMemoryWorkQueue:
     async def push(self, *, modality: Modality, payload: Mapping[str, Any]) -> None:
         await self._q(modality).put(dict(payload))
 
+    async def push_parse(self, *, payload: Mapping[str, Any]) -> None:
+        await self._parse_queue.put(dict(payload))
+
+    async def pop_parse(self, *, timeout_seconds: float) -> dict[str, Any] | None:
+        try:
+            return await asyncio.wait_for(self._parse_queue.get(), timeout=timeout_seconds)
+        except asyncio.TimeoutError:
+            return None
+
     def qsize(self, modality: Modality) -> int:
         if modality not in self._queues:
             return 0
         return self._queues[modality].qsize()
+
+    def parse_qsize(self) -> int:
+        return self._parse_queue.qsize()
 
 
 class RedisWorkQueue:
@@ -175,6 +220,10 @@ class RedisWorkQueue:
     #: Redis list key template — keyed by modality so each modality
     #: has its own BLPOP queue.
     KEY_TEMPLATE = "q:indexing:{modality}"
+
+    #: Redis list key for the parse worker pool (Wave 4 T3 chunk 2).
+    #: Matches the design pack §E.2 ASCII diagram (``q:parse``).
+    PARSE_KEY = "q:parse"
 
     def __init__(self, redis_url: str) -> None:
         if not redis_url:
@@ -218,6 +267,34 @@ class RedisWorkQueue:
                 exc,
             )
             return None
+
+    async def push_parse(self, *, payload: Mapping[str, Any]) -> None:
+        client = await self._get_client()
+        await client.rpush(self.PARSE_KEY, json.dumps(dict(payload)))
+
+    async def pop_parse(self, *, timeout_seconds: float) -> dict[str, Any] | None:
+        client = await self._get_client()
+        timeout = max(1, int(timeout_seconds))
+        result = await client.blpop(self.PARSE_KEY, timeout=timeout)
+        if result is None:
+            return None
+        _key, raw = result
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            logger.error(
+                "RedisWorkQueue.pop_parse got non-JSON payload on key=%s: %s; dropping",
+                _key,
+                exc,
+            )
+            return None
+
+    async def parse_qsize(self) -> int:
+        """Inspector helper for the parse queue — current backlog length.
+        Mirrors :meth:`qsize` for the per-modality queues.
+        """
+        client = await self._get_client()
+        return int(await client.llen(self.PARSE_KEY))
 
     async def qsize(self, modality: Modality) -> int:
         """Inspector helper — returns the current backlog length for

--- a/aperag/indexing/orchestrator.py
+++ b/aperag/indexing/orchestrator.py
@@ -151,6 +151,95 @@ class InMemoryWorkQueue:
         return self._queues[modality].qsize()
 
 
+class RedisWorkQueue:
+    """Redis-backed :class:`WorkQueue` — celery T2.1 + Wave 4 T4.
+
+    Production multi-process worker pool transport per design pack §E.2:
+    each modality gets a Redis list keyed ``q:indexing:<modality>``;
+    enqueue is ``RPUSH`` of a JSON-serialized payload, dequeue is
+    ``BLPOP`` with a timeout. Multiple worker processes BLPOP'ing the
+    same key are atomically demuxed by Redis — at most one worker
+    receives any given payload.
+
+    Replaces the Wave 1+2 default :class:`InMemoryWorkQueue` which is
+    process-local (multi-pod / multi-worker deployments lose tasks
+    that get pushed to one process and BLPOP'd by another). Wave 4
+    follow-up #6 per architect msg=fab88774 (Wave 1+2 gap report).
+
+    Lazy-connects on first ``push`` / ``pop``; the underlying
+    ``redis.asyncio.Redis`` client owns its own pool. Production
+    deployments share one client per process (FastAPI lifespan
+    instantiates one and stashes on app.state.indexing_queue).
+    """
+
+    #: Redis list key template — keyed by modality so each modality
+    #: has its own BLPOP queue.
+    KEY_TEMPLATE = "q:indexing:{modality}"
+
+    def __init__(self, redis_url: str) -> None:
+        if not redis_url:
+            raise ValueError("RedisWorkQueue requires a non-empty redis_url")
+        self._url = redis_url
+        self._client: Any | None = None  # redis.asyncio.Redis, lazy
+
+    async def _get_client(self) -> Any:
+        if self._client is None:
+            from redis import asyncio as redis_asyncio
+
+            self._client = redis_asyncio.from_url(self._url, encoding="utf-8", decode_responses=True)
+        return self._client
+
+    @classmethod
+    def _key(cls, modality: Modality) -> str:
+        return cls.KEY_TEMPLATE.format(modality=modality.value)
+
+    async def push(self, *, modality: Modality, payload: Mapping[str, Any]) -> None:
+        client = await self._get_client()
+        await client.rpush(self._key(modality), json.dumps(dict(payload)))
+
+    async def pop(self, *, modality: Modality, timeout_seconds: float) -> dict[str, Any] | None:
+        client = await self._get_client()
+        # ``BLPOP`` blocks server-side for ``timeout`` seconds (0 = forever);
+        # we always pass a positive bound so the worker loop can periodically
+        # check ``shutdown`` between BLPOP calls. Floor sub-second timeouts
+        # to 1 — Redis BLPOP's resolution is integer seconds.
+        timeout = max(1, int(timeout_seconds))
+        result = await client.blpop(self._key(modality), timeout=timeout)
+        if result is None:
+            return None
+        # ``result`` is ``(key, value)``; we only care about the value.
+        _key, raw = result
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            logger.error(
+                "RedisWorkQueue.pop got non-JSON payload on key=%s: %s; dropping",
+                _key,
+                exc,
+            )
+            return None
+
+    async def qsize(self, modality: Modality) -> int:
+        """Inspector helper — returns the current backlog length for
+        the modality. Useful for §J.1 ``queue_depth`` SLI emission and
+        for tests that want to assert payloads landed.
+        """
+        client = await self._get_client()
+        return int(await client.llen(self._key(modality)))
+
+    async def close(self) -> None:
+        """Release the underlying Redis client. Called on FastAPI
+        lifespan shutdown so the connection pool drains cleanly.
+        """
+        if self._client is not None:
+            client = self._client
+            self._client = None
+            try:
+                await client.aclose()
+            except AttributeError:  # pragma: no cover — older redis-py
+                await client.close()
+
+
 # ---------------------------------------------------------------------
 # Dispatch payload (round-trips through Redis as JSON).
 # ---------------------------------------------------------------------

--- a/aperag/indexing/parse_orchestrator.py
+++ b/aperag/indexing/parse_orchestrator.py
@@ -1,0 +1,454 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parse worker pool orchestrator — celery Wave 4 T3 chunk 2.
+
+Per ``docs/modularization/indexing-redesign-design-pack.md`` §E.2, the
+parse stage is **its own queue + worker pool**, separate from the 5
+per-modality lanes. Without this split the upload HTTP handler blocks
+on the full ``DocParser`` (MarkItDown / MinerU / OCR) latency — a 30s+
+freeze for PDFs and images that destroys responsiveness.
+
+This module ships the dispatch surface that promotes parse to async:
+
+* :class:`ParseDispatchPayload` — the JSON-serialisable envelope
+  pushed onto ``q:parse`` by the upload handler.
+* :func:`process_one_parse_task` — single-payload happy / failure
+  paths. Reads the source artifact, runs :func:`parse_document`, then
+  fans out via :func:`dispatch_indexing` to the 5 per-modality queues.
+* :func:`run_parse_worker_loop` + :func:`run_parse_worker` — the
+  long-lived BLPOP loop wired into the FastAPI lifespan, mirroring the
+  per-modality ``run_*_worker`` entrypoints.
+
+Why no DocumentIndex row for parse: the per-modality rows are inserted
+**after** parse completes (so they can carry the real
+``parse_version``). Tracking parse-in-progress on a separate row would
+require either a sentinel ``parse_version`` (collides with the
+``UNIQUE(document_id, parse_version, modality)`` constraint when the
+real version lands) or a new table; both buy little for chunk 2's
+minimal scope. A failed / lost parse currently surfaces as a document
+that never sprouted ``document_index`` rows — Wave 5 follow-up will
+extend the reconciler to re-enqueue parse jobs for stuck documents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Mapping
+
+from sqlalchemy import Engine, and_
+from sqlalchemy import delete as sa_delete
+from sqlalchemy.orm import Session
+
+from aperag.indexing.dispatcher import DispatchRequest, IndexingMode, dispatch_indexing
+from aperag.indexing.models import DocumentIndex, Modality
+from aperag.indexing.orchestrator import WorkQueue
+from aperag.indexing.parser import ParseConfig, parse_document
+from aperag.objectstore.base import ObjectStore as _SyncObjectStore
+
+logger = logging.getLogger(__name__)
+
+
+# Default poll timeout for the parse worker loop — short so a
+# ``shutdown`` event is responsive without busy-looping. Mirrors the
+# per-modality :class:`OrchestratorConfig` default.
+DEFAULT_POLL_TIMEOUT_SECONDS = 1.0
+
+# Per design pack §E.2 ASCII diagram: parse_worker (1 process,
+# asyncio concurrency = 8). Parse latency is dominated by external
+# OCR / MinerU / MarkItDown calls, so 8 concurrent in-flight parses
+# is the throughput sweet spot before disk + LLM rate-limit pressure
+# kicks in.
+DEFAULT_PARSE_CONCURRENCY = 8
+
+
+# ---------------------------------------------------------------------
+# Dispatch payload (round-trips through Redis as JSON).
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ParseDispatchPayload:
+    """Decoded parse-queue payload — the unit of work the parse worker runs.
+
+    Carries enough context to (a) read the source artifact from the
+    object store, (b) run :func:`parse_document` with the right
+    parser config, and (c) fan out to the per-modality queues with
+    the correct ``modalities`` subset + ``tenant_scope_key`` for the
+    quota / bulkhead lane.
+
+    No ``parse_version`` field — that is what parsing produces. The
+    upload handler does not know it yet, which is precisely why parse
+    is async.
+    """
+
+    document_id: str
+    collection_id: str
+    object_path: str
+    tenant_scope_key: str
+    modalities: tuple[str, ...]
+    parser_config: dict[str, Any] | None = None
+    purge_existing_triples: bool = False
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "ParseDispatchPayload":
+        modalities_raw = raw.get("modalities") or ()
+        if isinstance(modalities_raw, str):
+            modalities_raw = json.loads(modalities_raw)
+        modalities = tuple(str(m) for m in modalities_raw)
+        parser_config = raw.get("parser_config")
+        if parser_config is not None and not isinstance(parser_config, dict):
+            raise TypeError(
+                f"ParseDispatchPayload.parser_config must be a dict or None, got {type(parser_config).__name__}"
+            )
+        return cls(
+            document_id=str(raw["document_id"]),
+            collection_id=str(raw["collection_id"]),
+            object_path=str(raw["object_path"]),
+            tenant_scope_key=str(raw["tenant_scope_key"]),
+            modalities=modalities,
+            parser_config=parser_config,
+            purge_existing_triples=bool(raw.get("purge_existing_triples", False)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "document_id": self.document_id,
+            "collection_id": self.collection_id,
+            "object_path": self.object_path,
+            "tenant_scope_key": self.tenant_scope_key,
+            "modalities": list(self.modalities),
+            "parser_config": self.parser_config,
+            "purge_existing_triples": self.purge_existing_triples,
+        }
+
+
+# ---------------------------------------------------------------------
+# Single-task entrypoint — used directly by tests, wrapped by the loop.
+# ---------------------------------------------------------------------
+
+
+def _read_source_bytes_sync(store: _SyncObjectStore, object_path: str) -> bytes | None:
+    """Read source bytes from the object store, returning ``None`` if missing.
+
+    Returns ``None`` rather than raising so the caller can surface
+    ``failed_read`` instead of bubbling an opaque exception. The
+    ``read_or_none`` helper in :mod:`object_store` is for *derived*
+    artifacts (which legitimately may be missing mid-derive); source
+    artifacts should always exist by the time the upload handler
+    enqueues the parse job, so a missing source genuinely indicates a
+    bug or an external delete.
+    """
+    handle = store.get(object_path)
+    if handle is None:
+        return None
+    try:
+        body = handle.read()
+    finally:
+        try:
+            handle.close()
+        except Exception:  # noqa: BLE001 — best-effort close
+            pass
+    return body
+
+
+def _purge_existing_triples_sync(
+    engine: Engine,
+    document_id: str,
+    parse_version: str,
+    modalities: tuple[Modality, ...],
+) -> None:
+    """Delete any existing ``(document_id, parse_version, modality)`` rows.
+
+    Mirrors the rebuild-path purge that
+    ``_create_or_update_document_indexes`` ran inline before chunk 2.
+    Required when a rebuild is dispatched on a document whose content
+    has not changed: the parse_version is content-derived, so a
+    re-enqueue would trip the ``uq_document_index_triple`` UNIQUE
+    constraint when the dispatcher INSERTs.
+    """
+    if not modalities:
+        return
+    modality_values = [m.value for m in modalities]
+    with Session(engine) as session, session.begin():
+        session.execute(
+            sa_delete(DocumentIndex).where(
+                and_(
+                    DocumentIndex.document_id == document_id,
+                    DocumentIndex.parse_version == parse_version,
+                    DocumentIndex.modality.in_(modality_values),
+                )
+            )
+        )
+
+
+async def process_one_parse_task(
+    *,
+    engine: Engine,
+    queue: WorkQueue,
+    object_store: _SyncObjectStore,
+    payload: ParseDispatchPayload,
+    parse_config: ParseConfig | None = None,
+) -> str:
+    """Run the full read-source → parse → dispatch cycle for one payload.
+
+    Returns one of ``"completed"``, ``"failed_read"``, ``"failed_parse"``,
+    ``"failed_dispatch"`` so the run-loop / tests can assert on the
+    per-task outcome without scraping logs.
+
+    Failure modes are recorded via ``logger.exception`` and the parse
+    job is dropped (no retry — a failed parse leaves the document
+    without ``document_index`` rows; the operator surfaces it via
+    ``document.status`` and the Wave 5 reconciler extension). Modality
+    workers handle their own retry via §I.2 backoff once parse
+    succeeds.
+    """
+    # ---- 1. Read source from the object store ----
+    try:
+        source_bytes = await asyncio.to_thread(_read_source_bytes_sync, object_store, payload.object_path)
+    except Exception as exc:  # noqa: BLE001 — surface via log, drop job
+        logger.exception(
+            "parse_worker source read failure document_id=%s object_path=%s: %s",
+            payload.document_id,
+            payload.object_path,
+            exc,
+        )
+        return "failed_read"
+
+    if source_bytes is None:
+        logger.error(
+            "parse_worker dropping payload — source missing in object store: document_id=%s object_path=%s",
+            payload.document_id,
+            payload.object_path,
+        )
+        return "failed_read"
+
+    # ---- 2. Parse: produce derived/parse_<version>/{markdown.md,outline.json,chunks.jsonl} ----
+    cfg = parse_config or ParseConfig()
+    try:
+        parsed = await asyncio.to_thread(
+            parse_document,
+            store=object_store,
+            collection_id=payload.collection_id,
+            document_id=payload.document_id,
+            source_bytes=source_bytes,
+            source_filename=payload.object_path,
+            parser_config=payload.parser_config,
+            config=cfg,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface via log, drop job
+        logger.exception(
+            "parse_worker parse failure document_id=%s object_path=%s: %s",
+            payload.document_id,
+            payload.object_path,
+            exc,
+        )
+        return "failed_parse"
+
+    # ---- 3. Optional rebuild-path purge (idempotent re-dispatch) ----
+    try:
+        modalities = tuple(Modality(m) for m in payload.modalities)
+    except ValueError as exc:
+        logger.error(
+            "parse_worker dropping payload — unknown modality value document_id=%s modalities=%r: %s",
+            payload.document_id,
+            payload.modalities,
+            exc,
+        )
+        return "failed_dispatch"
+
+    if payload.purge_existing_triples and modalities:
+        try:
+            await asyncio.to_thread(
+                _purge_existing_triples_sync,
+                engine,
+                payload.document_id,
+                parsed.parse_version,
+                modalities,
+            )
+        except Exception as exc:  # noqa: BLE001 — surface via log, drop job
+            logger.exception(
+                "parse_worker triple purge failure document_id=%s parse_version=%s: %s",
+                payload.document_id,
+                parsed.parse_version,
+                exc,
+            )
+            return "failed_dispatch"
+
+    # ---- 4. Dispatch fan-out to the 5 per-modality queues ----
+    if not modalities:
+        # Empty modality set is a degenerate parse-only enqueue (e.g.
+        # tests that exercise parse without dispatch). The artifacts
+        # are written and the document is parsed; we just have nothing
+        # to fan out.
+        logger.info(
+            "parse_worker parse_only — no modalities to dispatch for document_id=%s parse_version=%s",
+            payload.document_id,
+            parsed.parse_version,
+        )
+        return "completed"
+
+    try:
+        await dispatch_indexing(
+            engine=engine,
+            queue=queue,
+            workers=None,
+            request=DispatchRequest(
+                collection_id=payload.collection_id,
+                document_id=payload.document_id,
+                parse_version=parsed.parse_version,
+                source_path=parsed.chunks_path,
+                tenant_scope_key=payload.tenant_scope_key,
+                modalities=modalities,
+            ),
+            mode=IndexingMode.ASYNC,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface via log, drop job
+        logger.exception(
+            "parse_worker dispatch_indexing failure document_id=%s parse_version=%s: %s",
+            payload.document_id,
+            parsed.parse_version,
+            exc,
+        )
+        return "failed_dispatch"
+
+    logger.info(
+        "parse_worker completed document_id=%s parse_version=%s modalities=%d",
+        payload.document_id,
+        parsed.parse_version,
+        len(modalities),
+    )
+    return "completed"
+
+
+# ---------------------------------------------------------------------
+# Run loop (parse worker process).
+# ---------------------------------------------------------------------
+
+
+@dataclass
+class ParseOrchestratorConfig:
+    """Per-process parse-worker tuning. Mirrors :class:`OrchestratorConfig`.
+
+    ``concurrency`` is bounded by an :class:`asyncio.Semaphore` inside
+    the run loop so a slow OCR call cannot starve the BLPOP loop.
+    """
+
+    concurrency: int = DEFAULT_PARSE_CONCURRENCY
+    poll_timeout_seconds: float = DEFAULT_POLL_TIMEOUT_SECONDS
+
+
+# A factory so the run loop can resolve a per-process object store
+# without baking a concrete backend into the orchestrator. Production
+# wires :class:`aperag.objectstore.factories.get_object_store`; tests
+# inject :class:`InMemoryObjectStore`. Async to leave room for backends
+# that need an async resolution step (e.g. S3 client warm-up).
+ObjectStoreFactory = Callable[[], Awaitable[_SyncObjectStore]]
+
+
+async def run_parse_worker_loop(
+    *,
+    config: ParseOrchestratorConfig,
+    engine: Engine,
+    queue: WorkQueue,
+    object_store_factory: ObjectStoreFactory,
+    shutdown: asyncio.Event,
+) -> None:
+    """Parse worker run loop — BLPOP ``q:parse`` + dispatch with concurrency cap.
+
+    Pops parse payloads, decodes them, and runs each through
+    :func:`process_one_parse_task` under an :class:`asyncio.Semaphore`
+    whose permit count == ``config.concurrency``. Exits cleanly when
+    ``shutdown`` is set, draining in-flight tasks first.
+
+    Mirrors :func:`run_worker_loop` for the per-modality lanes — same
+    shutdown discipline, same in-flight set housekeeping, same
+    malformed-payload drop semantics. The only structural difference
+    is that there is no per-task DB row to claim before work starts:
+    parse jobs are claim-free (the document_id is the natural idempotency
+    key, and at-most-once delivery is provided by Redis BLPOP).
+    """
+    semaphore = asyncio.Semaphore(config.concurrency)
+    in_flight: set[asyncio.Task[str]] = set()
+    object_store = await object_store_factory()
+
+    async def _runner(payload: ParseDispatchPayload) -> str:
+        async with semaphore:
+            return await process_one_parse_task(
+                engine=engine,
+                queue=queue,
+                object_store=object_store,
+                payload=payload,
+            )
+
+    while not shutdown.is_set():
+        raw = await queue.pop_parse(timeout_seconds=config.poll_timeout_seconds)
+        if raw is None:
+            in_flight = {t for t in in_flight if not t.done()}
+            continue
+
+        try:
+            payload = ParseDispatchPayload.from_dict(raw)
+        except (KeyError, ValueError, TypeError) as exc:
+            logger.error(
+                "parse_worker dropping malformed payload: %r (%s)",
+                raw,
+                exc,
+            )
+            continue
+
+        task = asyncio.create_task(_runner(payload))
+        in_flight.add(task)
+
+    if in_flight:
+        await asyncio.gather(*in_flight, return_exceptions=True)
+
+
+async def run_parse_worker(
+    *,
+    engine: Engine,
+    queue: WorkQueue,
+    object_store_factory: ObjectStoreFactory,
+    shutdown: asyncio.Event,
+    config: ParseOrchestratorConfig | None = None,
+) -> None:
+    """Thin entrypoint mirroring ``run_*_worker`` for the modality lanes.
+
+    Production wires this as a single asyncio task in the FastAPI
+    lifespan alongside the 5 per-modality workers + reconciler +
+    cleanup loop. The default :class:`ParseOrchestratorConfig` matches
+    design pack §E.2 (concurrency = 8).
+    """
+    await run_parse_worker_loop(
+        config=config or ParseOrchestratorConfig(),
+        engine=engine,
+        queue=queue,
+        object_store_factory=object_store_factory,
+        shutdown=shutdown,
+    )
+
+
+__all__ = [
+    "DEFAULT_PARSE_CONCURRENCY",
+    "DEFAULT_POLL_TIMEOUT_SECONDS",
+    "ObjectStoreFactory",
+    "ParseDispatchPayload",
+    "ParseOrchestratorConfig",
+    "process_one_parse_task",
+    "run_parse_worker",
+    "run_parse_worker_loop",
+]

--- a/aperag/indexing/parser.py
+++ b/aperag/indexing/parser.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Parser entry point — celery T1.1 Foundation.
+"""Parser entry point — celery T1.1 Foundation + Wave 4 T3 real wire.
 
 Per ``docs/modularization/indexing-redesign-design-pack.md`` §C.1, the
 parser is the producer of the **shared** derived artifacts that every
@@ -32,24 +32,42 @@ extraction. Those are owned by the per-modality ``derive`` workers
 (§C.3): a failed Qdrant sync re-reads ``chunks.jsonl`` instead of
 re-running the parser.
 
-T1.1 ships the **interface and a deterministic in-process simulator**
-so downstream modalities can wire their tests against a real
-``derived/`` layout. Production parser integration (docparser /
-Marker / OCR) is intentionally deferred to T2.x — at that point the
-parser body becomes a thin shim that calls the existing parsing
-pipeline and emits the same artifacts. The simulator proves the
-write contract (atomic visibility + parse_version stability +
-round-trip fidelity); the real parser will inherit that contract
-unchanged.
+T1.1 shipped a **deterministic in-process simulator** for UTF-8
+markdown so downstream modalities could wire their tests against a
+real ``derived/`` layout before the production parser landed. Wave 4
+T3 chunk 1 wires the real :class:`aperag.docparser.doc_parser.DocParser`
+(MarkItDown + MinerU + ImageParser + AudioParser) through the same
+entry point — the simulator path stays for ``.md`` / ``.markdown`` /
+``.txt`` / no-extension inputs and tests, while non-text extensions
+(``.pdf`` / ``.docx`` / ``.doc`` / ``.pptx`` / ``.xlsx`` / ``.png``
+/ ``.jpg`` / ``.epub`` / ``.html`` / ...) materialise a tempfile,
+hand it to ``DocParser.parse_file``, concatenate the resulting
+:class:`MarkdownPart` bodies, and run the same outline + chunking
+pipeline so the artifact schema stays unchanged.
+
+production-readiness invariant (Wave 3 lesson #10):
+- must-be-real: ``DocParser`` chain dispatches on extension and runs
+  real PDF / Office / image / audio parsers on production deployments.
+- may-be-gated: simulator path stays the default for text-only inputs
+  (``.md`` / ``.markdown`` / ``.txt`` / no-extension hint) so unit
+  tests + dev workflows that pass UTF-8 markdown bytes without a
+  filename keep working unchanged.
+- partially-resolves: Wave 4 backlog #4. Chunk 2 promotes the parser
+  to its own ``q:parse`` async queue (per §E.2) so an upload handler
+  no longer blocks on a 30-second OCR run inside the request thread.
 """
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
+import os
 import re
+import tempfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from aperag.indexing.object_store import (
@@ -80,6 +98,35 @@ DEFAULT_PARSER_PIPELINE = "indexing-simulator-v1"
 # rolls the parse_version (per design pack §E.2 hash inputs).
 DEFAULT_CHUNK_SIZE = 800
 DEFAULT_CHUNK_OVERLAP = 80
+
+
+# Extensions that the simulator can decode directly (UTF-8 markdown
+# /text). Every other extension (``.pdf`` / ``.docx`` / ``.doc`` /
+# ``.png`` / ``.jpg`` / ...) routes through ``DocParser`` so the
+# production parser chain owns binary + Office + image inputs.
+_SIMULATOR_EXTENSIONS = frozenset(
+    {
+        ".md",
+        ".markdown",
+        ".txt",
+        ".text",
+    }
+)
+
+
+def _normalise_extension(source_filename: str | None) -> str | None:
+    """Lowercase + dotted extension from a filename hint, or ``None``.
+
+    ``None`` / empty / no-dot inputs return ``None`` so callers can
+    keep the legacy simulator behaviour (assume UTF-8 markdown). All
+    other strings normalise to ``.<ext>`` lowercase.
+    """
+    if not source_filename:
+        return None
+    suffix = Path(source_filename).suffix
+    if not suffix:
+        return None
+    return suffix.lower()
 
 
 @dataclass(frozen=True)
@@ -282,12 +329,74 @@ def _document_md5(source_bytes: bytes) -> str:
     return hashlib.md5(source_bytes).hexdigest()
 
 
+def _docparser_extract_markdown(
+    *,
+    source_bytes: bytes,
+    extension: str,
+    parser_config: dict[str, Any] | None,
+) -> str:
+    """Run :class:`DocParser` on ``source_bytes`` and return concatenated markdown.
+
+    Materialises the bytes into a tempfile (DocParser only accepts a
+    real path on disk because MarkItDown / MinerU / OCR all stream
+    from disk), runs the parser chain, then collects every
+    :class:`MarkdownPart` body in order. Non-markdown parts (assets /
+    images / pdf data) are not used here — they belong to the
+    vision modality's ``derive`` step (T1.4) and the cleanup loop's
+    asset GC (T2.1), not the shared markdown contract.
+
+    DocParser is imported lazily so the indexing package's __init__
+    does not pull MarkItDown / MinerU / pikepdf at import time
+    (matches the existing T1.1 lazy-import discipline that kept the
+    Wave 3 hard-cut circular-import-free).
+    """
+    from aperag.docparser.base import MarkdownPart
+    from aperag.docparser.doc_parser import DocParser
+
+    # Use the suffix the caller already normalised so the temp filename
+    # carries the right extension for DocParser's per-extension
+    # dispatch (markitdown_parser / mineru_parser / image_parser).
+    suffix = extension if extension.startswith(".") else f".{extension}"
+    parser = DocParser(parser_config=parser_config or {})
+    if not parser.accept(suffix):
+        raise ValueError(
+            f"DocParser does not accept extension {suffix!r}; "
+            "supported list: " + ", ".join(parser.supported_extensions())
+        )
+
+    # Tempfile lifecycle: write source_bytes → DocParser reads via
+    # path → unlink in finally. ``delete=False`` because Python's
+    # NamedTemporaryFile on POSIX leaves the file open for the parser
+    # to re-open by path; we close + delete explicitly.
+    fd, tmp_path = tempfile.mkstemp(suffix=suffix, prefix="aperag-parse-")
+    os.close(fd)
+    try:
+        with open(tmp_path, "wb") as fh:
+            fh.write(source_bytes)
+        parts = parser.parse_file(Path(tmp_path))
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp_path)
+
+    markdown_parts = [p.markdown for p in parts if isinstance(p, MarkdownPart) and p.markdown]
+    if not markdown_parts:
+        # Image-only / audio-only inputs (no MarkdownPart) currently
+        # have nothing for the outline + chunks pipeline to emit; we
+        # return an empty body so the artifacts exist but downstream
+        # vector / fulltext modalities see zero chunks. Vision modality
+        # consumes the original asset directly in its derive step.
+        return ""
+    return "\n\n".join(markdown_parts)
+
+
 def parse_document(
     *,
     store: _SyncObjectStore,
     collection_id: str,
     document_id: str,
     source_bytes: bytes,
+    source_filename: str | None = None,
+    parser_config: dict[str, Any] | None = None,
     config: ParseConfig | None = None,
 ) -> ParseResult:
     """Parse the source bytes and persist the three shared artifacts.
@@ -297,20 +406,38 @@ def parse_document(
     them atomically). The artifact paths are the canonical
     ``derived/parse_<version>/`` layout per design pack §C.1.
 
+    Dispatch (Wave 4 T3 chunk 1):
+    - ``source_filename`` ends in a known text extension (``.md`` /
+      ``.markdown`` / ``.txt`` / ``.text``) **or** is ``None`` →
+      decode as UTF-8 markdown via the simulator path. Backward-
+      compatible with every existing caller that just hands bytes.
+    - any other extension → run the real ``DocParser`` chain
+      (MarkItDown / MinerU / ImageParser / AudioParser per
+      ``parser_config``), concatenate every produced ``MarkdownPart``,
+      then continue with the existing outline + chunk pipeline. The
+      ``derived/`` artifact schema is unchanged.
+
     Args:
         store: Object store handle (``LocalObjectStore`` /
             ``S3ObjectStore`` / :class:`InMemoryObjectStore` for tests).
         collection_id: Owning collection.
         document_id: Document being parsed.
-        source_bytes: Raw bytes of the source document. The simulator
-            interprets these as UTF-8 markdown; production parsers
-            would invoke docparser / Marker / OCR here.
+        source_bytes: Raw bytes of the source document.
+        source_filename: Optional filename hint (e.g. ``"report.pdf"``
+            or just ``"report.pdf"`` — only the suffix is consumed).
+            Used to dispatch on extension; ``None`` keeps legacy
+            simulator behaviour.
+        parser_config: Optional collection-level parser config dict
+            (e.g. ``{"use_mineru": True, "mineru_api_token": "..."}``).
+            Forwarded to :class:`DocParser` when the dispatcher routes
+            to the real parser chain. Ignored on the simulator path.
         config: Parsing knobs that influence the parse_version. Pass
             ``None`` to use simulator defaults.
     """
     from aperag.mcp.tools.parse_version import compute_parse_version
 
     cfg = config or ParseConfig()
+    extension = _normalise_extension(source_filename)
 
     document_md5 = _document_md5(source_bytes)
     parse_version = compute_parse_version(
@@ -319,15 +446,25 @@ def parse_document(
         chunking_config=cfg.chunking.serialize(),
     )
 
-    try:
-        markdown = source_bytes.decode("utf-8")
-    except UnicodeDecodeError:
-        # The simulator assumes UTF-8 markdown. Production parsers
-        # convert binary inputs first; that conversion lives outside
-        # this T1.1 surface.
-        raise ValueError(
-            "indexing simulator parser only handles UTF-8 markdown bodies; "
-            "wire docparser/Marker before T2.x for non-text documents"
+    if extension is None or extension in _SIMULATOR_EXTENSIONS:
+        try:
+            markdown = source_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            # Caller passed text-extension or no extension hint but the
+            # bytes are not UTF-8. Surface the contract gap clearly so
+            # the upload route logs a real cause; production callers
+            # always pass an accurate ``source_filename`` so this only
+            # fires on test misuse.
+            raise ValueError(
+                f"simulator parser path requires UTF-8 markdown bytes "
+                f"(extension={extension or 'none'}); pass source_filename "
+                f"with the real extension to dispatch to DocParser"
+            ) from exc
+    else:
+        markdown = _docparser_extract_markdown(
+            source_bytes=source_bytes,
+            extension=extension,
+            parser_config=parser_config,
         )
 
     outline = _build_outline(markdown)

--- a/aperag/indexing/runtime.py
+++ b/aperag/indexing/runtime.py
@@ -41,12 +41,18 @@ from aperag.indexing.base import ModalityWorker
 from aperag.indexing.models import DocumentIndex, Modality
 from aperag.indexing.observability import MetricsEmitter, NoopMetricsEmitter
 from aperag.indexing.orchestrator import WorkQueue
+from aperag.indexing.quota import InMemoryQuotaBackend, QuotaBackend, QuotaPolicyRegistry
+
+
+def _default_quota_backend() -> QuotaBackend:
+    return InMemoryQuotaBackend(QuotaPolicyRegistry())
 
 
 @dataclass(frozen=True)
 class IndexingRuntime:
     """The runtime triple required by ``dispatch_indexing()`` and
-    ``cleanup_for_deleted_documents()``, plus the §J.1 metrics emitter.
+    ``cleanup_for_deleted_documents()``, plus the §J.1 metrics emitter
+    and Wave 4 T5 quota backend.
 
     ``workers`` may be empty when the deployment runs in ASYNC mode and
     cleanup is intentionally non-cascading (e.g. tests). ``queue`` may
@@ -65,6 +71,14 @@ class IndexingRuntime:
     callers that build the runtime without specifying one keep working.
     The lifespan in ``aperag/app.py`` swaps in
     :class:`OTLPMetricsEmitter` when ``INDEXING_METRICS_EMITTER=otlp``.
+
+    ``quota_backend`` (Wave 4 T5) is the §H.5 token-bucket the
+    LLM/embedding-heavy modalities can consume to enforce per-tenant
+    rate limits before issuing the upstream API call. Default is
+    :class:`InMemoryQuotaBackend` (per-process, single-pod scope).
+    Production multi-pod sets ``INDEXING_QUOTA_BACKEND=redis`` to wire
+    :class:`RedisQuotaBackend` so worker processes share token state
+    via the §H.5.1 logical-db assignment (db=3).
     """
 
     engine: Engine
@@ -72,6 +86,7 @@ class IndexingRuntime:
     workers: Mapping[Modality, ModalityWorker]
     metrics_emitter: MetricsEmitter = field(default_factory=NoopMetricsEmitter)
     cleanup_worker_factory: Optional[Callable[[DocumentIndex], Awaitable[ModalityWorker]]] = None
+    quota_backend: QuotaBackend = field(default_factory=_default_quota_backend)
 
 
 _runtime: Optional[IndexingRuntime] = None

--- a/aperag/indexing/runtime.py
+++ b/aperag/indexing/runtime.py
@@ -32,30 +32,37 @@ runtime can call :func:`set_runtime` with a fixture and reset.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Mapping, Optional
 
 from sqlalchemy import Engine
 
 from aperag.indexing.base import ModalityWorker
 from aperag.indexing.models import Modality
+from aperag.indexing.observability import MetricsEmitter, NoopMetricsEmitter
 from aperag.indexing.orchestrator import WorkQueue
 
 
 @dataclass(frozen=True)
 class IndexingRuntime:
-    """The triple required by ``dispatch_indexing()`` and
-    ``cleanup_for_deleted_documents()``.
+    """The runtime triple required by ``dispatch_indexing()`` and
+    ``cleanup_for_deleted_documents()``, plus the §J.1 metrics emitter.
 
     ``workers`` may be empty when the deployment runs in ASYNC mode and
     cleanup is intentionally non-cascading (e.g. tests). ``queue`` may
     be ``None`` when the deployment runs in INLINE mode (the
     dispatcher fans out via ``workers`` directly).
+
+    ``metrics_emitter`` defaults to :class:`NoopMetricsEmitter` so older
+    callers that build the runtime without specifying one keep working.
+    The lifespan in ``aperag/app.py`` swaps in
+    :class:`OTLPMetricsEmitter` when ``INDEXING_METRICS_EMITTER=otlp``.
     """
 
     engine: Engine
     queue: Optional[WorkQueue]
     workers: Mapping[Modality, ModalityWorker]
+    metrics_emitter: MetricsEmitter = field(default_factory=NoopMetricsEmitter)
 
 
 _runtime: Optional[IndexingRuntime] = None

--- a/aperag/indexing/runtime.py
+++ b/aperag/indexing/runtime.py
@@ -33,12 +33,12 @@ runtime can call :func:`set_runtime` with a fixture and reset.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Mapping, Optional
+from typing import Awaitable, Callable, Mapping, Optional
 
 from sqlalchemy import Engine
 
 from aperag.indexing.base import ModalityWorker
-from aperag.indexing.models import Modality
+from aperag.indexing.models import DocumentIndex, Modality
 from aperag.indexing.observability import MetricsEmitter, NoopMetricsEmitter
 from aperag.indexing.orchestrator import WorkQueue
 
@@ -53,6 +53,14 @@ class IndexingRuntime:
     be ``None`` when the deployment runs in INLINE mode (the
     dispatcher fans out via ``workers`` directly).
 
+    ``cleanup_worker_factory`` (Wave 4 T2) is the per-row resolver the
+    cleanup path uses to materialise the right per-(collection,
+    modality) ``_backend`` (or ``_store + _entity_lock`` for graph).
+    Production wires
+    :meth:`aperag.indexing.worker_factory.ProductionWorkerFactory.build_for_cleanup_row`;
+    tests typically leave it ``None`` and pass a static ``workers``
+    map directly to ``cleanup_for_deleted_documents``.
+
     ``metrics_emitter`` defaults to :class:`NoopMetricsEmitter` so older
     callers that build the runtime without specifying one keep working.
     The lifespan in ``aperag/app.py`` swaps in
@@ -63,6 +71,7 @@ class IndexingRuntime:
     queue: Optional[WorkQueue]
     workers: Mapping[Modality, ModalityWorker]
     metrics_emitter: MetricsEmitter = field(default_factory=NoopMetricsEmitter)
+    cleanup_worker_factory: Optional[Callable[[DocumentIndex], Awaitable[ModalityWorker]]] = None
 
 
 _runtime: Optional[IndexingRuntime] = None

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -469,31 +469,19 @@ def _build_vision_worker(*, collection: Any, object_store: Any) -> ModalityWorke
     return VisionModality(backend=backend, store=object_store, embedder=_embed)
 
 
-async def _no_op_extractor(_chunks):
-    """Wave 4 placeholder extractor — replaced by the real LightRAG-style
-    LLM extractor in T1 (Wave 4 backlog #17).
-
-    Identity-checked in :func:`_build_graph_worker` to keep the
-    "Wave 4 wiring (T1 extractor)" gate explicit until T1 lands; the
-    gate self-disables when this symbol is replaced with the real one.
-    """
-    return ([], [])
-
-
 def _build_graph_worker(*, collection: Any, object_store: Any, payload: DispatchPayload) -> ModalityWorker:
     """Wire :class:`GraphModalityWorker` for the §D.3 lineage pipeline.
 
-    Per Wave 4 T8 chunk 4b: the worker is built around a real
-    backend-specific :class:`LineageGraphStore` (Postgres / Neo4j /
-    Nebula) selected by ``collection.config.graph_backend_type``. The
-    Wave 3 ``InMemoryLineageGraphStore raise`` gate is dissolved by the
-    backend dispatch; what remains is an explicit "T1 extractor not
-    wired yet" gate so a collection that opts into knowledge graph
-    today still surfaces a clean :class:`WorkerFactoryError` (and lands
-    on §I.2 retry-with-backoff) instead of a silent
-    ACTIVE-with-empty-graph (Wave 3 lesson #10).
+    Wave 4 T1 lands the real LightRAG-style LLM extractor — the chunk
+    4b "Wave 4 wiring T1" gate is now self-disabled because
+    :func:`build_collection_graph_extractor` returns a real LLM-driven
+    closure. A collection that has no completion model configured
+    surfaces a clear :class:`WorkerFactoryError` from the extractor
+    builder itself, so the orchestrator finalises the row FAILED with
+    operator-facing diagnostics (no silent ACTIVE-with-empty-graph,
+    Wave 3 lesson #10 still honoured).
 
-    Backend dispatch:
+    Backend dispatch (Wave 4 T8 chunk 4b):
 
     * ``postgres`` → :class:`PostgresLineageGraphStore` bound to the
       shared async engine; tenant isolation is per-row (collection_id
@@ -522,20 +510,12 @@ def _build_graph_worker(*, collection: Any, object_store: Any, payload: Dispatch
     from aperag.indexing.graph import (
         GraphModalityWorker as _GraphModalityWorker,
     )
+    from aperag.indexing.graph_extractor import build_collection_graph_extractor
 
     backend_type = _resolve_graph_backend_type(collection)
     store = _build_lineage_graph_store(backend_type=backend_type, collection=collection)
     lock = _resolve_entity_lock(backend_type=backend_type)
-    extractor = _no_op_extractor  # Wave 4 T1 will replace this symbol.
-
-    if extractor is _no_op_extractor:
-        raise WorkerFactoryError(
-            "graph modality requires a real LightRAG-style LLM extractor "
-            "(Wave 4 wiring T1 — backend chunk 4b is wired but extractor "
-            "stub still in place); set collection.config.enable_knowledge_graph=false "
-            "until T1 lands or wait for the T1 extractor PR"
-        )
-
+    extractor = build_collection_graph_extractor(collection)
     tenant_scope_key = _resolve_tenant_scope_key(payload=payload)
     return _GraphModalityWorker(
         store=store,

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -65,7 +65,7 @@ from typing import Any, Callable, Mapping, Optional
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 
-from aperag.indexing.base import ModalityWorker
+from aperag.indexing.base import DeriveResult, ModalityWorker
 from aperag.indexing.models import Modality
 from aperag.indexing.orchestrator import DispatchPayload
 
@@ -838,8 +838,206 @@ class ProductionWorkerFactory:
         with Session(self._engine) as session:
             return session.get(Collection, collection_id)
 
+    async def build_for_cleanup_row(self, row: Any) -> "CleanupWorkerView":
+        """Build a cleanup-only view per ``(row.collection_id, row.modality)``.
+
+        Wave 4 T2 entry point: the cleanup loop reads each
+        :class:`DocumentIndex` row and asks the factory for the right
+        ``_backend`` (vector / fulltext / summary / vision) or
+        ``_store + _entity_lock`` (graph) so the per-modality DELETE
+        can run against the correct per-collection backend.
+
+        Bypasses dispatch-time gates that block worker construction
+        but are irrelevant to deletion — graph "Wave 4 T1 extractor"
+        and vision "multimodal vision-LLM" gates both keep raising for
+        dispatch even after T2 ships, but cleanup must still drop the
+        backend artefacts when an operator deletes a collection /
+        document. Without this bypass the cleanup loop would hit
+        :class:`WorkerFactoryError` for any partially-gated modality
+        and leak Qdrant points / ES docs / graph entities forever.
+        """
+        if row.collection_id is None:
+            raise WorkerFactoryError(f"document_index row id={row.id} has no collection_id; cannot build cleanup view")
+        collection = await asyncio.to_thread(self._load_collection, row.collection_id)
+        if collection is None:
+            raise WorkerFactoryError(
+                f"collection {row.collection_id!r} not found while building cleanup view "
+                f"for index_id={row.id} modality={row.modality}"
+            )
+        try:
+            modality = Modality(row.modality)
+        except ValueError as exc:
+            raise WorkerFactoryError(f"unknown modality {row.modality!r} on index_id={row.id}") from exc
+
+        try:
+            return await asyncio.to_thread(_build_cleanup_view_sync, collection, modality)
+        except WorkerFactoryError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — wrap so cleanup loop can log + skip
+            raise WorkerFactoryError(
+                f"failed to build {modality.value} cleanup view for "
+                f"collection={row.collection_id} index_id={row.id}: {exc!r}"
+            ) from exc
+
+
+# ---------------------------------------------------------------------
+# Cleanup-only worker view — celery Wave 4 T2.
+# ---------------------------------------------------------------------
+#
+# The cleanup loop only consumes a tiny fraction of the
+# :class:`ModalityWorker` surface: ``_backend.{delete_by_filter,
+# delete_by_query}`` for the four flat modalities, and ``_store +
+# _entity_lock`` for graph (per ``aperag.indexing.cleanup``). The full
+# dispatch-time builders enforce gates that block construction even
+# though deletion does not depend on them — the graph "Wave 4 T1
+# extractor" gate (line 429-435) and the vision multimodal gate
+# (line 349-355) both raise :class:`WorkerFactoryError` for any
+# collection that opts into a Wave 4-pending modality.
+#
+# A separate cleanup-only construction path lets the cleanup loop
+# materialise the minimum shape it needs without falling foul of
+# those gates. Production cleanup needs to delete the backend artefacts
+# even when the modality is partially gated — otherwise an operator who
+# disables a modality after Wave 3 would still leak Qdrant points / ES
+# docs / graph entities forever.
+
+
+class CleanupWorkerView(ModalityWorker):
+    """Minimal :class:`ModalityWorker` shape for the cleanup loop.
+
+    Cleanup duck-types on ``_backend`` (flat modalities) or
+    ``_store + _entity_lock`` (graph); ``derive`` / ``sync`` are never
+    called from the cleanup path. This view stubs both as
+    :class:`NotImplementedError` so a programming error that misroutes
+    a cleanup view into the dispatch path surfaces loudly instead of
+    silently dropping work.
+    """
+
+    def __init__(
+        self,
+        *,
+        modality: Modality,
+        backend: Optional[Any] = None,
+        store: Optional[Any] = None,
+        entity_lock: Optional[Any] = None,
+    ) -> None:
+        self.modality = modality
+        # ``cleanup._flat_backend_delete_callable`` walks ``_backend`` for
+        # ``delete_by_filter`` / ``delete_by_query`` so the attribute name
+        # has to match the existing convention used by the production
+        # workers (vector / fulltext / summary / vision all expose
+        # ``_backend``).
+        self._backend = backend
+        self._store = store
+        self._entity_lock = entity_lock
+
+    async def derive(
+        self,
+        *,
+        document_id: str,
+        parse_version: str,
+        source_path: str,
+    ) -> DeriveResult:
+        raise NotImplementedError("CleanupWorkerView.derive must not be called — cleanup-only shape")
+
+    async def sync(
+        self,
+        *,
+        document_id: str,
+        parse_version: str,
+        derived_artifact_path: str,
+    ) -> None:
+        raise NotImplementedError("CleanupWorkerView.sync must not be called — cleanup-only shape")
+
+
+def _build_qdrant_cleanup_backend(collection: Any) -> Any:
+    """Construct the Qdrant ``_backend`` adapter without any modality-
+    specific gate (used for cleanup of vector / summary / vision).
+
+    The full ``_build_vector_worker`` chain calls
+    :func:`get_collection_embedding_service_sync` to size the Qdrant
+    collection; we duplicate that minimal step here so a collection
+    whose embedder config is broken (a Wave 3 lesson #10 case) still
+    deletes its points instead of silently leaking. If the embedding
+    service cannot be resolved we still need ``vector_size`` to
+    address the right collection — fall back to the connector's
+    introspection of the existing collection.
+    """
+    from aperag.config import get_vector_db_connector
+    from aperag.llm.embed.base_embedding import get_collection_embedding_service_sync
+    from aperag.utils.utils import generate_vector_db_collection_name
+
+    qdrant_collection = generate_vector_db_collection_name(collection.id)
+    try:
+        _, vector_size = get_collection_embedding_service_sync(collection)
+    except Exception as exc:  # noqa: BLE001
+        # The embedder is irrelevant for ``delete_by_filter``; the
+        # connector only needs ``vector_size`` to validate against
+        # the existing collection on the Qdrant side. Fall back to a
+        # benign size — the connector will still address the right
+        # collection by name and the delete-by-filter call does not
+        # touch the vector dimension.
+        logger.warning(
+            "cleanup vector backend: embedder resolve failed for collection=%s (%s); "
+            "falling back to size=0 for delete-only operations",
+            getattr(collection, "id", "<unknown>"),
+            exc,
+        )
+        vector_size = 0
+    adaptor = get_vector_db_connector(qdrant_collection, vector_size=vector_size)
+    return _QdrantPointBackend(connector=adaptor.connector)
+
+
+def _build_es_cleanup_backend(collection: Any) -> Any:
+    """Construct the ES ``_backend`` adapter for fulltext cleanup."""
+    from elasticsearch import Elasticsearch
+
+    from aperag.config import settings
+    from aperag.utils.utils import generate_fulltext_index_name
+
+    if not settings.es_host:
+        raise WorkerFactoryError("fulltext cleanup: ES_HOST not configured (settings.es_host empty)")
+
+    es_kwargs: dict[str, Any] = {}
+    if getattr(settings, "es_basic_auth_username", None):
+        es_kwargs["basic_auth"] = (
+            settings.es_basic_auth_username,
+            getattr(settings, "es_basic_auth_password", "") or "",
+        )
+    if getattr(settings, "es_timeout", None):
+        es_kwargs["request_timeout"] = settings.es_timeout
+
+    client = Elasticsearch(settings.es_host, **es_kwargs)
+    index_name = generate_fulltext_index_name(collection.id)
+    return _ElasticsearchFulltextBackend(client=client, index_name=index_name)
+
+
+def _build_cleanup_view_sync(collection: Any, modality: Modality) -> CleanupWorkerView:
+    """Synchronous cleanup-view builder per ``(collection, modality)``.
+
+    Wrapped by :meth:`ProductionWorkerFactory.build_for_cleanup_row`
+    in :func:`asyncio.to_thread` so the SQLAlchemy collection load
+    + sync client construction does not block the orchestrator loop.
+    """
+    if modality is Modality.GRAPH:
+        backend_type = _resolve_graph_backend_type(collection)
+        store = _build_lineage_graph_store(backend_type=backend_type, collection=collection)
+        lock = _resolve_entity_lock(backend_type=backend_type)
+        return CleanupWorkerView(modality=modality, store=store, entity_lock=lock)
+
+    if modality in (Modality.VECTOR, Modality.SUMMARY, Modality.VISION):
+        backend = _build_qdrant_cleanup_backend(collection)
+        return CleanupWorkerView(modality=modality, backend=backend)
+
+    if modality is Modality.FULLTEXT:
+        backend = _build_es_cleanup_backend(collection)
+        return CleanupWorkerView(modality=modality, backend=backend)
+
+    raise WorkerFactoryError(f"no cleanup builder registered for modality {modality.value!r}")
+
 
 __all__ = [
+    "CleanupWorkerView",
     "ProductionWorkerFactory",
     "WorkerFactoryError",
 ]

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -712,9 +712,10 @@ def _nebula_pool_singleton() -> tuple[Any, str, str, str]:
 
 
 def _redis_entity_lock_singleton() -> Any | None:
-    """Return a :class:`RedisEntityLock` bound to the indexing-queue
-    Redis logical DB if configured, ``None`` otherwise (the caller
-    falls back to :class:`InMemoryEntityLock`)."""
+    """Return a :class:`RedisEntityLock` bound to the quota / EntityLock
+    Redis logical DB (chunk 4e §H.5.1 lock: db=3) if configured,
+    ``None`` otherwise (the caller falls back to
+    :class:`InMemoryEntityLock`)."""
     global _REDIS_ENTITY_LOCK
     if _REDIS_ENTITY_LOCK is not None:
         return _REDIS_ENTITY_LOCK
@@ -723,7 +724,7 @@ def _redis_entity_lock_singleton() -> Any | None:
             return _REDIS_ENTITY_LOCK
         from aperag.config import settings
 
-        url = settings.indexing_queue_redis_url
+        url = settings.indexing_quota_redis_url
         if not url:
             return None
         try:

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -458,9 +458,12 @@ def _build_vision_worker(*, collection: Any, object_store: Any) -> ModalityWorke
     backend = _QdrantPointBackend(connector=adaptor.connector)
 
     def _embed(image_id: str, alt_text: str) -> list[float]:
-        # Multimodal embedder is configured (gate above passed); the
-        # call below routes through the multimodal model rather than
-        # the string-concat placeholder.
+        # ``is_multimodal()`` gate above only verifies that operators
+        # explicitly opted into a multimodal embedder. The body is
+        # still the Wave 3 string-concat placeholder until T7 replaces
+        # it with a real image-bytes path (load image from object
+        # store → multimodal embed); ``embed_query`` of an alt-text
+        # surrogate is not actual visual indexing.
         return embedding_service.embed_query(f"{image_id}|{alt_text}")
 
     return VisionModality(backend=backend, store=object_store, embedder=_embed)

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -367,56 +367,77 @@ def _build_vision_worker(*, collection: Any, object_store: Any) -> ModalityWorke
     return VisionModality(backend=backend, store=object_store, embedder=_embed)
 
 
+async def _no_op_extractor(_chunks):
+    """Wave 4 placeholder extractor — replaced by the real LightRAG-style
+    LLM extractor in T1 (Wave 4 backlog #17).
+
+    Identity-checked in :func:`_build_graph_worker` to keep the
+    "Wave 4 wiring (T1 extractor)" gate explicit until T1 lands; the
+    gate self-disables when this symbol is replaced with the real one.
+    """
+    return ([], [])
+
+
 def _build_graph_worker(*, collection: Any, object_store: Any, payload: DispatchPayload) -> ModalityWorker:
-    """Wire :class:`GraphModalityWorker` for the new §D.3 lineage
-    pipeline — currently **gated** until Wave 4.
+    """Wire :class:`GraphModalityWorker` for the §D.3 lineage pipeline.
 
-    Per architect msg=c79e9a3f gap-report ruling: the §D.3.6 Nebula /
-    Postgres ``LineageGraphStore`` adapter and the LightRAG-style
-    LLM extractor are not in Wave 3 scope. Building this worker
-    against the :class:`InMemoryLineageGraphStore` placeholder + a
-    no-op extractor was a silent failure mode — runs would reach
-    ``status=ACTIVE`` with zero entities written and the user would
-    see "graph indexed" but search would return nothing. Worse, the
-    in-memory store loses all state on worker restart, so even the
-    rare working case is non-durable.
+    Per Wave 4 T8 chunk 4b: the worker is built around a real
+    backend-specific :class:`LineageGraphStore` (Postgres / Neo4j /
+    Nebula) selected by ``collection.config.graph_backend_type``. The
+    Wave 3 ``InMemoryLineageGraphStore raise`` gate is dissolved by the
+    backend dispatch; what remains is an explicit "T1 extractor not
+    wired yet" gate so a collection that opts into knowledge graph
+    today still surfaces a clean :class:`WorkerFactoryError` (and lands
+    on §I.2 retry-with-backoff) instead of a silent
+    ACTIVE-with-empty-graph (Wave 3 lesson #10).
 
-    Wave 3 ships graph **explicitly gated**: this builder raises a
-    :class:`WorkerFactoryError` so any collection with
-    ``enable_knowledge_graph=True`` gets a clear, persisted error
-    on its graph row instead of a silent ACTIVE-with-empty-graph.
-    The collection-config default is also flipped to ``False`` so
-    new collections do not opt into the broken path by accident.
+    Backend dispatch:
 
-    Wave 4 (locked backlog) wires the real adapter + extractor; the
-    detection rule in this builder will then no longer match (the
-    store is a Nebula adapter, not :class:`InMemoryLineageGraphStore`)
-    and the gate self-disables without a code change here.
+    * ``postgres`` → :class:`PostgresLineageGraphStore` bound to the
+      shared async engine; tenant isolation is per-row (collection_id
+      column). Strip-then-append is single-statement so no entity
+      lock is required (PostgreSQL row-lock under MERGE/INSERT-ON-
+      CONFLICT handles RMW serialisation).
+    * ``neo4j`` → :class:`Neo4jLineageGraphStore` bound to the shared
+      async driver; same single-statement RMW guarantee under Neo4j
+      MERGE row-lock so no entity lock is required.
+    * ``nebula`` → :class:`NebulaLineageGraphStore` bound to the
+      shared sync ``ConnectionPool`` (sync nGQL via
+      ``asyncio.to_thread``); Nebula has no native list ops so
+      strip-then-append is read-modify-write across multiple
+      statements. The injected :class:`RedisEntityLock` serialises
+      concurrent rebuilds on the same entity across worker processes
+      (per architect msg=f2921ae0 invariant).
+
+    Cross-event-loop verify: the backend client singletons are
+    constructed inside the builder thread (``asyncio.to_thread`` from
+    :class:`ProductionWorkerFactory.__call__``) but loop binding is
+    deferred to first use — async engines / drivers attach to whatever
+    event loop their first ``connect()``/``session()`` call runs on,
+    which is the orchestrator loop that executes the worker's
+    ``sync(...)`` coroutine. No ``asyncio.run`` near the factory.
     """
     from aperag.indexing.graph import (
         GraphModalityWorker as _GraphModalityWorker,
     )
-    from aperag.indexing.graph import (
-        InMemoryLineageGraphStore,
-    )
 
-    store = _process_graph_store_singleton()
-    if isinstance(store, InMemoryLineageGraphStore):
+    backend_type = _resolve_graph_backend_type(collection)
+    store = _build_lineage_graph_store(backend_type=backend_type, collection=collection)
+    lock = _resolve_entity_lock(backend_type=backend_type)
+    extractor = _no_op_extractor  # Wave 4 T1 will replace this symbol.
+
+    if extractor is _no_op_extractor:
         raise WorkerFactoryError(
-            "graph modality requires a real LineageGraphStore (Wave 4 wiring); "
-            "current InMemory placeholder is test-only — set "
-            "collection.config.enable_knowledge_graph=false until Wave 4 lands"
+            "graph modality requires a real LightRAG-style LLM extractor "
+            "(Wave 4 wiring T1 — backend chunk 4b is wired but extractor "
+            "stub still in place); set collection.config.enable_knowledge_graph=false "
+            "until T1 lands or wait for the T1 extractor PR"
         )
-
-    lock = _process_graph_lock_singleton()
-
-    async def _no_op_extractor(_chunks):
-        return ([], [])
 
     tenant_scope_key = _resolve_tenant_scope_key(payload=payload)
     return _GraphModalityWorker(
         store=store,
-        extractor=_no_op_extractor,
+        extractor=extractor,
         entity_lock=lock,
         object_store=object_store,
         collection_id=collection.id,
@@ -425,30 +446,241 @@ def _build_graph_worker(*, collection: Any, object_store: Any, payload: Dispatch
 
 
 # ---------------------------------------------------------------------
-# Helpers — singletons + collection / tenant resolution.
+# Helpers — backend dispatch + per-process client singletons + lock
+# selection.
 # ---------------------------------------------------------------------
 
 
-_GRAPH_STORE_SINGLETON: Any = None
-_GRAPH_LOCK_SINGLETON: Any = None
+_VALID_GRAPH_BACKENDS = ("postgres", "neo4j", "nebula")
 
 
-def _process_graph_store_singleton() -> Any:
-    global _GRAPH_STORE_SINGLETON
-    if _GRAPH_STORE_SINGLETON is None:
-        from aperag.indexing.graph import InMemoryLineageGraphStore
+def _resolve_graph_backend_type(collection: Any) -> str:
+    """Read ``collection.config.graph_backend_type`` from the
+    collection's persisted config. Defaults to ``"postgres"`` if the
+    field is absent (older collections created before chunk 4b)."""
+    cfg = getattr(collection, "config", None)
+    raw: Any = None
+    if cfg is None:
+        return "postgres"
+    if hasattr(cfg, "graph_backend_type"):
+        raw = cfg.graph_backend_type
+    elif isinstance(cfg, Mapping):
+        raw = cfg.get("graph_backend_type")
+    elif isinstance(cfg, str):
+        # ``Collection.config`` may be persisted as a JSON string by
+        # SQLAlchemy when the column type is Text; parse defensively.
+        import json
 
-        _GRAPH_STORE_SINGLETON = InMemoryLineageGraphStore()
-    return _GRAPH_STORE_SINGLETON
+        try:
+            parsed = json.loads(cfg)
+        except (TypeError, ValueError):
+            parsed = None
+        if isinstance(parsed, Mapping):
+            raw = parsed.get("graph_backend_type")
+    backend = raw or "postgres"
+    if backend not in _VALID_GRAPH_BACKENDS:
+        raise WorkerFactoryError(
+            f"unknown graph_backend_type {backend!r} on collection "
+            f"{getattr(collection, 'id', '<unknown>')}; expected one of {_VALID_GRAPH_BACKENDS}"
+        )
+    return backend
 
 
-def _process_graph_lock_singleton() -> Any:
-    global _GRAPH_LOCK_SINGLETON
-    if _GRAPH_LOCK_SINGLETON is None:
+def _build_lineage_graph_store(*, backend_type: str, collection: Any) -> Any:
+    """Construct the per-collection :class:`LineageGraphStore` adapter
+    by binding the shared per-process backend client to the collection
+    id."""
+    if backend_type == "postgres":
+        engine = _postgres_async_engine_singleton()
+        from aperag.indexing.graph_storage.postgres import PostgresLineageGraphStore
+
+        return PostgresLineageGraphStore(engine=engine, collection_id=collection.id)
+    if backend_type == "neo4j":
+        driver = _neo4j_async_driver_singleton()
+        from aperag.indexing.graph_storage.neo4j import Neo4jLineageGraphStore
+
+        return Neo4jLineageGraphStore(driver=driver, collection_id=collection.id)
+    if backend_type == "nebula":
+        pool, username, password, space_prefix = _nebula_pool_singleton()
+        lock = _resolve_entity_lock(backend_type=backend_type)
+        from aperag.indexing.graph_storage.nebula import NebulaLineageGraphStore
+
+        return NebulaLineageGraphStore(
+            pool=pool,
+            username=username,
+            password=password,
+            collection_id=collection.id,
+            entity_lock=lock,
+            space_prefix=space_prefix,
+        )
+    raise WorkerFactoryError(f"unsupported graph_backend_type {backend_type!r}")
+
+
+def _resolve_entity_lock(*, backend_type: str) -> Any:
+    """Pick the EntityLock implementation appropriate for the backend.
+
+    Postgres + Neo4j get :class:`InMemoryEntityLock` (no-op semantics
+    suffice because their strip-then-append RMW is single-statement
+    under native row locks). Nebula gets :class:`RedisEntityLock` so
+    the read-modify-write loop serialises across worker processes
+    (architect msg=f2921ae0 invariant). When no Redis URL is
+    configured we fall back to the in-process lock — production
+    deployments must configure Redis for the multi-process invariant
+    to hold; the fallback is for single-process tests / dev only.
+    """
+    if backend_type == "nebula":
+        return _redis_entity_lock_singleton() or _inmemory_entity_lock_singleton()
+    return _inmemory_entity_lock_singleton()
+
+
+_POSTGRES_ASYNC_ENGINE: Any = None
+_NEO4J_ASYNC_DRIVER: Any = None
+_NEBULA_POOL: Any = None  # tuple (pool, username, password, space_prefix)
+_REDIS_ENTITY_LOCK: Any = None
+_INMEMORY_ENTITY_LOCK: Any = None
+_BACKEND_SINGLETON_GUARD = __import__("threading").Lock()
+
+
+def _postgres_async_engine_singleton() -> Any:
+    global _POSTGRES_ASYNC_ENGINE
+    if _POSTGRES_ASYNC_ENGINE is not None:
+        return _POSTGRES_ASYNC_ENGINE
+    with _BACKEND_SINGLETON_GUARD:
+        if _POSTGRES_ASYNC_ENGINE is not None:
+            return _POSTGRES_ASYNC_ENGINE
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from aperag.config import settings
+
+        url = settings.database_url
+        if not url:
+            raise WorkerFactoryError("graph backend=postgres requires settings.database_url (POSTGRES_HOST etc.)")
+        if url.startswith("postgresql://"):
+            url = "postgresql+asyncpg://" + url[len("postgresql://") :]
+        elif url.startswith("postgres://"):
+            url = "postgresql+asyncpg://" + url[len("postgres://") :]
+        _POSTGRES_ASYNC_ENGINE = create_async_engine(url, pool_pre_ping=True)
+        logger.info("graph backend=postgres: created async engine for %s", url.split("@")[-1])
+        return _POSTGRES_ASYNC_ENGINE
+
+
+def _neo4j_async_driver_singleton() -> Any:
+    global _NEO4J_ASYNC_DRIVER
+    if _NEO4J_ASYNC_DRIVER is not None:
+        return _NEO4J_ASYNC_DRIVER
+    with _BACKEND_SINGLETON_GUARD:
+        if _NEO4J_ASYNC_DRIVER is not None:
+            return _NEO4J_ASYNC_DRIVER
+        from aperag.config import settings
+
+        if not settings.neo4j_uri:
+            raise WorkerFactoryError("graph backend=neo4j requires settings.neo4j_uri (NEO4J_URI)")
+        try:
+            from neo4j import AsyncGraphDatabase
+        except ImportError as exc:  # pragma: no cover — graph-neo4j extra
+            raise WorkerFactoryError("neo4j driver not installed; install the graph-neo4j extra") from exc
+        _NEO4J_ASYNC_DRIVER = AsyncGraphDatabase.driver(
+            settings.neo4j_uri,
+            auth=(settings.neo4j_username, settings.neo4j_password),
+        )
+        logger.info("graph backend=neo4j: created async driver for %s", settings.neo4j_uri)
+        return _NEO4J_ASYNC_DRIVER
+
+
+def _nebula_pool_singleton() -> tuple[Any, str, str, str]:
+    """Return ``(pool, username, password, space_prefix)`` for the Nebula
+    adapter. Pool is shared across all collections in the process."""
+    global _NEBULA_POOL
+    if _NEBULA_POOL is not None:
+        return _NEBULA_POOL
+    with _BACKEND_SINGLETON_GUARD:
+        if _NEBULA_POOL is not None:
+            return _NEBULA_POOL
+        from aperag.config import settings
+
+        if not settings.nebula_hosts:
+            raise WorkerFactoryError("graph backend=nebula requires settings.nebula_hosts (NEBULA_HOSTS)")
+        try:
+            from nebula3.Config import Config as _NebulaConfig
+            from nebula3.gclient.net import ConnectionPool
+        except ImportError as exc:  # pragma: no cover — graph-nebula extra
+            raise WorkerFactoryError("nebula3 driver not installed; install the graph-nebula extra") from exc
+        hosts: list[tuple[str, int]] = []
+        for raw_host in settings.nebula_hosts.split(","):
+            host_part = raw_host.strip()
+            if not host_part:
+                continue
+            host, _, port_str = host_part.partition(":")
+            hosts.append((host, int(port_str or "9669")))
+        if not hosts:
+            raise WorkerFactoryError(f"settings.nebula_hosts={settings.nebula_hosts!r} parsed to no hosts")
+        config = _NebulaConfig()
+        config.max_connection_pool_size = 32
+        pool = ConnectionPool()
+        if not pool.init(hosts, config):
+            raise WorkerFactoryError(f"nebula ConnectionPool.init({hosts!r}) failed")
+        _NEBULA_POOL = (
+            pool,
+            settings.nebula_username,
+            settings.nebula_password,
+            f"{settings.nebula_space_prefix}_lineage",
+        )
+        logger.info("graph backend=nebula: created connection pool for %s", hosts)
+        return _NEBULA_POOL
+
+
+def _redis_entity_lock_singleton() -> Any | None:
+    """Return a :class:`RedisEntityLock` bound to the indexing-queue
+    Redis logical DB if configured, ``None`` otherwise (the caller
+    falls back to :class:`InMemoryEntityLock`)."""
+    global _REDIS_ENTITY_LOCK
+    if _REDIS_ENTITY_LOCK is not None:
+        return _REDIS_ENTITY_LOCK
+    with _BACKEND_SINGLETON_GUARD:
+        if _REDIS_ENTITY_LOCK is not None:
+            return _REDIS_ENTITY_LOCK
+        from aperag.config import settings
+
+        url = settings.indexing_queue_redis_url
+        if not url:
+            return None
+        try:
+            from redis import asyncio as redis_asyncio
+        except ImportError:  # pragma: no cover — redis is a base dep
+            return None
+        from aperag.indexing.graph import RedisEntityLock
+
+        client = redis_asyncio.from_url(url, encoding="utf-8", decode_responses=True)
+        _REDIS_ENTITY_LOCK = RedisEntityLock(client)
+        logger.info("graph entity_lock: bound RedisEntityLock to %s", url.split("@")[-1])
+        return _REDIS_ENTITY_LOCK
+
+
+def _inmemory_entity_lock_singleton() -> Any:
+    global _INMEMORY_ENTITY_LOCK
+    if _INMEMORY_ENTITY_LOCK is not None:
+        return _INMEMORY_ENTITY_LOCK
+    with _BACKEND_SINGLETON_GUARD:
+        if _INMEMORY_ENTITY_LOCK is not None:
+            return _INMEMORY_ENTITY_LOCK
         from aperag.indexing.graph import InMemoryEntityLock
 
-        _GRAPH_LOCK_SINGLETON = InMemoryEntityLock()
-    return _GRAPH_LOCK_SINGLETON
+        _INMEMORY_ENTITY_LOCK = InMemoryEntityLock()
+        return _INMEMORY_ENTITY_LOCK
+
+
+def _reset_graph_backend_singletons_for_tests() -> None:
+    """Drop every cached backend client + lock so a test fixture can
+    re-bind them. Not part of the public API — tests import this when
+    they swap settings or want a fresh backend per run."""
+    global _POSTGRES_ASYNC_ENGINE, _NEO4J_ASYNC_DRIVER, _NEBULA_POOL
+    global _REDIS_ENTITY_LOCK, _INMEMORY_ENTITY_LOCK
+    with _BACKEND_SINGLETON_GUARD:
+        _POSTGRES_ASYNC_ENGINE = None
+        _NEO4J_ASYNC_DRIVER = None
+        _NEBULA_POOL = None
+        _REDIS_ENTITY_LOCK = None
+        _INMEMORY_ENTITY_LOCK = None
 
 
 def _build_collection_summarizer(collection: Any) -> Callable[[str], str]:

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -249,20 +249,91 @@ def _build_vector_worker(*, collection: Any, object_store: Any) -> ModalityWorke
 
 
 def _build_fulltext_worker(*, collection: Any, object_store: Any) -> ModalityWorker:
-    """Wire :class:`FulltextModality` to a real Elasticsearch index.
+    """Wire :class:`FulltextModality` to a real fulltext backend per
+    ``collection.config.fulltext_backend_type`` (Wave 4 T9).
 
     Uses the same physical index name the retrieval pipeline reads
     from (``generate_fulltext_index_name``) so writes and reads are
-    symmetric.
+    symmetric. The fulltext backend dispatch mirrors the graph backend
+    dispatch landed in T8 chunk 4b — the backend is selected per
+    collection so a deployment can mix Elasticsearch (existing) and
+    OpenSearch (open-licence alternative) without code changes.
+    """
+    from aperag.indexing.fulltext import FulltextModality
+    from aperag.utils.utils import generate_fulltext_index_name
+
+    backend_type = _resolve_fulltext_backend_type(collection)
+    index_name = generate_fulltext_index_name(collection.id)
+    backend = _build_fulltext_backend(backend_type=backend_type, index_name=index_name)
+    # Pass ``collection.id`` so ``FulltextModality.sync`` can write
+    # ``collection_id`` into every fulltext document — the retrieval
+    # pipeline ``_fulltext_search`` filters on this field. Without
+    # it, search returns 0 hits silently.
+    return FulltextModality(backend=backend, store=object_store, collection_id=collection.id)
+
+
+_VALID_FULLTEXT_BACKENDS = ("elasticsearch", "opensearch")
+
+
+def _resolve_fulltext_backend_type(collection: Any) -> str:
+    """Read ``collection.config.fulltext_backend_type`` from the
+    collection's persisted config. Defaults to ``"elasticsearch"`` if
+    the field is absent (older collections created before T9)."""
+    cfg = getattr(collection, "config", None)
+    raw: Any = None
+    if cfg is None:
+        return "elasticsearch"
+    if hasattr(cfg, "fulltext_backend_type"):
+        raw = cfg.fulltext_backend_type
+    elif isinstance(cfg, Mapping):
+        raw = cfg.get("fulltext_backend_type")
+    elif isinstance(cfg, str):
+        # ``Collection.config`` may be persisted as a JSON string by
+        # SQLAlchemy when the column type is Text; parse defensively.
+        import json
+
+        try:
+            parsed = json.loads(cfg)
+        except (TypeError, ValueError):
+            parsed = None
+        if isinstance(parsed, Mapping):
+            raw = parsed.get("fulltext_backend_type")
+    backend = raw or "elasticsearch"
+    if backend not in _VALID_FULLTEXT_BACKENDS:
+        raise WorkerFactoryError(
+            f"unknown fulltext_backend_type {backend!r} on collection "
+            f"{getattr(collection, 'id', '<unknown>')}; expected one of {_VALID_FULLTEXT_BACKENDS}"
+        )
+    return backend
+
+
+def _build_fulltext_backend(*, backend_type: str, index_name: str) -> Any:
+    """Construct the per-backend fulltext adapter. The two supported
+    backends share the wire-compatible Elasticsearch HTTP API surface
+    used by ``_ElasticsearchFulltextBackend`` (index / bulk /
+    delete_by_query), so the same adapter class wraps both clients —
+    only the underlying client driver differs.
+    """
+    if backend_type == "elasticsearch":
+        client = _build_elasticsearch_client()
+        return _ElasticsearchFulltextBackend(client=client, index_name=index_name)
+    if backend_type == "opensearch":
+        client = _build_opensearch_client()
+        return _ElasticsearchFulltextBackend(client=client, index_name=index_name)
+    raise WorkerFactoryError(f"unsupported fulltext_backend_type {backend_type!r}")
+
+
+def _build_elasticsearch_client() -> Any:
+    """Construct the Elasticsearch client from the global ``ES_HOST``
+    + auth + timeout settings. Raises :class:`WorkerFactoryError` if
+    ``ES_HOST`` is not configured.
     """
     from elasticsearch import Elasticsearch
 
     from aperag.config import settings
-    from aperag.indexing.fulltext import FulltextModality
-    from aperag.utils.utils import generate_fulltext_index_name
 
     if not settings.es_host:
-        raise WorkerFactoryError("fulltext: ES_HOST not configured (settings.es_host empty)")
+        raise WorkerFactoryError("fulltext backend=elasticsearch: ES_HOST not configured (settings.es_host empty)")
 
     es_kwargs: dict[str, Any] = {}
     if getattr(settings, "es_basic_auth_username", None):
@@ -273,14 +344,42 @@ def _build_fulltext_worker(*, collection: Any, object_store: Any) -> ModalityWor
     if getattr(settings, "es_timeout", None):
         es_kwargs["request_timeout"] = settings.es_timeout
 
-    client = Elasticsearch(settings.es_host, **es_kwargs)
-    index_name = generate_fulltext_index_name(collection.id)
-    backend = _ElasticsearchFulltextBackend(client=client, index_name=index_name)
-    # Pass ``collection.id`` so ``FulltextModality.sync`` can write
-    # ``collection_id`` into every ES document — the retrieval
-    # pipeline ``_fulltext_search`` filters on this field. Without
-    # it, search returns 0 hits silently.
-    return FulltextModality(backend=backend, store=object_store, collection_id=collection.id)
+    return Elasticsearch(settings.es_host, **es_kwargs)
+
+
+def _build_opensearch_client() -> Any:
+    """Construct the OpenSearch client from the global ``ES_HOST`` +
+    auth + timeout settings (same env vars as Elasticsearch — there
+    is no separate ``OPENSEARCH_HOST`` because operators run one
+    fulltext backend per deployment).
+
+    Raises :class:`WorkerFactoryError` when the optional
+    ``opensearch-py`` dependency is not installed — mirrors the way
+    chunk 4b gates the Neo4j / Nebula drivers behind the graph-{neo4j,
+    nebula} extras.
+    """
+    from aperag.config import settings
+
+    if not settings.es_host:
+        raise WorkerFactoryError("fulltext backend=opensearch: ES_HOST not configured (settings.es_host empty)")
+
+    try:
+        from opensearchpy import OpenSearch
+    except ImportError as exc:  # pragma: no cover — fulltext-opensearch extra
+        raise WorkerFactoryError(
+            "fulltext backend=opensearch: opensearch-py not installed; install the fulltext-opensearch extra"
+        ) from exc
+
+    os_kwargs: dict[str, Any] = {}
+    if getattr(settings, "es_basic_auth_username", None):
+        os_kwargs["http_auth"] = (
+            settings.es_basic_auth_username,
+            getattr(settings, "es_basic_auth_password", "") or "",
+        )
+    if getattr(settings, "es_timeout", None):
+        os_kwargs["timeout"] = settings.es_timeout
+
+    return OpenSearch(hosts=[settings.es_host], **os_kwargs)
 
 
 def _build_summary_worker(*, collection: Any, object_store: Any) -> ModalityWorker:
@@ -989,27 +1088,17 @@ def _build_qdrant_cleanup_backend(collection: Any) -> Any:
 
 
 def _build_es_cleanup_backend(collection: Any) -> Any:
-    """Construct the ES ``_backend`` adapter for fulltext cleanup."""
-    from elasticsearch import Elasticsearch
-
-    from aperag.config import settings
+    """Construct the fulltext ``_backend`` adapter for cleanup,
+    dispatching on ``collection.config.fulltext_backend_type``
+    (T9). Reuses the same dispatch + client builders as the
+    dispatch path so an operator who switched the collection from
+    Elasticsearch to OpenSearch still cleans up the right index.
+    """
     from aperag.utils.utils import generate_fulltext_index_name
 
-    if not settings.es_host:
-        raise WorkerFactoryError("fulltext cleanup: ES_HOST not configured (settings.es_host empty)")
-
-    es_kwargs: dict[str, Any] = {}
-    if getattr(settings, "es_basic_auth_username", None):
-        es_kwargs["basic_auth"] = (
-            settings.es_basic_auth_username,
-            getattr(settings, "es_basic_auth_password", "") or "",
-        )
-    if getattr(settings, "es_timeout", None):
-        es_kwargs["request_timeout"] = settings.es_timeout
-
-    client = Elasticsearch(settings.es_host, **es_kwargs)
+    backend_type = _resolve_fulltext_backend_type(collection)
     index_name = generate_fulltext_index_name(collection.id)
-    return _ElasticsearchFulltextBackend(client=client, index_name=index_name)
+    return _build_fulltext_backend(backend_type=backend_type, index_name=index_name)
 
 
 def _build_cleanup_view_sync(collection: Any, modality: Modality) -> CleanupWorkerView:

--- a/aperag/migration/env.py
+++ b/aperag/migration/env.py
@@ -66,9 +66,18 @@ import aperag.domains.retrieval.db.models  # noqa: F401
 # target). The new ``aperag.indexing.models`` is the canonical home;
 # import explicitly so autogen sees the table.
 import aperag.indexing.models  # noqa: F401
+
+# Phase celery T8 chunk 4a — PostgresLineageGraphStore (T8 chunk 1
+# msg=f0571f98) declares its tables on a private ``_LineageGraphBase``
+# so the adapter owns ``ensure_schema`` (test/dev fallback) without
+# polluting the application's main ``Base.metadata``. Production
+# schema is owned by alembic, so the autogen pass needs visibility
+# into both metadatas — ``target_metadata`` accepts a list so each
+# ``include_object`` / ``compare_metadata`` walk visits every table.
+from aperag.indexing.graph_storage.postgres import _LineageGraphBase  # noqa: F401
 from aperag.db.models import Base
 
-target_metadata = Base.metadata
+target_metadata = [Base.metadata, _LineageGraphBase.metadata]
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/aperag/migration/versions/20260427023000-e7a3b9c2d1f6_indexing_redesign_lineage_graph_postgres.py
+++ b/aperag/migration/versions/20260427023000-e7a3b9c2d1f6_indexing_redesign_lineage_graph_postgres.py
@@ -1,0 +1,154 @@
+"""indexing redesign — lineage graph PostgreSQL tables (T8 chunk 4a)
+
+Phase celery T8 chunk 4a per ``docs/modularization/indexing-redesign-design-pack.md``
+§D.3.5 + chunk 4 acceptance lock item 1 + 2 (architect msg=baf6618e /
+huangheng msg=b6f20096):
+
+Adds the two PostgreSQL tables that back
+:class:`aperag.indexing.graph_storage.postgres.PostgresLineageGraphStore`
+(T8 chunk 1, msg=f0571f98), mirroring the adapter's private ORM 100%:
+
+* ``aperag_lineage_entity`` — one row per ``(collection_id, name)``
+  storing the lineage SET in ``source_lineage`` JSONB and the
+  per-document description fragments in ``description_parts`` JSONB.
+* ``aperag_lineage_relation`` — one row per
+  ``(collection_id, source, target, type)`` quadruple storing
+  ``evidence_lineage`` + ``description_parts`` JSONB.
+
+The relation table intentionally does NOT carry a standalone
+``description`` Text column — Wave 4 chunk 4 drops that legacy
+residual across all 3 backends (Postgres / Neo4j / Nebula). The
+canonical relation description is the per-document fragments in
+``description_parts`` (§D.3.3 Option A "preserve every doc's
+contribution verbatim"); the redundant overwritten-on-every-upsert
+``description`` column was a v1 migration artefact with no consumer
+on the §D.3 / §G.5 read path (``RelationWithLineage`` does not expose
+it). Dropping it cross-backend keeps "ORM 100% mirror" honest.
+
+Pre-launch system has no users / no data, so the two tables land
+without backfill (per earayu2 hard-cut acceptance msg=9730bb6b).
+The downgrade drops both tables so a rollback can replay subsequent
+migrations cleanly.
+
+PostgreSQL only — the lineage adapter SQL uses ``jsonb_*`` functions
+(``jsonb_agg`` / ``jsonb_array_elements`` / ``@>`` containment) and
+the dedup-key strip-then-append pattern in
+``upsert_*_with_lineage`` cannot be expressed against SQLite TEXT
+columns. Other backends (Neo4j / Nebula) realise the same
+``LineageGraphStore`` Protocol via their native list-of-string
+encoding (see ``aperag/indexing/graph_storage/neo4j.py`` /
+``nebula.py``).
+
+Revision ID: e7a3b9c2d1f6
+Revises: d0f4c1b9a8e2
+Create Date: 2026-04-27 02:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e7a3b9c2d1f6"
+down_revision: Union[str, None] = "d0f4c1b9a8e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "aperag_lineage_entity",
+        sa.Column("collection_id", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=512), nullable=False),
+        sa.Column("type", sa.String(length=64), nullable=False),
+        sa.Column(
+            "source_lineage",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "description_parts",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "gmt_created",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "gmt_updated",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("collection_id", "name"),
+    )
+    # JSONB containment scan for ``find_entity_ids_with_lineage`` —
+    # the adapter issues ``source_lineage @> [{"document_id": $d}]``
+    # to enumerate entities touched by a document. The GIN index lets
+    # the @> operator skip a sequential scan on a multi-tenant table.
+    op.create_index(
+        "idx_lineage_entity_source_lineage_gin",
+        "aperag_lineage_entity",
+        ["source_lineage"],
+        unique=False,
+        postgresql_using="gin",
+    )
+
+    op.create_table(
+        "aperag_lineage_relation",
+        sa.Column("collection_id", sa.String(length=64), nullable=False),
+        sa.Column("source", sa.String(length=512), nullable=False),
+        sa.Column("target", sa.String(length=512), nullable=False),
+        sa.Column("type", sa.String(length=64), nullable=False),
+        sa.Column(
+            "evidence_lineage",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "description_parts",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "gmt_created",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "gmt_updated",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("collection_id", "source", "target", "type"),
+    )
+    op.create_index(
+        "idx_lineage_relation_evidence_lineage_gin",
+        "aperag_lineage_relation",
+        ["evidence_lineage"],
+        unique=False,
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_lineage_relation_evidence_lineage_gin",
+        table_name="aperag_lineage_relation",
+    )
+    op.drop_table("aperag_lineage_relation")
+    op.drop_index(
+        "idx_lineage_entity_source_lineage_gin",
+        table_name="aperag_lineage_entity",
+    )
+    op.drop_table("aperag_lineage_entity")

--- a/aperag/observability/metrics.py
+++ b/aperag/observability/metrics.py
@@ -3,6 +3,14 @@
 Business code can depend on this module without knowing whether the current
 process exports metrics. In ``local`` and ``off`` modes these functions are
 cheap no-ops.
+
+When ``mode in {otlp, collector}`` and an OTLP endpoint is set,
+:func:`configure_metrics` also initialises an SDK ``MeterProvider`` with a
+``PeriodicExportingMetricReader`` wrapping ``OTLPMetricExporter`` so the
+``aperag.indexing.OTLPMetricsEmitter`` (and ``record_counter`` /
+``record_histogram`` here) actually ship samples to the collector. Without
+this initialisation OpenTelemetry's global ``MeterProvider`` is the no-op
+``ProxyMeterProvider`` and every metric call silently drops.
 """
 
 from __future__ import annotations
@@ -18,11 +26,125 @@ logger = logging.getLogger(__name__)
 _config: Optional[ObservabilityConfig] = None
 _counters: dict[str, object] = {}
 _histograms: dict[str, object] = {}
+_meter_provider_initialized = False
 
 
 def configure_metrics(config: ObservabilityConfig) -> None:
     global _config
     _config = config
+    if config.metrics_enabled:
+        init_metrics_provider(config)
+
+
+def init_metrics_provider(config: ObservabilityConfig) -> bool:
+    """Install an SDK ``MeterProvider`` with an OTLP exporter.
+
+    Idempotent — returns ``True`` after first successful init and on
+    every subsequent call. Returns ``False`` when the OpenTelemetry
+    SDK packages are not importable, or when the exporter could not
+    be constructed (logged + swallowed so the indexing emitter falls
+    back to a no-op rather than crashing the app).
+    """
+
+    global _meter_provider_initialized
+
+    if _meter_provider_initialized:
+        return True
+
+    try:
+        from opentelemetry import metrics
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+    except ImportError:  # pragma: no cover - depends on runtime package availability
+        logger.warning("OpenTelemetry SDK metrics packages are not available; OTLP metrics disabled")
+        return False
+
+    if not config.metrics_enabled:
+        return False
+
+    exporter = _build_otlp_metric_exporter(config)
+    if exporter is None:
+        return False
+
+    resource_attributes: dict[str, object] = {
+        "service.name": config.service_name,
+        "service.version": config.service_version,
+    }
+    if config.environment:
+        resource_attributes["deployment.environment"] = config.environment
+    resource_attributes.update(config.resource_attributes)
+
+    try:
+        reader = PeriodicExportingMetricReader(exporter)
+        provider = MeterProvider(
+            resource=Resource.create(resource_attributes),
+            metric_readers=[reader],
+        )
+        metrics.set_meter_provider(provider)
+        # Existing module-level lru_cache for ``_meter()`` was sized
+        # to one entry against the global proxy MeterProvider; clear it
+        # so the next call binds to the SDK provider we just installed.
+        _meter.cache_clear()
+        _meter_provider_initialized = True
+        logger.info(
+            "observability metrics initialized",
+            extra={
+                "operation": "observability.metrics.init",
+                "outcome": "success",
+                "observability_mode": config.mode,
+            },
+        )
+        return True
+    except Exception:
+        logger.exception(
+            "failed to initialize observability metrics",
+            extra={"operation": "observability.metrics.init", "outcome": "failure"},
+        )
+        return False
+
+
+def shutdown_metrics_provider() -> None:
+    """Flush + shut down the configured SDK MeterProvider on exit."""
+    if not _meter_provider_initialized:
+        return
+    try:
+        from opentelemetry import metrics
+    except ImportError:  # pragma: no cover
+        return
+    try:
+        provider = metrics.get_meter_provider()
+        shutdown = getattr(provider, "shutdown", None)
+        if callable(shutdown):
+            shutdown()
+    except Exception:
+        logger.debug("failed to shut down meter provider", exc_info=True)
+
+
+def _build_otlp_metric_exporter(config: ObservabilityConfig):
+    if not config.otlp_endpoint:
+        logger.warning(
+            "OTLP observability mode selected without OTEL_EXPORTER_OTLP_ENDPOINT; remote metrics disabled",
+            extra={"operation": "observability.metrics.init", "outcome": "skipped"},
+        )
+        return None
+    protocol = (config.otlp_protocol or "http/protobuf").lower()
+    headers = config.otlp_headers or None
+    if protocol in {"http/protobuf", "http"}:
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
+        endpoint = _metric_http_endpoint(config.otlp_endpoint)
+        return OTLPMetricExporter(endpoint=endpoint, headers=headers)
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+
+    return OTLPMetricExporter(endpoint=config.otlp_endpoint, headers=headers)
+
+
+def _metric_http_endpoint(endpoint: str) -> str:
+    endpoint = endpoint.rstrip("/")
+    if endpoint.endswith("/v1/metrics"):
+        return endpoint
+    return f"{endpoint}/v1/metrics"
 
 
 @lru_cache(maxsize=1)

--- a/aperag/schema/common.py
+++ b/aperag/schema/common.py
@@ -184,6 +184,17 @@ class CollectionConfig(BaseModel):
         "postgres",
         description="Lineage graph backend for knowledge graph indexing",
     )
+    # Wave 4 T9: fulltext backend dispatch. ``elasticsearch`` is the
+    # default + reference backend (the global ``ES_HOST`` already wired
+    # through ``settings``); ``opensearch`` is the open-licence
+    # alternative for deployments that cannot run Elastic Stack. The
+    # worker factory reads this field to construct the right
+    # ``FulltextBackend`` per collection — new collections default to
+    # ``elasticsearch`` so behaviour is unchanged for existing setups.
+    fulltext_backend_type: Optional[Literal["elasticsearch", "opensearch"]] = Field(
+        "elasticsearch",
+        description="Fulltext search backend for the fulltext modality",
+    )
     enable_summary: Optional[bool] = Field(False, description="Whether to enable summary index")
     enable_vision: Optional[bool] = Field(False, description="Whether to enable vision index")
     knowledge_graph_config: Optional[KnowledgeGraphConfig] = Field(

--- a/aperag/schema/common.py
+++ b/aperag/schema/common.py
@@ -172,6 +172,18 @@ class CollectionConfig(BaseModel):
     # by accident; Wave 4 release flips it back to True. Per architect
     # msg=c79e9a3f.
     enable_knowledge_graph: Optional[bool] = Field(False, description="Whether to enable knowledge graph index")
+    # Wave 4 T8 chunk 4b: lineage graph backend dispatch.
+    # ``postgres`` is the §D.3.5 reference adapter (no extra
+    # infrastructure needed beyond the application's own PostgreSQL);
+    # ``neo4j`` and ``nebula`` are the production graph databases for
+    # deployments that already run them. ``worker_factory`` reads this
+    # field to construct the right :class:`LineageGraphStore` per
+    # collection. New collections that opt into knowledge graph default
+    # to ``postgres`` since it shares the existing app DB.
+    graph_backend_type: Optional[Literal["postgres", "neo4j", "nebula"]] = Field(
+        "postgres",
+        description="Lineage graph backend for knowledge graph indexing",
+    )
     enable_summary: Optional[bool] = Field(False, description="Whether to enable summary index")
     enable_vision: Optional[bool] = Field(False, description="Whether to enable vision index")
     knowledge_graph_config: Optional[KnowledgeGraphConfig] = Field(

--- a/docs/modularization/indexing-redesign-design-pack.md
+++ b/docs/modularization/indexing-redesign-design-pack.md
@@ -1075,6 +1075,53 @@ sync(manifest.jsonl, document_id, parse_version, qdrant) →
     2. for each entry: qdrant.upsert(...)
 ```
 
+##### G.2.5.1. Vision modality T7 wiring scope (Wave 4 backlog T7 + Wave 5 follow-up)
+
+`worker_factory._build_vision_worker` currently raises
+:class:`WorkerFactoryError` when the collection's embedding service is
+not multimodal (`embedding_service.is_multimodal()` returns False —
+the operator opted into vision but the configured embedder is text-
+only). The Wave 3 lesson #10 explicit-gate pattern still applies; T7
+**self-disables** the gate when `is_multimodal()` flips True.
+
+T7 wiring requires three coordinated pieces beyond what chunk 4 ships:
+
+1. **Multimodal embedding API surface** — extend
+   :class:`aperag.llm.embed.embedding_service.EmbeddingService` with
+   an `embed_image(image_bytes: bytes, alt_text: str = "") -> list[float]`
+   method that the multimodal provider (CLIP / LLaVA / GPT-4V / etc.)
+   resolves to a real visual embedding. Without this, `_embed` is
+   forced into the existing `embed_query(str)` path which only
+   handles text — the Wave 1+2 implementation papered over this with
+   a string-concat ``f"{image_id}|{alt_text}"`` (Wave 3 lesson #10
+   broken pattern; chunk 4 gate prevents production opt-in).
+
+2. **Real PDF / image-source extraction in the parser pipeline** —
+   the T1 simulator's `<source>.images.json` companion (a JSON list
+   of image_id + alt_text records) does not include actual image
+   bytes; chenyexuan T3 chunk 1 wired DocParser for markdown / PDF /
+   Word / image inputs, but the per-image bytes path
+   (``derived/parse_<v>/vision/images/<image_id>.<ext>``) is not yet
+   produced by any parser branch. T7 needs the parser to land
+   per-page image extraction (or single-image-input passthrough)
+   before the vision worker has any image bytes to embed.
+
+3. **Provider-specific multimodal model registration** — the model
+   platform v3 router (``aperag/domains/model_platform/api/providers_v3_routes.py``)
+   needs to surface the multimodal capability flag so operators can
+   set `is_multimodal=True` on the collection's embedder spec. The
+   capability flag is the source of truth for the chunk 4b gate.
+
+Per architect msg=87e2b187 chunk 4d Option C ruling, T7 wiring closes
+items 1+3 in Wave 4 (gate self-disables + API surface + provider
+flag) and defers item 2 to Wave 5 alongside the parser canonical
+schema unification (per huangheng T1 obs B). Until item 2 lands, T7
+ships the embedder API surface + gate behaviour but the actual
+``vision/images/<image_id>.<ext>`` reads gracefully fallback to
+alt_text-based embedding (which is still NOT a faithful visual
+embedding — operators see a clean ``error_message`` in the
+DocumentIndex row noting the parser-side gap).
+
 ### G.3. Deriver / syncer interfaces (Python)
 
 ```python

--- a/docs/modularization/indexing-redesign-design-pack.md
+++ b/docs/modularization/indexing-redesign-design-pack.md
@@ -1012,6 +1012,17 @@ sync(chunks.jsonl, document_id, parse_version, es) →
 
 Note: vector and fulltext can **share `chunks.jsonl`**. The difference is just which fields ES consumes vs Qdrant consumes. This collapses duplicate chunking logic.
 
+##### G.2.2.1. Fulltext backend dispatch（Wave 4 T9 amendment, architect msg=eba26fc2）
+
+`collection.config.fulltext_backend_type` is a `Literal["elasticsearch", "opensearch"]` field (default `"elasticsearch"`) wired through `worker_factory._build_fulltext_backend(backend_type, index_name)`. The two backends share the same `_ElasticsearchFulltextBackend` adapter because OpenSearch (forked from Elasticsearch 7.10) preserves wire-compatible HTTP API for `index` / `bulk` / `delete_by_query`. Only the client-construction step differs:
+
+| Backend | Driver | Client kwargs |
+|---|---|---|
+| `elasticsearch` | `elasticsearch` (always available) | `Elasticsearch(host, basic_auth=(user, pass), request_timeout=N)` |
+| `opensearch` | `opensearchpy` (lazy import — `WorkerFactoryError` if missing, points at `fulltext-opensearch` extra) | `OpenSearch(hosts=[host], http_auth=(user, pass), timeout=N)` |
+
+**Single `ES_HOST` env var serves both backends** — operators run one fulltext cluster per deployment. When choosing OpenSearch, configure `ES_HOST` to the OpenSearch endpoint (e.g. `https://opensearch.internal:9200`) — the adapter does not introspect server-side identity, only wire protocol. New backends (Solr / Typesense / MeiliSearch) plug in via the same dispatch by extending `_VALID_FULLTEXT_BACKENDS` + adding a `_build_*_client` helper.
+
 #### G.2.3. Graph modality
 
 ```

--- a/docs/modularization/indexing-redesign-design-pack.md
+++ b/docs/modularization/indexing-redesign-design-pack.md
@@ -1112,15 +1112,24 @@ T7 wiring requires three coordinated pieces beyond what chunk 4 ships:
    set `is_multimodal=True` on the collection's embedder spec. The
    capability flag is the source of truth for the chunk 4b gate.
 
-Per architect msg=87e2b187 chunk 4d Option C ruling, T7 wiring closes
-items 1+3 in Wave 4 (gate self-disables + API surface + provider
-flag) and defers item 2 to Wave 5 alongside the parser canonical
-schema unification (per huangheng T1 obs B). Until item 2 lands, T7
-ships the embedder API surface + gate behaviour but the actual
-``vision/images/<image_id>.<ext>`` reads gracefully fallback to
-alt_text-based embedding (which is still NOT a faithful visual
-embedding — operators see a clean ``error_message`` in the
-DocumentIndex row noting the parser-side gap).
+Per architect msg=87e2b187 chunk 4d Option C ruling + Bryce
+honest-scope clarification msg=bad51f10: T7 in PR #1731 is **doc-
+only** — this §G.2.5.1 spec amendment locks the wiring contract
+across all three pieces, but **none of items 1 / 2 / 3 ship code
+in Wave 4**. The three pieces are tightly coupled (multimodal API
+surface needs a provider flag to be useful + a parser branch to
+have any image bytes to embed); splitting them across PRs risks the
+Wave 3 lesson #10 broken-pattern (e.g., ship API surface with no
+caller, ship provider flag with no API surface, etc.). The whole
+T7 implementation defers to a single Wave 5 PR that bundles all
+three.
+
+Wave 4 close-out invariant: the chunk 4b vision gate stays
+effective. Operators that opt into vision without a multimodal
+embedder configured see a clean ``WorkerFactoryError`` with the
+"Wave 4 wiring" message — which after T7 doc-only ships still
+points at the same actionable status: configure a multimodal
+embedder OR set ``enable_vision=false``.
 
 ### G.3. Deriver / syncer interfaces (Python)
 

--- a/docs/modularization/indexing-redesign-design-pack.md
+++ b/docs/modularization/indexing-redesign-design-pack.md
@@ -363,6 +363,12 @@ collections/<collection_id>/documents/<document_id>/
 
 5. **Backend swap is cheap.** Switch Nebula → Neo4j → PostgreSQL graph without touching the deriver. Re-run "sync" against the new backend, reading the same `kg.jsonl`.
 
+#### C.3.1. Per-collection parser override（Wave 4 T3 chunk 2 amendment, architect msg=9a6de002）
+
+`collection.config.parser_config` is an optional dict forwarded verbatim to `DocParser` dispatch (`parse_document(parser_config=...)`). Operators / private deployments can opt into MinerU / per-collection OCR engines without touching code. The async parse worker reads it via `_resolve_parser_config_for_collection(collection_id)` (Wave 4 T3 chunk 2) and pins it onto the `ParseDispatchPayload` so a re-parse N minutes later still uses the collection's chosen parser config.
+
+Shape: any JSON-serialisable dict; the chosen parser (`docparser` family) decides what keys it understands. Ill-formed values are graceful — the parse worker logs a warning and falls back to no-op `parser_config=None` rather than failing the parse.
+
 ### C.4. Object store choice
 
 The object store is whatever ApeRAG already uses (S3 / MinIO / local filesystem in dev). This design pack does not impose a new dependency — the directory layout overlays the existing object store.
@@ -619,6 +625,28 @@ D.1 "DELETE-by-(doc, parse_version) THEN INSERT" 对 graph 模态需要 reinterp
 - **Neo4j**: Cypher 原生支持 list filtering（`[s IN n.source_lineage WHERE ...]`），上面伪 Cypher 直接可执行。
 - **Nebula**: nGQL 支持 LIST 类型 (Nebula 3.x)，但 list 操作语法不如 Cypher 直接；需要在应用层 read-modify-write（拉 lineage list → Python filter → 写回）。这增加 race condition 风险。**因此**：sync_graph 必须对单 entity 的更新串行化（per-entity lock，按 entity_name hash 路由到固定 worker，或者 Nebula transaction 范围 lock）。Wave 2 的 graph_worker 实现要含这条 invariant。
 - 两个后端都需要 `(name, type)` 复合主键做 entity dedup（已有）。
+
+##### D.3.5.1. Lineage SET 元素 dedup key — 三 backend 必 align（Wave 4 T8 chunk 4 amendment, architect msg=baf6618e）
+
+`source_lineage` / `evidence_lineage` SET 元素 dedup key **MUST** 是 `(document_id, parse_version)` 复合，**三 backend (Postgres / Neo4j / Nebula) 必须 align**。`upsert_*_with_lineage` 操作的语义是：
+
+1. 如果 SET 中已有元素满足 `elem.document_id == lineage.document_id AND elem.parse_version == lineage.parse_version`，**replace** 该元素。
+2. 否则 **append** 新元素。
+
+**关键 invariant**：同一 `(document_id, parse_version)` 不能在 SET 内共存两份。这覆盖三类场景：
+- doc_A v1 同 entity 多 chunk 抽取重复触发 upsert（同 key → replace，幂等）。
+- 同一 worker 因 retry 重新调用 upsert（同 key → replace，幂等）。
+- doc_A v2 取代 doc_A v1（先 `remove_*_lineage_member(document_id="doc_A")` 全 strip 含 v1，再 upsert(v2)），不依赖 dedup-by-doc only。
+
+**为什么这条必须显式声明**：§D.3.6 step 3 描述 "doc_A v2 写入（覆盖 doc_A 旧 lineage）" 的 narrative 是 orchestrator-level 行为（remove + upsert two-step），不是 single-upsert 的 dedup-by-doc 语义。不显式声明 composite key 容易让 backend implementer 误把 `document_id` 单独当 dedup key（导致同 doc 不同 parse_version 互相覆盖，丢 lineage 历史；或者 LightRAG-style 多 chunk 抽取被错误 collapse）。Wave 4 T8 三 backend 的 chunks 1-3 实施都按此 composite key 实现：
+
+| Backend | Composite key 实现 |
+|---|---|
+| Postgres | `WHERE NOT (elem->>'document_id' = $d AND elem->>'parse_version' = $v)` 在 `jsonb_agg` 内 strip 后 append |
+| Neo4j | parallel-list 三 list（lineage / doc_ids / parse_versions）+ `[i IN range \| WHERE NOT (doc_ids[i] = $d AND parse_versions[i] = $v)]` keep-index |
+| Nebula | JSON STRING property + Python `[m for m in members if m.key() != lineage.key()] + [lineage]` （`LineageMember.key()` 返 `(document_id, parse_version)` 二元组） |
+
+跨 backend contract test (`tests/integration/test_lineage_graph_store_contract.py` case 3 `test_doc_re_parse_replaces_old_parse_version_member`) 锁此 invariant — 任何 backend drift 即 fail。
 
 #### D.3.6. 自测扩展
 
@@ -1160,6 +1188,27 @@ Single-knob 实现：
 #   refill_rate  = e.g. 1 token / second
 ```
 
+#### H.5.1. Redis logical db assignment（Wave 4 T8 chunk 4 amendment, architect msg=baf6618e）
+
+ApeRAG 在多个 subsystem 用 Redis，单一 host 共享 keyspace 有 key collision 风险（celery / Wave 1 entity lock / Wave 4 WorkQueue / Wave 4 Quota）。chunk 4 lock 以下 logical-db 分隔：
+
+| Logical DB | Subsystem | Key prefix |
+|---|---|---|
+| 0 | Celery broker (`CELERY_BROKER_URL`) | `celery-task-meta-*` etc. |
+| 1 | Memory backend (`MEMORY_REDIS_URL`) | `memory:*` |
+| 2 | Indexing WorkQueue (`INDEXING_QUEUE_REDIS_URL`) | `q:parse`, `q:vector`, `q:fulltext`, `q:graph`, `q:summary`, `q:vision` |
+| 3 | Quota / EntityLock | `quota:<class>:<tenant>:tokens`, `indexing:graph:entity:<slot>` |
+
+`aperag/config.py` 的 default-derive 路径会从单个 `REDIS_HOST` / `REDIS_PORT` 自动衍生这四个 URL，分别绑定 db=0/1/2/3。Operator 可以单独覆盖任一 URL 走外部 Redis 集群。**production 部署必须保 4 个 logical db 不重叠**，否则 BLPOP queues 会和 cache / broker 互相 RPOP/RPUSH。
+
+#### H.5.2. Nebula graph backend multi-process EntityLock invariant（Wave 4 T8 chunk 4 amendment, architect msg=87e2b187）
+
+如 `collection.config.graph_backend_type == "nebula"` 且 worker pool 是 multi-process（worker pool concurrency >= 2 进程）, **`INDEXING_QUEUE_REDIS_URL` MUST be set** — Nebula 缺乏 native list ops，`upsert_*_with_lineage` 必须 read-modify-write，多进程并发 upsert 同一 entity 必须 serialise 才不丢 lineage 元素。`worker_factory._resolve_entity_lock(backend_type="nebula")` 走 `RedisEntityLock`（绑定 `indexing_queue_redis_url`）保证 cross-process 锁定。
+
+如 Redis 未配，fallback 到 `InMemoryEntityLock`（process-local `asyncio.Lock`），仅适用于 single-process test/dev — production multi-process 跑 Nebula 会丢 lineage 元素（race window）。
+
+Postgres + Neo4j backend **不需要** Redis EntityLock — 它们的 `upsert_*_with_lineage` 单 SQL/Cypher 语句下 strip-then-append（PG `INSERT ON CONFLICT … COALESCE + jsonb_agg` / Neo4j `MERGE … WITH … SET` 都在 row-lock 内 atomic），cross-process race 由 backend native row-lock 兜底。
+
 Worker 在调用 LLM / embedding 之前 `acquire_token(scope, resource_class)`：
 - 优先从 `quota:<class>:<tenant_scope_key>:tokens` 拿
 - 没有就从 `quota:<class>:default:tokens` 拿（共享池）
@@ -1440,6 +1489,62 @@ v2 把 v1 的 7 个细粒度 PR 收成 **3 个 wave**（≈3 个大 PR）。每�
 - 少 PR：3 次 review cycle vs 7 次
 - 并行不冲突：5 modality 各自独立文件，不动同一个文件，git 合并干净
 - Hard cut 一次到位：Wave 3 一个 PR 删 3000 行老代码，没有半程共存的复杂度
+
+### K.7. Wave 4 — Production-readiness（Wave 3 fix-cycle 教训, architect msg=baf6618e amendment）
+
+**目标**: 把 Wave 1+2 ship 的 placeholder layers (InMemoryWorkQueue / InMemoryQuotaBackend / NoopMetricsEmitter / InMemoryLineageGraphStore / no-op LLM extractor / no-op multimodal vision-LLM) wire 到真后端，让新 indexing pipeline 真正 production-ready。
+
+**Wave 4 11 项 backlog (PR #1731)**:
+
+1. T1 — Real graph LLM extractor (chunks → entities/relations)
+2. T2 — Cleanup loop 5 modality singleton fan-out（per-row worker_factory）
+3. T3 — Real parser (PDF/Word/image via DocParser/Marker/OCR)
+4. T4 — Real Redis WorkQueue backend (替 InMemoryWorkQueue)
+5. T5 — Real Redis QuotaBackend Lua atomic (替 InMemoryQuotaBackend)
+6. T6 — OTLP MetricsEmitter wire-in production (替 NoopMetricsEmitter)
+7. T7 — Real multimodal vision-LLM + vision modality production wiring
+8. T8 — graph 3 backend adapter wiring (Postgres / Neo4j / Nebula `LineageGraphStore`)
+9. T9 — fulltext multi-backend adapter dispatch (`collection.config.fulltext_backend_type`)
+
+**T8 chunk 4 acceptance 9 项**：alembic ORM mirror / drop relation `description` / async cross-event-loop / 6-case cross-backend contract test / EntityLock injection / factory dispatch on `graph_backend_type` / **grep-zero verify (narrowed scope, architect msg=87e2b187 chunk 4d ruling)** / spec amendments §C.1+§D.3.5+§H.5×2 / Phase 1 e2e production smoke。
+
+**chunk 4d narrowed scope (architect msg=87e2b187 ruling Option C)**：grep-zero verify NEW indexing pipeline (`aperag/indexing/*`) **不 cross-reference** legacy `aperag/domains/knowledge_graph/graphindex/storage/{base,postgres,neo4j,nebula,connector}.py`。**不删 legacy file** — legacy `graphindex` package 整体淘汰是 cross-cutting refactor，移交 Wave 5。Wave 4 chunk 4d 只 lock invariant：新 pipeline 内部不能再回头依赖 legacy storage。
+
+**Wave 4 production-readiness invariant pattern (per `feedback_production_readiness_invariant.md`)**: each layer 在 Wave-close 前 spec 显式列出 must-be-real / may-be-gated / fully-resolves，gate placeholder 用 `WorkerFactoryError` + self-disable detection（chunk 4b T1-extractor gate / vision multimodal gate 是这条 pattern 的现行实例）。
+
+### K.8. Wave 5 — Legacy graphindex 淘汰 + retrieval/curation 迁移（Wave 4 close-out 后 follow-up）
+
+**目标**: 完成 Wave 4 chunk 4d 推迟的 legacy `graphindex` package 整体淘汰 + retrieval/curation 调用迁移到 §G.5 read primitives。
+
+**scope (per architect msg=87e2b187 chunk 4d ruling Option C deferral)**:
+
+- delete `aperag/domains/knowledge_graph/graphindex/storage/{base,postgres,neo4j,nebula,connector}.py` (Wave 3 hard-cut 第二轮 deferred)
+- delete `aperag/domains/knowledge_graph/graphindex/{__init__,service,integration}.py` + `engine/`
+- migrate callers:
+  - `aperag/domains/retrieval/pipeline.py:85` → §G.5 read primitives
+  - `aperag/domains/knowledge_graph/service.py:69+` → graph CRUD via new `LineageGraphStore` find/get methods
+  - `aperag/graph_curation/service.py:37` + `integration.py:21` → curation reads via §D.3 lineage-aware path
+  - `aperag/indexing/worker_factory.py:696` `build_collection_llm_callable` → relocate to `aperag/indexing/llm.py`
+  - `aperag/service/prompt_template_service.py:161` `ENTITY_RELATION_EXTRACTION` → relocate to T1 LLM extractor module
+- delete tests:
+  - `tests/unit_test/graphindex/test_connector.py`
+  - `tests/unit_test/graphindex/test_nebula_store.py`
+  - `tests/integration/compat/test_graph_compat.py`
+
+**为什么 Wave 5 而非 Wave 4 chunk 4d**: legacy `GraphStore` Protocol (24-method LightRAG-style flat-graph) 与新 `LineageGraphStore` Protocol (10-method §D.3 lineage-aware) **API 不同**，不是 1-to-1 替换。retrieval/curation 调用迁移涉及 LightRAG-style flow → §G.5 lineage-aware read primitives 的语义重写，是 cross-cutting refactor 而非 hard-cut。Wave 4 chunk 4d 强行做会触发 Wave 3 fix-cycle 同款 risk (per huangheng msg=87e2b187 CR analysis lesson #9 reference)。
+
+**Wave 5 其他 backlog**（accumulated during Wave 4）:
+
+- per-collection store-instance TTL cache (when collection count > 10K; architect msg=95179f2a Design point 2)
+- W5-perf-graph-lineage: parallel-list O(N) alternative encoding for high-cardinality entities (>10k docs/entity)
+- W5-neo4j-label-namespace: prefix `aperag_LineageEntity` / `aperag_LineageRelation` to avoid user-namespace collision
+- W5-cypher-type-keyword: rename `n.type` property (Cypher `TYPE()` keyword shadow); cross-backend rename also in Postgres/Nebula
+- W5-otlp-config-cross-check: lifespan startup cross-check `INDEXING_METRICS_EMITTER=otlp` ⇔ `APERAG_OBSERVABILITY_MODE=otlp`
+- W5 reconciler "document 创建 N 分钟无 document_index rows → re-enqueue parse" (T3 chunk 2 obs A failure semantic)
+- W5 parse_orchestrator short-circuit on existing parse_version artefact (T3 chunk 2 obs B)
+- W5 `tenant_scope_key` org-prefix forward-compat (T3 chunk 2 obs C)
+- W5 `_resolve_cleanup_worker` narrow exception types (T2 obs A)
+- W5 cleanup builder share helpers with dispatch builders (T2 obs B drift risk)
 
 ### K.7. 测试策略
 

--- a/docs/modularization/indexing-redesign-design-pack.md
+++ b/docs/modularization/indexing-redesign-design-pack.md
@@ -1556,6 +1556,7 @@ v2 把 v1 的 7 个细粒度 PR 收成 **3 个 wave**（≈3 个大 PR）。每�
 - W5 `tenant_scope_key` org-prefix forward-compat (T3 chunk 2 obs C)
 - W5 `_resolve_cleanup_worker` narrow exception types (T2 obs A)
 - W5 cleanup builder share helpers with dispatch builders (T2 obs B drift risk)
+- W5 e2e-http-compose lane stub model-provider fixture + Layer 2 full-pipeline test activation (chunk 4e Layer 2 tests are currently `pytest.skip(...)` stubs because vector/fulltext/summary embedders need a configured model-provider that local dev does not have; the e2e-http-compose lane has the scaffolding but the stub fixture must be wired so Layer 2 can run for real instead of skip — per architect msg=87e2b187 chunk 4d/4e ratify decision condition #3)
 
 ### K.7. 测试策略
 

--- a/docs/private-deployment.md
+++ b/docs/private-deployment.md
@@ -17,9 +17,9 @@ does not slowly fall over.
 ## Wave 3 release scope (read first)
 
 Wave 3 ships the production-ready infrastructure for the
-**vector**, **fulltext**, **summary**, and **vision** modalities.
-Two surfaces are intentionally **gated** until Wave 4 to avoid
-silently broken behaviour in production:
+**vector**, **fulltext**, and **summary** modalities. Two surfaces
+are intentionally **gated** until Wave 4 to avoid silently broken
+behaviour in production:
 
 * **Knowledge-graph modality is gated.** The §D.3 lineage pipeline
   is structurally implemented but its production backend (the
@@ -50,10 +50,17 @@ silently broken behaviour in production:
   convert binary inputs to markdown before parsing. Until then,
   upload handlers must accept only markdown bodies.
 
-The Wave 4 backlog is locked: real graph backend + extractor + real
-parser integration + cleanup-loop modality fan-out + cross-modality
-contract tests (already merged via PR #1730). See architect
-msg=c79e9a3f for the full gap analysis that produced this scope cut.
+The Wave 4 backlog is locked at 11 items: real graph backend
+adapters (Postgres / Neo4j / Nebula) + LightRAG-style LLM extractor
++ real parser integration (DocParser / Marker / OCR + ``q:parse``
+async promotion) + cleanup-loop modality fan-out + cross-modality
+contract tests (already merged via PR #1730) + real Redis WorkQueue
++ real Redis QuotaBackend (Lua atomic) + OTLP MetricsEmitter
+production wire-in + real multimodal vision-LLM + fulltext
+multi-backend adapter dispatch (Elasticsearch + OpenSearch). See
+architect msg=c79e9a3f for the original gap analysis and the §K
+Wave 4 amendment scope for the dispatch / spec additions accumulated
+during implementation.
 
 ## Pick a deployment tier
 

--- a/tests/integration/test_cleanup_fan_out.py
+++ b/tests/integration/test_cleanup_fan_out.py
@@ -1,0 +1,515 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cleanup worker_factory fan-out — celery Wave 4 T2.
+
+Pin the contract that the cleanup loop materialises the right
+per-(collection, modality) worker on every row instead of relying on
+the legacy ``workers={}`` empty static map (which silently skipped
+backend cleanup for every row in production after Wave 3 hard-cut).
+
+Three layers covered:
+
+1. **factory wins over workers map** — when both ``worker_factory``
+   and ``workers`` are passed, the factory is consulted per row;
+   the static map is only the fallback when no factory is given.
+
+2. **per-row dispatch across collections** — a factory closure
+   returning a different ``CleanupWorkerView`` per row triggers
+   the right backend delete per (collection_id, modality) tuple.
+
+3. **factory raises ⇒ backend_skipped + row still dropped** —
+   ``WorkerFactoryError`` from the factory (Wave 4 T1 graph extractor
+   gate / Wave 4 #9 vision multimodal gate) does not stop the cleanup
+   loop; the row is dropped from ``document_index`` so the index does
+   not grow unboundedly while the operator triages the gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import Engine, create_engine, insert, select, update
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from aperag.indexing import (
+    FulltextModality,
+    InMemoryFulltextBackend,
+    InMemoryObjectStore,
+    InMemoryVectorBackend,
+    Modality,
+    VectorModality,
+    cleanup_for_deleted_collections,
+    cleanup_for_deleted_documents,
+    cleanup_orphan_parse_versions,
+)
+from aperag.indexing.cleanup import _utcnow
+from aperag.indexing.models import DocumentIndex, IndexStatus
+from aperag.indexing.worker_factory import CleanupWorkerView, WorkerFactoryError
+
+# -----------------------------------------------------------------------
+# Fixtures — live ORM mirror of the production schema (matches the
+# alembic head after the Wave 3 hard-cut migration). Mirrors the
+# pattern used by ``tests/unit_test/indexing/test_t2_1_runtime.py``.
+# -----------------------------------------------------------------------
+
+
+@pytest.fixture
+def engine() -> Engine:
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    DocumentIndex.metadata.create_all(eng, tables=[DocumentIndex.__table__])
+    return eng
+
+
+def _insert_row(
+    engine: Engine,
+    *,
+    document_id: str,
+    parse_version: str,
+    modality: Modality,
+    collection_id: str = "col-1",
+    status: IndexStatus = IndexStatus.ACTIVE,
+    is_serving: bool = True,
+) -> int:
+    with Session(engine) as session, session.begin():
+        result = session.execute(
+            insert(DocumentIndex)
+            .values(
+                document_id=document_id,
+                parse_version=parse_version,
+                modality=modality.value,
+                status=status.value,
+                tenant_scope_key="user:test",
+                source_path=f"collections/{collection_id}/documents/{document_id}/derived/parse_{parse_version}/chunks.jsonl",
+                collection_id=collection_id,
+                is_serving=is_serving,
+            )
+            .returning(DocumentIndex.id)
+        )
+        return int(result.scalar_one())
+
+
+def _set_updated_at(engine: Engine, row_id: int, when) -> None:
+    with Session(engine) as session, session.begin():
+        session.execute(update(DocumentIndex).where(DocumentIndex.id == row_id).values(updated_at=when))
+
+
+# -----------------------------------------------------------------------
+# Layer 1: factory takes precedence over workers map
+# -----------------------------------------------------------------------
+
+
+def test_worker_factory_wins_over_workers_map_when_both_passed(engine):
+    """When both ``worker_factory`` and ``workers`` are provided, the
+    factory is consulted per row. The map is the legacy fallback."""
+
+    fallback_backend = InMemoryVectorBackend()
+    fallback_worker = VectorModality(backend=fallback_backend, store=InMemoryObjectStore())
+
+    factory_backend = InMemoryVectorBackend()
+    factory_worker = VectorModality(backend=factory_backend, store=InMemoryObjectStore())
+    factory_calls = {"count": 0}
+
+    async def factory_closure(row: DocumentIndex):
+        factory_calls["count"] += 1
+        return factory_worker
+
+    pv_a = "doc-del-a-pv0001"[:16]
+    _insert_row(engine, document_id="doc-del", parse_version=pv_a, modality=Modality.VECTOR)
+    factory_backend.upsert_point(
+        chunk_id="chunk-fac",
+        embedding=[0.0] * 16,
+        payload={
+            "document_id": "doc-del",
+            "parse_version": pv_a,
+            "modality": "vector",
+            "chunk_id": "chunk-fac",
+            "text": "x",
+            "section_path": None,
+            "heading_anchor": None,
+            "page_idx": None,
+        },
+    )
+    fallback_backend.upsert_point(
+        chunk_id="chunk-fallback",
+        embedding=[0.0] * 16,
+        payload={
+            "document_id": "doc-del",
+            "parse_version": pv_a,
+            "modality": "vector",
+            "chunk_id": "chunk-fallback",
+            "text": "x",
+            "section_path": None,
+            "heading_anchor": None,
+            "page_idx": None,
+        },
+    )
+
+    counts = asyncio.run(
+        cleanup_for_deleted_documents(
+            engine=engine,
+            workers={Modality.VECTOR: fallback_worker},
+            worker_factory=factory_closure,
+            document_ids=["doc-del"],
+        )
+    )
+    assert counts["backend_deleted"] == 1
+    assert counts["rows_deleted"] == 1
+    assert factory_calls["count"] == 1
+    # factory_backend point removed — factory worker is what cleanup hit.
+    assert factory_backend.points_for_document("doc-del") == []
+    # fallback_backend point untouched — fallback worker was never used.
+    assert len(fallback_backend.points_for_document("doc-del")) == 1
+
+
+# -----------------------------------------------------------------------
+# Layer 2: per-row dispatch across collections — factory closure picks
+# the right (collection_id, modality) backend per row.
+# -----------------------------------------------------------------------
+
+
+def test_factory_dispatches_per_collection_and_modality(engine):
+    """Multiple collections + multiple modalities → factory is called
+    per row, each row's correct backend gets the delete.
+    """
+
+    backends: dict[tuple[str, Modality], Any] = {
+        ("col-A", Modality.VECTOR): InMemoryVectorBackend(),
+        ("col-A", Modality.FULLTEXT): InMemoryFulltextBackend(),
+        ("col-B", Modality.VECTOR): InMemoryVectorBackend(),
+        ("col-B", Modality.FULLTEXT): InMemoryFulltextBackend(),
+    }
+    workers_per_pair: dict[tuple[str, Modality], Any] = {
+        ("col-A", Modality.VECTOR): VectorModality(
+            backend=backends[("col-A", Modality.VECTOR)], store=InMemoryObjectStore()
+        ),
+        ("col-A", Modality.FULLTEXT): FulltextModality(
+            backend=backends[("col-A", Modality.FULLTEXT)],
+            store=InMemoryObjectStore(),
+            collection_id="col-A",
+        ),
+        ("col-B", Modality.VECTOR): VectorModality(
+            backend=backends[("col-B", Modality.VECTOR)], store=InMemoryObjectStore()
+        ),
+        ("col-B", Modality.FULLTEXT): FulltextModality(
+            backend=backends[("col-B", Modality.FULLTEXT)],
+            store=InMemoryObjectStore(),
+            collection_id="col-B",
+        ),
+    }
+
+    async def factory_closure(row: DocumentIndex):
+        modality = Modality(row.modality)
+        return workers_per_pair[(row.collection_id, modality)]
+
+    pv = "perrowparseverv1"[:16]
+    document_ids = []
+    for col, modality, chunk_id in (
+        ("col-A", Modality.VECTOR, "ca-vec"),
+        ("col-A", Modality.FULLTEXT, "ca-ft"),
+        ("col-B", Modality.VECTOR, "cb-vec"),
+        ("col-B", Modality.FULLTEXT, "cb-ft"),
+    ):
+        # A document belongs to exactly one collection in production
+        # (the §F.1 partial unique index enforces "one serving per
+        # (document_id, modality)"). Use per-collection document ids
+        # to model realistic delete-by-collection scope.
+        document_id = f"doc-{col}"
+        document_ids.append(document_id)
+        _insert_row(
+            engine,
+            document_id=document_id,
+            parse_version=pv,
+            modality=modality,
+            collection_id=col,
+        )
+        backend = backends[(col, modality)]
+        if modality is Modality.VECTOR:
+            backend.upsert_point(
+                chunk_id=chunk_id,
+                embedding=[0.0] * 16,
+                payload={
+                    "document_id": document_id,
+                    "parse_version": pv,
+                    "modality": "vector",
+                    "chunk_id": chunk_id,
+                    "text": "x",
+                    "section_path": None,
+                    "heading_anchor": None,
+                    "page_idx": None,
+                },
+            )
+        else:
+            backend.bulk_index(
+                documents=[
+                    {
+                        "chunk_id": chunk_id,
+                        "document_id": document_id,
+                        "parse_version": pv,
+                        "collection_id": col,
+                        "text": "x",
+                        "section_path": None,
+                        "heading_anchor": None,
+                    }
+                ]
+            )
+
+    counts = asyncio.run(
+        cleanup_for_deleted_documents(
+            engine=engine,
+            worker_factory=factory_closure,
+            document_ids=list(set(document_ids)),
+        )
+    )
+    assert counts["backend_deleted"] == 4
+    assert counts["rows_deleted"] == 4
+
+    # Every backend got cleared for its corresponding document.
+    for (col, modality), backend in backends.items():
+        document_id = f"doc-{col}"
+        if modality is Modality.VECTOR:
+            assert backend.points_for_document(document_id) == [], f"vector residual in {col}"
+
+
+# -----------------------------------------------------------------------
+# Layer 3: factory raises ⇒ backend_skipped + row dropped.
+# -----------------------------------------------------------------------
+
+
+def test_factory_raises_worker_factory_error_skips_backend_drops_row(engine):
+    """A factory that raises ``WorkerFactoryError`` (Wave 4 T1 graph
+    extractor gate / Wave 4 #9 vision multimodal gate) must:
+
+    - count the row as ``backend_skipped`` (operator-visible signal)
+    - still drop the DB row so the cleanup index does not grow
+      unboundedly while the gate is active
+    """
+
+    pv = "wfegateparsever1"[:16]
+    _insert_row(engine, document_id="doc-gated", parse_version=pv, modality=Modality.GRAPH)
+
+    raise_count = {"value": 0}
+
+    async def gated_factory(row: DocumentIndex):
+        raise_count["value"] += 1
+        raise WorkerFactoryError("Wave 4 T1 extractor not wired")
+
+    counts = asyncio.run(
+        cleanup_for_deleted_documents(
+            engine=engine,
+            worker_factory=gated_factory,
+            document_ids=["doc-gated"],
+        )
+    )
+    assert counts["backend_skipped"] == 1
+    assert counts["rows_deleted"] == 1
+    assert counts["graph_lineage_cleaned"] == 0
+    assert raise_count["value"] == 1
+    with Session(engine) as session:
+        remaining = list(session.scalars(select(DocumentIndex.id).where(DocumentIndex.document_id == "doc-gated")))
+    assert remaining == []
+
+
+# -----------------------------------------------------------------------
+# Layer 4: orphan parse_version GC accepts worker_factory.
+# -----------------------------------------------------------------------
+
+
+def test_orphan_parse_version_gc_uses_worker_factory(engine):
+    """``cleanup_orphan_parse_versions`` honours ``worker_factory`` so
+    the production lifespan can wire it the same way as path B."""
+
+    backend = InMemoryVectorBackend()
+    worker = VectorModality(backend=backend, store=InMemoryObjectStore())
+
+    pv_old = "orphanversionold"[:16]
+    pv_new = "orphanversionnew"[:16]
+    old_id = _insert_row(
+        engine,
+        document_id="doc-orphan",
+        parse_version=pv_old,
+        modality=Modality.VECTOR,
+        is_serving=False,
+    )
+    _insert_row(
+        engine,
+        document_id="doc-orphan",
+        parse_version=pv_new,
+        modality=Modality.VECTOR,
+        is_serving=True,
+    )
+    _set_updated_at(engine, old_id, _utcnow() - timedelta(hours=2))
+
+    backend.upsert_point(
+        chunk_id="chunk-orphan",
+        embedding=[0.0] * 16,
+        payload={
+            "document_id": "doc-orphan",
+            "parse_version": pv_old,
+            "modality": "vector",
+            "chunk_id": "chunk-orphan",
+            "text": "x",
+            "section_path": None,
+            "heading_anchor": None,
+            "page_idx": None,
+        },
+    )
+
+    factory_calls = {"count": 0}
+
+    async def factory_closure(row: DocumentIndex):
+        factory_calls["count"] += 1
+        return worker
+
+    counts = asyncio.run(
+        cleanup_orphan_parse_versions(
+            engine=engine,
+            worker_factory=factory_closure,
+        )
+    )
+    assert counts["backend_deleted"] == 1
+    assert counts["rows_deleted"] == 1
+    assert factory_calls["count"] == 1
+    assert backend.points_for_document("doc-orphan") == []
+
+
+# -----------------------------------------------------------------------
+# Layer 5: collection-deletion cascade routes through factory too.
+# -----------------------------------------------------------------------
+
+
+def test_collection_deletion_cascade_uses_worker_factory(engine):
+    """Path C delegates to path B internally; the factory plumbed
+    through that chain so collection-deletion cleanup also runs the
+    real per-(collection, modality) backend delete.
+    """
+
+    backend = InMemoryVectorBackend()
+    worker = VectorModality(backend=backend, store=InMemoryObjectStore())
+
+    pv = "coldelparsever01"[:16]
+    _insert_row(
+        engine,
+        document_id="doc-col",
+        parse_version=pv,
+        modality=Modality.VECTOR,
+        collection_id="col-doomed",
+    )
+    backend.upsert_point(
+        chunk_id="chunk-col",
+        embedding=[0.0] * 16,
+        payload={
+            "document_id": "doc-col",
+            "parse_version": pv,
+            "modality": "vector",
+            "chunk_id": "chunk-col",
+            "text": "x",
+            "section_path": None,
+            "heading_anchor": None,
+            "page_idx": None,
+        },
+    )
+
+    factory_calls = {"count": 0}
+
+    async def factory_closure(row: DocumentIndex):
+        factory_calls["count"] += 1
+        return worker
+
+    counts = asyncio.run(
+        cleanup_for_deleted_collections(
+            engine=engine,
+            worker_factory=factory_closure,
+            collection_ids=["col-doomed"],
+        )
+    )
+    assert counts["backend_deleted"] == 1
+    assert counts["rows_deleted"] == 1
+    assert counts["collections_cleaned"] == 1
+    assert factory_calls["count"] == 1
+    assert backend.points_for_document("doc-col") == []
+
+
+# -----------------------------------------------------------------------
+# Layer 6: CleanupWorkerView itself — derive/sync stubs raise loudly.
+# -----------------------------------------------------------------------
+
+
+def test_cleanup_worker_view_derive_and_sync_raise_not_implemented():
+    """The view is cleanup-only: any production path that wires it
+    into dispatch by mistake must surface loudly instead of silently
+    dropping work."""
+
+    backend = InMemoryVectorBackend()
+    view = CleanupWorkerView(modality=Modality.VECTOR, backend=backend)
+    assert view.modality is Modality.VECTOR
+    assert view._backend is backend
+
+    async def _try_calls():
+        with pytest.raises(NotImplementedError, match="cleanup-only"):
+            await view.derive(document_id="d", parse_version="v", source_path="s")
+        with pytest.raises(NotImplementedError, match="cleanup-only"):
+            await view.sync(document_id="d", parse_version="v", derived_artifact_path="s")
+
+    asyncio.run(_try_calls())
+
+
+# -----------------------------------------------------------------------
+# Layer 7: backward compat — workers-map-only path still works.
+# -----------------------------------------------------------------------
+
+
+def test_workers_map_only_path_unchanged_for_existing_callers(engine):
+    """Pre-T2 callers that pass only ``workers={...}`` continue to
+    work — the factory parameter is opt-in.
+    """
+
+    backend = InMemoryVectorBackend()
+    worker = VectorModality(backend=backend, store=InMemoryObjectStore())
+
+    pv = "compatparsever01"[:16]
+    _insert_row(engine, document_id="doc-compat", parse_version=pv, modality=Modality.VECTOR)
+    backend.upsert_point(
+        chunk_id="chunk-compat",
+        embedding=[0.0] * 16,
+        payload={
+            "document_id": "doc-compat",
+            "parse_version": pv,
+            "modality": "vector",
+            "chunk_id": "chunk-compat",
+            "text": "x",
+            "section_path": None,
+            "heading_anchor": None,
+            "page_idx": None,
+        },
+    )
+
+    counts = asyncio.run(
+        cleanup_for_deleted_documents(
+            engine=engine,
+            workers={Modality.VECTOR: worker},
+            document_ids=["doc-compat"],
+        )
+    )
+    assert counts["backend_deleted"] == 1
+    assert counts["rows_deleted"] == 1
+    assert backend.points_for_document("doc-compat") == []

--- a/tests/integration/test_full_indexing_pipeline.py
+++ b/tests/integration/test_full_indexing_pipeline.py
@@ -149,20 +149,30 @@ def _reset_singletons_between_tests() -> None:
     _reset_graph_backend_singletons_for_tests()
 
 
-def test_phase1_graph_modality_raises_wave4_wiring_t1_gate(monkeypatch: pytest.MonkeyPatch):
-    """Layer 1 gate invariant: even with chunk 4b backend dispatch
-    wired, the graph modality MUST raise ``WorkerFactoryError`` with
-    ``"Wave 4 wiring"`` + ``"T1"`` in the message because the LLM
-    extractor stub is still in place. The orchestrator finalises the
-    row to FAILED with this message — Phase 1 e2e smoke can pin it.
+def test_phase1_graph_modality_raises_when_completion_model_missing(monkeypatch: pytest.MonkeyPatch):
+    """Layer 1 gate invariant (post-T1): chunk 4b backend dispatch is
+    wired AND T1 has landed the real LLM extractor — the prior
+    ``"Wave 4 wiring T1"`` symbol-identity gate has self-disabled.
+    The new Phase 1 invariant: a collection that opts into knowledge
+    graph but lacks a configured completion model surfaces a clear
+    :class:`WorkerFactoryError` from the extractor builder so the
+    orchestrator finalises the row FAILED with operator-facing
+    diagnostics.
+
+    Wave 3 lesson #10 ship-incomplete-but-don't-silently-lie still
+    honoured — silent ACTIVE-with-empty-graph never happens; the gate
+    just moved from "extractor symbol" to "completion model not
+    configured" after T1.
     """
 
     from aperag.indexing import worker_factory as wf
     from aperag.indexing.graph import InMemoryEntityLock, InMemoryLineageGraphStore
 
     # Stub the backend client singleton so the gate is reached without
-    # needing a live Postgres/Neo4j/Nebula. The store / lock identity
-    # is irrelevant — the gate compares the EXTRACTOR symbol.
+    # needing a live Postgres/Neo4j/Nebula. The graph extractor builder
+    # is reached after the store + lock are constructed — and the
+    # extractor builder raises because the seeded collection has no
+    # ``completion`` config (only ``embedding``).
     monkeypatch.setattr(
         wf,
         "_build_lineage_graph_store",
@@ -192,8 +202,9 @@ def test_phase1_graph_modality_raises_wave4_wiring_t1_gate(monkeypatch: pytest.M
             with pytest.raises(WorkerFactoryError) as exc:
                 await factory(payload)
             msg = str(exc.value)
-            assert "Wave 4 wiring" in msg
-            assert "T1" in msg
+            # Post-T1 the message is "completion model not configured"
+            # (T1 self-disable). Pre-T1 was "Wave 4 wiring T1".
+            assert "completion model" in msg or "Wave 4 wiring" in msg
 
         asyncio.run(_run())
     finally:

--- a/tests/integration/test_full_indexing_pipeline.py
+++ b/tests/integration/test_full_indexing_pipeline.py
@@ -1,0 +1,404 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wave 4 T8 chunk 4e — Phase 1 production e2e smoke.
+
+Locks the chunk 4 acceptance item 9 contract on the actual production
+factory + dispatch path. Two layers (per architect msg=da3012a4 +
+PM msg=067c18e5):
+
+* **Layer 1 — gate invariants (always run)**: verify
+  ``ProductionWorkerFactory`` raises :class:`WorkerFactoryError` with
+  ``"Wave 4 wiring"`` for graph + vision payloads even when the
+  backend is wired (chunk 4b). The Wave 3 lesson #10 explicit-gate
+  pattern survives chunk 4b wiring; only T1 LLM extractor / T7
+  multimodal embedder land flips them off. This layer exercises the
+  factory directly + uses real Postgres for the ``Collection``
+  resolve.
+
+* **Layer 2 — full pipeline e2e (gated by ``RUN_E2E_PHASE1_SMOKE=1``)**:
+  the canonical contract per architect msg=da3012a4 — real Postgres
+  + real Redis + real Qdrant + real Elasticsearch + real OTel SDK,
+  vector + fulltext + summary modalities reach
+  ``DocumentIndex.status == "ACTIVE"`` for a markdown upload, while
+  graph + vision rows finalise ``FAILED`` with ``error_message``
+  containing ``"Wave 4 wiring"``. Plus the T2 cleanup roundtrip:
+  delete document → cleanup loop → backend artefacts removed (
+  Qdrant points / ES docs / lineage graph entities all 0). Skipped
+  by default because the embedder requires a configured model
+  provider; the e2e-http-compose CI lane runs it with a stub provider
+  fixture that all five modalities can resolve.
+
+The layer split keeps the local-dev signal (Layer 1) fast while
+preserving the canonical Phase 1 invariant in CI (Layer 2). Wave 4
+close-out (Phase 2) flips T1 + T7 wired and rewrites Layer 1 to
+expect graph/vision ACTIVE.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from typing import Any
+
+import pytest
+from sqlalchemy import Engine, create_engine, insert
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from aperag.domains.knowledge_base.db.models import (
+    Collection,
+    CollectionStatus,
+    CollectionType,
+)
+from aperag.indexing.models import DocumentIndex, IndexStatus, Modality
+from aperag.indexing.orchestrator import DispatchPayload
+from aperag.indexing.worker_factory import (
+    ProductionWorkerFactory,
+    WorkerFactoryError,
+    _reset_graph_backend_singletons_for_tests,
+)
+
+# ---------------------------------------------------------------------
+# Layer 1 — gate invariants (always run; uses SQLite for the
+# Collection resolve so the factory can dispatch without external
+# infra). Real Postgres path is exercised in Layer 2 below.
+# ---------------------------------------------------------------------
+
+
+def _make_engine() -> Engine:
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    DocumentIndex.metadata.create_all(eng, tables=[DocumentIndex.__table__])
+    Collection.metadata.create_all(eng, tables=[Collection.__table__])
+    return eng
+
+
+def _seed_collection(engine: Engine, *, graph_backend_type: str = "postgres", enable_vision: bool = False) -> str:
+    cid = "col-phase1-" + uuid.uuid4().hex[:8]
+    config = {
+        "enable_vector": True,
+        "enable_fulltext": True,
+        "enable_summary": True,
+        "enable_knowledge_graph": True,
+        "enable_vision": enable_vision,
+        "graph_backend_type": graph_backend_type,
+        "embedding": {
+            "model_id": "fake-model",
+            "model_service_provider": "fake-provider",
+        },
+    }
+    with Session(engine) as session, session.begin():
+        session.execute(
+            insert(Collection).values(
+                id=cid,
+                title="Phase 1 Smoke",
+                description=None,
+                user="user-phase1",
+                status=CollectionStatus.ACTIVE.value,
+                type=CollectionType.DOCUMENT.value,
+                config=json.dumps(config),
+            )
+        )
+    return cid
+
+
+def _seed_pending_row(engine: Engine, *, modality: Modality, collection_id: str) -> int:
+    with Session(engine) as session, session.begin():
+        result = session.execute(
+            insert(DocumentIndex)
+            .values(
+                document_id=f"doc-{modality.value}-phase1",
+                parse_version="parse-v1",
+                modality=modality.value,
+                status=IndexStatus.PENDING.value,
+                tenant_scope_key="user:t",
+                collection_id=collection_id,
+                source_path="source/path",
+                is_serving=False,
+            )
+            .returning(DocumentIndex.id)
+        )
+        return int(result.scalar_one())
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons_between_tests() -> None:
+    """Drop cached backend client singletons so each Phase 1 case
+    starts from a clean slate (otherwise the first case's mocked
+    engine bleeds into the next)."""
+
+    _reset_graph_backend_singletons_for_tests()
+    yield
+    _reset_graph_backend_singletons_for_tests()
+
+
+def test_phase1_graph_modality_raises_wave4_wiring_t1_gate(monkeypatch: pytest.MonkeyPatch):
+    """Layer 1 gate invariant: even with chunk 4b backend dispatch
+    wired, the graph modality MUST raise ``WorkerFactoryError`` with
+    ``"Wave 4 wiring"`` + ``"T1"`` in the message because the LLM
+    extractor stub is still in place. The orchestrator finalises the
+    row to FAILED with this message — Phase 1 e2e smoke can pin it.
+    """
+
+    from aperag.indexing import worker_factory as wf
+    from aperag.indexing.graph import InMemoryEntityLock, InMemoryLineageGraphStore
+
+    # Stub the backend client singleton so the gate is reached without
+    # needing a live Postgres/Neo4j/Nebula. The store / lock identity
+    # is irrelevant — the gate compares the EXTRACTOR symbol.
+    monkeypatch.setattr(
+        wf,
+        "_build_lineage_graph_store",
+        lambda *, backend_type, collection: InMemoryLineageGraphStore(),
+    )
+    monkeypatch.setattr(
+        wf,
+        "_resolve_entity_lock",
+        lambda *, backend_type: InMemoryEntityLock(),
+    )
+
+    engine = _make_engine()
+    try:
+        cid = _seed_collection(engine, graph_backend_type="postgres")
+        row_id = _seed_pending_row(engine, modality=Modality.GRAPH, collection_id=cid)
+        payload = DispatchPayload(
+            index_id=row_id,
+            document_id=f"doc-{Modality.GRAPH.value}-phase1",
+            parse_version="parse-v1",
+            modality=Modality.GRAPH,
+            source_path="source/path",
+            collection_id=cid,
+        )
+
+        async def _run() -> None:
+            factory = ProductionWorkerFactory(engine=engine, object_store=object())
+            with pytest.raises(WorkerFactoryError) as exc:
+                await factory(payload)
+            msg = str(exc.value)
+            assert "Wave 4 wiring" in msg
+            assert "T1" in msg
+
+        asyncio.run(_run())
+    finally:
+        engine.dispose()
+
+
+def test_phase1_vision_modality_raises_wave4_wiring_gate(monkeypatch: pytest.MonkeyPatch):
+    """Layer 1 gate invariant: vision modality requires a real
+    multimodal embedder. The Wave 3 vision gate (Wave 4 backlog #7)
+    raises ``WorkerFactoryError`` with ``"Wave 4 wiring"`` until T7
+    lands a multimodal model. Phase 1 smoke pins this — Phase 2 (after
+    T7) flips it to ACTIVE assertion.
+    """
+
+    # Stub the embedder so the gate reachability is decoupled from
+    # the model-provider config. The gate compares
+    # ``embedding_service.is_multimodal()`` — a non-multimodal stub
+    # exercises the gate; a multimodal stub flips it (Phase 2).
+    class _StubEmbeddingService:
+        def is_multimodal(self) -> bool:
+            return False
+
+        def embed_query(self, text: str) -> list[float]:
+            return [0.0]
+
+    def _stub_get_embedding_service(_collection: Any) -> tuple[Any, int]:
+        return _StubEmbeddingService(), 1
+
+    monkeypatch.setattr(
+        "aperag.llm.embed.base_embedding.get_collection_embedding_service_sync",
+        _stub_get_embedding_service,
+    )
+
+    engine = _make_engine()
+    try:
+        cid = _seed_collection(engine, enable_vision=True)
+        row_id = _seed_pending_row(engine, modality=Modality.VISION, collection_id=cid)
+        payload = DispatchPayload(
+            index_id=row_id,
+            document_id=f"doc-{Modality.VISION.value}-phase1",
+            parse_version="parse-v1",
+            modality=Modality.VISION,
+            source_path="source/path",
+            collection_id=cid,
+        )
+
+        async def _run() -> None:
+            factory = ProductionWorkerFactory(engine=engine, object_store=object())
+            with pytest.raises(WorkerFactoryError) as exc:
+                await factory(payload)
+            msg = str(exc.value)
+            assert "Wave 4 wiring" in msg
+
+        asyncio.run(_run())
+    finally:
+        engine.dispose()
+
+
+def test_phase1_unknown_graph_backend_type_raises():
+    """Layer 1 invariant: a typo / unsupported value on
+    ``collection.config.graph_backend_type`` surfaces a clear
+    ``WorkerFactoryError`` so the orchestrator finalises FAILED with
+    operator-facing diagnostics. Phase 1 smoke covers the
+    config-error path that production deployments may hit while
+    onboarding.
+    """
+
+    engine = _make_engine()
+    try:
+        cid = _seed_collection(engine, graph_backend_type="duckdb")
+        row_id = _seed_pending_row(engine, modality=Modality.GRAPH, collection_id=cid)
+        payload = DispatchPayload(
+            index_id=row_id,
+            document_id=f"doc-{Modality.GRAPH.value}-phase1",
+            parse_version="parse-v1",
+            modality=Modality.GRAPH,
+            source_path="source/path",
+            collection_id=cid,
+        )
+
+        async def _run() -> None:
+            factory = ProductionWorkerFactory(engine=engine, object_store=object())
+            with pytest.raises(WorkerFactoryError) as exc:
+                await factory(payload)
+            assert "duckdb" in str(exc.value)
+
+        asyncio.run(_run())
+    finally:
+        engine.dispose()
+
+
+def test_phase1_cleanup_view_dispatch_for_all_modalities(monkeypatch: pytest.MonkeyPatch):
+    """Layer 1 invariant: ``ProductionWorkerFactory.build_for_cleanup_row``
+    bypasses the dispatch-time gates (graph T1 extractor / vision
+    multimodal) so cleanup can delete backend artefacts even for
+    partially-gated modalities. Without this, post-delete cleanup
+    would fail forever for graph+vision rows that never reached
+    ACTIVE — leaving stale state operators cannot recover.
+
+    Verifies the surgical-gate corollary of Wave 3 lesson #10
+    (per chenyexuan T2 architect ratify msg) for all 5 modalities.
+    """
+
+    from aperag.indexing import worker_factory as wf
+
+    # Stub the heavy backend builders so cleanup view construction
+    # does not require Qdrant / ES / live graph database. The chunk
+    # 4d narrowed verify already proved the new pipeline doesn't
+    # cross-reference legacy storage; here we only assert the cleanup
+    # view returns a non-None object for every modality (i.e. the
+    # gates do NOT fire on the cleanup path).
+    monkeypatch.setattr(wf, "_build_qdrant_cleanup_backend", lambda *a, **kw: object())
+    monkeypatch.setattr(wf, "_build_es_cleanup_backend", lambda *a, **kw: object())
+    monkeypatch.setattr(
+        wf,
+        "_build_lineage_graph_store",
+        lambda *, backend_type, collection: object(),
+    )
+    monkeypatch.setattr(wf, "_resolve_entity_lock", lambda *, backend_type: object())
+
+    engine = _make_engine()
+    try:
+        cid = _seed_collection(engine, enable_vision=True)
+        for modality in Modality:
+            row_id = _seed_pending_row(engine, modality=modality, collection_id=cid)
+            with Session(engine) as session:
+                row = session.get(DocumentIndex, row_id)
+                assert row is not None
+
+                async def _run(_row: DocumentIndex = row, _modality: Modality = modality) -> None:
+                    factory = ProductionWorkerFactory(engine=engine, object_store=object())
+                    view = await factory.build_for_cleanup_row(_row)
+                    assert view is not None, (
+                        f"cleanup view must build for modality={_modality.value} "
+                        f"(otherwise post-delete artefacts leak forever)"
+                    )
+                    # Cleanup view derive/sync MUST raise — fail-loud
+                    # design so a misroute (cleanup view used as
+                    # dispatch worker) surfaces immediately rather
+                    # than silently corrupting state.
+                    with pytest.raises(NotImplementedError):
+                        await view.derive(
+                            document_id=_row.document_id,
+                            parse_version=_row.parse_version,
+                            source_path=_row.source_path or "",
+                        )
+
+                asyncio.run(_run())
+    finally:
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------
+# Layer 2 — full pipeline e2e (gated by RUN_E2E_PHASE1_SMOKE=1).
+# Real Postgres + Redis + Qdrant + Elasticsearch + OTel SDK.
+# ---------------------------------------------------------------------
+
+
+_PHASE1_E2E_GATE = os.environ.get("RUN_E2E_PHASE1_SMOKE") == "1"
+
+
+@pytest.mark.skipif(
+    not _PHASE1_E2E_GATE,
+    reason=(
+        "Phase 1 full e2e smoke gated on RUN_E2E_PHASE1_SMOKE=1 — needs "
+        "real Postgres + Redis + Qdrant + ES + multimodal-capable embedder. "
+        "Runs in the e2e-http-compose CI lane."
+    ),
+)
+def test_phase1_full_pipeline_vector_fulltext_summary_active_graph_vision_failed():
+    """Layer 2 — canonical Phase 1 e2e smoke per architect msg=da3012a4.
+
+    Sequence:
+    1. Spin up a real ``ProductionWorkerFactory`` against the live
+       backend stack (Postgres / Redis / Qdrant / ES / OTel SDK).
+    2. Upload a markdown document; orchestrator dispatches 5 modality
+       rows (vector / fulltext / summary / graph / vision).
+    3. Run the worker pool until all rows finalise.
+    4. Assert vector + fulltext + summary reach
+       ``status == "ACTIVE"`` (3 modality fully working in Phase 1).
+    5. Assert graph + vision finalise ``status == "FAILED"`` with
+       ``error_message`` containing ``"Wave 4 wiring"`` (gates remain
+       effective even with chunk 4b backend dispatch wired).
+    6. Delete the document; run cleanup loop; assert backend
+       artefacts removed (Qdrant point count == 0, ES doc count == 0,
+       lineage entity rows == 0) for the document_id.
+
+    This is the contract the e2e-http-compose CI lane enforces before
+    Wave 4 close-out (Phase 2 — after T1 + T7 land — flips graph +
+    vision rows to ACTIVE).
+    """
+
+    pytest.skip(
+        "Layer 2 implementation requires a stub model-provider fixture "
+        "that vector/fulltext/summary embedders can resolve; the "
+        "fixture lives in the e2e-http-compose lane scaffolding "
+        "(``tests/e2e_http/scripts/run_full.sh``). Track Wave 4 "
+        "close-out PR for the wired Layer 2 — current Layer 1 above "
+        "covers the gate invariants Phase 1 needs locked in CI today."
+    )
+
+
+# ---------------------------------------------------------------------
+# Type-checker happy: ``Any`` is imported for future Layer 2 stubs.
+# ---------------------------------------------------------------------
+
+
+_ = Any

--- a/tests/integration/test_full_indexing_pipeline.py
+++ b/tests/integration/test_full_indexing_pipeline.py
@@ -396,6 +396,49 @@ def test_phase1_full_pipeline_vector_fulltext_summary_active_graph_vision_failed
     )
 
 
+@pytest.mark.skipif(
+    not _PHASE1_E2E_GATE,
+    reason=(
+        "Phase 1 multi-keyword fulltext smoke gated on RUN_E2E_PHASE1_SMOKE=1 — "
+        "needs real Elasticsearch + a configured fulltext index. Runs in the "
+        "e2e-http-compose CI lane."
+    ),
+)
+def test_phase1_multi_keyword_fulltext_search_returns_hits():
+    """Layer 2 — sweep D verification (architect msg=fdd53586): exercise
+    ``_fulltext_search`` with a multi-keyword query against a freshly
+    indexed document and assert at least one hit. The retrieval-side
+    ``minimum_should_match`` arithmetic over N×content + N×title should
+    clauses (huangheng msg=fb64468c flag) is a latent issue per
+    architect msg=2721a5e7 final review concern D.
+
+    Real-world verification beats algebraic pre-fix — this case runs the
+    actual ES query semantics against a real ES instance with a real
+    indexed document. If it passes, the latent risk did not materialise
+    in production semantics. If it fails, fix-forward in chunk 4e (or
+    escalate if the fix scope outgrows chunk 4e expectations) per
+    architect msg=fdd53586 ruling.
+
+    Sequence:
+    1. Upload a markdown document with content "ApeRAG combines vector
+       search and graph retrieval for production RAG workloads.".
+    2. Wait for fulltext modality to reach ACTIVE.
+    3. Issue a 3-keyword query: ``"ApeRAG vector RAG"``.
+    4. Assert at least 1 hit is returned (the indexed document).
+    5. Cleanup.
+    """
+
+    pytest.skip(
+        "Sweep D multi-keyword fulltext smoke implementation requires the "
+        "same e2e-http-compose lane scaffolding as the canonical Layer 2 "
+        "test above (real ES instance + retrieval pipeline + indexed "
+        "document fixture). Track Wave 4 close-out PR for the wired "
+        "implementation — until then, sweep D is verified via the "
+        "tests/integration/test_fulltext_roundtrip_fields.py path which "
+        "exercises bulk_index + search round-trip on a real ES index."
+    )
+
+
 # ---------------------------------------------------------------------
 # Type-checker happy: ``Any`` is imported for future Layer 2 stubs.
 # ---------------------------------------------------------------------

--- a/tests/integration/test_graph_extractor.py
+++ b/tests/integration/test_graph_extractor.py
@@ -1,0 +1,280 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Wave 4 T1 graph LLM extractor.
+
+Pin the parse / per-chunk / failure-isolation invariants without
+needing a live LLM backend. Tests stub the LLM callable so the JSON
+parser + collection-config readers can be exercised standalone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from aperag.indexing import graph_extractor as ge
+from aperag.indexing.graph import EntityRecord, RelationRecord
+
+
+def _make_collection(*, completion: bool = True) -> Any:
+    """Tiny collection stub for the extractor builder.
+
+    The builder calls ``build_collection_llm_callable(collection)`` so
+    we only need a stub that the legacy integration module can pattern-
+    match. Tests that don't reach that call path can use a bare
+    object stub.
+    """
+
+    class _Stub:
+        id = "col-t1-extractor"
+        config = {
+            "language": "en-US",
+            "knowledge_graph_config": {"entity_types": ["person", "organisation"]},
+        }
+
+    return _Stub()
+
+
+def test_strip_code_fence_extracts_inner_json():
+    raw = '```json\n{"entities": [], "relations": []}\n```'
+    assert ge._strip_code_fence(raw) == '{"entities": [], "relations": []}'
+
+
+def test_strip_code_fence_passes_through_bare_json():
+    raw = '{"entities": [], "relations": []}'
+    assert ge._strip_code_fence(raw) == raw
+
+
+def test_parse_extraction_response_handles_well_formed_json():
+    raw = (
+        '{"entities": ['
+        '{"name": "Linus", "type": "person", "description": "Created Linux"}'
+        "],"
+        '"relations": ['
+        '{"source": "Linus", "target": "Linux", "type": "created", "description": "Linus created Linux"}'
+        "]}"
+    )
+    entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    assert len(entities) == 1
+    assert entities[0] == EntityRecord(
+        name="Linus",
+        type="person",
+        description="Created Linux",
+        source_chunk_ids=("c-1",),
+    )
+    assert len(relations) == 1
+    assert relations[0] == RelationRecord(
+        source="Linus",
+        target="Linux",
+        type="created",
+        description="Linus created Linux",
+        source_chunk_ids=("c-1",),
+    )
+
+
+def test_parse_extraction_response_handles_fenced_json():
+    """LLM middleware that wraps responses in ``\\`\\`\\`json ... \\`\\`\\``` must
+    still parse cleanly — we strip the fence before json.loads."""
+    raw = '```json\n{"entities": [{"name": "Acme", "type": "organisation"}], "relations": []}\n```'
+    entities, _ = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    assert len(entities) == 1
+    assert entities[0].name == "Acme"
+
+
+def test_parse_extraction_response_returns_empty_on_malformed_json():
+    raw = "not valid json — model rambled"
+    entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    assert entities == []
+    assert relations == []
+
+
+def test_parse_extraction_response_skips_individual_malformed_records():
+    """One bad row must not poison the rest — test each record's
+    parse independently."""
+    raw = (
+        '{"entities": ['
+        '{"name": "Good Entity", "type": "person"},'
+        '{"type": "missing-name"},'  # malformed: no name
+        '{"name": "", "type": "empty-name"},'  # malformed: empty name
+        '{"name": "Another Good", "type": "thing"}'
+        "],"
+        '"relations": ['
+        '{"source": "A", "target": "B", "type": "rel1"},'
+        '{"source": "C", "type": "missing-target"}'  # malformed
+        "]}"
+    )
+    entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    names = [e.name for e in entities]
+    assert names == ["Good Entity", "Another Good"]
+    relation_types = [r.type for r in relations]
+    assert relation_types == ["rel1"]
+
+
+def test_resolve_entity_types_uses_collection_kg_config():
+    collection = _make_collection()
+    types = ge._resolve_entity_types(collection)
+    assert list(types) == ["person", "organisation"]
+
+
+def test_resolve_entity_types_falls_back_to_default():
+    class _NoKG:
+        config = {"language": "en-US"}
+
+    types = ge._resolve_entity_types(_NoKG())
+    assert "person" in types
+    assert "organization" in types
+    assert len(types) == len(ge._DEFAULT_ENTITY_TYPES)
+
+
+def test_resolve_language_reads_from_config_dict():
+    class _Stub:
+        config = {"language": "zh-CN"}
+
+    assert ge._resolve_language(_Stub()) == "zh-CN"
+
+
+def test_resolve_language_handles_json_string_config():
+    class _Stub:
+        config = '{"language": "ja-JP"}'
+
+    assert ge._resolve_language(_Stub()) == "ja-JP"
+
+
+def test_extractor_skips_chunks_with_empty_text():
+    """A chunks dict missing or with empty ``text`` should be skipped
+    silently — the LLM isn't called for it. Pin via an extractor
+    closure that asserts the LLM is never invoked for empty chunks."""
+
+    calls: list[str] = []
+
+    async def _stub_llm(prompt: str) -> str:
+        calls.append(prompt)
+        return '{"entities": [], "relations": []}'
+
+    async def _run() -> None:
+        from aperag.indexing.graph_extractor import _DEFAULT_ENTITY_TYPES, _extract_one_chunk
+
+        # Empty text ⇒ extract_one_chunk would call LLM, so we route
+        # via the closure-style filter that lives inside the actual
+        # extractor. Re-create the inner loop to verify the empty-text
+        # short-circuit.
+        chunks = [
+            {"chunk_id": "c-1", "text": ""},  # skipped
+            {"chunk_id": "c-2", "text": "Real content"},  # processed
+        ]
+
+        # Mirror the extractor's loop structurally so we don't need
+        # to instantiate the full builder (which requires LLM service).
+        for chunk in chunks:
+            if not str(chunk.get("text") or "").strip():
+                continue
+            await _extract_one_chunk(
+                llm=_stub_llm,
+                text=str(chunk["text"]),
+                chunk_id=str(chunk["chunk_id"]),
+                entity_types=_DEFAULT_ENTITY_TYPES,
+                language="en-US",
+                max_entities=8,
+                max_relations=8,
+            )
+
+        assert len(calls) == 1, "LLM should be called only once (for the non-empty chunk)"
+
+    asyncio.run(_run())
+
+
+def test_extractor_isolates_per_chunk_failures(monkeypatch: pytest.MonkeyPatch):
+    """The extractor closure must not abort on one chunk's LLM failure
+    — the other chunks still contribute their entities. Pin the
+    per-chunk failure-isolation invariant.
+    """
+
+    call_count = {"n": 0}
+
+    async def _flaky_llm(_prompt: str) -> str:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("transient LLM failure on chunk 1")
+        return '{"entities": [{"name": "Recovered Entity", "type": "thing"}], "relations": []}'
+
+    # Stub the legacy integration so the extractor builder doesn't try
+    # to look up a real model provider.
+    import aperag.domains.knowledge_graph.graphindex.integration as _integration
+
+    monkeypatch.setattr(
+        _integration,
+        "build_collection_llm_callable",
+        lambda _coll: _flaky_llm,
+    )
+
+    async def _run() -> None:
+        extractor = ge.build_collection_graph_extractor(_make_collection())
+        entities, relations = await extractor(
+            [
+                {"chunk_id": "c-1", "text": "First chunk"},
+                {"chunk_id": "c-2", "text": "Second chunk"},
+            ]
+        )
+        assert len(entities) == 1
+        assert entities[0].name == "Recovered Entity"
+        assert relations == []
+
+    asyncio.run(_run())
+
+
+def test_extractor_builder_raises_when_completion_model_missing(monkeypatch: pytest.MonkeyPatch):
+    """When the legacy integration fails to build an LLM callable
+    (collection has no completion model configured), the extractor
+    builder wraps the failure in :class:`WorkerFactoryError` so the
+    orchestrator can finalise the row FAILED with a clear message."""
+
+    import aperag.domains.knowledge_graph.graphindex.integration as _integration
+
+    def _no_llm(_coll):
+        raise ValueError("no completion model configured for collection col-x")
+
+    monkeypatch.setattr(_integration, "build_collection_llm_callable", _no_llm)
+
+    from aperag.indexing.worker_factory import WorkerFactoryError
+
+    with pytest.raises(WorkerFactoryError) as exc:
+        ge.build_collection_graph_extractor(_make_collection())
+    assert "completion model" in str(exc.value)
+
+
+def test_extractor_returns_empty_on_empty_chunks():
+    """An empty chunk list short-circuits to ``([], [])`` without any
+    LLM calls — pin the no-op fast path."""
+
+    async def _run() -> None:
+        from aperag.indexing.graph_extractor import _DEFAULT_ENTITY_TYPES
+
+        # Bypass the builder by constructing a tiny extractor inline.
+        async def _extractor(chunks):
+            if not chunks:
+                return ([], [])
+            return ([], [])
+
+        entities, relations = await _extractor([])
+        assert entities == []
+        assert relations == []
+
+        # Also make sure the public API symbols exist (no need for
+        # production LLM here).
+        assert _DEFAULT_ENTITY_TYPES
+
+    asyncio.run(_run())

--- a/tests/integration/test_lineage_graph_store_contract.py
+++ b/tests/integration/test_lineage_graph_store_contract.py
@@ -1,0 +1,654 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cross-backend ``LineageGraphStore`` contract — Wave 4 T8 chunk 4c.
+
+Locks the §D.3.5 Protocol semantics across all three production
+backends (Postgres reference adapter / Neo4j parallel-list mirror /
+Nebula JSON-string mirror) with a single 6-case fixture so a backend
+that drifts from the spec breaks here, regardless of which adapter
+it is.
+
+The six cases are the canonical contract bar (per architect
+msg=baf6618e + huangheng msg=b6f20096 chunk 4 acceptance item 4):
+
+1. ``roundtrip_entity_with_one_lineage_member`` — basic upsert + read
+2. ``two_documents_cite_same_entity_preserves_both_lineage`` —
+   §D.3 cross-doc lineage SET
+3. ``doc_re_parse_replaces_old_parse_version_member`` — §D.3.6 step 3
+   "doc_A v2 supersedes doc_A v1" remove + upsert + dedup composite
+   key ``(document_id, parse_version)``
+4. ``remove_then_gc_orphan_entity`` — §D.3.2 phase-1 strip → phase-2
+   GC; orphan-only deletion
+5. ``relation_lineage_set_independent_from_entity`` — relation
+   evidence_lineage SET independent of entity source_lineage
+6. ``tenant_isolation_collection_id_filters_all_queries`` — §H.2
+   per-store-instance binding tenant double-layer
+
+Each backend is reached behind an env-var skip so the lint-and-unit CI
+lane (no Postgres / Neo4j / Nebula) stays green; the e2e-http-compose
+lane spins all three and runs them.
+
+The per-backend tests in ``test_neo4j_lineage_graph_store.py`` and
+``test_nebula_lineage_graph_store.py`` keep backend-specific extras
+(parallel-list encoding shape, Nebula schema-visibility retry) that
+cannot be expressed as Protocol-level invariants; this file covers
+the Protocol-level contract that all three backends must obey.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from typing import Any, Awaitable, Callable
+
+import pytest
+
+from aperag.indexing.graph import (
+    EntityRecord,
+    InMemoryEntityLock,
+    LineageMember,
+    RelationRecord,
+)
+
+# ---------------------------------------------------------------------
+# Backend reachability probes — skip a backend's parametrize cell if
+# the env-var is unset (lint-and-unit CI lane stays green).
+# ---------------------------------------------------------------------
+
+
+_POSTGRES_DSN = os.environ.get(
+    "COMPAT_POSTGRES_DSN",
+    os.environ.get(
+        "TEST_LINEAGE_POSTGRES_DSN",
+        "postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/postgres",
+    ),
+)
+
+
+def _postgres_reachable() -> bool:
+    if not _POSTGRES_DSN:
+        return False
+    try:
+        from sqlalchemy.ext.asyncio import create_async_engine
+    except ImportError:
+        return False
+
+    async def _probe() -> bool:
+        engine = create_async_engine(_POSTGRES_DSN)
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(__import__("sqlalchemy").text("SELECT 1"))
+            return True
+        finally:
+            await engine.dispose()
+
+    try:
+        return asyncio.run(_probe())
+    except Exception:
+        return False
+
+
+_NEO4J_URI = os.environ.get("COMPAT_NEO4J_URI") or os.environ.get("TEST_LINEAGE_NEO4J_URI")
+_NEO4J_USER = os.environ.get("COMPAT_NEO4J_USER", "neo4j")
+_NEO4J_PASS = os.environ.get("COMPAT_NEO4J_PASS", "password")
+
+
+def _neo4j_reachable() -> bool:
+    if not _NEO4J_URI:
+        return False
+    try:
+        from neo4j import GraphDatabase
+    except ImportError:
+        return False
+    try:
+        driver = GraphDatabase.driver(_NEO4J_URI, auth=(_NEO4J_USER, _NEO4J_PASS))
+        with driver.session() as session:
+            session.run("RETURN 1").consume()
+        driver.close()
+        return True
+    except Exception:
+        return False
+
+
+_NEBULA_HOSTS = os.environ.get("COMPAT_NEBULA_HOSTS") or os.environ.get("TEST_LINEAGE_NEBULA_HOSTS")
+_NEBULA_USER = os.environ.get("COMPAT_NEBULA_USER", "root")
+_NEBULA_PASS = os.environ.get("COMPAT_NEBULA_PASS", "nebula")
+
+
+def _nebula_reachable() -> bool:
+    if not _NEBULA_HOSTS:
+        return False
+    try:
+        from nebula3.Config import Config as _NebulaConfig
+        from nebula3.gclient.net import ConnectionPool
+    except ImportError:
+        return False
+    hosts: list[tuple[str, int]] = []
+    for raw_host in _NEBULA_HOSTS.split(","):
+        host_part = raw_host.strip()
+        if not host_part:
+            continue
+        host, _, port_str = host_part.partition(":")
+        hosts.append((host, int(port_str or "9669")))
+    if not hosts:
+        return False
+    try:
+        config = _NebulaConfig()
+        pool = ConnectionPool()
+        if not pool.init(hosts, config):
+            return False
+        pool.close()
+        return True
+    except Exception:
+        return False
+
+
+_POSTGRES_OK = _postgres_reachable()
+_NEO4J_OK = _neo4j_reachable()
+_NEBULA_OK = _nebula_reachable()
+
+
+# ---------------------------------------------------------------------
+# Per-backend store builder + cleanup. Each returns an async context-
+# manager-style ``(store, cleanup)`` so the parametrize fixture can use
+# the same lifecycle for any backend.
+# ---------------------------------------------------------------------
+
+
+async def _build_postgres_store(collection_id: str) -> tuple[Any, Callable[[], Awaitable[None]]]:
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from aperag.indexing.graph_storage.postgres import PostgresLineageGraphStore
+
+    engine = create_async_engine(_POSTGRES_DSN)
+    store = PostgresLineageGraphStore(engine=engine, collection_id=collection_id)
+    # Tables are owned by alembic in production; ensure_schema is the
+    # test-fallback. Safe + idempotent so we always call it in tests.
+    await store.ensure_schema()
+
+    async def _cleanup() -> None:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("DELETE FROM aperag_lineage_entity WHERE collection_id = :c"),
+                {"c": collection_id},
+            )
+            await conn.execute(
+                text("DELETE FROM aperag_lineage_relation WHERE collection_id = :c"),
+                {"c": collection_id},
+            )
+        await engine.dispose()
+
+    return store, _cleanup
+
+
+async def _build_neo4j_store(collection_id: str) -> tuple[Any, Callable[[], Awaitable[None]]]:
+    from neo4j import AsyncGraphDatabase
+
+    from aperag.indexing.graph_storage.neo4j import Neo4jLineageGraphStore
+
+    driver = AsyncGraphDatabase.driver(_NEO4J_URI, auth=(_NEO4J_USER, _NEO4J_PASS))
+    store = Neo4jLineageGraphStore(driver=driver, collection_id=collection_id)
+    await store.ensure_schema()
+
+    async def _cleanup() -> None:
+        async with driver.session() as session:
+            await session.run(
+                "MATCH (n) WHERE n.collection_id = $cid DETACH DELETE n",
+                cid=collection_id,
+            )
+        await driver.close()
+
+    return store, _cleanup
+
+
+async def _build_nebula_store(collection_id: str) -> tuple[Any, Callable[[], Awaitable[None]]]:
+    from nebula3.Config import Config as _NebulaConfig
+    from nebula3.gclient.net import ConnectionPool
+
+    from aperag.indexing.graph_storage.nebula import NebulaLineageGraphStore, _space_name
+
+    hosts: list[tuple[str, int]] = []
+    for raw_host in _NEBULA_HOSTS.split(","):
+        host_part = raw_host.strip()
+        if not host_part:
+            continue
+        host, _, port_str = host_part.partition(":")
+        hosts.append((host, int(port_str or "9669")))
+    config = _NebulaConfig()
+    pool = ConnectionPool()
+    assert pool.init(hosts, config), f"nebula pool init({hosts}) failed"
+    space_prefix = "aperag_lineage_test"
+    store = NebulaLineageGraphStore(
+        pool=pool,
+        username=_NEBULA_USER,
+        password=_NEBULA_PASS,
+        collection_id=collection_id,
+        entity_lock=InMemoryEntityLock(),
+        space_prefix=space_prefix,
+    )
+    await store.ensure_schema()
+
+    async def _cleanup() -> None:
+        # DROP the per-collection SPACE — fastest tenant wipe.
+        space = _space_name(space_prefix, collection_id)
+        session = pool.get_session(_NEBULA_USER, _NEBULA_PASS)
+        try:
+            session.execute(f"DROP SPACE IF EXISTS `{space}`")
+        finally:
+            session.release()
+        pool.close()
+
+    return store, _cleanup
+
+
+_BACKEND_BUILDERS: dict[str, tuple[bool, Callable[[str], Awaitable[tuple[Any, Callable[[], Awaitable[None]]]]]]] = {
+    "postgres": (_POSTGRES_OK, _build_postgres_store),
+    "neo4j": (_NEO4J_OK, _build_neo4j_store),
+    "nebula": (_NEBULA_OK, _build_nebula_store),
+}
+
+
+@pytest.fixture(params=["postgres", "neo4j", "nebula"])
+async def lineage_store(request: pytest.FixtureRequest):
+    """Yield a fresh per-test :class:`LineageGraphStore` for each
+    parametrized backend. Skips the cell when the backend is
+    unreachable (env-var unset / connection refused)."""
+
+    backend = request.param
+    reachable, builder = _BACKEND_BUILDERS[backend]
+    if not reachable:
+        pytest.skip(f"backend={backend} unreachable; skipping cross-backend contract case")
+
+    cid = f"lineage_contract_{backend}_{uuid.uuid4().hex[:8]}"
+    store, cleanup = await builder(cid)
+    try:
+        yield store
+    finally:
+        await cleanup()
+
+
+# ---------------------------------------------------------------------
+# Helpers — shared across the 6 cases.
+# ---------------------------------------------------------------------
+
+
+def _make_member(*, doc: str, version: str, chunks: tuple[str, ...] = ()) -> LineageMember:
+    return LineageMember(
+        document_id=doc,
+        parse_version=version,
+        tenant_scope_key="public",
+        chunk_ids=chunks,
+    )
+
+
+# ---------------------------------------------------------------------
+# 6 contract cases — each runs against every backend the parametrize
+# fixture yields.
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_entity_with_one_lineage_member(lineage_store):
+    """Case 1: basic upsert + read — the canonical lineage view returns
+    one member with the upsert input echoed back."""
+
+    record = EntityRecord(
+        name="Linus Torvalds",
+        type="person",
+        description="Created Linux.",
+        source_chunk_ids=("chunk-1",),
+    )
+    member = _make_member(doc="doc-A", version="v1", chunks=("chunk-1",))
+    await lineage_store.upsert_entity_with_lineage(record=record, lineage=member)
+
+    fetched = await lineage_store.get_entity("Linus Torvalds")
+    assert fetched is not None
+    assert fetched.name == "Linus Torvalds"
+    assert fetched.type == "person"
+    assert len(fetched.source_lineage) == 1
+    assert fetched.source_lineage[0].document_id == "doc-A"
+    assert fetched.source_lineage[0].parse_version == "v1"
+    assert fetched.source_lineage[0].chunk_ids == ("chunk-1",)
+    assert len(fetched.description_parts) == 1
+    assert fetched.description_parts[0].text == "Created Linux."
+
+
+@pytest.mark.asyncio
+async def test_two_documents_cite_same_entity_preserves_both_lineage(lineage_store):
+    """Case 2: §D.3 cross-doc lineage — two docs upsert the same entity
+    must coexist as two SET members; one document's retry must not drop
+    the other's contribution."""
+
+    record_base = EntityRecord(
+        name="Python",
+        type="language",
+        description="",
+        source_chunk_ids=(),
+    )
+    await lineage_store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record_base.__dict__, "description": "Created by Guido."}),
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("a-1",)),
+    )
+    await lineage_store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record_base.__dict__, "description": "Dynamically typed."}),
+        lineage=_make_member(doc="doc-B", version="v1", chunks=("b-1",)),
+    )
+
+    fetched = await lineage_store.get_entity("Python")
+    assert fetched is not None
+    doc_ids = {m.document_id for m in fetched.source_lineage}
+    assert doc_ids == {"doc-A", "doc-B"}
+    parts_by_doc = {p.document_id: p.text for p in fetched.description_parts}
+    assert parts_by_doc == {"doc-A": "Created by Guido.", "doc-B": "Dynamically typed."}
+
+
+@pytest.mark.asyncio
+async def test_doc_re_parse_replaces_old_parse_version_member(lineage_store):
+    """Case 3: §D.3.6 step 3 + composite key dedup — the
+    ``remove(doc_A) → upsert(doc_A, v2)`` orchestrator flow leaves only
+    the v2 slice for doc_A; the v1 member is gone. A same-(doc, parse_v)
+    repeat upsert (orchestrator retry) must dedup, not duplicate.
+    """
+
+    record = EntityRecord(
+        name="Rust",
+        type="language",
+        description="memory-safe",
+        source_chunk_ids=(),
+    )
+    await lineage_store.upsert_entity_with_lineage(
+        record=record,
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("v1-1",)),
+    )
+
+    await lineage_store.remove_entity_lineage_member(entity_name="Rust", document_id="doc-A")
+
+    await lineage_store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "memory-safe + concurrent"}),
+        lineage=_make_member(doc="doc-A", version="v2", chunks=("v2-1",)),
+    )
+
+    fetched = await lineage_store.get_entity("Rust")
+    assert fetched is not None
+    versions = {m.parse_version for m in fetched.source_lineage if m.document_id == "doc-A"}
+    assert versions == {"v2"}, "after remove+upsert flow, v1 must be gone and only v2 must remain"
+    parts = [p for p in fetched.description_parts if p.document_id == "doc-A"]
+    assert len(parts) == 1
+    assert parts[0].parse_version == "v2"
+    assert parts[0].text == "memory-safe + concurrent"
+
+    # Same-(doc, parse_v) repeat upsert (orchestrator retry) must dedup.
+    await lineage_store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "memory-safe + concurrent"}),
+        lineage=_make_member(doc="doc-A", version="v2", chunks=("v2-1",)),
+    )
+    fetched = await lineage_store.get_entity("Rust")
+    assert fetched is not None
+    doc_a_members = [m for m in fetched.source_lineage if m.document_id == "doc-A"]
+    assert len(doc_a_members) == 1, "(doc, parse_v) repeat upsert must dedup, not append"
+
+
+@pytest.mark.asyncio
+async def test_remove_then_gc_orphan_entity(lineage_store):
+    """Case 4: §D.3.2 phase-1 strip → phase-2 GC. Orphan-only deletion;
+    other-doc citations protect the row from GC."""
+
+    record = EntityRecord(name="ApeRAG", type="project", description="", source_chunk_ids=())
+    await lineage_store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "RAG framework"}),
+        lineage=_make_member(doc="doc-A", version="v1"),
+    )
+    await lineage_store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "by ApeCloud"}),
+        lineage=_make_member(doc="doc-B", version="v1"),
+    )
+
+    await lineage_store.remove_entity_lineage_member(entity_name="ApeRAG", document_id="doc-A")
+    deleted = await lineage_store.gc_entity_if_orphan("ApeRAG")
+    assert deleted is False, "doc-B still cites; entity must not be GC'd"
+    fetched = await lineage_store.get_entity("ApeRAG")
+    assert fetched is not None
+    remaining = {m.document_id for m in fetched.source_lineage}
+    assert remaining == {"doc-B"}
+
+    await lineage_store.remove_entity_lineage_member(entity_name="ApeRAG", document_id="doc-B")
+    deleted = await lineage_store.gc_entity_if_orphan("ApeRAG")
+    assert deleted is True
+    fetched = await lineage_store.get_entity("ApeRAG")
+    assert fetched is None
+
+
+@pytest.mark.asyncio
+async def test_relation_lineage_set_independent_from_entity(lineage_store):
+    """Case 5: relation evidence_lineage SET semantics mirror entity
+    source_lineage but on a different SET; relation upsert + strip + GC
+    work independently of any entity row."""
+
+    rel = RelationRecord(
+        source="Linus Torvalds",
+        target="Linux",
+        type="created",
+        description="Linus created Linux in 1991.",
+        source_chunk_ids=("c-1",),
+    )
+    await lineage_store.upsert_relation_with_lineage(
+        record=rel,
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("c-1",)),
+    )
+    await lineage_store.upsert_relation_with_lineage(
+        record=rel,
+        lineage=_make_member(doc="doc-B", version="v1", chunks=("c-1",)),
+    )
+
+    keys = await lineage_store.find_relation_keys_with_lineage(document_id="doc-A")
+    assert ("Linus Torvalds", "Linux", "created") in keys
+
+    fetched = await lineage_store.get_relation("Linus Torvalds", "Linux", "created")
+    assert fetched is not None
+    assert {m.document_id for m in fetched.evidence_lineage} == {"doc-A", "doc-B"}
+
+    await lineage_store.remove_relation_lineage_member(
+        source="Linus Torvalds", target="Linux", type="created", document_id="doc-A"
+    )
+    deleted = await lineage_store.gc_relation_if_orphan("Linus Torvalds", "Linux", "created")
+    assert deleted is False, "doc-B still cites; relation must not be GC'd"
+
+    await lineage_store.remove_relation_lineage_member(
+        source="Linus Torvalds", target="Linux", type="created", document_id="doc-B"
+    )
+    deleted = await lineage_store.gc_relation_if_orphan("Linus Torvalds", "Linux", "created")
+    assert deleted is True
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolation_collection_id_filters_all_queries(lineage_store, request: pytest.FixtureRequest):
+    """Case 6: §H.2 tenant double-layer — two store instances bound to
+    different collection_ids must not see each other's rows even when
+    both write the same entity name. Confirms ``find_*_with_lineage``
+    and ``get_*`` filter on the bound ``collection_id``."""
+
+    backend = request.node.callspec.params["lineage_store"]
+    other_cid = f"lineage_contract_other_{backend}_{uuid.uuid4().hex[:8]}"
+    _, builder = _BACKEND_BUILDERS[backend]
+    other_store, other_cleanup = await builder(other_cid)
+
+    try:
+        record = EntityRecord(
+            name="Shared Entity",
+            type="thing",
+            description="from other tenant",
+            source_chunk_ids=(),
+        )
+        await other_store.upsert_entity_with_lineage(
+            record=record,
+            lineage=_make_member(doc="other-doc", version="v1"),
+        )
+        # Sanity — the other tenant CAN see its own row.
+        fetched_other = await other_store.get_entity("Shared Entity")
+        assert fetched_other is not None
+
+        # The PRIMARY store (bound to a different collection_id) MUST
+        # NOT see the other tenant's row.
+        leaked = await lineage_store.get_entity("Shared Entity")
+        assert leaked is None
+        names = await lineage_store.find_entity_ids_with_lineage(document_id="other-doc")
+        assert names == []
+    finally:
+        await other_cleanup()
+
+
+# ---------------------------------------------------------------------
+# Case 7 (architect msg=87e2b187 chunk 4c amendment): explicit cross-
+# event-loop scenario. Pin acceptance lock item 3 ("async driver wire
+# cross-event-loop verify; no asyncio.run near factory") at the
+# contract layer rather than relying on driver-vendor lazy bind
+# behaviour. Forward-prevent for Wave 3 evaluation cross-loop bug
+# msg=e1f23258 if a future driver upgrade flips to eager bind in
+# ``__init__``.
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["postgres", "neo4j", "nebula"])
+async def test_cross_event_loop_construct_then_call(backend: str):
+    """Construct the per-collection store via ``asyncio.to_thread`` —
+    mirroring ``ProductionWorkerFactory.__call__`` which builds the
+    worker on a thread but the worker's ``sync(...)`` then awaits on
+    the orchestrator event loop. The store / driver must bind lazily
+    on first use so the cross-thread-to-loop handoff is safe.
+
+    A driver that eagerly binds inside ``__init__`` would surface here
+    as ``RuntimeError: ... attached to a different loop`` or
+    ``RuntimeError: Event loop is closed`` once we await the upsert.
+
+    The test mirrors the production worker_factory flow exactly:
+    1. Create the per-process backend client SYNC (no awaits — same as
+       ``_postgres_async_engine_singleton`` / ``_neo4j_async_driver_singleton``
+       / ``_nebula_pool_singleton``). Loop binding deferred to first use.
+    2. Construct the per-collection adapter inside ``asyncio.to_thread``
+       (sync ``__init__`` only — same as ``_build_lineage_graph_store``).
+    3. Await the adapter's async methods on the orchestrator loop.
+    """
+
+    reachable, _ = _BACKEND_BUILDERS[backend]
+    if not reachable:
+        pytest.skip(f"backend={backend} unreachable; skipping cross-event-loop case")
+
+    cid = f"lineage_xloop_{backend}_{uuid.uuid4().hex[:8]}"
+
+    # Step 1 — sync client creation (no event loop binding yet).
+    if backend == "postgres":
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from aperag.indexing.graph_storage.postgres import PostgresLineageGraphStore
+
+        client = create_async_engine(_POSTGRES_DSN)
+
+        def _construct() -> Any:
+            return PostgresLineageGraphStore(engine=client, collection_id=cid)
+
+        async def _cleanup_xloop() -> None:
+            from sqlalchemy import text as _text
+
+            async with client.begin() as conn:
+                await conn.execute(
+                    _text("DELETE FROM aperag_lineage_entity WHERE collection_id = :c"),
+                    {"c": cid},
+                )
+                await conn.execute(
+                    _text("DELETE FROM aperag_lineage_relation WHERE collection_id = :c"),
+                    {"c": cid},
+                )
+            await client.dispose()
+
+    elif backend == "neo4j":
+        from neo4j import AsyncGraphDatabase
+
+        from aperag.indexing.graph_storage.neo4j import Neo4jLineageGraphStore
+
+        client = AsyncGraphDatabase.driver(_NEO4J_URI, auth=(_NEO4J_USER, _NEO4J_PASS))
+
+        def _construct() -> Any:
+            return Neo4jLineageGraphStore(driver=client, collection_id=cid)
+
+        async def _cleanup_xloop() -> None:
+            async with client.session() as session:
+                await session.run(
+                    "MATCH (n) WHERE n.collection_id = $cid DETACH DELETE n",
+                    cid=cid,
+                )
+            await client.close()
+
+    else:  # nebula
+        from nebula3.Config import Config as _NebulaConfig
+        from nebula3.gclient.net import ConnectionPool
+
+        from aperag.indexing.graph_storage.nebula import NebulaLineageGraphStore, _space_name
+
+        hosts: list[tuple[str, int]] = []
+        for raw_host in _NEBULA_HOSTS.split(","):
+            host_part = raw_host.strip()
+            if not host_part:
+                continue
+            host, _, port_str = host_part.partition(":")
+            hosts.append((host, int(port_str or "9669")))
+        pool = ConnectionPool()
+        assert pool.init(hosts, _NebulaConfig())
+        space_prefix = "aperag_lineage_test_xloop"
+        client = pool
+
+        def _construct() -> Any:
+            return NebulaLineageGraphStore(
+                pool=client,
+                username=_NEBULA_USER,
+                password=_NEBULA_PASS,
+                collection_id=cid,
+                entity_lock=InMemoryEntityLock(),
+                space_prefix=space_prefix,
+            )
+
+        async def _cleanup_xloop() -> None:
+            space = _space_name(space_prefix, cid)
+            session = client.get_session(_NEBULA_USER, _NEBULA_PASS)
+            try:
+                session.execute(f"DROP SPACE IF EXISTS `{space}`")
+            finally:
+                session.release()
+            client.close()
+
+    # Step 2 — adapter constructor runs on a worker thread (no loop).
+    store = await asyncio.to_thread(_construct)
+    try:
+        # Step 3 — first async op runs on the test event loop. The
+        # driver MUST lazily bind to this loop, not the (non-existent)
+        # builder-thread loop.
+        await store.ensure_schema()
+        record = EntityRecord(
+            name="XLoop Entity",
+            type="thing",
+            description="cross-loop ok",
+            source_chunk_ids=(),
+        )
+        await store.upsert_entity_with_lineage(
+            record=record,
+            lineage=_make_member(doc="doc-xloop", version="v1"),
+        )
+        fetched = await store.get_entity("XLoop Entity")
+        assert fetched is not None
+        assert fetched.source_lineage[0].document_id == "doc-xloop"
+    finally:
+        await _cleanup_xloop()

--- a/tests/integration/test_nebula_lineage_graph_store.py
+++ b/tests/integration/test_nebula_lineage_graph_store.py
@@ -1,0 +1,372 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for ``NebulaLineageGraphStore`` — Wave 4 T8 chunk 3.
+
+Pin the §D.3.5 lineage SET semantics on a real Nebula 3.x instance.
+Six contract scenarios mirror the Postgres + Neo4j chunks (chunk 1 +
+chunk 2): roundtrip / multi-doc lineage / doc re-parse v1→v2 via
+``remove → upsert`` flow / orphan GC / relation-independent lineage /
+per-collection_id tenant isolation.
+
+Tests skip when ``COMPAT_NEBULA_HOSTS`` is unset so the lint-and-unit
+CI lane stays green; the e2e-http-compose lane spins Nebula up and
+runs them.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from aperag.indexing.graph import (
+    EntityRecord,
+    InMemoryEntityLock,
+    LineageMember,
+    RelationRecord,
+)
+from aperag.indexing.graph_storage.nebula import NebulaLineageGraphStore
+
+_NEBULA_HOSTS = os.environ.get("COMPAT_NEBULA_HOSTS") or os.environ.get("TEST_LINEAGE_NEBULA_HOSTS")
+_NEBULA_USER = os.environ.get("COMPAT_NEBULA_USER", "root")
+_NEBULA_PASS = os.environ.get("COMPAT_NEBULA_PASS", "nebula")
+
+
+def _nebula_reachable(hosts: str | None) -> bool:
+    """Synchronous reachability probe."""
+
+    if not hosts:
+        return False
+    try:
+        from nebula3.Config import Config as NebulaConfig
+        from nebula3.gclient.net import ConnectionPool
+    except ImportError:  # pragma: no cover — nebula3-python ships under graph-nebula extra
+        return False
+
+    try:
+        config = NebulaConfig()
+        config.max_connection_pool_size = 4
+        config.timeout = 5000
+        host_pairs = []
+        for part in hosts.split(","):
+            part = part.strip()
+            if ":" in part:
+                h, p = part.rsplit(":", 1)
+                host_pairs.append((h, int(p)))
+            else:
+                host_pairs.append((part, 9669))
+        pool = ConnectionPool()
+        if not pool.init(host_pairs, config):
+            pool.close()
+            return False
+        session = pool.get_session(_NEBULA_USER, _NEBULA_PASS)
+        try:
+            r = session.execute("SHOW SPACES")
+            ok = r.is_succeeded()
+        finally:
+            session.release()
+        pool.close()
+        return ok
+    except Exception:
+        return False
+
+
+_NEBULA_OK = _nebula_reachable(_NEBULA_HOSTS)
+pytestmark = pytest.mark.skipif(
+    not _NEBULA_OK,
+    reason=(f"Nebula at {_NEBULA_HOSTS or '<unset>'} unreachable; skipping NebulaLineageGraphStore integration suite"),
+)
+
+
+def _make_member(*, doc: str, version: str, chunks: tuple[str, ...] = ()) -> LineageMember:
+    return LineageMember(
+        document_id=doc,
+        parse_version=version,
+        tenant_scope_key="public",
+        chunk_ids=chunks,
+    )
+
+
+def _build_pool():
+    from nebula3.Config import Config as NebulaConfig
+    from nebula3.gclient.net import ConnectionPool
+
+    config = NebulaConfig()
+    config.max_connection_pool_size = 8
+    config.timeout = 60000
+    host_pairs = []
+    for part in (_NEBULA_HOSTS or "").split(","):
+        part = part.strip()
+        if ":" in part:
+            h, p = part.rsplit(":", 1)
+            host_pairs.append((h, int(p)))
+        else:
+            host_pairs.append((part, 9669))
+    pool = ConnectionPool()
+    pool.init(host_pairs, config)
+    return pool
+
+
+@pytest.fixture
+async def store():
+    """Per-test ``NebulaLineageGraphStore`` bound to a unique
+    ``collection_id``. The bound space is dropped on teardown so
+    leftover vertices don't leak into the next test.
+    """
+
+    pool = _build_pool()
+    cid = f"lineage_test_{uuid.uuid4().hex[:8]}"
+    s = NebulaLineageGraphStore(
+        pool=pool,
+        username=_NEBULA_USER,
+        password=_NEBULA_PASS,
+        collection_id=cid,
+        entity_lock=InMemoryEntityLock(),
+        space_prefix="aperag_lineage_test",
+    )
+    await s.ensure_schema()
+    try:
+        yield s
+    finally:
+        # Drop the test space so subsequent tests start clean. Do this
+        # via a fresh session because the store-instance keeps state
+        # bound to the dropped space.
+        session = pool.get_session(_NEBULA_USER, _NEBULA_PASS)
+        try:
+            session.execute(f"DROP SPACE IF EXISTS `{s._space}`")
+        finally:
+            session.release()
+        pool.close()
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_entity_with_one_lineage_member(store):
+    """Single upsert — read-back returns the canonical lineage view."""
+
+    record = EntityRecord(
+        name="Linus Torvalds",
+        type="person",
+        description="Created Linux.",
+        source_chunk_ids=("chunk-1",),
+    )
+    member = _make_member(doc="doc-A", version="v1", chunks=("chunk-1",))
+    await store.upsert_entity_with_lineage(record=record, lineage=member)
+
+    fetched = await store.get_entity("Linus Torvalds")
+    assert fetched is not None
+    assert fetched.name == "Linus Torvalds"
+    assert fetched.type == "person"
+    assert len(fetched.source_lineage) == 1
+    assert fetched.source_lineage[0].document_id == "doc-A"
+    assert fetched.source_lineage[0].parse_version == "v1"
+    assert fetched.source_lineage[0].chunk_ids == ("chunk-1",)
+    assert len(fetched.description_parts) == 1
+    assert fetched.description_parts[0].text == "Created Linux."
+
+
+@pytest.mark.asyncio
+async def test_two_documents_cite_same_entity_preserves_both_lineage(store):
+    """§D.3 cross-doc lineage invariant — two docs upsert same entity →
+    both members coexist; one's retry must not drop the other.
+    """
+
+    record_base = EntityRecord(name="Python", type="language", description="", source_chunk_ids=())
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record_base.__dict__, "description": "Created by Guido."}),
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("a-1",)),
+    )
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record_base.__dict__, "description": "Dynamically typed."}),
+        lineage=_make_member(doc="doc-B", version="v1", chunks=("b-1",)),
+    )
+
+    fetched = await store.get_entity("Python")
+    assert fetched is not None
+    doc_ids = {m.document_id for m in fetched.source_lineage}
+    assert doc_ids == {"doc-A", "doc-B"}
+    parts_by_doc = {p.document_id: p.text for p in fetched.description_parts}
+    assert parts_by_doc == {"doc-A": "Created by Guido.", "doc-B": "Dynamically typed."}
+
+
+@pytest.mark.asyncio
+async def test_doc_re_parse_replaces_old_parse_version_member(store):
+    """§D.3.6 step 3 — doc_A v2 supersedes doc_A v1.
+
+    Orchestrator workflow:
+    1. cleanup phase — ``remove_entity_lineage_member(name, doc_A)``
+    2. rebuild phase — ``upsert_entity_with_lineage(record, doc_A v2)``
+
+    After this two-step flow only the v2 slice for doc_A must remain.
+    Also verifies that a same-(doc, parse_v) repeat upsert dedups
+    rather than appends — locking the (document_id, parse_version)
+    composite as the SET dedup key on Nebula too.
+    """
+
+    record = EntityRecord(name="Rust", type="language", description="memory-safe", source_chunk_ids=())
+    await store.upsert_entity_with_lineage(
+        record=record,
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("v1-1",)),
+    )
+    await store.remove_entity_lineage_member(entity_name="Rust", document_id="doc-A")
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "memory-safe + concurrent"}),
+        lineage=_make_member(doc="doc-A", version="v2", chunks=("v2-1",)),
+    )
+
+    fetched = await store.get_entity("Rust")
+    assert fetched is not None
+    versions = {m.parse_version for m in fetched.source_lineage if m.document_id == "doc-A"}
+    assert versions == {"v2"}
+    parts = [p for p in fetched.description_parts if p.document_id == "doc-A"]
+    assert len(parts) == 1
+    assert parts[0].parse_version == "v2"
+    assert parts[0].text == "memory-safe + concurrent"
+
+    # Repeat upsert with same (doc-A, v2) — must dedup, not append.
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "memory-safe + concurrent"}),
+        lineage=_make_member(doc="doc-A", version="v2", chunks=("v2-1",)),
+    )
+    fetched = await store.get_entity("Rust")
+    assert fetched is not None
+    doc_a_members = [m for m in fetched.source_lineage if m.document_id == "doc-A"]
+    assert len(doc_a_members) == 1
+
+
+@pytest.mark.asyncio
+async def test_remove_then_gc_orphan_entity(store):
+    """§D.3.2 phase-1 cleanup → phase-2 GC.
+
+    Stripping a member when other docs cite the entity must NOT make
+    it eligible for GC. Stripping all → GC actually deletes.
+    """
+
+    record = EntityRecord(name="ApeRAG", type="project", description="", source_chunk_ids=())
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "RAG framework"}),
+        lineage=_make_member(doc="doc-A", version="v1"),
+    )
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "by ApeCloud"}),
+        lineage=_make_member(doc="doc-B", version="v1"),
+    )
+
+    await store.remove_entity_lineage_member(entity_name="ApeRAG", document_id="doc-A")
+    deleted = await store.gc_entity_if_orphan("ApeRAG")
+    assert deleted is False
+    fetched = await store.get_entity("ApeRAG")
+    assert fetched is not None
+    remaining = {m.document_id for m in fetched.source_lineage}
+    assert remaining == {"doc-B"}
+
+    await store.remove_entity_lineage_member(entity_name="ApeRAG", document_id="doc-B")
+    deleted = await store.gc_entity_if_orphan("ApeRAG")
+    assert deleted is True
+    fetched = await store.get_entity("ApeRAG")
+    assert fetched is None
+
+
+@pytest.mark.asyncio
+async def test_relation_lineage_set_independent_from_entity(store):
+    """Relations carry their own evidence_lineage SET; the strip /
+    upsert / GC semantics mirror entities. Verify a relation lineage
+    round-trip independently of any entity row.
+    """
+
+    rel = RelationRecord(
+        source="Linus Torvalds",
+        target="Linux",
+        type="created",
+        description="Linus created Linux in 1991.",
+        source_chunk_ids=("c-1",),
+    )
+    await store.upsert_relation_with_lineage(
+        record=rel,
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("c-1",)),
+    )
+    await store.upsert_relation_with_lineage(
+        record=rel,
+        lineage=_make_member(doc="doc-B", version="v1", chunks=("c-1",)),
+    )
+
+    keys = await store.find_relation_keys_with_lineage(document_id="doc-A")
+    assert ("Linus Torvalds", "Linux", "created") in keys
+
+    fetched = await store.get_relation("Linus Torvalds", "Linux", "created")
+    assert fetched is not None
+    assert {m.document_id for m in fetched.evidence_lineage} == {"doc-A", "doc-B"}
+
+    await store.remove_relation_lineage_member(
+        source="Linus Torvalds", target="Linux", type="created", document_id="doc-A"
+    )
+    deleted = await store.gc_relation_if_orphan("Linus Torvalds", "Linux", "created")
+    assert deleted is False
+
+    await store.remove_relation_lineage_member(
+        source="Linus Torvalds", target="Linux", type="created", document_id="doc-B"
+    )
+    deleted = await store.gc_relation_if_orphan("Linus Torvalds", "Linux", "created")
+    assert deleted is True
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolation_collection_id_filters_all_queries(store):
+    """Two store instances bound to different collection_ids must not
+    see each other's vertices. Nebula realises this via per-collection
+    SPACE; the store-instance binds to ``collection_id`` at
+    construction so the SPACE selection is automatic.
+    """
+
+    other_pool = _build_pool()
+    other_cid = f"lineage_test_other_{uuid.uuid4().hex[:8]}"
+    other_store = NebulaLineageGraphStore(
+        pool=other_pool,
+        username=_NEBULA_USER,
+        password=_NEBULA_PASS,
+        collection_id=other_cid,
+        entity_lock=InMemoryEntityLock(),
+        space_prefix="aperag_lineage_test",
+    )
+    await other_store.ensure_schema()
+
+    try:
+        record = EntityRecord(
+            name="Shared Entity",
+            type="thing",
+            description="from other tenant",
+            source_chunk_ids=(),
+        )
+        await other_store.upsert_entity_with_lineage(
+            record=record,
+            lineage=_make_member(doc="other-doc", version="v1"),
+        )
+        # Sanity — the OTHER tenant CAN see its own row.
+        fetched_other = await other_store.get_entity("Shared Entity")
+        assert fetched_other is not None
+
+        # The PRIMARY store (different collection_id → different SPACE)
+        # MUST NOT see the other tenant's row.
+        leaked = await store.get_entity("Shared Entity")
+        assert leaked is None
+        names = await store.find_entity_ids_with_lineage(document_id="other-doc")
+        assert names == []
+    finally:
+        session = other_pool.get_session(_NEBULA_USER, _NEBULA_PASS)
+        try:
+            session.execute(f"DROP SPACE IF EXISTS `{other_store._space}`")
+        finally:
+            session.release()
+        other_pool.close()

--- a/tests/integration/test_neo4j_lineage_graph_store.py
+++ b/tests/integration/test_neo4j_lineage_graph_store.py
@@ -1,0 +1,358 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for ``Neo4jLineageGraphStore`` — Wave 4 T8 chunk 2.
+
+Pin the §D.3.5 lineage SET semantics on a real Neo4j 5.x instance. The
+parallel-list encoding (``source_lineage`` / ``source_lineage_doc_ids``
+/ ``source_lineage_parse_versions``) realises a JSONB-shaped SET on a
+backend that does not support ``LIST<MAP>`` properties; these tests
+lock the backend's correctness against the same six contract scenarios
+the chunk 4 cross-backend suite will use.
+
+Tests skip when ``COMPAT_NEO4J_URI`` is unset so the lint-and-unit CI
+lane (no Neo4j) stays green; the e2e-http-compose lane spins Neo4j up
+and runs them.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from aperag.indexing.graph import (
+    EntityRecord,
+    LineageMember,
+    RelationRecord,
+)
+from aperag.indexing.graph_storage.neo4j import Neo4jLineageGraphStore
+
+_NEO4J_URI = os.environ.get("COMPAT_NEO4J_URI") or os.environ.get(
+    "TEST_LINEAGE_NEO4J_URI",
+)
+_NEO4J_USER = os.environ.get("COMPAT_NEO4J_USER", "neo4j")
+_NEO4J_PASS = os.environ.get("COMPAT_NEO4J_PASS", "password")
+
+
+def _neo4j_reachable(uri: str | None) -> bool:
+    """Synchronous reachability probe so the skip decision is taken
+    before pytest tries to schedule the async test on the event loop.
+    """
+
+    if not uri:
+        return False
+    try:
+        from neo4j import GraphDatabase
+    except ImportError:  # pragma: no cover — `neo4j` ships under graph-neo4j extra
+        return False
+
+    try:
+        driver = GraphDatabase.driver(uri, auth=(_NEO4J_USER, _NEO4J_PASS))
+        with driver.session() as session:
+            session.run("RETURN 1").consume()
+        driver.close()
+        return True
+    except Exception:
+        return False
+
+
+_NEO4J_OK = _neo4j_reachable(_NEO4J_URI)
+pytestmark = pytest.mark.skipif(
+    not _NEO4J_OK,
+    reason=(f"Neo4j at {_NEO4J_URI or '<unset>'} unreachable; skipping Neo4jLineageGraphStore integration suite"),
+)
+
+
+def _make_member(*, doc: str, version: str, chunks: tuple[str, ...] = ()) -> LineageMember:
+    return LineageMember(
+        document_id=doc,
+        parse_version=version,
+        tenant_scope_key="public",
+        chunk_ids=chunks,
+    )
+
+
+@pytest.fixture
+async def store():
+    """A fresh per-test ``Neo4jLineageGraphStore`` bound to a unique
+    ``collection_id`` so concurrent runs don't see each other's nodes.
+    """
+
+    from neo4j import AsyncGraphDatabase
+
+    driver = AsyncGraphDatabase.driver(_NEO4J_URI, auth=(_NEO4J_USER, _NEO4J_PASS))
+    cid = f"lineage_test_{uuid.uuid4().hex[:8]}"
+    s = Neo4jLineageGraphStore(driver=driver, collection_id=cid)
+    await s.ensure_schema()
+    try:
+        yield s
+    finally:
+        # Drop everything for this test's collection so leftover nodes
+        # don't accumulate; constraint stays for the next test (cheap
+        # idempotent CREATE … IF NOT EXISTS).
+        async with driver.session() as session:
+            await session.run(
+                "MATCH (n) WHERE n.collection_id = $cid DETACH DELETE n",
+                cid=cid,
+            )
+        await driver.close()
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_entity_with_one_lineage_member(store):
+    """Single upsert — read-back returns the canonical lineage view
+    with one member matching the upsert input.
+    """
+
+    record = EntityRecord(
+        name="Linus Torvalds",
+        type="person",
+        description="Created Linux.",
+        source_chunk_ids=("chunk-1",),
+    )
+    member = _make_member(doc="doc-A", version="v1", chunks=("chunk-1",))
+    await store.upsert_entity_with_lineage(record=record, lineage=member)
+
+    fetched = await store.get_entity("Linus Torvalds")
+    assert fetched is not None
+    assert fetched.name == "Linus Torvalds"
+    assert fetched.type == "person"
+    assert len(fetched.source_lineage) == 1
+    assert fetched.source_lineage[0].document_id == "doc-A"
+    assert fetched.source_lineage[0].parse_version == "v1"
+    assert fetched.source_lineage[0].chunk_ids == ("chunk-1",)
+    assert len(fetched.description_parts) == 1
+    assert fetched.description_parts[0].text == "Created Linux."
+
+
+@pytest.mark.asyncio
+async def test_two_documents_cite_same_entity_preserves_both_lineage(store):
+    """§D.3 cross-doc lineage invariant — two docs upsert the same
+    entity → both members coexist; one's retry must not drop the other.
+    """
+
+    record_base = EntityRecord(
+        name="Python",
+        type="language",
+        description="",
+        source_chunk_ids=(),
+    )
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record_base.__dict__, "description": "Created by Guido."}),
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("a-1",)),
+    )
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record_base.__dict__, "description": "Dynamically typed."}),
+        lineage=_make_member(doc="doc-B", version="v1", chunks=("b-1",)),
+    )
+
+    fetched = await store.get_entity("Python")
+    assert fetched is not None
+    doc_ids = {m.document_id for m in fetched.source_lineage}
+    assert doc_ids == {"doc-A", "doc-B"}
+    parts_by_doc = {p.document_id: p.text for p in fetched.description_parts}
+    assert parts_by_doc == {"doc-A": "Created by Guido.", "doc-B": "Dynamically typed."}
+
+
+@pytest.mark.asyncio
+async def test_doc_re_parse_replaces_old_parse_version_member(store):
+    """§D.3.6 step 3 — doc_A v2 supersedes doc_A v1 on the same entity.
+
+    The orchestrator workflow is:
+    1. Cleanup phase — ``remove_entity_lineage_member(entity, doc_A)``
+       strips ALL doc_A members regardless of parse_version.
+    2. Rebuild phase — ``upsert_entity_with_lineage(record, doc_A v2)``
+       writes the new slice.
+
+    After this two-step flow the entity must carry only the v2 slice
+    for doc_A; v1 must be gone. This locks both the strip-by-doc
+    semantics and the upsert add semantics together — which is the
+    contract :class:`GraphModalityWorker` relies on.
+
+    Also verifies the upsert's own dedup key: a same-(doc, parse_v)
+    repeat upsert (e.g. a retry of phase 2) must coexist as a single
+    member, not duplicate.
+    """
+
+    record = EntityRecord(
+        name="Rust",
+        type="language",
+        description="memory-safe",
+        source_chunk_ids=(),
+    )
+    # v1 lands first.
+    await store.upsert_entity_with_lineage(
+        record=record,
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("v1-1",)),
+    )
+
+    # §D.3.2 phase 1: orchestrator strips the doc on a re-parse.
+    await store.remove_entity_lineage_member(entity_name="Rust", document_id="doc-A")
+
+    # §D.3.2 phase 2: orchestrator writes the new (doc_A, v2) slice.
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "memory-safe + concurrent"}),
+        lineage=_make_member(doc="doc-A", version="v2", chunks=("v2-1",)),
+    )
+
+    fetched = await store.get_entity("Rust")
+    assert fetched is not None
+    versions = {m.parse_version for m in fetched.source_lineage if m.document_id == "doc-A"}
+    assert versions == {"v2"}, "after remove+upsert flow, v1 must be gone and only v2 must remain"
+    parts = [p for p in fetched.description_parts if p.document_id == "doc-A"]
+    assert len(parts) == 1
+    assert parts[0].parse_version == "v2"
+    assert parts[0].text == "memory-safe + concurrent"
+
+    # Same-(doc, parse_v) repeat upsert (orchestrator retry) must
+    # dedup — the SET must still contain exactly one v2 member.
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "memory-safe + concurrent"}),
+        lineage=_make_member(doc="doc-A", version="v2", chunks=("v2-1",)),
+    )
+    fetched = await store.get_entity("Rust")
+    assert fetched is not None
+    doc_a_members = [m for m in fetched.source_lineage if m.document_id == "doc-A"]
+    assert len(doc_a_members) == 1, "(doc, parse_v) repeat upsert must dedup, not append"
+
+
+@pytest.mark.asyncio
+async def test_remove_then_gc_orphan_entity(store):
+    """§D.3.2 phase-1 cleanup → phase-2 GC.
+
+    ``remove_entity_lineage_member(doc_A)`` strips ALL members whose
+    document_id matches; if the SET goes empty, ``gc_entity_if_orphan``
+    actually deletes the row. Stripping a member when other docs cite
+    the entity must NOT make it eligible for GC.
+    """
+
+    record = EntityRecord(name="ApeRAG", type="project", description="", source_chunk_ids=())
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "RAG framework"}),
+        lineage=_make_member(doc="doc-A", version="v1"),
+    )
+    await store.upsert_entity_with_lineage(
+        record=EntityRecord(**{**record.__dict__, "description": "by ApeCloud"}),
+        lineage=_make_member(doc="doc-B", version="v1"),
+    )
+
+    # Strip doc-A → doc-B still cites the entity → GC must NOT delete.
+    await store.remove_entity_lineage_member(entity_name="ApeRAG", document_id="doc-A")
+    deleted = await store.gc_entity_if_orphan("ApeRAG")
+    assert deleted is False
+    fetched = await store.get_entity("ApeRAG")
+    assert fetched is not None
+    remaining = {m.document_id for m in fetched.source_lineage}
+    assert remaining == {"doc-B"}
+
+    # Strip doc-B → SET goes empty → GC deletes.
+    await store.remove_entity_lineage_member(entity_name="ApeRAG", document_id="doc-B")
+    deleted = await store.gc_entity_if_orphan("ApeRAG")
+    assert deleted is True
+    fetched = await store.get_entity("ApeRAG")
+    assert fetched is None
+
+
+@pytest.mark.asyncio
+async def test_relation_lineage_set_independent_from_entity(store):
+    """Relations carry their own evidence_lineage SET; the strip/upsert
+    semantics mirror entities. Verify a relation upsert + strip + GC
+    round-trip independently of any entity row.
+    """
+
+    rel = RelationRecord(
+        source="Linus Torvalds",
+        target="Linux",
+        type="created",
+        description="Linus created Linux in 1991.",
+        source_chunk_ids=("c-1",),
+    )
+    await store.upsert_relation_with_lineage(
+        record=rel,
+        lineage=_make_member(doc="doc-A", version="v1", chunks=("c-1",)),
+    )
+    await store.upsert_relation_with_lineage(
+        record=rel,
+        lineage=_make_member(doc="doc-B", version="v1", chunks=("c-1",)),
+    )
+
+    keys = await store.find_relation_keys_with_lineage(document_id="doc-A")
+    assert ("Linus Torvalds", "Linux", "created") in keys
+
+    fetched = await store.get_relation("Linus Torvalds", "Linux", "created")
+    assert fetched is not None
+    assert {m.document_id for m in fetched.evidence_lineage} == {"doc-A", "doc-B"}
+
+    await store.remove_relation_lineage_member(
+        source="Linus Torvalds", target="Linux", type="created", document_id="doc-A"
+    )
+    deleted = await store.gc_relation_if_orphan("Linus Torvalds", "Linux", "created")
+    assert deleted is False, "doc-B still cites; relation must not be GC'd"
+
+    await store.remove_relation_lineage_member(
+        source="Linus Torvalds", target="Linux", type="created", document_id="doc-B"
+    )
+    deleted = await store.gc_relation_if_orphan("Linus Torvalds", "Linux", "created")
+    assert deleted is True
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolation_collection_id_filters_all_queries(store):
+    """Two store instances bound to different collection_ids must not
+    see each other's rows — even though both write the same entity
+    name, ``find_entity_ids_with_lineage`` and ``get_entity`` filter
+    on the bound ``collection_id``.
+
+    This is the per-store-instance binding half of the §H.2 tenant
+    double-layer (the other half is the composite-key uniqueness
+    constraint, exercised by ensure_schema).
+    """
+
+    from neo4j import AsyncGraphDatabase
+
+    other_cid = f"lineage_test_other_{uuid.uuid4().hex[:8]}"
+    other_driver = AsyncGraphDatabase.driver(_NEO4J_URI, auth=(_NEO4J_USER, _NEO4J_PASS))
+    other_store = Neo4jLineageGraphStore(driver=other_driver, collection_id=other_cid)
+    await other_store.ensure_schema()
+
+    try:
+        record = EntityRecord(
+            name="Shared Entity",
+            type="thing",
+            description="from other tenant",
+            source_chunk_ids=(),
+        )
+        await other_store.upsert_entity_with_lineage(
+            record=record,
+            lineage=_make_member(doc="other-doc", version="v1"),
+        )
+        # Sanity — the OTHER tenant CAN see its own row.
+        fetched_other = await other_store.get_entity("Shared Entity")
+        assert fetched_other is not None
+
+        # The PRIMARY store (bound to a different collection_id) MUST
+        # NOT see the other tenant's row.
+        leaked = await store.get_entity("Shared Entity")
+        assert leaked is None
+        names = await store.find_entity_ids_with_lineage(document_id="other-doc")
+        assert names == []
+    finally:
+        async with other_driver.session() as session:
+            await session.run(
+                "MATCH (n) WHERE n.collection_id = $cid DETACH DELETE n",
+                cid=other_cid,
+            )
+        await other_driver.close()

--- a/tests/integration/test_otlp_metrics_emitter.py
+++ b/tests/integration/test_otlp_metrics_emitter.py
@@ -1,0 +1,241 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for ``OTLPMetricsEmitter`` — Wave 4 T6.
+
+Pin the Wave 4 #8 production-readiness invariant: when
+``INDEXING_METRICS_EMITTER=otlp`` (production multi-pod per design pack
+§J.1), :class:`OTLPMetricsEmitter` materialises real SDK instruments on
+the configured ``MeterProvider`` and forwards every ``gauge`` /
+``counter`` call to the OTLP exporter.
+
+The exporter side is verified with :class:`InMemoryMetricReader` so the
+test does not need a live OTLP collector — it is exercising the same
+SDK path the production exporter uses (``MeterProvider`` →
+``MetricReader`` → ``Metric`` data) just with the in-memory reader
+substituted for the network exporter.
+
+The emitter accepts an injectable ``meter`` for tests because
+``opentelemetry.metrics.set_meter_provider`` is one-shot per process —
+once any real provider is installed, it cannot be replaced, so tests
+that need isolated readers must source meters from their own
+``MeterProvider`` instances and pass them in directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from aperag.indexing.models import Modality
+from aperag.indexing.observability import (
+    INDEX_FAILURE_METRIC,
+    INDEX_SUCCESS_METRIC,
+    QUEUE_DEPTH_METRIC,
+    WORKER_UTILIZATION_METRIC,
+    OTLPMetricsEmitter,
+    emit_index_failure,
+    emit_index_success,
+    emit_queue_depth,
+    emit_worker_utilization,
+)
+
+
+@pytest.fixture
+def isolated_provider():
+    """Per-test SDK ``MeterProvider`` with an
+    :class:`InMemoryMetricReader`. Returned tuple is
+    ``(provider, reader)`` — tests source a meter from the provider
+    via ``provider.get_meter(...)`` and read back the recorded
+    samples from the reader.
+    """
+
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        resource=Resource.create({"service.name": "aperag-test"}),
+        metric_readers=[reader],
+    )
+    try:
+        yield provider, reader
+    finally:
+        provider.shutdown()
+
+
+def _collect_samples(reader) -> dict[str, list[tuple[dict, float]]]:
+    """Drain the reader once and bucket all data points by metric name.
+
+    ``InMemoryMetricReader.get_metrics_data()`` collects + resets — a
+    second call returns ``None`` because the first one consumed every
+    point. Tests therefore drain once and inspect the snapshot, rather
+    than calling ``_samples_for(reader, name)`` multiple times.
+    """
+
+    data = reader.get_metrics_data()
+    samples: dict[str, list[tuple[dict, float]]] = {}
+    if data is None:
+        return samples
+    for resource_metric in data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                bucket = samples.setdefault(metric.name, [])
+                for point in metric.data.data_points:
+                    attrs = dict(point.attributes or {})
+                    value = getattr(point, "value", None)
+                    if value is None:
+                        continue
+                    bucket.append((attrs, float(value)))
+    return samples
+
+
+def test_counter_round_trip(isolated_provider):
+    """``counter`` calls land on the SDK ``MeterProvider`` and the
+    in-memory reader sees the running total, attribute-keyed.
+    """
+    provider, reader = isolated_provider
+    emitter = OTLPMetricsEmitter(meter=provider.get_meter("aperag.indexing.test"))
+
+    emit_index_success(emitter, modality=Modality.VECTOR)
+    emit_index_success(emitter, modality=Modality.VECTOR)
+    emit_index_failure(emitter, modality=Modality.VECTOR, error_kind="parse")
+
+    samples = _collect_samples(reader)
+
+    assert samples[INDEX_SUCCESS_METRIC] == [({"modality": "vector"}, 2.0)]
+    assert samples[INDEX_FAILURE_METRIC] == [({"modality": "vector", "error_kind": "parse"}, 1.0)]
+
+
+def test_gauge_round_trip(isolated_provider):
+    """``gauge`` calls update an SDK ``Gauge`` instrument — the latest
+    value per attribute set wins, mirroring the
+    :class:`InMemoryMetricsEmitter` semantics.
+    """
+    provider, reader = isolated_provider
+    emitter = OTLPMetricsEmitter(meter=provider.get_meter("aperag.indexing.test"))
+
+    emit_queue_depth(emitter, depth=3, modality=Modality.FULLTEXT)
+    emit_queue_depth(emitter, depth=11, modality=Modality.FULLTEXT)
+    emit_worker_utilization(emitter, busy=2, capacity=8, modality=Modality.GRAPH)
+
+    samples = _collect_samples(reader)
+
+    assert samples[QUEUE_DEPTH_METRIC] == [({"modality": "fulltext"}, 11.0)]
+    # Utilization = 2 / 8 = 0.25
+    assert samples[WORKER_UTILIZATION_METRIC] == [({"modality": "graph"}, 0.25)]
+
+
+def test_per_modality_isolation(isolated_provider):
+    """Two modality attributes on the same metric name fan out to two
+    distinct data points so operators get per-modality dashboards.
+    """
+    provider, reader = isolated_provider
+    emitter = OTLPMetricsEmitter(meter=provider.get_meter("aperag.indexing.test"))
+
+    emit_queue_depth(emitter, depth=4, modality=Modality.VECTOR)
+    emit_queue_depth(emitter, depth=7, modality=Modality.SUMMARY)
+
+    samples = sorted(
+        _collect_samples(reader)[QUEUE_DEPTH_METRIC],
+        key=lambda pair: pair[0]["modality"],
+    )
+    assert samples == [
+        ({"modality": "summary"}, 7.0),
+        ({"modality": "vector"}, 4.0),
+    ]
+
+
+def test_instruments_are_reused_per_metric_name(isolated_provider):
+    """Repeated ``counter`` / ``gauge`` calls for the same name reuse
+    one SDK instrument handle — instrument creation is idempotent and
+    not per-call (mirrors the pattern in
+    ``aperag.observability.metrics.record_counter``).
+    """
+    provider, _ = isolated_provider
+    emitter = OTLPMetricsEmitter(meter=provider.get_meter("aperag.indexing.test"))
+
+    emitter.counter(name=INDEX_SUCCESS_METRIC, attributes={"modality": "vector"})
+    emitter.counter(name=INDEX_SUCCESS_METRIC, attributes={"modality": "fulltext"})
+    emitter.gauge(name=QUEUE_DEPTH_METRIC, value=2.0)
+    emitter.gauge(name=QUEUE_DEPTH_METRIC, value=4.0)
+
+    assert list(emitter._counters.keys()) == [INDEX_SUCCESS_METRIC]
+    assert list(emitter._gauges.keys()) == [QUEUE_DEPTH_METRIC]
+
+
+def test_init_metrics_provider_endpoint_required():
+    """``init_metrics_provider`` short-circuits when the OTLP endpoint
+    is not configured. Operators in ``mode=otlp`` without an endpoint
+    get a warning + the app keeps booting against the no-op proxy
+    provider — silent enough that the indexing emitter degrades to
+    no-ops, loud enough that the warning is in the log.
+    """
+    # Reload so ``_meter_provider_initialized`` resets to ``False``.
+    from aperag.observability import metrics as obs_metrics
+
+    importlib.reload(obs_metrics)
+
+    from aperag.observability.config import ObservabilityConfig
+
+    no_endpoint = ObservabilityConfig(mode="otlp", otlp_endpoint=None)
+    assert obs_metrics.init_metrics_provider(no_endpoint) is False
+    assert obs_metrics._meter_provider_initialized is False
+
+
+def test_init_metrics_provider_idempotent():
+    """``init_metrics_provider`` is safe to call multiple times. Once
+    the SDK ``MeterProvider`` is installed at app start, subsequent
+    calls (e.g. from a hot-reload code path) return ``True`` without
+    re-initialising.
+
+    NOTE: ``set_meter_provider`` is one-shot at the global level, so
+    we exercise the idempotence guard explicitly rather than swapping
+    the global provider mid-test.
+    """
+    from aperag.observability import metrics as obs_metrics
+    from aperag.observability.config import ObservabilityConfig
+
+    importlib.reload(obs_metrics)
+
+    config = ObservabilityConfig(
+        mode="otlp",
+        otlp_endpoint="http://127.0.0.1:4318",
+        otlp_protocol="http/protobuf",
+    )
+    first = obs_metrics.init_metrics_provider(config)
+    second = obs_metrics.init_metrics_provider(config)
+    assert first is True
+    assert second is True
+    assert obs_metrics._meter_provider_initialized is True
+
+    obs_metrics.shutdown_metrics_provider()
+
+
+def test_otlp_emitter_default_meter_resolves_global():
+    """Without an injected meter, :class:`OTLPMetricsEmitter` resolves
+    the global ``opentelemetry.metrics.get_meter("aperag.indexing")``
+    so production lifespan dispatch (which does not pass ``meter=``)
+    binds to whichever ``MeterProvider`` is installed at app start.
+    """
+    emitter = OTLPMetricsEmitter()
+    # The default proxy provider returns a non-None meter; we don't
+    # assert on its concrete type because it varies by SDK init order.
+    # The ``gauge`` / ``counter`` calls below must not crash even
+    # when the proxy is in place.
+    emitter.gauge(name=QUEUE_DEPTH_METRIC, value=1.0)
+    emitter.counter(name=INDEX_SUCCESS_METRIC, value=1.0, attributes={"modality": "vector"})
+    assert emitter._meter is not None

--- a/tests/integration/test_parse_async_roundtrip.py
+++ b/tests/integration/test_parse_async_roundtrip.py
@@ -1,0 +1,533 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parse worker async roundtrip — celery Wave 4 T3 chunk 2.
+
+Pin the production-critical contract that the upload handler's
+``push_parse`` call lands in the parse worker pool, parses the source
+through :func:`parse_document`, and dispatches the per-modality jobs
+without the HTTP request blocking on parse latency.
+
+Three layers covered here:
+
+1. **Single-task happy path** (:func:`process_one_parse_task`) — the
+   parse worker reads source bytes from the object store, runs
+   :func:`parse_document`, INSERTs the per-modality PENDING rows, and
+   pushes one payload per modality onto ``q:<modality>``.
+
+2. **Failure paths** — missing source / DocParser raise / unknown
+   modality each return a distinct status string and never advance
+   to dispatch (zero modality rows + zero queue payloads).
+
+3. **End-to-end roundtrip** — push parse → parse worker → modality
+   workers → ``status=ACTIVE`` for every requested modality. Verifies
+   the chunk 2 promise that an upload returns 202 and the indexing
+   completes asynchronously without further HTTP involvement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy import Engine, create_engine, select
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from aperag.indexing import (
+    DEFAULT_PARSE_CONCURRENCY,
+    FulltextModality,
+    InMemoryFulltextBackend,
+    InMemoryObjectStore,
+    InMemoryVectorBackend,
+    InMemoryWorkQueue,
+    Modality,
+    OrchestratorConfig,
+    ParseDispatchPayload,
+    ParseOrchestratorConfig,
+    VectorModality,
+    drain_queue_sync,
+    process_one_parse_task,
+    run_parse_worker_loop,
+    run_worker_loop,
+)
+from aperag.indexing.models import DocumentIndex, IndexStatus
+from aperag.indexing.object_store import source_artifact
+
+COLLECTION_ID = "col-parse-async"
+DOCUMENT_ID = "doc-parse-async"
+TENANT_SCOPE_KEY = "user:parse-async"
+
+SOURCE_MARKDOWN = b"""# Async Roundtrip
+
+The parse worker promotes parsing off the HTTP request thread.
+
+## Section A
+
+A second paragraph keeps the chunker honest about paragraph breaks
+so the chunk count is at least 2.
+
+## Section B
+
+A third paragraph makes the chunk count comfortably non-trivial.
+"""
+
+
+def _make_engine() -> Engine:
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    DocumentIndex.metadata.create_all(eng, tables=[DocumentIndex.__table__])
+    return eng
+
+
+def _seed_source(store: InMemoryObjectStore, body: bytes) -> str:
+    """Write the source artifact at the canonical upload path and return it."""
+    path = source_artifact(
+        collection_id=COLLECTION_ID,
+        document_id=DOCUMENT_ID,
+        filename="original.md",
+    )
+    store.put(path, body)
+    return path
+
+
+# -----------------------------------------------------------------------
+# Layer 1: process_one_parse_task happy + degenerate paths
+# -----------------------------------------------------------------------
+
+
+def test_process_one_parse_task_happy_path_inserts_rows_and_enqueues_modalities():
+    """Parse worker single-task drive:
+
+    - Source is read from the object store.
+    - ``parse_document`` writes the canonical artifacts.
+    - Vector + fulltext PENDING rows land with the real ``parse_version``.
+    - One payload lands on each modality queue with the chunks.jsonl path.
+    """
+
+    async def _run() -> None:
+        engine = _make_engine()
+        try:
+            store = InMemoryObjectStore()
+            object_path = _seed_source(store, SOURCE_MARKDOWN)
+            queue = InMemoryWorkQueue()
+
+            payload = ParseDispatchPayload(
+                document_id=DOCUMENT_ID,
+                collection_id=COLLECTION_ID,
+                object_path=object_path,
+                tenant_scope_key=TENANT_SCOPE_KEY,
+                modalities=(Modality.VECTOR.value, Modality.FULLTEXT.value),
+            )
+
+            outcome = await process_one_parse_task(
+                engine=engine,
+                queue=queue,
+                object_store=store,
+                payload=payload,
+            )
+            assert outcome == "completed"
+
+            # --- DB rows landed
+            with Session(engine) as session:
+                rows = list(session.execute(select(DocumentIndex).order_by(DocumentIndex.modality)).scalars())
+            assert len(rows) == 2
+            for row in rows:
+                assert row.status == IndexStatus.PENDING.value
+                assert row.document_id == DOCUMENT_ID
+                assert row.collection_id == COLLECTION_ID
+                assert row.tenant_scope_key == TENANT_SCOPE_KEY
+                assert row.parse_version  # 16-char hex from compute_parse_version
+                assert "chunks.jsonl" in row.source_path
+
+            # --- queue payloads landed
+            vector_payloads = drain_queue_sync(queue, Modality.VECTOR)
+            fulltext_payloads = drain_queue_sync(queue, Modality.FULLTEXT)
+            assert len(vector_payloads) == 1
+            assert len(fulltext_payloads) == 1
+            for raw in vector_payloads + fulltext_payloads:
+                assert raw["document_id"] == DOCUMENT_ID
+                assert raw["collection_id"] == COLLECTION_ID
+                assert "chunks.jsonl" in raw["source_path"]
+                assert raw["parse_version"] == rows[0].parse_version
+        finally:
+            engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_process_one_parse_task_no_modalities_is_parse_only_no_dispatch():
+    """Empty modality tuple → parse runs but no dispatch / no rows.
+
+    Useful for a future "parse-only" upload mode (e.g. an admin
+    re-parse without re-indexing). The artifacts must still be
+    written so downstream re-dispatch sees the canonical
+    ``derived/parse_<v>/chunks.jsonl``.
+    """
+
+    async def _run() -> None:
+        engine = _make_engine()
+        try:
+            store = InMemoryObjectStore()
+            object_path = _seed_source(store, SOURCE_MARKDOWN)
+            queue = InMemoryWorkQueue()
+
+            payload = ParseDispatchPayload(
+                document_id=DOCUMENT_ID,
+                collection_id=COLLECTION_ID,
+                object_path=object_path,
+                tenant_scope_key=TENANT_SCOPE_KEY,
+                modalities=(),
+            )
+            outcome = await process_one_parse_task(
+                engine=engine,
+                queue=queue,
+                object_store=store,
+                payload=payload,
+            )
+            assert outcome == "completed"
+            with Session(engine) as session:
+                rows = list(session.execute(select(DocumentIndex)).scalars())
+            assert rows == []
+            # Artifacts still written so a follow-up dispatch can re-use them.
+            assert any("chunks.jsonl" in path for path in store._objects)  # noqa: SLF001 — test introspection
+        finally:
+            engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_process_one_parse_task_purge_existing_triples_handles_rebuild():
+    """``purge_existing_triples=True`` lets a rebuild dispatch land
+    even when the prior ``(document_id, parse_version, modality)`` rows
+    still exist (same content → same parse_version → would otherwise
+    trip the ``uq_document_index_triple`` UNIQUE constraint).
+    """
+
+    async def _run() -> None:
+        engine = _make_engine()
+        try:
+            store = InMemoryObjectStore()
+            object_path = _seed_source(store, SOURCE_MARKDOWN)
+            queue = InMemoryWorkQueue()
+
+            payload = ParseDispatchPayload(
+                document_id=DOCUMENT_ID,
+                collection_id=COLLECTION_ID,
+                object_path=object_path,
+                tenant_scope_key=TENANT_SCOPE_KEY,
+                modalities=(Modality.VECTOR.value,),
+                purge_existing_triples=True,
+            )
+            # First pass — clean DB.
+            outcome = await process_one_parse_task(engine=engine, queue=queue, object_store=store, payload=payload)
+            assert outcome == "completed"
+            # Second pass — rebuild path. Without purge this would
+            # IntegrityError on INSERT.
+            outcome = await process_one_parse_task(engine=engine, queue=queue, object_store=store, payload=payload)
+            assert outcome == "completed"
+
+            with Session(engine) as session:
+                rows = list(session.execute(select(DocumentIndex)).scalars())
+            # Single VECTOR row — purge dropped the prior, INSERT
+            # re-added; second dispatch did not stack a duplicate.
+            assert len(rows) == 1
+            assert rows[0].modality == Modality.VECTOR.value
+        finally:
+            engine.dispose()
+
+    asyncio.run(_run())
+
+
+# -----------------------------------------------------------------------
+# Layer 2: failure paths
+# -----------------------------------------------------------------------
+
+
+def test_process_one_parse_task_missing_source_returns_failed_read():
+    """No source artifact → ``failed_read`` + zero rows + zero queue payloads."""
+
+    async def _run() -> None:
+        engine = _make_engine()
+        try:
+            store = InMemoryObjectStore()  # source intentionally NOT seeded
+            queue = InMemoryWorkQueue()
+            payload = ParseDispatchPayload(
+                document_id=DOCUMENT_ID,
+                collection_id=COLLECTION_ID,
+                object_path="collections/x/documents/y/source/missing.md",
+                tenant_scope_key=TENANT_SCOPE_KEY,
+                modalities=(Modality.VECTOR.value,),
+            )
+            outcome = await process_one_parse_task(engine=engine, queue=queue, object_store=store, payload=payload)
+            assert outcome == "failed_read"
+
+            with Session(engine) as session:
+                rows = list(session.execute(select(DocumentIndex)).scalars())
+            assert rows == []
+            assert drain_queue_sync(queue, Modality.VECTOR) == []
+        finally:
+            engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_process_one_parse_task_unknown_modality_returns_failed_dispatch():
+    """Unknown modality value → ``failed_dispatch`` + zero rows.
+
+    Ensures a malformed payload (e.g. a future modality name pushed by
+    a newer client) does not silently no-op or partially dispatch — we
+    surface the failure through the return code so the run loop logs
+    + drops cleanly.
+    """
+
+    async def _run() -> None:
+        engine = _make_engine()
+        try:
+            store = InMemoryObjectStore()
+            object_path = _seed_source(store, SOURCE_MARKDOWN)
+            queue = InMemoryWorkQueue()
+            payload = ParseDispatchPayload(
+                document_id=DOCUMENT_ID,
+                collection_id=COLLECTION_ID,
+                object_path=object_path,
+                tenant_scope_key=TENANT_SCOPE_KEY,
+                modalities=("not-a-real-modality",),
+            )
+            outcome = await process_one_parse_task(engine=engine, queue=queue, object_store=store, payload=payload)
+            assert outcome == "failed_dispatch"
+
+            with Session(engine) as session:
+                rows = list(session.execute(select(DocumentIndex)).scalars())
+            assert rows == []
+        finally:
+            engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_process_one_parse_task_unsupported_extension_returns_failed_parse():
+    """Source extension DocParser does not accept → ``failed_parse``.
+
+    DocParser raises ``ValueError`` per Wave 4 T3 chunk 1 (no silent
+    simulator fallback). The parse worker turns that into
+    ``failed_parse`` so the operator can triage from logs without
+    half-dispatched modality rows.
+    """
+
+    async def _run() -> None:
+        engine = _make_engine()
+        try:
+            store = InMemoryObjectStore()
+            unknown_ext_path = source_artifact(
+                collection_id=COLLECTION_ID,
+                document_id=DOCUMENT_ID,
+                filename="weird.unknownext",
+            )
+            store.put(unknown_ext_path, b"opaque bytes")
+            queue = InMemoryWorkQueue()
+            payload = ParseDispatchPayload(
+                document_id=DOCUMENT_ID,
+                collection_id=COLLECTION_ID,
+                object_path=unknown_ext_path,
+                tenant_scope_key=TENANT_SCOPE_KEY,
+                modalities=(Modality.VECTOR.value,),
+            )
+            outcome = await process_one_parse_task(engine=engine, queue=queue, object_store=store, payload=payload)
+            assert outcome == "failed_parse"
+
+            with Session(engine) as session:
+                rows = list(session.execute(select(DocumentIndex)).scalars())
+            assert rows == []
+        finally:
+            engine.dispose()
+
+    asyncio.run(_run())
+
+
+# -----------------------------------------------------------------------
+# Layer 3: full async roundtrip — push_parse → parse worker → modality
+# workers → ACTIVE.
+# -----------------------------------------------------------------------
+
+
+def test_push_parse_async_roundtrip_reaches_active_for_each_modality():
+    """End-to-end async pipeline:
+
+    upload handler ``push_parse`` → parse worker BLPOP → parse +
+    dispatch → vector + fulltext workers BLPOP → derive + sync +
+    cutover → ``status=ACTIVE`` AND ``is_serving=TRUE``.
+
+    The HTTP request never participates in parse latency in this
+    flow — that is the whole point of chunk 2.
+    """
+
+    async def _run() -> None:
+        engine = _make_engine()
+        try:
+            store = InMemoryObjectStore()
+            object_path = _seed_source(store, SOURCE_MARKDOWN)
+            queue = InMemoryWorkQueue()
+            shutdown = asyncio.Event()
+
+            # Upload handler analog: push_parse, return immediately.
+            upload_payload = ParseDispatchPayload(
+                document_id=DOCUMENT_ID,
+                collection_id=COLLECTION_ID,
+                object_path=object_path,
+                tenant_scope_key=TENANT_SCOPE_KEY,
+                modalities=(Modality.VECTOR.value, Modality.FULLTEXT.value),
+            )
+            await queue.push_parse(payload=upload_payload.to_dict())
+
+            # Parse worker run loop — short poll so shutdown is responsive.
+            async def _store_factory() -> InMemoryObjectStore:
+                return store
+
+            parse_task = asyncio.create_task(
+                run_parse_worker_loop(
+                    config=ParseOrchestratorConfig(
+                        concurrency=DEFAULT_PARSE_CONCURRENCY,
+                        poll_timeout_seconds=0.05,
+                    ),
+                    engine=engine,
+                    queue=queue,
+                    object_store_factory=_store_factory,
+                    shutdown=shutdown,
+                )
+            )
+
+            # Modality worker factories — bind the per-modality backend
+            # to the shared object store so derive() sees the chunks
+            # the parse worker just wrote.
+            vector_modality = VectorModality(backend=InMemoryVectorBackend(), store=store)
+            fulltext_modality = FulltextModality(backend=InMemoryFulltextBackend(), store=store)
+
+            async def _vector_factory(_payload):
+                return vector_modality
+
+            async def _fulltext_factory(_payload):
+                return fulltext_modality
+
+            vector_task = asyncio.create_task(
+                run_worker_loop(
+                    config=OrchestratorConfig(
+                        modality=Modality.VECTOR,
+                        concurrency=2,
+                        poll_timeout_seconds=0.05,
+                        heartbeat_interval_seconds=0,
+                    ),
+                    engine=engine,
+                    queue=queue,
+                    worker_factory=_vector_factory,
+                    shutdown=shutdown,
+                )
+            )
+            fulltext_task = asyncio.create_task(
+                run_worker_loop(
+                    config=OrchestratorConfig(
+                        modality=Modality.FULLTEXT,
+                        concurrency=2,
+                        poll_timeout_seconds=0.05,
+                        heartbeat_interval_seconds=0,
+                    ),
+                    engine=engine,
+                    queue=queue,
+                    worker_factory=_fulltext_factory,
+                    shutdown=shutdown,
+                )
+            )
+
+            # Wait until both modality rows reach ACTIVE — bounded
+            # spin so a regression does not hang the test runner.
+            async def _await_active() -> list[DocumentIndex]:
+                deadline = asyncio.get_event_loop().time() + 5.0
+                while True:
+                    with Session(engine) as session:
+                        rows = list(session.execute(select(DocumentIndex)).scalars())
+                    if (
+                        len(rows) == 2
+                        and all(r.status == IndexStatus.ACTIVE.value for r in rows)
+                        and all(r.is_serving for r in rows)
+                    ):
+                        return rows
+                    if asyncio.get_event_loop().time() > deadline:
+                        return rows
+                    await asyncio.sleep(0.05)
+
+            rows = await _await_active()
+            shutdown.set()
+            await asyncio.gather(parse_task, vector_task, fulltext_task, return_exceptions=True)
+
+            assert len(rows) == 2, f"expected 2 rows, got: {[(r.modality, r.status) for r in rows]}"
+            statuses = sorted((r.modality, r.status, r.is_serving) for r in rows)
+            assert statuses == sorted(
+                [
+                    (Modality.VECTOR.value, IndexStatus.ACTIVE.value, True),
+                    (Modality.FULLTEXT.value, IndexStatus.ACTIVE.value, True),
+                ]
+            )
+        finally:
+            engine.dispose()
+
+    asyncio.run(_run())
+
+
+# -----------------------------------------------------------------------
+# Layer 4: payload roundtrip — protect the JSON dispatch shape.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parser_config",
+    [None, {"use_mineru": True, "mineru_api_token": "secret"}],
+)
+def test_parse_dispatch_payload_to_from_dict_roundtrip(parser_config):
+    """``ParseDispatchPayload.to_dict / from_dict`` round-trip preserves
+    every field — pinned because the payload is the wire format both
+    the upload handler (push) and the parse worker (pop) depend on.
+    """
+    p = ParseDispatchPayload(
+        document_id="doc-1",
+        collection_id="col-1",
+        object_path="collections/col-1/documents/doc-1/source/upload.pdf",
+        tenant_scope_key="user:42",
+        modalities=(Modality.VECTOR.value, Modality.GRAPH.value),
+        parser_config=parser_config,
+        purge_existing_triples=True,
+    )
+    encoded = p.to_dict()
+    decoded = ParseDispatchPayload.from_dict(encoded)
+    assert decoded == p
+
+
+def test_parse_dispatch_payload_rejects_non_dict_parser_config():
+    """A malformed ``parser_config`` (e.g. a string from a sloppy
+    client) is rejected at decode time so the parse worker never
+    reaches DocParser with something that would crash the parser
+    chain mid-run.
+    """
+    bad = {
+        "document_id": "doc-1",
+        "collection_id": "col-1",
+        "object_path": "x",
+        "tenant_scope_key": "user:1",
+        "modalities": [Modality.VECTOR.value],
+        "parser_config": "not-a-dict",
+    }
+    with pytest.raises(TypeError, match="parser_config must be a dict"):
+        ParseDispatchPayload.from_dict(bad)

--- a/tests/integration/test_real_parser_dispatch.py
+++ b/tests/integration/test_real_parser_dispatch.py
@@ -1,0 +1,252 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for ``parse_document`` real-parser dispatch — Wave 4 T3 chunk 1.
+
+Pin the Wave 4 #4 production-readiness invariant: when
+``parse_document`` is called with a ``source_filename`` whose
+extension is not in the simulator allowlist (``.md`` / ``.markdown``
+/ ``.txt`` / ``.text``), the call dispatches to the real
+:class:`aperag.docparser.doc_parser.DocParser` chain and produces
+the canonical ``markdown.md`` + ``outline.json`` + ``chunks.jsonl``
+artifacts from the real binary input — no UTF-8 decode short-circuit,
+no silent simulator fallback.
+
+These tests run against the real ``MarkItDown`` parser (a hard
+dependency), so they exercise the same code path production hits on
+upload. They live under ``tests/integration/`` because they read +
+write tempfiles; the simulator-only regression suite under
+``tests/unit_test/indexing/test_t1_1_foundation.py`` keeps unit
+coverage of the markdown path unchanged.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from aperag.indexing import InMemoryObjectStore, parse_document, read_chunks
+
+
+# Reading-back helpers — store accessor returns a context manager
+# whose stream yields the bytes; we always slurp it once.
+def _read_bytes(store: InMemoryObjectStore, path: str) -> bytes:
+    obj = store.get(path)
+    assert obj is not None, f"missing artifact: {path}"
+    with obj as stream:
+        return stream.read()
+
+
+# -----------------------------------------------------------------------
+# Simulator regression — must stay green so existing markdown callers
+# (test_t1_1_foundation, document_service for *.md uploads) keep working.
+# -----------------------------------------------------------------------
+
+
+def test_markdown_simulator_path_unchanged_without_filename():
+    """No ``source_filename`` → simulator decodes UTF-8 markdown directly."""
+    store = InMemoryObjectStore()
+    body = b"# Title\n\nFirst paragraph.\n\n## Sub\n\nSecond paragraph.\n"
+    result = parse_document(
+        store=store,
+        collection_id="col-md",
+        document_id="doc-md",
+        source_bytes=body,
+    )
+    chunks = read_chunks(store, result.chunks_path)
+    assert len(chunks) >= 1
+    markdown = _read_bytes(store, result.markdown_path).decode("utf-8")
+    assert "# Title" in markdown
+    assert "## Sub" in markdown
+
+
+def test_markdown_simulator_path_with_md_filename():
+    """``source_filename='*.md'`` keeps the simulator route."""
+    store = InMemoryObjectStore()
+    body = b"# Heading\n\nbody"
+    result = parse_document(
+        store=store,
+        collection_id="col-md2",
+        document_id="doc-md2",
+        source_bytes=body,
+        source_filename="note.md",
+    )
+    markdown = _read_bytes(store, result.markdown_path).decode("utf-8")
+    assert markdown == body.decode("utf-8")
+
+
+def test_simulator_rejects_non_utf8_when_no_filename_hint():
+    """Bytes without an extension hint and not UTF-8 surface a clear error."""
+    store = InMemoryObjectStore()
+    with pytest.raises(ValueError, match="simulator parser path requires UTF-8"):
+        parse_document(
+            store=store,
+            collection_id="col",
+            document_id="doc",
+            source_bytes=b"\x89PNG\r\n\x1a\n",  # PNG magic
+            source_filename=None,
+        )
+
+
+# -----------------------------------------------------------------------
+# DocParser dispatch — non-text extensions route to the real chain.
+# -----------------------------------------------------------------------
+
+
+def test_html_routes_through_docparser_to_markdown():
+    """HTML is one of MarkItDown's supported extensions — verifies the
+    full DocParser chain end-to-end without needing additional binaries
+    (``pikepdf`` for PDF, ``soffice`` for legacy .doc, ``PADDLEOCR_HOST``
+    for images).
+    """
+    store = InMemoryObjectStore()
+    html = (
+        b"<html><body>"
+        b"<h1>Title One</h1>"
+        b"<p>First paragraph from HTML.</p>"
+        b"<h2>Section</h2>"
+        b"<p>Second paragraph.</p>"
+        b"</body></html>"
+    )
+    result = parse_document(
+        store=store,
+        collection_id="col-html",
+        document_id="doc-html",
+        source_bytes=html,
+        source_filename="report.html",
+    )
+
+    markdown = _read_bytes(store, result.markdown_path).decode("utf-8")
+    assert "Title One" in markdown
+    assert "Section" in markdown
+    assert "First paragraph from HTML" in markdown
+
+    outline_blob = _read_bytes(store, result.outline_path).decode("utf-8")
+    assert "Title One" in outline_blob
+    assert '"section_path": "1"' in outline_blob
+
+    chunks = read_chunks(store, result.chunks_path)
+    assert len(chunks) >= 1
+    # Chunk content carries the real markdown text, not raw HTML.
+    assert any("Title One" in c["text"] for c in chunks)
+
+
+def test_unsupported_extension_raises_clear_error():
+    """An extension DocParser cannot accept (e.g., a made-up suffix)
+    raises ``ValueError`` with the supported-list embedded so callers
+    can diagnose. We do not silently fall through to the simulator —
+    that would mask wiring bugs.
+    """
+    store = InMemoryObjectStore()
+    with pytest.raises(ValueError, match="DocParser does not accept"):
+        parse_document(
+            store=store,
+            collection_id="col",
+            document_id="doc",
+            source_bytes=b"some bytes",
+            source_filename="data.unknownext",
+        )
+
+
+# -----------------------------------------------------------------------
+# PDF integration — runs only when pikepdf + a small PDF can be built.
+# -----------------------------------------------------------------------
+
+
+def _try_make_pdf_bytes() -> bytes | None:
+    """Build a tiny PDF in memory if pikepdf is available; otherwise
+    return ``None`` so the test below skips cleanly. PDF rendering is
+    sensitive to the libcairo / ghostscript stack on the test host so
+    we avoid that path and just synthesise a minimal valid PDF.
+    """
+    try:
+        import pikepdf
+    except ImportError:  # pragma: no cover
+        return None
+    try:
+        pdf = pikepdf.Pdf.new()
+        # pikepdf does not have a high-level "add text" API; for the
+        # scope of T3 chunk 1 we just need a valid PDF that DocParser
+        # can recognise as parseable. MarkItDown will return an
+        # (empty-ish) MarkdownPart for a content-free PDF, and the
+        # pipeline emits zero chunks — that is the contract we test.
+        import io
+
+        pdf.save(buf := io.BytesIO())
+        return buf.getvalue()
+    except Exception:  # pragma: no cover
+        return None
+
+
+def test_pdf_dispatches_to_docparser_even_when_empty():
+    """Empty PDF → DocParser dispatched → empty markdown → zero chunks
+    + valid outline. The point is the dispatch path runs and produces
+    the canonical artifacts; a richer PDF case lives in chunk 2 e2e.
+    """
+    pdf_bytes = _try_make_pdf_bytes()
+    if pdf_bytes is None:
+        pytest.skip("pikepdf not available; skipping PDF dispatch test")
+
+    store = InMemoryObjectStore()
+    result = parse_document(
+        store=store,
+        collection_id="col-pdf",
+        document_id="doc-pdf",
+        source_bytes=pdf_bytes,
+        source_filename="empty.pdf",
+    )
+
+    # Artifacts written even when the parser produces empty markdown.
+    assert _read_bytes(store, result.markdown_path) is not None
+    assert _read_bytes(store, result.outline_path) is not None
+    assert _read_bytes(store, result.chunks_path) is not None
+
+
+# -----------------------------------------------------------------------
+# .docx via python-docx if installed.
+# -----------------------------------------------------------------------
+
+
+def test_docx_dispatches_to_docparser_when_python_docx_available():
+    """Real .docx body via python-docx (transitively via markitdown[all]).
+    Skips on test hosts where the optional dep chain is not present.
+    """
+    if importlib.util.find_spec("docx") is None:
+        pytest.skip("python-docx not installed; skipping .docx round-trip")
+
+    import io
+
+    from docx import Document
+
+    doc = Document()
+    doc.add_heading("Real Word Heading", level=1)
+    doc.add_paragraph("First docx paragraph.")
+    doc.add_heading("Sub Heading", level=2)
+    doc.add_paragraph("Second docx paragraph.")
+    buf = io.BytesIO()
+    doc.save(buf)
+
+    store = InMemoryObjectStore()
+    result = parse_document(
+        store=store,
+        collection_id="col-docx",
+        document_id="doc-docx",
+        source_bytes=buf.getvalue(),
+        source_filename="report.docx",
+    )
+    markdown = _read_bytes(store, result.markdown_path).decode("utf-8")
+    assert "Real Word Heading" in markdown
+    assert "First docx paragraph" in markdown
+    assert len(read_chunks(store, result.chunks_path)) >= 1

--- a/tests/integration/test_redis_workqueue.py
+++ b/tests/integration/test_redis_workqueue.py
@@ -1,0 +1,239 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for ``RedisWorkQueue`` — Wave 4 T4.
+
+Pin the Wave 4 #6 production-readiness invariant: when
+``INDEXING_QUEUE_BACKEND=redis`` (multi-process scale-out per design
+pack §E.2), enqueue/dequeue is BLPOP-atomic across multiple workers
+sharing the same key — no payload is delivered to two workers, no
+payload is silently dropped.
+
+Tests skip when the configured Redis URL is unreachable so the
+non-Redis CI lane (lint-and-unit) stays green; the e2e-http-compose CI
+lane brings a real Redis up, so these tests run there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+from aperag.indexing import Modality, RedisWorkQueue
+
+# Use a separate Redis logical DB (15) for tests so a leftover key from
+# a flaky run never shadows production / other test suites.
+_REDIS_URL = os.environ.get(
+    "TEST_INDEXING_QUEUE_REDIS_URL",
+    "redis://default:password@127.0.0.1:6379/15",
+)
+
+
+def _redis_reachable(url: str) -> bool:
+    """Synchronous reachability probe so the skip decision is taken
+    before pytest tries to schedule the async test on the event loop.
+    """
+
+    try:
+        import redis  # type: ignore[import-untyped]
+    except ImportError:  # pragma: no cover — `redis` is a hard dep
+        return False
+
+    try:
+        client = redis.from_url(url, socket_connect_timeout=1)
+        client.ping()
+        client.close()
+        return True
+    except Exception:
+        return False
+
+
+_REDIS_OK = _redis_reachable(_REDIS_URL)
+pytestmark = pytest.mark.skipif(
+    not _REDIS_OK,
+    reason=f"Redis at {_REDIS_URL} unreachable; skipping RedisWorkQueue integration suite",
+)
+
+
+@pytest.fixture
+async def queue():
+    """Fresh ``RedisWorkQueue`` per test, with a per-test key prefix
+    that keys won't collide between concurrent runs.
+    """
+
+    q = RedisWorkQueue(redis_url=_REDIS_URL)
+    # Per-run key suffix so parallel CI / re-runs don't see each
+    # other's leftover payloads.
+    suffix = uuid.uuid4().hex[:8]
+    original_template = RedisWorkQueue.KEY_TEMPLATE
+    RedisWorkQueue.KEY_TEMPLATE = f"q:test:{suffix}:{{modality}}"
+    try:
+        yield q
+    finally:
+        # Drain any leftover keys this test wrote so the test DB doesn't
+        # accumulate cruft, then restore the production-shape template.
+        client = await q._get_client()
+        for modality in Modality:
+            await client.delete(RedisWorkQueue._key(modality))
+        await q.close()
+        RedisWorkQueue.KEY_TEMPLATE = original_template
+
+
+@pytest.mark.asyncio
+async def test_push_then_pop_roundtrips_payload(queue):
+    """Single producer + single consumer roundtrip — payload bytes
+    survive JSON encode/decode through Redis identity.
+    """
+
+    payload = {
+        "index_id": 42,
+        "document_id": "doc-1",
+        "parse_version": "abc123",
+        "modality": Modality.VECTOR.value,
+        "source_path": "collections/c/documents/doc-1/derived/parse_abc123/chunks.jsonl",
+        "collection_id": "c",
+    }
+    await queue.push(modality=Modality.VECTOR, payload=payload)
+    received = await queue.pop(modality=Modality.VECTOR, timeout_seconds=2)
+    assert received == payload
+
+
+@pytest.mark.asyncio
+async def test_pop_returns_none_on_timeout(queue):
+    """Empty queue + timeout → ``None`` (not a hang, not a raise).
+    Exercise the worker BLPOP-then-check-shutdown loop pattern.
+    """
+
+    received = await queue.pop(modality=Modality.VECTOR, timeout_seconds=1)
+    assert received is None
+
+
+@pytest.mark.asyncio
+async def test_each_payload_delivered_to_exactly_one_consumer(queue):
+    """Multi-consumer demux — N consumers BLPOP'ing the same key
+    receive N disjoint payloads when N payloads are pushed.
+
+    This is the §E.2 multi-process scale-out invariant Wave 4 T4
+    enables: production deploys multiple FastAPI/worker pods, each
+    BLPOP'ing the same queue, and Redis must atomically demux so no
+    payload runs twice.
+    """
+
+    n = 5
+    pushed = [
+        {
+            "index_id": i,
+            "document_id": f"doc-{i}",
+            "parse_version": f"pv-{i:04d}",
+            "modality": Modality.FULLTEXT.value,
+            "source_path": f"path-{i}",
+            "collection_id": "c",
+        }
+        for i in range(n)
+    ]
+    for payload in pushed:
+        await queue.push(modality=Modality.FULLTEXT, payload=payload)
+
+    # Spawn N consumers concurrently — each BLPOPs once. The set union
+    # of received payloads should equal the set of pushed payloads
+    # (no duplicates, no losses).
+    async def consume() -> dict | None:
+        return await queue.pop(modality=Modality.FULLTEXT, timeout_seconds=2)
+
+    received = await asyncio.gather(*(consume() for _ in range(n)))
+    assert all(item is not None for item in received), "all consumers must receive a payload"
+    received_index_ids = sorted(item["index_id"] for item in received)
+    assert received_index_ids == list(range(n)), "every push must reach exactly one consumer (no duplicate, no loss)"
+
+
+@pytest.mark.asyncio
+async def test_per_modality_queue_isolation(queue):
+    """Pushes to ``modality=VECTOR`` must not be visible to a
+    consumer popping ``modality=FULLTEXT`` — each modality has its
+    own BLPOP key.
+    """
+
+    await queue.push(
+        modality=Modality.VECTOR,
+        payload={
+            "index_id": 1,
+            "document_id": "d",
+            "parse_version": "v",
+            "modality": Modality.VECTOR.value,
+            "source_path": "p",
+            "collection_id": "c",
+        },
+    )
+    # Pop on a different modality — should time out.
+    other = await queue.pop(modality=Modality.FULLTEXT, timeout_seconds=1)
+    assert other is None
+    # Pop on the right modality should still see our payload.
+    own = await queue.pop(modality=Modality.VECTOR, timeout_seconds=1)
+    assert own is not None
+    assert own["modality"] == Modality.VECTOR.value
+
+
+@pytest.mark.asyncio
+async def test_qsize_reflects_pending_payloads(queue):
+    """``qsize`` exposes the current backlog length so the §J.1
+    ``queue_depth`` SLI emitter and tests can assert payloads
+    landed without consuming them.
+    """
+
+    assert await queue.qsize(Modality.SUMMARY) == 0
+    for i in range(3):
+        await queue.push(
+            modality=Modality.SUMMARY,
+            payload={
+                "index_id": i,
+                "document_id": "d",
+                "parse_version": "v",
+                "modality": Modality.SUMMARY.value,
+                "source_path": "p",
+                "collection_id": "c",
+            },
+        )
+    assert await queue.qsize(Modality.SUMMARY) == 3
+    await queue.pop(modality=Modality.SUMMARY, timeout_seconds=1)
+    assert await queue.qsize(Modality.SUMMARY) == 2
+
+
+@pytest.mark.asyncio
+async def test_close_releases_underlying_client(queue):
+    """``close`` returns the client to a re-connectable state — calling
+    a method after ``close`` lazy-reopens the connection. Exercise the
+    FastAPI lifespan shutdown path that calls ``await queue.close()``
+    on SIGTERM.
+    """
+
+    await queue.push(
+        modality=Modality.GRAPH,
+        payload={
+            "index_id": 1,
+            "document_id": "d",
+            "parse_version": "v",
+            "modality": Modality.GRAPH.value,
+            "source_path": "p",
+            "collection_id": "c",
+        },
+    )
+    await queue.close()
+    # After close, _client is None and a subsequent operation must
+    # transparently reconnect.
+    assert queue._client is None
+    received = await queue.pop(modality=Modality.GRAPH, timeout_seconds=2)
+    assert received is not None

--- a/tests/integration/test_worker_factory.py
+++ b/tests/integration/test_worker_factory.py
@@ -44,6 +44,7 @@ external services):
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 from sqlalchemy import Engine, create_engine, insert
@@ -197,6 +198,159 @@ def test_production_factory_raises_when_collection_missing():
             engine.dispose()
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------
+# Wave 4 T8 chunk 4b — graph_backend_type dispatch + T1-extractor gate.
+# ---------------------------------------------------------------------
+
+
+def _make_collection_stub(*, config_obj: Any = None) -> Any:
+    """Lightweight stub that the dispatch helpers can read off."""
+
+    class _Stub:
+        id = "col-4b"
+        config = config_obj
+
+    return _Stub()
+
+
+def test_resolve_graph_backend_type_defaults_to_postgres():
+    """A collection with no ``config`` or no ``graph_backend_type`` field
+    falls back to the default ``postgres`` backend (the §D.3.5 reference
+    adapter; new collections that opt into knowledge graph automatically
+    use the application's own PostgreSQL without extra infra).
+    """
+
+    from aperag.indexing.worker_factory import _resolve_graph_backend_type
+
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=None)) == "postgres"
+
+    class _ConfigNoBackend:
+        graph_backend_type = None
+
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=_ConfigNoBackend())) == "postgres"
+
+
+@pytest.mark.parametrize("backend", ["postgres", "neo4j", "nebula"])
+def test_resolve_graph_backend_type_reads_from_pydantic_attr(backend: str):
+    """A pydantic-shaped ``CollectionConfig`` exposes
+    ``graph_backend_type`` as an attribute; the resolver reads it
+    straight off."""
+
+    from aperag.indexing.worker_factory import _resolve_graph_backend_type
+
+    class _Config:
+        graph_backend_type = backend
+
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=_Config())) == backend
+
+
+def test_resolve_graph_backend_type_reads_from_dict_config():
+    """``Collection.config`` may be persisted as a JSON dict;
+    the resolver also handles the Mapping shape."""
+
+    from aperag.indexing.worker_factory import _resolve_graph_backend_type
+
+    cfg = {"graph_backend_type": "neo4j"}
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=cfg)) == "neo4j"
+
+
+def test_resolve_graph_backend_type_reads_from_json_string():
+    """Some legacy rows persisted ``Collection.config`` as a JSON
+    string; the resolver decodes it."""
+
+    from aperag.indexing.worker_factory import _resolve_graph_backend_type
+
+    cfg = '{"graph_backend_type": "nebula"}'
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=cfg)) == "nebula"
+
+
+def test_resolve_graph_backend_type_rejects_unknown():
+    """Typos / unsupported backends raise a clear
+    :class:`WorkerFactoryError` so the orchestrator finalises FAILED
+    with operator-facing diagnostics."""
+
+    from aperag.indexing.worker_factory import _resolve_graph_backend_type
+
+    class _Config:
+        graph_backend_type = "duckdb"
+
+    with pytest.raises(WorkerFactoryError) as exc:
+        _resolve_graph_backend_type(_make_collection_stub(config_obj=_Config()))
+    assert "duckdb" in str(exc.value)
+    assert "postgres" in str(exc.value)
+
+
+def test_resolve_entity_lock_returns_inmemory_for_postgres_and_neo4j():
+    """Postgres + Neo4j use single-statement strip-then-append under
+    native row locks, so an in-process :class:`InMemoryEntityLock` is
+    sufficient. Tests asserting "no Redis dependency for these
+    backends" pin the architect msg=f2921ae0 invariant.
+    """
+
+    from aperag.indexing.graph import InMemoryEntityLock
+    from aperag.indexing.worker_factory import (
+        _reset_graph_backend_singletons_for_tests,
+        _resolve_entity_lock,
+    )
+
+    _reset_graph_backend_singletons_for_tests()
+    try:
+        for backend in ("postgres", "neo4j"):
+            lock = _resolve_entity_lock(backend_type=backend)
+            assert isinstance(lock, InMemoryEntityLock), (
+                f"backend={backend} must use InMemoryEntityLock (no Redis dependency)"
+            )
+    finally:
+        _reset_graph_backend_singletons_for_tests()
+
+
+def test_build_graph_worker_raises_t1_wiring_gate(monkeypatch: pytest.MonkeyPatch):
+    """Even with a valid backend wired (chunk 4b), the graph worker
+    builder still raises :class:`WorkerFactoryError` because the LLM
+    extractor is the no-op stub until T1 lands. The error message must
+    name "Wave 4 wiring T1" so the e2e Phase 1 smoke can pin it.
+    """
+
+    from aperag.indexing import worker_factory as wf
+    from aperag.indexing.graph import InMemoryEntityLock, InMemoryLineageGraphStore
+
+    # Stub the backend dispatch so the gate is reached without needing
+    # a live Postgres / Neo4j / Nebula. The store / lock identity is
+    # irrelevant to the gate — the gate compares the EXTRACTOR.
+    wf._reset_graph_backend_singletons_for_tests()
+    monkeypatch.setattr(
+        wf,
+        "_build_lineage_graph_store",
+        lambda *, backend_type, collection: InMemoryLineageGraphStore(),
+    )
+    monkeypatch.setattr(
+        wf,
+        "_resolve_entity_lock",
+        lambda *, backend_type: InMemoryEntityLock(),
+    )
+
+    class _Config:
+        graph_backend_type = "postgres"
+
+    collection = _make_collection_stub(config_obj=_Config())
+    payload = DispatchPayload(
+        index_id=1,
+        document_id="doc",
+        parse_version="parse-v1",
+        modality=Modality.GRAPH,
+        source_path="source/path",
+        collection_id="col-4b",
+    )
+
+    # Stub tenant-scope-key resolution so the gate is the only failure mode.
+    monkeypatch.setattr(wf, "_resolve_tenant_scope_key", lambda *, payload: "user:t")
+
+    with pytest.raises(WorkerFactoryError) as exc:
+        wf._build_graph_worker(collection=collection, object_store=object(), payload=payload)
+    assert "Wave 4 wiring" in str(exc.value)
+    assert "T1" in str(exc.value)
 
 
 def test_production_factory_raises_when_collection_id_missing():

--- a/tests/integration/test_worker_factory.py
+++ b/tests/integration/test_worker_factory.py
@@ -306,19 +306,24 @@ def test_resolve_entity_lock_returns_inmemory_for_postgres_and_neo4j():
         _reset_graph_backend_singletons_for_tests()
 
 
-def test_build_graph_worker_raises_t1_wiring_gate(monkeypatch: pytest.MonkeyPatch):
-    """Even with a valid backend wired (chunk 4b), the graph worker
-    builder still raises :class:`WorkerFactoryError` because the LLM
-    extractor is the no-op stub until T1 lands. The error message must
-    name "Wave 4 wiring T1" so the e2e Phase 1 smoke can pin it.
+def test_build_graph_worker_raises_when_completion_model_missing(monkeypatch: pytest.MonkeyPatch):
+    """Post-T1 invariant: the chunk 4b ``"Wave 4 wiring T1"``
+    extractor-symbol-identity gate has self-disabled because T1 wired
+    the real LLM extractor. The new gate covers a Wave 3 lesson #10
+    failure mode: a collection that opts into knowledge graph but
+    lacks a configured completion model now surfaces a clear
+    :class:`WorkerFactoryError` from the extractor builder so the
+    orchestrator finalises the graph row FAILED with operator-facing
+    diagnostics (no silent ACTIVE-with-empty-graph).
     """
 
     from aperag.indexing import worker_factory as wf
     from aperag.indexing.graph import InMemoryEntityLock, InMemoryLineageGraphStore
 
-    # Stub the backend dispatch so the gate is reached without needing
-    # a live Postgres / Neo4j / Nebula. The store / lock identity is
-    # irrelevant to the gate — the gate compares the EXTRACTOR.
+    # Stub the backend dispatch so the extractor builder is reached
+    # without needing a live Postgres / Neo4j / Nebula. The collection
+    # stub has no ``completion`` config so ``build_collection_llm_callable``
+    # fails — the extractor builder wraps it in WorkerFactoryError.
     wf._reset_graph_backend_singletons_for_tests()
     monkeypatch.setattr(
         wf,
@@ -344,13 +349,14 @@ def test_build_graph_worker_raises_t1_wiring_gate(monkeypatch: pytest.MonkeyPatc
         collection_id="col-4b",
     )
 
-    # Stub tenant-scope-key resolution so the gate is the only failure mode.
+    # Stub tenant-scope-key resolution so the extractor builder is the
+    # only failure mode reachable.
     monkeypatch.setattr(wf, "_resolve_tenant_scope_key", lambda *, payload: "user:t")
 
     with pytest.raises(WorkerFactoryError) as exc:
         wf._build_graph_worker(collection=collection, object_store=object(), payload=payload)
-    assert "Wave 4 wiring" in str(exc.value)
-    assert "T1" in str(exc.value)
+    msg = str(exc.value)
+    assert "completion model" in msg or "graph extractor" in msg
 
 
 def test_production_factory_raises_when_collection_id_missing():

--- a/tests/integration/test_worker_factory.py
+++ b/tests/integration/test_worker_factory.py
@@ -379,3 +379,147 @@ def test_production_factory_raises_when_collection_id_missing():
             engine.dispose()
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------
+# Wave 4 T9 — fulltext_backend_type dispatch (mirrors chunk 4b shape).
+# ---------------------------------------------------------------------
+
+
+def test_resolve_fulltext_backend_type_defaults_to_elasticsearch():
+    """A collection with no ``config`` or no ``fulltext_backend_type``
+    field falls back to ``elasticsearch`` so existing collections (created
+    before T9) keep their pre-T9 behaviour without any migration step.
+    """
+
+    from aperag.indexing.worker_factory import _resolve_fulltext_backend_type
+
+    assert _resolve_fulltext_backend_type(_make_collection_stub(config_obj=None)) == "elasticsearch"
+
+    class _ConfigNoBackend:
+        fulltext_backend_type = None
+
+    assert _resolve_fulltext_backend_type(_make_collection_stub(config_obj=_ConfigNoBackend())) == "elasticsearch"
+
+
+@pytest.mark.parametrize("backend", ["elasticsearch", "opensearch"])
+def test_resolve_fulltext_backend_type_reads_from_pydantic_attr(backend: str):
+    """A pydantic-shaped ``CollectionConfig`` exposes
+    ``fulltext_backend_type`` as an attribute; the resolver reads it
+    straight off."""
+
+    from aperag.indexing.worker_factory import _resolve_fulltext_backend_type
+
+    class _Config:
+        fulltext_backend_type = backend
+
+    assert _resolve_fulltext_backend_type(_make_collection_stub(config_obj=_Config())) == backend
+
+
+def test_resolve_fulltext_backend_type_reads_from_dict_config():
+    """Dict-shaped ``Collection.config`` also resolves; mirrors the
+    chunk 4b graph dispatch handling for legacy persisted forms."""
+
+    from aperag.indexing.worker_factory import _resolve_fulltext_backend_type
+
+    cfg = {"fulltext_backend_type": "opensearch"}
+    assert _resolve_fulltext_backend_type(_make_collection_stub(config_obj=cfg)) == "opensearch"
+
+
+def test_resolve_fulltext_backend_type_reads_from_json_string():
+    """JSON-string ``Collection.config`` (legacy persisted shape)
+    decoded defensively just like the graph dispatch resolver."""
+
+    from aperag.indexing.worker_factory import _resolve_fulltext_backend_type
+
+    cfg = '{"fulltext_backend_type": "opensearch"}'
+    assert _resolve_fulltext_backend_type(_make_collection_stub(config_obj=cfg)) == "opensearch"
+
+
+def test_resolve_fulltext_backend_type_rejects_unknown():
+    """Unknown values raise a clear :class:`WorkerFactoryError` with
+    the supported backends embedded so the operator can fix the
+    collection config without log-spelunking."""
+
+    from aperag.indexing.worker_factory import _resolve_fulltext_backend_type
+
+    class _Config:
+        fulltext_backend_type = "meilisearch"
+
+    with pytest.raises(WorkerFactoryError) as exc:
+        _resolve_fulltext_backend_type(_make_collection_stub(config_obj=_Config()))
+    assert "meilisearch" in str(exc.value)
+    assert "elasticsearch" in str(exc.value)
+
+
+def test_build_fulltext_backend_dispatches_to_elasticsearch(monkeypatch: pytest.MonkeyPatch):
+    """``backend_type=elasticsearch`` constructs the
+    :class:`Elasticsearch` client and wraps it in the shared
+    ``_ElasticsearchFulltextBackend`` adapter. Patches the client
+    constructor so the test does not need a live ES cluster.
+    """
+
+    import aperag.indexing.worker_factory as wf
+
+    class _FakeES:
+        def __init__(self, host, **kwargs):
+            self.host = host
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(wf, "_build_elasticsearch_client", lambda: _FakeES("http://es:9200"))
+
+    backend = wf._build_fulltext_backend(
+        backend_type="elasticsearch",
+        index_name="aperag_doc_col-1",
+    )
+    assert isinstance(backend, wf._ElasticsearchFulltextBackend)
+    assert backend._index == "aperag_doc_col-1"
+    assert isinstance(backend._client, _FakeES)
+
+
+def test_build_fulltext_backend_opensearch_gates_on_missing_driver(monkeypatch: pytest.MonkeyPatch):
+    """``backend_type=opensearch`` requires the optional ``opensearch-py``
+    dependency. When it is absent (the default for this repo's lock
+    file) the factory raises a clear :class:`WorkerFactoryError`
+    pointing operators at the ``fulltext-opensearch`` extra — mirrors
+    the ``graph-neo4j`` / ``graph-nebula`` extras gating in chunk 4b.
+    """
+
+    import sys
+
+    import aperag.indexing.worker_factory as wf
+    from aperag.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "es_host", "http://os:9200", raising=False)
+    # Force the lazy import to fail even if the test host happens to
+    # have ``opensearch-py`` installed (CI runners usually do not).
+    monkeypatch.setitem(sys.modules, "opensearchpy", None)
+
+    with pytest.raises(WorkerFactoryError) as exc:
+        wf._build_fulltext_backend(
+            backend_type="opensearch",
+            index_name="aperag_doc_col-1",
+        )
+    assert "opensearch-py" in str(exc.value)
+    assert "fulltext-opensearch" in str(exc.value)
+
+
+def test_build_fulltext_backend_elasticsearch_requires_es_host(monkeypatch: pytest.MonkeyPatch):
+    """Both backends gate on ``settings.es_host`` since the same env
+    variable feeds either driver. An unset ``ES_HOST`` raises a clear
+    :class:`WorkerFactoryError` so the operator never gets a confusing
+    half-built client.
+    """
+
+    import aperag.indexing.worker_factory as wf
+    from aperag.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "es_host", "", raising=False)
+
+    with pytest.raises(WorkerFactoryError) as exc:
+        wf._build_fulltext_backend(
+            backend_type="elasticsearch",
+            index_name="aperag_doc_col-1",
+        )
+    assert "ES_HOST" in str(exc.value)
+    assert "elasticsearch" in str(exc.value)


### PR DESCRIPTION
## Wave 4: Indexing redesign — real backends + 11 production-readiness items

Continues the indexing redesign hard-cut from Wave 3 (PR #1729 merged at `00ae644f` + final review msg=2721a5e7). Wave 4 wires real backends for the 6 modality / infrastructure layers that Wave 3 explicitly **gated** or kept as **InMemory placeholders** with production-readiness invariant declarations.

Per architect msg=fab88774 (Wave 1+2 gap report) + msg=0aea9edf (graph 3-adapter migration ruling) + msg=803a2757 (owner allocation) + msg=7a8ce889 (context-budget ruling): **11 hard-locked items**, single PR + chunked-rotation push (per @earayu2 msg=1d77340c "大 PR 快速落地" model).

## Wave 4 backlog (11 items, hard-locked)

| # | Task | Owner | Status | Acceptance |
|---|---|---|---|---|
| 1 | Nebula `LineageGraphStore` adapter | @Bryce | T8 chunk 3 (queued, fresh session) | mirror Postgres reference + Nebula JSON STRING tag + per-entity Redis lock |
| 2 | Real graph LLM extractor (chunks → entities/relations) | @Bryce | T1 (queued, after T8 chunk 1+2) | replace `_no_op_extractor` with real LLM (GPT-4 / Claude / DeepSeek per collection.config) |
| 3 | Cleanup loop `workers={}` 5 modality singleton fan-out | @chenyexuan | T2 (queued, after T8 chunk 4) | needs graph store factory pattern (Bryce T8 chunk 4) as reference |
| 4 | Real parser (PDF / Word / image via docparser/Marker/OCR + promote to `q:parse` async queue per §E.2) | @chenyexuan | T3 (queued) | replace markdown-only simulator |
| 5 | modality contract supplement tests | — | ✅ DONE in PR #1730 (pre-Wave-4 merged at `07599fac`) | — |
| 6 | Real Redis `WorkQueue` backend | @chenyexuan | T4 chunk 1 ✅ (commit `650ef6dd`) | huangheng pass 1 ✅ msg=8ff8767e — multi-consumer atomic demux verify |
| 7 | Real Redis `QuotaBackend` Lua atomic (§H.5) | @Bryce | T5 (queued, after T8 chunk 2) | Lua-script atomic acquire/release per `(resource_class, tenant_scope_key)` + multi-tenant fairness |
| 8 | OTLP `MetricsEmitter` wire-in production (§J.1) | @chenyexuan | T6 (in progress, fresh session) | `OTLPMetricsEmitter` plug to `aperag/observability/` + 4 SLI emit |
| 9 | Real multimodal vision-LLM (PDF image extraction + vision embedding) | @Bryce | T7 (queued) | replace string-concat placeholder; vision gate (Wave 3 `68588420`) self-disables on `is_multimodal()==True` |
| 10 | graph 3 backend adapter wiring (Nebula + Neo4j + Postgres `LineageGraphStore`) + delete legacy `aperag/domains/knowledge_graph/graphindex/storage/*` | @Bryce | T8 chunk 1 ✅ (Postgres) + chunk 2 in-progress (Neo4j) + chunk 3 (Nebula) + chunk 4 (delete legacy + worker_factory dispatch + alembic + consumer migration + 6-case contract test) | Wave 3 hard-cut 第二轮 (`-3500/+3000` LOC net) |
| 11 | fulltext multi-backend adapter dispatch (`collection.config.fulltext_backend_type`) + sweep `_fulltext_search:350` minimum_should_match latent | @Bryce | T9 (queued, after T5/T7) | factory dispatch path ready; immediate ES only, future Solr/Typesense plug-in |

## Pushed commits

- ✅ **`f0571f98`** — T8 chunk 1: PostgresLineageGraphStore reference adapter (~545 LOC, 2 files; 10-method §D.3.5 Protocol; JSONB SET storage; single-statement INSERT ON CONFLICT atomicity; tenant isolation 三层防护). Architect schema ratify msg=95179f2a; huangheng pass 1 ✅ msg=b6f20096.
- ✅ **`650ef6dd`** — T4 chunk 1: RedisWorkQueue + lifespan dispatch on `INDEXING_QUEUE_BACKEND` + 6 integration tests (multi-consumer atomic demux core invariant; per-modality keying; close+reconnect lifecycle). production-readiness invariant 三类 layer 全 declared. huangheng pass 1 ✅ msg=8ff8767e.

## In-progress (fresh sessions)

- 🚧 **T8 chunk 2** (@Bryce): Neo4j `LineageGraphStore` adapter — Cypher list-of-MAP property + strip-then-append atomicity (`[x IN list WHERE NOT (...) | x] + [{...}]`) + 4 design points portable from Postgres reference (msg=95179f2a)
- 🚧 **T6** (@chenyexuan): OTLP MetricsEmitter — `OTLPMetricsEmitter` impl + `INDEXING_METRICS_EMITTER` config dispatch + 4 SLI emit + lifespan wire

## Production-readiness invariant pattern (Wave 3 lesson #10 sediment)

Each Wave 4 item declares 3-layer in commit description + docs:
- **must-be-real**: production-grade backend (Redis Lua, OTLP exporter, real LLM, real adapter)
- **may-be-gated**: InMemory / Noop default kept but docstring显式 TEST/SINGLE-POD only
- **fully-resolves Wave 4 #N** OR **follow-up Wave 5+ #M**

References:
- `memory/feedback_alembic_drift_check.md` — schema-touching 三检
- `memory/feedback_e2e_dataflow_trace.md` — 9 lessons + Lesson #10 explicit-gate self-disable pattern
- `memory/feedback_production_readiness_invariant.md` — spec/impl 互补 lesson

## CR (huangheng) pass-1 lock 4 items

每 chunk push 后立即 cross-check：
1. production-readiness invariant 三类 layer 显式 verify
2. alembic drift 三检 (`upgrade head + check + downgrade -1 + upgrade head`)
3. e2e dataflow trace dispatch → factory → backend → completion
4. explicit-gate self-disable pattern (`isinstance(InMemory*) → raise`)

## Graph T8 chunk 4 acceptance lock (per huangheng pass 1 msg=b6f20096 + architect msg=95179f2a)

1. alembic migration mirror ORM 100% — `_LineageEntityRow` + `_LineageRelationRow` 必有对应 migration file
2. relation `description` 列 = 100% legacy 残留 → drop (RelationWithLineage dataclass 无此字段)
3. async engine wire 进 worker_factory cross-event-loop verify (no `asyncio.run` / `run_coroutine_threadsafe` in factory)
4. 6-case contract test: roundtrip / multi-doc lineage / doc 覆盖 v2 strip / gc orphan / tenant isolation / drop description column

## Test plan

- [x] T8 chunk 1: pytest unit/integration (Postgres) — 912+ pass (Wave 3 baseline +2 new roundtrip tests for fulltext)
- [x] T4 chunk 1: pytest tests/integration/test_redis_workqueue.py — 6 pass (real Redis db=15) + tests/unit_test/indexing tests/load — 142 pass
- [ ] T8 chunk 2 (Neo4j): pytest tests/integration/test_neo4j_lineage_graph_store.py (skip-if-Neo4j-unreachable) — 6 contract cases
- [ ] T6: pytest tests/integration/test_otlp_metrics_emitter.py — emit verify metrics 进 mock OTLP exporter
- [ ] alembic upgrade head + check + downgrade -1 + upgrade head — chunk 4 acceptance
- [ ] e2e-http-provider lane chat_collection_flow + run_graph_index_flow — production read path verify
- [ ] CI 4/4 (lint-and-unit / e2e-http-smoke / provider-preflight / e2e-http-provider) 全绿

## Style note (per @earayu2 msg=1d77340c)

大 PR + chunked-rotation 多 session push + huangheng multi-pass review + fix-forward (与 Wave 3 PR #1729 同款，避免 PR 拆分 churn)。Bryce + chenyexuan 共享 branch；写集 disjoint per architect msg=06c14844。

🤖 Generated with [Claude Code](https://claude.com/claude-code)