### PR TITLE
test(e2e-http): introduce SHAPE concept + remove qdrant from api depends_on (PR-1 of 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,17 +277,17 @@ test-http-smoke-compose:
 test-http-full-compose:
 	@./tests/e2e_http/scripts/run_compose_full.sh
 
-# Backend-combo shortcuts. Lite = single-PG (pgvector + PG-graph) for the
-# ApeRAG-Lite deployment; Full = Qdrant vector + Neo4j graph for the
-# distributed deployment. Connector-level swap correctness is covered by
-# tests/integration/compat/* (see test-compat-graph / test-compat-vector).
+# Deployment-shape shortcuts. Each SHAPE references a file under
+# tests/e2e_http/shapes/<shape>.env that declares the (vector backend,
+# graph backend, services, profiles) combination as one named form.
+# Add a new shape by adding a new file there. Connector-level swap
+# correctness is covered by tests/integration/compat/* (see
+# test-compat-graph / test-compat-vector).
 test-http-smoke-compose-lite:
-	@VECTOR_DB_TYPE=pgvector GRAPH_DB_TYPE=postgresql \
-		./tests/e2e_http/scripts/run_compose_smoke.sh
+	@SHAPE=lite ./tests/e2e_http/scripts/run_compose_smoke.sh
 
 test-http-smoke-compose-full:
-	@VECTOR_DB_TYPE=qdrant GRAPH_DB_TYPE=neo4j \
-		./tests/e2e_http/scripts/run_compose_smoke.sh
+	@SHAPE=full-neo4j ./tests/e2e_http/scripts/run_compose_smoke.sh
 
 test-http-up-k8s:
 	@./tests/e2e_http/runners/k8s/up.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,16 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
-      qdrant:
-        condition: service_healthy
       es:
         condition: service_healthy
+      # Vector backend is intentionally NOT in depends_on. ApeRAG's
+      # VectorStoreConnectorAdaptor (aperag/vectorstore/connector.py) is
+      # lazy-import + lazy-instantiate, so the api boots cleanly with
+      # VECTOR_DB_TYPE=pgvector even when no qdrant container is running.
+      # Hard-binding qdrant here forced every deployment shape to start
+      # qdrant, which masked "code accidentally still calls qdrant" bugs
+      # in pgvector mode. Runners (tests/e2e_http/runners/compose/up.sh)
+      # are responsible for starting the chosen vector backend.
     volumes:
       - ~/.cache:/root/.cache
       - aperag-shared-data:/shared

--- a/tests/e2e_http/runners/compose/README.md
+++ b/tests/e2e_http/runners/compose/README.md
@@ -14,3 +14,33 @@ Non-responsibilities:
 - defining what smoke means
 
 This runner is intentionally replaceable. The suite must remain runnable against future K8s-backed environments with the same bootstrap and Hurl files.
+
+## Deployment shapes (`SHAPE`)
+
+ApeRAG supports several real production deployment forms — different choices of vector backend (Qdrant or pgvector) and graph backend (PostgreSQL, Neo4j, or Nebula). Each named combination is a *shape*.
+
+```
+SHAPE=lite       ./tests/e2e_http/runners/compose/up.sh
+SHAPE=full-neo4j ./tests/e2e_http/runners/compose/up.sh
+```
+
+Each shape file under `tests/e2e_http/shapes/<shape>.env` declares:
+
+| Variable | Purpose |
+|---|---|
+| `SHAPE_VECTOR_DB_TYPE` | `qdrant` or `pgvector` — written into `.env` so the api picks it up |
+| `SHAPE_GRAPH_DB_TYPE` | `postgresql` / `neo4j` / `nebula` — same treatment |
+| `SHAPE_COMPOSE_SERVICES` | space-separated service list passed to `docker compose up` |
+| `SHAPE_COMPOSE_PROFILES` | profile flags (e.g. `--profile neo4j`) |
+
+Adding a new shape = adding one new file. The runner / Makefile / CI all reference the shape by name, so the new combination is reachable from every entry point.
+
+### Available shapes (today)
+
+- **lite** — single-PG ApeRAG-Lite: pgvector + PG-graph, no qdrant/neo4j containers
+- **full-neo4j** — distributed: Qdrant + Neo4j
+- **full-nebula** — distributed: Qdrant + Nebula
+
+### Backward compatibility
+
+Callers that haven't migrated to `SHAPE` may still pass `VECTOR_DB_TYPE` / `GRAPH_DB_TYPE` directly; the runner derives services and profiles from those values. Defaults (no env vars at all) preserve the historical Qdrant + PG-graph behavior.

--- a/tests/e2e_http/runners/compose/up.sh
+++ b/tests/e2e_http/runners/compose/up.sh
@@ -8,10 +8,59 @@ E2E_BASE_URL="${E2E_BASE_URL:-http://127.0.0.1:8000}"
 E2E_HEALTH_ATTEMPTS="${E2E_HEALTH_ATTEMPTS:-90}"
 E2E_HEALTH_SLEEP_SECONDS="${E2E_HEALTH_SLEEP_SECONDS:-2}"
 
-# Backend selection. Defaults preserve historical behavior (Qdrant + PG-graph).
-VECTOR_DB_TYPE="${VECTOR_DB_TYPE:-qdrant}"
-GRAPH_DB_TYPE="${GRAPH_DB_TYPE:-postgresql}"
+# SHAPE is the canonical knob — it sources tests/e2e_http/shapes/<shape>.env
+# which declares the (vector backend, graph backend, service set, compose
+# profiles) combination as a single named deployment form. Adding a new
+# shape is one new file under tests/e2e_http/shapes/.
+#
+# For backward compatibility, callers may instead set VECTOR_DB_TYPE
+# and/or GRAPH_DB_TYPE directly (PR #1740 entry point); the service list
+# and profiles are then derived from those choices.
+SHAPE="${SHAPE:-}"
 
+if [[ -n "${SHAPE}" ]]; then
+  SHAPE_FILE="${ROOT_DIR}/tests/e2e_http/shapes/${SHAPE}.env"
+  if [[ ! -f "${SHAPE_FILE}" ]]; then
+    echo "Unknown SHAPE='${SHAPE}': ${SHAPE_FILE} not found." >&2
+    echo "Available shapes:" >&2
+    ls "${ROOT_DIR}/tests/e2e_http/shapes/" 2>/dev/null \
+      | sed 's/\.env$//' | sed 's/^/  - /' >&2
+    exit 2
+  fi
+  # shellcheck disable=SC1090
+  source "${SHAPE_FILE}"
+  VECTOR_DB_TYPE="${SHAPE_VECTOR_DB_TYPE}"
+  GRAPH_DB_TYPE="${SHAPE_GRAPH_DB_TYPE}"
+  E2E_COMPOSE_SERVICES="${E2E_COMPOSE_SERVICES:-${SHAPE_COMPOSE_SERVICES}}"
+  E2E_COMPOSE_PROFILES="${E2E_COMPOSE_PROFILES:-${SHAPE_COMPOSE_PROFILES}}"
+else
+  VECTOR_DB_TYPE="${VECTOR_DB_TYPE:-qdrant}"
+  GRAPH_DB_TYPE="${GRAPH_DB_TYPE:-postgresql}"
+
+  case "${VECTOR_DB_TYPE}" in
+    qdrant)   default_services="postgres redis es qdrant api" ;;
+    pgvector) default_services="postgres redis es api" ;;
+    *)
+      echo "VECTOR_DB_TYPE must be one of: qdrant, pgvector (got '${VECTOR_DB_TYPE}')" >&2
+      exit 2
+      ;;
+  esac
+
+  case "${GRAPH_DB_TYPE}" in
+    postgresql) default_profiles="" ;;
+    neo4j)      default_profiles="--profile neo4j" ;;
+    nebula)     default_profiles="--profile nebula" ;;
+    *)
+      echo "GRAPH_DB_TYPE must be one of: postgresql, neo4j, nebula (got '${GRAPH_DB_TYPE}')" >&2
+      exit 2
+      ;;
+  esac
+
+  E2E_COMPOSE_SERVICES="${E2E_COMPOSE_SERVICES:-${default_services}}"
+  E2E_COMPOSE_PROFILES="${E2E_COMPOSE_PROFILES:-${default_profiles}}"
+fi
+
+# Final validation (catches bad values inside shape files too).
 case "${VECTOR_DB_TYPE}" in
   qdrant|pgvector) ;;
   *)
@@ -19,25 +68,12 @@ case "${VECTOR_DB_TYPE}" in
     exit 2
     ;;
 esac
-
 case "${GRAPH_DB_TYPE}" in
   postgresql|neo4j|nebula) ;;
   *)
     echo "GRAPH_DB_TYPE must be one of: postgresql, neo4j, nebula (got '${GRAPH_DB_TYPE}')" >&2
     exit 2
     ;;
-esac
-
-# Always include qdrant in the service set: the api container's depends_on
-# requires it healthy regardless of which vector backend is selected. Leaving
-# qdrant idle in pgvector mode is cheap and avoids docker-compose surgery.
-DEFAULT_SERVICES="postgres redis qdrant es api"
-E2E_COMPOSE_SERVICES="${E2E_COMPOSE_SERVICES:-${DEFAULT_SERVICES}}"
-
-profile_flags=()
-case "${GRAPH_DB_TYPE}" in
-  neo4j)  profile_flags=(--profile neo4j) ;;
-  nebula) profile_flags=(--profile nebula) ;;
 esac
 
 if [[ ! -f "${ROOT_DIR}/.env" ]]; then
@@ -62,14 +98,15 @@ update_env_var() {
 update_env_var VECTOR_DB_TYPE "${VECTOR_DB_TYPE}"
 update_env_var GRAPH_DB_TYPE "${GRAPH_DB_TYPE}"
 
-echo "Compose runner starting (vector=${VECTOR_DB_TYPE}, graph=${GRAPH_DB_TYPE}, profiles='${profile_flags[*]:-}')"
+label="${SHAPE:-vector=${VECTOR_DB_TYPE},graph=${GRAPH_DB_TYPE}}"
+echo "Compose runner starting (shape=${label}, services='${E2E_COMPOSE_SERVICES}', profiles='${E2E_COMPOSE_PROFILES}')"
 
-# `${array[@]+"${array[@]}"}` is the set -u-safe expansion for an empty array.
-docker compose ${profile_flags[@]+"${profile_flags[@]}"} -f docker-compose.yml up -d --build ${E2E_COMPOSE_SERVICES}
+# shellcheck disable=SC2086
+docker compose ${E2E_COMPOSE_PROFILES} -f docker-compose.yml up -d --build ${E2E_COMPOSE_SERVICES}
 
 for ((i = 1; i <= E2E_HEALTH_ATTEMPTS; i++)); do
   if curl --silent --show-error --fail "${E2E_BASE_URL}/health" >/dev/null; then
-    echo "Compose runner ready at ${E2E_BASE_URL} (vector=${VECTOR_DB_TYPE}, graph=${GRAPH_DB_TYPE})"
+    echo "Compose runner ready at ${E2E_BASE_URL} (shape=${label})"
     exit 0
   fi
   sleep "${E2E_HEALTH_SLEEP_SECONDS}"

--- a/tests/e2e_http/shapes/full-nebula.env
+++ b/tests/e2e_http/shapes/full-nebula.env
@@ -1,0 +1,9 @@
+# SHAPE: full-nebula — distributed deployment with Qdrant + Nebula.
+#
+# Same as full-neo4j but with Nebula as the graph backend (activated via
+# the "nebula" compose profile). Provided for completeness; not currently
+# wired into CI matrix (deferred to a follow-up).
+SHAPE_VECTOR_DB_TYPE=qdrant
+SHAPE_GRAPH_DB_TYPE=nebula
+SHAPE_COMPOSE_SERVICES="postgres redis es qdrant api"
+SHAPE_COMPOSE_PROFILES="--profile nebula"

--- a/tests/e2e_http/shapes/full-neo4j.env
+++ b/tests/e2e_http/shapes/full-neo4j.env
@@ -1,0 +1,8 @@
+# SHAPE: full-neo4j — distributed deployment with Qdrant + Neo4j.
+#
+# Postgres holds relational data only. Vector data lives in Qdrant.
+# Graph data lives in Neo4j (activated via the "neo4j" compose profile).
+SHAPE_VECTOR_DB_TYPE=qdrant
+SHAPE_GRAPH_DB_TYPE=neo4j
+SHAPE_COMPOSE_SERVICES="postgres redis es qdrant api"
+SHAPE_COMPOSE_PROFILES="--profile neo4j"

--- a/tests/e2e_http/shapes/lite.env
+++ b/tests/e2e_http/shapes/lite.env
@@ -1,0 +1,10 @@
+# SHAPE: lite — single-PG ApeRAG-Lite deployment.
+#
+# All three storage layers (relational, vector, graph) live in the same
+# pgvector-enabled PostgreSQL container. No qdrant, neo4j, or nebula
+# services are started. This shape validates that the api boots and
+# serves traffic without any optional storage backend.
+SHAPE_VECTOR_DB_TYPE=pgvector
+SHAPE_GRAPH_DB_TYPE=postgresql
+SHAPE_COMPOSE_SERVICES="postgres redis es api"
+SHAPE_COMPOSE_PROFILES=""


### PR DESCRIPTION
## Summary

Follow-up to #1740. That PR added a vector/graph backend matrix to `e2e-http-smoke`, but the matrix lanes were structurally identical at the container level (qdrant ran in both because of `depends_on`) and there was no single name for a deployment shape (each combo was assembled inline from loose env vars).

This PR makes "deployment shape" a first-class concept and cleans up the depends_on hack. CI is intentionally untouched — a follow-up PR will replace #1740's smoke matrix with thin caller workflows (`e2e-http-lite.yml`, `e2e-http-full.yml`) that invoke a shared reusable workflow keyed on `SHAPE`.

## Changes

- **`docker-compose.yml`** — remove qdrant from api's `depends_on`. `aperag/vectorstore/connector.py`'s `VectorStoreConnectorAdaptor` is lazy-import + lazy-instantiate, so the api boots cleanly with `VECTOR_DB_TYPE=pgvector` even when no qdrant container is running. Local dev (`make stack-up`, bare `docker compose up -d`) still starts qdrant unchanged because qdrant has no profile.
- **`tests/e2e_http/shapes/{lite,full-neo4j,full-nebula}.env`** — new shape definition files. Each declares `(vector, graph, services, profiles)` as one named form. Adding a shape = adding one file.
- **`tests/e2e_http/runners/compose/up.sh`** — accepts `SHAPE=<name>` as the canonical knob; sources the shape file. Direct `VECTOR_DB_TYPE` / `GRAPH_DB_TYPE` overrides are preserved for backward compatibility with #1740's CI matrix. In both modes the service list is now derived from the vector backend choice (lite shapes don't start qdrant anymore).
- **`Makefile`** — `test-http-smoke-compose-{lite,full}` switch to `SHAPE=lite` / `SHAPE=full-neo4j`.
- **`tests/e2e_http/runners/compose/README.md`** — documents SHAPE.

## Why qdrant could be removed from `depends_on`

`aperag/vectorstore/connector.py` only imports the SDK for the configured `VECTOR_DB_TYPE` (lazy). When `VECTOR_DB_TYPE=pgvector`, `qdrant_client` is never imported and no qdrant connection is attempted at boot. The previous hard-bind forced every shape to start qdrant, masking any "code accidentally still calls qdrant" regression.

## Test plan

- [x] Local sanity-check: SHAPE=lite, full-neo4j, full-nebula, bogus, and back-compat path (VECTOR_DB_TYPE/GRAPH_DB_TYPE direct) all behave correctly. Bad values inside shape files are caught by final validation. .env updates remain idempotent.
- [ ] CI green on the existing matrix (#1740 entry point, exercised through back-compat path)
- [ ] Lite job specifically: api starts and serves `/health` with no qdrant container running

## Notes

- No CI/workflow changes in this PR.
- Closes context for #测试 task #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)