### PR TITLE
feat(celery Wave 6 #36): rename type → entity_type / relation_type cross-backend

### DIFF
--- a/aperag/domains/retrieval/pipeline.py
+++ b/aperag/domains/retrieval/pipeline.py
@@ -100,7 +100,7 @@ def _render_graph_context_text(entities: list[Any], relations: list[Any]) -> str
         for e in entities:
             desc_parts = [p.text.strip() for p in (e.description_parts or ()) if p.text and p.text.strip()]
             desc = " | ".join(desc_parts) or "(no description)"
-            type_label = e.type or "entity"
+            type_label = e.entity_type or "entity"
             lines.append(f"- [{type_label}] {e.name} — {desc}")
     if relations:
         if lines:

--- a/aperag/indexing/graph.py
+++ b/aperag/indexing/graph.py
@@ -204,10 +204,19 @@ class EntityRecord:
     The ``source_chunk_ids`` are the chunk ids that mention the
     entity within THIS document's parse. They contribute to the new
     lineage member that ``sync`` adds during phase-2 rebuild.
+
+    Wave 6 #36 (per §K.10 item 7 + architect ruling): the field is
+    named ``entity_type`` (not ``type``) to free the bare ``type``
+    name across the §D.3 Protocol surface so callers can introduce
+    Python type-hint metadata or Cypher ``TYPE()`` keyword usage on
+    relation edges without shadow conflicts. The on-wire ``to_dict``
+    JSON key is also ``entity_type`` to keep storage and Python
+    surface identical (hard-cut per earayu2 msg=30c81478 — no
+    production data on the legacy ``type`` shape).
     """
 
     name: str
-    type: str
+    entity_type: str
     description: str
     source_chunk_ids: tuple[str, ...]
 
@@ -215,7 +224,7 @@ class EntityRecord:
         return {
             "kind": "entity",
             "name": self.name,
-            "type": self.type,
+            "entity_type": self.entity_type,
             "description": self.description,
             "source_chunk_ids": list(self.source_chunk_ids),
         }
@@ -223,23 +232,28 @@ class EntityRecord:
 
 @dataclass(frozen=True)
 class RelationRecord:
-    """One relation row read from / written to ``kg.jsonl``."""
+    """One relation row read from / written to ``kg.jsonl``.
+
+    Wave 6 #36: ``relation_type`` (was ``type``) frees the bare
+    ``type`` name; cross-backend column / property / tag-prop renames
+    follow in `graph_storage/{postgres,neo4j,nebula}.py`.
+    """
 
     source: str
     target: str
-    type: str
+    relation_type: str
     description: str
     source_chunk_ids: tuple[str, ...]
 
     def relation_key(self) -> tuple[str, str, str]:
-        return (self.source, self.target, self.type)
+        return (self.source, self.target, self.relation_type)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "kind": "relation",
             "source": self.source,
             "target": self.target,
-            "type": self.type,
+            "relation_type": self.relation_type,
             "description": self.description,
             "source_chunk_ids": list(self.source_chunk_ids),
         }
@@ -256,7 +270,7 @@ class EntityWithLineage:
     """
 
     name: str
-    type: str
+    entity_type: str
     source_lineage: tuple[LineageMember, ...]
     description_parts: tuple[DescriptionPart, ...]
 
@@ -265,7 +279,7 @@ class EntityWithLineage:
 class RelationWithLineage:
     source: str
     target: str
-    type: str
+    relation_type: str
     evidence_lineage: tuple[LineageMember, ...]
     description_parts: tuple[DescriptionPart, ...]
 
@@ -582,7 +596,7 @@ class LineageGraphStore(Protocol):
 @dataclass
 class _InMemoryEntityRow:
     name: str
-    type: str
+    entity_type: str
     description_parts: dict[tuple[str, str], DescriptionPart] = field(default_factory=dict)
     source_lineage: dict[tuple[str, str], LineageMember] = field(default_factory=dict)
 
@@ -591,7 +605,7 @@ class _InMemoryEntityRow:
 class _InMemoryRelationRow:
     source: str
     target: str
-    type: str
+    relation_type: str
     description_parts: dict[tuple[str, str], DescriptionPart] = field(default_factory=dict)
     evidence_lineage: dict[tuple[str, str], LineageMember] = field(default_factory=dict)
 
@@ -710,12 +724,12 @@ class InMemoryLineageGraphStore:
         async with self._guard:
             row = self._entities.get(record.name)
             if row is None:
-                row = _InMemoryEntityRow(name=record.name, type=record.type)
+                row = _InMemoryEntityRow(name=record.name, entity_type=record.entity_type)
                 self._entities[record.name] = row
             else:
                 # Type may evolve as new docs refine the entity; keep
                 # the most recently observed value.
-                row.type = record.type
+                row.entity_type = record.entity_type
             row.source_lineage[lineage.key()] = lineage
             row.description_parts[lineage.key()] = DescriptionPart(
                 document_id=lineage.document_id,
@@ -733,7 +747,11 @@ class InMemoryLineageGraphStore:
         async with self._guard:
             row = self._relations.get(rel_key)
             if row is None:
-                row = _InMemoryRelationRow(source=record.source, target=record.target, type=record.type)
+                row = _InMemoryRelationRow(
+                    source=record.source,
+                    target=record.target,
+                    relation_type=record.relation_type,
+                )
                 self._relations[rel_key] = row
             row.evidence_lineage[lineage.key()] = lineage
             row.description_parts[lineage.key()] = DescriptionPart(
@@ -751,7 +769,7 @@ class InMemoryLineageGraphStore:
                 return None
             return EntityWithLineage(
                 name=row.name,
-                type=row.type,
+                entity_type=row.entity_type,
                 source_lineage=tuple(_sorted_lineage(row.source_lineage.values())),
                 description_parts=tuple(_sorted_description_parts(row.description_parts.values())),
             )
@@ -765,7 +783,7 @@ class InMemoryLineageGraphStore:
             return RelationWithLineage(
                 source=row.source,
                 target=row.target,
-                type=row.type,
+                relation_type=row.relation_type,
                 evidence_lineage=tuple(_sorted_lineage(row.evidence_lineage.values())),
                 description_parts=tuple(_sorted_description_parts(row.description_parts.values())),
             )
@@ -791,7 +809,7 @@ class InMemoryLineageGraphStore:
                 matches.append(
                     EntityWithLineage(
                         name=row.name,
-                        type=row.type,
+                        entity_type=row.entity_type,
                         source_lineage=tuple(_sorted_lineage(row.source_lineage.values())),
                         description_parts=tuple(_sorted_description_parts(row.description_parts.values())),
                     )
@@ -822,7 +840,7 @@ class InMemoryLineageGraphStore:
                     continue
                 seen_entities[name] = EntityWithLineage(
                     name=row.name,
-                    type=row.type,
+                    entity_type=row.entity_type,
                     source_lineage=tuple(_sorted_lineage(row.source_lineage.values())),
                     description_parts=tuple(_sorted_description_parts(row.description_parts.values())),
                 )
@@ -837,7 +855,7 @@ class InMemoryLineageGraphStore:
                             seen_relations[rel_key] = RelationWithLineage(
                                 source=rel_row.source,
                                 target=rel_row.target,
-                                type=rel_row.type,
+                                relation_type=rel_row.relation_type,
                                 evidence_lineage=tuple(_sorted_lineage(rel_row.evidence_lineage.values())),
                                 description_parts=tuple(_sorted_description_parts(rel_row.description_parts.values())),
                             )
@@ -849,7 +867,7 @@ class InMemoryLineageGraphStore:
                                 continue
                             seen_entities[neighbour] = EntityWithLineage(
                                 name=row.name,
-                                type=row.type,
+                                entity_type=row.entity_type,
                                 source_lineage=tuple(_sorted_lineage(row.source_lineage.values())),
                                 description_parts=tuple(_sorted_description_parts(row.description_parts.values())),
                             )
@@ -859,7 +877,7 @@ class InMemoryLineageGraphStore:
                 current = next_frontier
 
         entities = sorted(seen_entities.values(), key=lambda e: e.name)
-        relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.type))
+        relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.relation_type))
         return (entities, relations)
 
 
@@ -945,7 +963,7 @@ def parse_kg_jsonl(body: bytes) -> tuple[list[EntityRecord], list[RelationRecord
             entities.append(
                 EntityRecord(
                     name=str(record["name"]),
-                    type=str(record["type"]),
+                    entity_type=str(record["entity_type"]),
                     description=str(record.get("description", "")),
                     source_chunk_ids=tuple(str(cid) for cid in record.get("source_chunk_ids", [])),
                 )
@@ -955,7 +973,7 @@ def parse_kg_jsonl(body: bytes) -> tuple[list[EntityRecord], list[RelationRecord
                 RelationRecord(
                     source=str(record["source"]),
                     target=str(record["target"]),
-                    type=str(record["type"]),
+                    relation_type=str(record["relation_type"]),
                     description=str(record.get("description", "")),
                     source_chunk_ids=tuple(str(cid) for cid in record.get("source_chunk_ids", [])),
                 )
@@ -1124,7 +1142,11 @@ class GraphModalityWorker(ModalityWorker):
                 tenant_scope_key=self._tenant_scope_key,
                 chunk_ids=relation_record.source_chunk_ids,
             )
-            lock_key = _relation_lock_key(relation_record.source, relation_record.target, relation_record.type)
+            lock_key = _relation_lock_key(
+                relation_record.source,
+                relation_record.target,
+                relation_record.relation_type,
+            )
             async with self._entity_lock.acquire(lock_key):
                 await self._store.upsert_relation_with_lineage(record=relation_record, lineage=lineage)
 

--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -275,11 +275,15 @@ def _entity_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> EntityRecord:
     name = str(raw["name"]).strip()
     if not name:
         raise ValueError("entity name cannot be empty")
-    entity_type = str(raw.get("type") or "")
+    # The LLM extraction prompt still emits ``type`` in its JSON output
+    # (LightRAG-style template); we accept either the canonical
+    # ``entity_type`` field (post-Wave-6 #36 rename) or the legacy
+    # ``type`` field for backward compat with prompt templates.
+    entity_type = str(raw.get("entity_type") or raw.get("type") or "")
     description = str(raw.get("description") or "")
     return EntityRecord(
         name=name,
-        type=entity_type,
+        entity_type=entity_type,
         description=description,
         source_chunk_ids=(chunk_id,) if chunk_id else (),
     )
@@ -290,12 +294,12 @@ def _relation_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> RelationRec
     target = str(raw["target"]).strip()
     if not source or not target:
         raise ValueError("relation source/target cannot be empty")
-    rel_type = str(raw.get("type") or "")
+    rel_type = str(raw.get("relation_type") or raw.get("type") or "")
     description = str(raw.get("description") or "")
     return RelationRecord(
         source=source,
         target=target,
-        type=rel_type,
+        relation_type=rel_type,
         description=description,
         source_chunk_ids=(chunk_id,) if chunk_id else (),
     )

--- a/aperag/indexing/graph_storage/nebula.py
+++ b/aperag/indexing/graph_storage/nebula.py
@@ -348,12 +348,15 @@ class NebulaLineageGraphStore:
             )
 
             tag_stmts = [
+                # Wave 6 #36: tag-prop renamed ``type`` → ``entity_type`` /
+                # ``relation_type`` per architect Pattern 3 ruling.
+                # Hard-cut per earayu2 msg=30c81478 (no production data).
                 f"CREATE TAG IF NOT EXISTS `{_ENTITY_TAG}`("
-                f"name string, type string, "
+                f"name string, entity_type string, "
                 f"source_lineage_json string, description_parts_json string, "
                 f"gmt_created datetime, gmt_updated datetime)",
                 f"CREATE TAG IF NOT EXISTS `{_RELATION_TAG}`("
-                f"source string, target string, type string, "
+                f"source string, target string, relation_type string, "
                 f"evidence_lineage_json string, description_parts_json string, "
                 f"gmt_created datetime, gmt_updated datetime)",
                 f"CREATE TAG INDEX IF NOT EXISTS `idx_{_ENTITY_TAG}_name` ON `{_ENTITY_TAG}`(name(256))",
@@ -394,7 +397,7 @@ class NebulaLineageGraphStore:
         vid = _entity_vid(entity_name)
         stmt = (
             f'FETCH PROP ON `{_ENTITY_TAG}` "{_escape_str(vid)}" '
-            f"YIELD `{_ENTITY_TAG}`.type AS type, "
+            f"YIELD `{_ENTITY_TAG}`.entity_type AS entity_type, "
             f"`{_ENTITY_TAG}`.source_lineage_json AS sl, "
             f"`{_ENTITY_TAG}`.description_parts_json AS dp"
         )
@@ -479,7 +482,7 @@ class NebulaLineageGraphStore:
         vid = _entity_vid(name)
         stmt = (
             f"INSERT VERTEX `{_ENTITY_TAG}`"
-            f"(name, type, source_lineage_json, description_parts_json, gmt_created, gmt_updated) "
+            f"(name, entity_type, source_lineage_json, description_parts_json, gmt_created, gmt_updated) "
             f'VALUES "{_escape_str(vid)}":('
             f'"{_escape_str(name)}", "{_escape_str(type_value)}", '
             f'"{_escape_str(_members_to_json(source_lineage))}", '
@@ -500,7 +503,7 @@ class NebulaLineageGraphStore:
         vid = _relation_vid(source, target, type_value)
         stmt = (
             f"INSERT VERTEX `{_RELATION_TAG}`"
-            f"(source, target, type, "
+            f"(source, target, relation_type, "
             f"evidence_lineage_json, description_parts_json, gmt_created, gmt_updated) "
             f'VALUES "{_escape_str(vid)}":('
             f'"{_escape_str(source)}", "{_escape_str(target)}", "{_escape_str(type_value)}", '
@@ -562,7 +565,7 @@ class NebulaLineageGraphStore:
         stmt = (
             f'FETCH PROP ON `{_ENTITY_TAG}` "{_escape_str(vid)}" '
             f"YIELD `{_ENTITY_TAG}`.name AS name, "
-            f"`{_ENTITY_TAG}`.type AS type, "
+            f"`{_ENTITY_TAG}`.entity_type AS entity_type, "
             f"`{_ENTITY_TAG}`.source_lineage_json AS sl, "
             f"`{_ENTITY_TAG}`.description_parts_json AS dp"
         )
@@ -583,7 +586,7 @@ class NebulaLineageGraphStore:
             f'FETCH PROP ON `{_RELATION_TAG}` "{_escape_str(vid)}" '
             f"YIELD `{_RELATION_TAG}`.source AS source, "
             f"`{_RELATION_TAG}`.target AS target, "
-            f"`{_RELATION_TAG}`.type AS type, "
+            f"`{_RELATION_TAG}`.relation_type AS relation_type, "
             f"`{_RELATION_TAG}`.evidence_lineage_json AS el, "
             f"`{_RELATION_TAG}`.description_parts_json AS dp"
         )
@@ -716,7 +719,7 @@ class NebulaLineageGraphStore:
                     new_parts = [p for p in parts if p.key() != new_part.key()] + [new_part]
                 self._write_entity_vertex(
                     name=record.name,
-                    type_value=record.type,
+                    type_value=record.entity_type,
                     source_lineage=new_members,
                     description_parts=new_parts,
                 )
@@ -730,10 +733,10 @@ class NebulaLineageGraphStore:
             parse_version=lineage.parse_version,
             text=record.description,
         )
-        async with self._entity_lock.acquire(_relation_vid(record.source, record.target, record.type)):
+        async with self._entity_lock.acquire(_relation_vid(record.source, record.target, record.relation_type)):
 
             def _upsert() -> None:
-                row = self._read_relation_lineage(record.source, record.target, record.type)
+                row = self._read_relation_lineage(record.source, record.target, record.relation_type)
                 if row is None:
                     new_members = [lineage]
                     new_parts = [new_part]
@@ -744,7 +747,7 @@ class NebulaLineageGraphStore:
                 self._write_relation_vertex(
                     source=record.source,
                     target=record.target,
-                    type_value=record.type,
+                    type_value=record.relation_type,
                     evidence_lineage=new_members,
                     description_parts=new_parts,
                 )
@@ -763,7 +766,7 @@ class NebulaLineageGraphStore:
             type_value, members, parts = row
             return EntityWithLineage(
                 name=entity_name,
-                type=type_value,
+                entity_type=type_value,
                 source_lineage=tuple(members),
                 description_parts=tuple(parts),
             )
@@ -781,7 +784,7 @@ class NebulaLineageGraphStore:
             return RelationWithLineage(
                 source=source,
                 target=target,
-                type=type,
+                relation_type=type,
                 evidence_lineage=tuple(members),
                 description_parts=tuple(parts),
             )
@@ -820,7 +823,7 @@ class NebulaLineageGraphStore:
                 matches.append(
                     EntityWithLineage(
                         name=name,
-                        type=type_value,
+                        entity_type=type_value,
                         source_lineage=tuple(members),
                         description_parts=tuple(parts),
                     )
@@ -853,7 +856,7 @@ class NebulaLineageGraphStore:
                 type_value, members, parts = row
                 seen_entities[name] = EntityWithLineage(
                     name=name,
-                    type=type_value,
+                    entity_type=type_value,
                     source_lineage=tuple(members),
                     description_parts=tuple(parts),
                 )
@@ -882,7 +885,7 @@ class NebulaLineageGraphStore:
                         seen_relations[key] = RelationWithLineage(
                             source=src,
                             target=tgt,
-                            type=rtype,
+                            relation_type=rtype,
                             evidence_lineage=tuple(members),
                             description_parts=tuple(parts),
                         )
@@ -896,7 +899,7 @@ class NebulaLineageGraphStore:
                 current = next_frontier
 
             entities = sorted(seen_entities.values(), key=lambda e: e.name)
-            relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.type))
+            relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.relation_type))
             return (entities, relations)
 
         return await asyncio.to_thread(_walk)

--- a/aperag/indexing/graph_storage/neo4j.py
+++ b/aperag/indexing/graph_storage/neo4j.py
@@ -34,7 +34,7 @@ prefix (Wave 5 P5A item 4) prevents collisions with user-owned graphs
 in shared Neo4j deployments.
 
     (:aperag_LineageEntity {
-        collection_id, name, type,
+        collection_id, name, entity_type,
         source_lineage,                  -- list<string>, JSON-encoded LineageMember
         source_lineage_doc_ids,          -- list<string>, parallel index, dedup + strip-by-doc filter
         source_lineage_parse_versions,   -- list<string>, parallel index, dedup composite key
@@ -45,7 +45,7 @@ in shared Neo4j deployments.
     })
 
     (:aperag_LineageRelation {
-        collection_id, source, target, type,
+        collection_id, source, target, relation_type,
         evidence_lineage,
         evidence_lineage_doc_ids,
         evidence_lineage_parse_versions,
@@ -208,7 +208,7 @@ class Neo4jLineageGraphStore:
             await session.run(
                 f"CREATE CONSTRAINT {_RELATION_CONSTRAINT_NAME} IF NOT EXISTS "
                 f"FOR (r:{_RELATION_LABEL}) "
-                f"REQUIRE (r.collection_id, r.source, r.target, r.type) IS UNIQUE"
+                f"REQUIRE (r.collection_id, r.source, r.target, r.relation_type) IS UNIQUE"
             )
 
     # -- find-by-document scans (pre-rebuild phase) -------------------
@@ -231,7 +231,7 @@ class Neo4jLineageGraphStore:
         query = (
             f"MATCH (r:{_RELATION_LABEL} {{collection_id: $collection_id}}) "
             f"WHERE $document_id IN r.evidence_lineage_doc_ids "
-            f"RETURN r.source AS source, r.target AS target, r.type AS type"
+            f"RETURN r.source AS source, r.target AS target, r.relation_type AS relation_type"
         )
         async with self._session() as session:
             result = await session.run(
@@ -239,7 +239,7 @@ class Neo4jLineageGraphStore:
                 collection_id=self._collection_id,
                 document_id=document_id,
             )
-            return [(rec["source"], rec["target"], rec["type"]) async for rec in result]
+            return [(rec["source"], rec["target"], rec["relation_type"]) async for rec in result]
 
     # -- strip-by-document (pre-rebuild phase) ------------------------
 
@@ -274,7 +274,7 @@ class Neo4jLineageGraphStore:
     async def remove_relation_lineage_member(self, *, source: str, target: str, type: str, document_id: str) -> None:
         query = (
             f"MATCH (r:{_RELATION_LABEL} "
-            f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
+            f"  {{collection_id: $collection_id, source: $source, target: $target, relation_type: $relation_type}}) "
             f"WITH r, "
             f"  [i IN range(0, size(r.evidence_lineage_doc_ids) - 1) "
             f"   WHERE r.evidence_lineage_doc_ids[i] <> $document_id] AS el_keep, "
@@ -294,7 +294,7 @@ class Neo4jLineageGraphStore:
                 collection_id=self._collection_id,
                 source=source,
                 target=target,
-                type=type,
+                relation_type=type,
                 document_id=document_id,
             )
 
@@ -315,7 +315,7 @@ class Neo4jLineageGraphStore:
     async def gc_relation_if_orphan(self, source: str, target: str, type: str) -> bool:
         query = (
             f"MATCH (r:{_RELATION_LABEL} "
-            f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
+            f"  {{collection_id: $collection_id, source: $source, target: $target, relation_type: $relation_type}}) "
             f"WHERE size(r.evidence_lineage) = 0 "
             f"DELETE r "
             f"RETURN count(r) AS deleted"
@@ -326,7 +326,7 @@ class Neo4jLineageGraphStore:
                 collection_id=self._collection_id,
                 source=source,
                 target=target,
-                type=type,
+                relation_type=type,
             )
             rec = await result.single()
             return bool(rec and rec["deleted"] > 0)
@@ -367,7 +367,7 @@ class Neo4jLineageGraphStore:
             f"  [i IN range(0, size(n.description_parts_doc_ids) - 1) "
             f"   WHERE NOT (n.description_parts_doc_ids[i] = $document_id "
             f"              AND n.description_parts_parse_versions[i] = $parse_version)] AS dp_keep "
-            f"SET n.type = $type, "
+            f"SET n.entity_type = $entity_type, "
             f"    n.source_lineage = [i IN sl_keep | n.source_lineage[i]] + [$member_json], "
             f"    n.source_lineage_doc_ids = [i IN sl_keep | n.source_lineage_doc_ids[i]] + [$document_id], "
             f"    n.source_lineage_parse_versions = "
@@ -384,7 +384,7 @@ class Neo4jLineageGraphStore:
                 query,
                 collection_id=self._collection_id,
                 name=record.name,
-                type=record.type,
+                entity_type=record.entity_type,
                 document_id=lineage.document_id,
                 parse_version=lineage.parse_version,
                 member_json=member_json,
@@ -402,7 +402,7 @@ class Neo4jLineageGraphStore:
         )
         query = (
             f"MERGE (r:{_RELATION_LABEL} "
-            f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
+            f"  {{collection_id: $collection_id, source: $source, target: $target, relation_type: $relation_type}}) "
             f"ON CREATE SET "
             f"  r.evidence_lineage = [], "
             f"  r.evidence_lineage_doc_ids = [], "
@@ -436,7 +436,7 @@ class Neo4jLineageGraphStore:
                 collection_id=self._collection_id,
                 source=record.source,
                 target=record.target,
-                type=record.type,
+                relation_type=record.relation_type,
                 document_id=lineage.document_id,
                 parse_version=lineage.parse_version,
                 member_json=member_json,
@@ -448,7 +448,7 @@ class Neo4jLineageGraphStore:
     async def get_entity(self, entity_name: str) -> EntityWithLineage | None:
         query = (
             f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $collection_id, name: $name}}) "
-            f"RETURN n.name AS name, n.type AS type, "
+            f"RETURN n.name AS name, n.entity_type AS entity_type, "
             f"       n.source_lineage AS source_lineage, "
             f"       n.description_parts AS description_parts"
         )
@@ -459,7 +459,7 @@ class Neo4jLineageGraphStore:
                 return None
             return EntityWithLineage(
                 name=rec["name"],
-                type=rec["type"] or "",
+                entity_type=rec["entity_type"] or "",
                 source_lineage=tuple(LineageMember.from_dict(json.loads(s)) for s in (rec["source_lineage"] or [])),
                 description_parts=tuple(
                     DescriptionPart.from_dict(json.loads(s)) for s in (rec["description_parts"] or [])
@@ -469,8 +469,8 @@ class Neo4jLineageGraphStore:
     async def get_relation(self, source: str, target: str, type: str) -> RelationWithLineage | None:
         query = (
             f"MATCH (r:{_RELATION_LABEL} "
-            f"  {{collection_id: $collection_id, source: $source, target: $target, type: $type}}) "
-            f"RETURN r.source AS source, r.target AS target, r.type AS type, "
+            f"  {{collection_id: $collection_id, source: $source, target: $target, relation_type: $relation_type}}) "
+            f"RETURN r.source AS source, r.target AS target, r.relation_type AS relation_type, "
             f"       r.evidence_lineage AS evidence_lineage, "
             f"       r.description_parts AS description_parts"
         )
@@ -480,7 +480,7 @@ class Neo4jLineageGraphStore:
                 collection_id=self._collection_id,
                 source=source,
                 target=target,
-                type=type,
+                relation_type=type,
             )
             rec = await result.single()
             if rec is None:
@@ -488,7 +488,7 @@ class Neo4jLineageGraphStore:
             return RelationWithLineage(
                 source=rec["source"],
                 target=rec["target"],
-                type=rec["type"],
+                relation_type=rec["relation_type"],
                 evidence_lineage=tuple(LineageMember.from_dict(json.loads(s)) for s in (rec["evidence_lineage"] or [])),
                 description_parts=tuple(
                     DescriptionPart.from_dict(json.loads(s)) for s in (rec["description_parts"] or [])
@@ -512,7 +512,7 @@ class Neo4jLineageGraphStore:
         cypher = (
             f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $collection_id}}) "
             f"WHERE toLower(n.name) CONTAINS toLower($query) "
-            f"RETURN n.name AS name, n.type AS type, "
+            f"RETURN n.name AS name, n.entity_type AS entity_type, "
             f"       n.source_lineage AS source_lineage, "
             f"       n.description_parts AS description_parts "
             f"ORDER BY n.name "
@@ -528,7 +528,7 @@ class Neo4jLineageGraphStore:
             return [
                 EntityWithLineage(
                     name=rec["name"],
-                    type=rec["type"] or "",
+                    entity_type=rec["entity_type"] or "",
                     source_lineage=tuple(LineageMember.from_dict(json.loads(s)) for s in (rec["source_lineage"] or [])),
                     description_parts=tuple(
                         DescriptionPart.from_dict(json.loads(s)) for s in (rec["description_parts"] or [])
@@ -555,7 +555,7 @@ class Neo4jLineageGraphStore:
             cypher = (
                 f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $collection_id}}) "
                 f"WHERE n.name IN $names "
-                f"RETURN n.name AS name, n.type AS type, "
+                f"RETURN n.name AS name, n.entity_type AS entity_type, "
                 f"       n.source_lineage AS source_lineage, "
                 f"       n.description_parts AS description_parts"
             )
@@ -565,7 +565,7 @@ class Neo4jLineageGraphStore:
                     continue
                 seen_entities[rec["name"]] = EntityWithLineage(
                     name=rec["name"],
-                    type=rec["type"] or "",
+                    entity_type=rec["entity_type"] or "",
                     source_lineage=tuple(LineageMember.from_dict(json.loads(s)) for s in (rec["source_lineage"] or [])),
                     description_parts=tuple(
                         DescriptionPart.from_dict(json.loads(s)) for s in (rec["description_parts"] or [])
@@ -578,19 +578,19 @@ class Neo4jLineageGraphStore:
             cypher = (
                 f"MATCH (r:{_RELATION_LABEL} {{collection_id: $collection_id}}) "
                 f"WHERE r.source IN $names OR r.target IN $names "
-                f"RETURN r.source AS source, r.target AS target, r.type AS type, "
+                f"RETURN r.source AS source, r.target AS target, r.relation_type AS relation_type, "
                 f"       r.evidence_lineage AS evidence_lineage, "
                 f"       r.description_parts AS description_parts"
             )
             result = await session.run(cypher, collection_id=self._collection_id, names=names)
             next_frontier: set[str] = set()
             async for rec in result:
-                key = (rec["source"], rec["target"], rec["type"])
+                key = (rec["source"], rec["target"], rec["relation_type"])
                 if key not in seen_relations:
                     seen_relations[key] = RelationWithLineage(
                         source=rec["source"],
                         target=rec["target"],
-                        type=rec["type"],
+                        relation_type=rec["relation_type"],
                         evidence_lineage=tuple(
                             LineageMember.from_dict(json.loads(s)) for s in (rec["evidence_lineage"] or [])
                         ),
@@ -616,7 +616,7 @@ class Neo4jLineageGraphStore:
                 current = next_list
 
         entities = sorted(seen_entities.values(), key=lambda e: e.name)
-        relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.type))
+        relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.relation_type))
         return (entities, relations)
 
 

--- a/aperag/indexing/graph_storage/postgres.py
+++ b/aperag/indexing/graph_storage/postgres.py
@@ -116,7 +116,12 @@ class _LineageEntityRow(_LineageGraphBase):
 
     collection_id = Column(String(64), primary_key=True)
     name = Column(String(512), primary_key=True)
-    type = Column(String(64), nullable=False)
+    # Wave 6 #36: column renamed ``type`` → ``entity_type`` to free the
+    # bare ``type`` name across the §D.3 Protocol surface (frees Python
+    # ``type`` builtin from ORM attribute shadow). Alembic migration
+    # ``f8a4c5b9d3e1`` performs the column rename hard-cut (no
+    # production data per earayu2 msg=30c81478).
+    entity_type = Column(String(64), nullable=False)
     source_lineage = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     description_parts = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     # Wave 5 P5B: ORM uses the same ``server_default=CURRENT_TIMESTAMP``
@@ -151,7 +156,8 @@ class _LineageRelationRow(_LineageGraphBase):
     collection_id = Column(String(64), primary_key=True)
     source = Column(String(512), primary_key=True)
     target = Column(String(512), primary_key=True)
-    type = Column(String(64), primary_key=True)
+    # Wave 6 #36: column renamed ``type`` → ``relation_type``.
+    relation_type = Column(String(64), primary_key=True)
     # Wave 4 chunk 4 dropped the legacy ``description`` Text column —
     # the per-document fragments in ``description_parts`` are the
     # canonical source. ``RelationWithLineage`` does not expose a
@@ -247,7 +253,7 @@ class PostgresLineageGraphStore:
     async def find_relation_keys_with_lineage(self, *, document_id: str) -> list[tuple[str, str, str]]:
         sql = text(
             f"""
-            SELECT source, target, type
+            SELECT source, target, relation_type
             FROM {RELATION_TABLE}
             WHERE collection_id = :collection_id
               AND evidence_lineage @> jsonb_build_array(
@@ -257,7 +263,7 @@ class PostgresLineageGraphStore:
         )
         async with self._engine.connect() as conn:
             result = await conn.execute(sql, {"collection_id": self._collection_id, "document_id": document_id})
-            return [(row.source, row.target, row.type) for row in result]
+            return [(row.source, row.target, row.relation_type) for row in result]
 
     # -- strip-by-document (pre-rebuild phase) ------------------------
 
@@ -308,7 +314,7 @@ class PostgresLineageGraphStore:
                 ),
                 gmt_updated = NOW()
             WHERE collection_id = :collection_id
-              AND source = :source AND target = :target AND type = :type
+              AND source = :source AND target = :target AND relation_type = :relation_type
             """
         )
         async with self._engine.begin() as conn:
@@ -318,7 +324,7 @@ class PostgresLineageGraphStore:
                     "collection_id": self._collection_id,
                     "source": source,
                     "target": target,
-                    "type": type,
+                    "relation_type": type,
                     "document_id": document_id,
                 },
             )
@@ -343,7 +349,7 @@ class PostgresLineageGraphStore:
             f"""
             DELETE FROM {RELATION_TABLE}
             WHERE collection_id = :collection_id
-              AND source = :source AND target = :target AND type = :type
+              AND source = :source AND target = :target AND relation_type = :relation_type
               AND jsonb_array_length(evidence_lineage) = 0
             """
         )
@@ -354,7 +360,7 @@ class PostgresLineageGraphStore:
                     "collection_id": self._collection_id,
                     "source": source,
                     "target": target,
-                    "type": type,
+                    "relation_type": type,
                 },
             )
             return (result.rowcount or 0) > 0
@@ -376,17 +382,17 @@ class PostgresLineageGraphStore:
         sql = text(
             f"""
             INSERT INTO {ENTITY_TABLE} (
-                collection_id, name, type, source_lineage, description_parts,
+                collection_id, name, entity_type, source_lineage, description_parts,
                 gmt_created, gmt_updated
             )
             VALUES (
-                :collection_id, :name, :type,
+                :collection_id, :name, :entity_type,
                 jsonb_build_array(CAST(:member_json AS jsonb)),
                 jsonb_build_array(CAST(:part_json AS jsonb)),
                 NOW(), NOW()
             )
             ON CONFLICT (collection_id, name) DO UPDATE
-            SET type = EXCLUDED.type,
+            SET entity_type = EXCLUDED.entity_type,
                 source_lineage = (
                     -- strip any existing element with the same
                     -- (document_id, parse_version) key, then append
@@ -413,7 +419,7 @@ class PostgresLineageGraphStore:
                 {
                     "collection_id": self._collection_id,
                     "name": record.name,
-                    "type": record.type,
+                    "entity_type": record.entity_type,
                     "document_id": lineage.document_id,
                     "parse_version": lineage.parse_version,
                     "member_json": member_json,
@@ -433,17 +439,17 @@ class PostgresLineageGraphStore:
         sql = text(
             f"""
             INSERT INTO {RELATION_TABLE} (
-                collection_id, source, target, type,
+                collection_id, source, target, relation_type,
                 evidence_lineage, description_parts,
                 gmt_created, gmt_updated
             )
             VALUES (
-                :collection_id, :source, :target, :type,
+                :collection_id, :source, :target, :relation_type,
                 jsonb_build_array(CAST(:member_json AS jsonb)),
                 jsonb_build_array(CAST(:part_json AS jsonb)),
                 NOW(), NOW()
             )
-            ON CONFLICT (collection_id, source, target, type) DO UPDATE
+            ON CONFLICT (collection_id, source, target, relation_type) DO UPDATE
             SET evidence_lineage = (
                     COALESCE(
                         (SELECT jsonb_agg(elem) FROM jsonb_array_elements({RELATION_TABLE}.evidence_lineage) elem
@@ -468,7 +474,7 @@ class PostgresLineageGraphStore:
                     "collection_id": self._collection_id,
                     "source": record.source,
                     "target": record.target,
-                    "type": record.type,
+                    "relation_type": record.relation_type,
                     "document_id": lineage.document_id,
                     "parse_version": lineage.parse_version,
                     "member_json": member_json,
@@ -483,7 +489,7 @@ class PostgresLineageGraphStore:
             result = await conn.execute(
                 select(
                     _LineageEntityRow.name,
-                    _LineageEntityRow.type,
+                    _LineageEntityRow.entity_type,
                     _LineageEntityRow.source_lineage,
                     _LineageEntityRow.description_parts,
                 ).where(
@@ -496,7 +502,7 @@ class PostgresLineageGraphStore:
                 return None
             return EntityWithLineage(
                 name=row.name,
-                type=row.type,
+                entity_type=row.entity_type,
                 source_lineage=tuple(LineageMember.from_dict(elem) for elem in (row.source_lineage or [])),
                 description_parts=tuple(DescriptionPart.from_dict(part) for part in (row.description_parts or [])),
             )
@@ -507,14 +513,14 @@ class PostgresLineageGraphStore:
                 select(
                     _LineageRelationRow.source,
                     _LineageRelationRow.target,
-                    _LineageRelationRow.type,
+                    _LineageRelationRow.relation_type,
                     _LineageRelationRow.evidence_lineage,
                     _LineageRelationRow.description_parts,
                 ).where(
                     _LineageRelationRow.collection_id == self._collection_id,
                     _LineageRelationRow.source == source,
                     _LineageRelationRow.target == target,
-                    _LineageRelationRow.type == type,
+                    _LineageRelationRow.relation_type == type,
                 )
             )
             row = result.first()
@@ -523,7 +529,7 @@ class PostgresLineageGraphStore:
             return RelationWithLineage(
                 source=row.source,
                 target=row.target,
-                type=row.type,
+                relation_type=row.relation_type,
                 evidence_lineage=tuple(LineageMember.from_dict(elem) for elem in (row.evidence_lineage or [])),
                 description_parts=tuple(DescriptionPart.from_dict(part) for part in (row.description_parts or [])),
             )
@@ -545,7 +551,7 @@ class PostgresLineageGraphStore:
             result = await conn.execute(
                 select(
                     _LineageEntityRow.name,
-                    _LineageEntityRow.type,
+                    _LineageEntityRow.entity_type,
                     _LineageEntityRow.source_lineage,
                     _LineageEntityRow.description_parts,
                 )
@@ -559,7 +565,7 @@ class PostgresLineageGraphStore:
             return [
                 EntityWithLineage(
                     name=row.name,
-                    type=row.type,
+                    entity_type=row.entity_type,
                     source_lineage=tuple(LineageMember.from_dict(elem) for elem in (row.source_lineage or [])),
                     description_parts=tuple(DescriptionPart.from_dict(part) for part in (row.description_parts or [])),
                 )
@@ -584,7 +590,7 @@ class PostgresLineageGraphStore:
             result = await conn.execute(
                 select(
                     _LineageEntityRow.name,
-                    _LineageEntityRow.type,
+                    _LineageEntityRow.entity_type,
                     _LineageEntityRow.source_lineage,
                     _LineageEntityRow.description_parts,
                 ).where(
@@ -597,7 +603,7 @@ class PostgresLineageGraphStore:
                     continue
                 seen_entities[row.name] = EntityWithLineage(
                     name=row.name,
-                    type=row.type,
+                    entity_type=row.entity_type,
                     source_lineage=tuple(LineageMember.from_dict(elem) for elem in (row.source_lineage or [])),
                     description_parts=tuple(DescriptionPart.from_dict(part) for part in (row.description_parts or [])),
                 )
@@ -612,7 +618,7 @@ class PostgresLineageGraphStore:
                 select(
                     _LineageRelationRow.source,
                     _LineageRelationRow.target,
-                    _LineageRelationRow.type,
+                    _LineageRelationRow.relation_type,
                     _LineageRelationRow.evidence_lineage,
                     _LineageRelationRow.description_parts,
                 ).where(
@@ -622,12 +628,12 @@ class PostgresLineageGraphStore:
             )
             next_frontier: set[str] = set()
             for row in result:
-                key = (row.source, row.target, row.type)
+                key = (row.source, row.target, row.relation_type)
                 if key not in seen_relations:
                     seen_relations[key] = RelationWithLineage(
                         source=row.source,
                         target=row.target,
-                        type=row.type,
+                        relation_type=row.relation_type,
                         evidence_lineage=tuple(LineageMember.from_dict(elem) for elem in (row.evidence_lineage or [])),
                         description_parts=tuple(
                             DescriptionPart.from_dict(part) for part in (row.description_parts or [])
@@ -652,7 +658,7 @@ class PostgresLineageGraphStore:
                 current = next_frontier
 
         entities = sorted(seen_entities.values(), key=lambda e: e.name)
-        relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.type))
+        relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.relation_type))
         return (entities, relations)
 
 

--- a/aperag/migration/versions/20260427040000-f8a4c5b9d3e1_rename_lineage_type_columns.py
+++ b/aperag/migration/versions/20260427040000-f8a4c5b9d3e1_rename_lineage_type_columns.py
@@ -1,0 +1,54 @@
+"""rename ``type`` columns on ``aperag_lineage_*`` tables
+
+Wave 6 #36 (per architect Pattern 3 ruling): the ``type`` columns on
+``aperag_lineage_entity`` and ``aperag_lineage_relation`` are renamed
+to ``entity_type`` and ``relation_type`` respectively. Frees the bare
+``type`` name across the §D.3 ``LineageGraphStore`` Protocol surface
+so callers can introduce Python type-hint metadata or
+Cypher ``TYPE()`` keyword usage without shadow conflicts on either
+the ORM attribute side or the SQL/Cypher property side.
+
+Hard-cut per earayu2 msg=30c81418 — graph indexing was gated behind
+``enable_knowledge_graph=False`` by default since Wave 4, so there is
+no production data on the legacy ``type`` columns. We rename in place
+without a backfill / dual-column transitional state.
+
+Revision ID: f8a4c5b9d3e1
+Revises: f1c8d2a5b6e3
+Create Date: 2026-04-27 04:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "f8a4c5b9d3e1"
+down_revision: Union[str, None] = "f1c8d2a5b6e3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "aperag_lineage_entity",
+        "type",
+        new_column_name="entity_type",
+    )
+    op.alter_column(
+        "aperag_lineage_relation",
+        "type",
+        new_column_name="relation_type",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "aperag_lineage_entity",
+        "entity_type",
+        new_column_name="type",
+    )
+    op.alter_column(
+        "aperag_lineage_relation",
+        "relation_type",
+        new_column_name="type",
+    )

--- a/tests/integration/test_graph_extractor.py
+++ b/tests/integration/test_graph_extractor.py
@@ -72,7 +72,7 @@ def test_parse_extraction_response_handles_well_formed_json():
     assert len(entities) == 1
     assert entities[0] == EntityRecord(
         name="Linus",
-        type="person",
+        entity_type="person",
         description="Created Linux",
         source_chunk_ids=("c-1",),
     )
@@ -80,7 +80,7 @@ def test_parse_extraction_response_handles_well_formed_json():
     assert relations[0] == RelationRecord(
         source="Linus",
         target="Linux",
-        type="created",
+        relation_type="created",
         description="Linus created Linux",
         source_chunk_ids=("c-1",),
     )
@@ -120,7 +120,7 @@ def test_parse_extraction_response_skips_individual_malformed_records():
     entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
     names = [e.name for e in entities]
     assert names == ["Good Entity", "Another Good"]
-    relation_types = [r.type for r in relations]
+    relation_types = [r.relation_type for r in relations]
     assert relation_types == ["rel1"]
 
 

--- a/tests/integration/test_lineage_graph_store_contract.py
+++ b/tests/integration/test_lineage_graph_store_contract.py
@@ -308,7 +308,7 @@ async def test_roundtrip_entity_with_one_lineage_member(lineage_store):
 
     record = EntityRecord(
         name="Linus Torvalds",
-        type="person",
+        entity_type="person",
         description="Created Linux.",
         source_chunk_ids=("chunk-1",),
     )
@@ -318,7 +318,7 @@ async def test_roundtrip_entity_with_one_lineage_member(lineage_store):
     fetched = await lineage_store.get_entity("Linus Torvalds")
     assert fetched is not None
     assert fetched.name == "Linus Torvalds"
-    assert fetched.type == "person"
+    assert fetched.entity_type == "person"
     assert len(fetched.source_lineage) == 1
     assert fetched.source_lineage[0].document_id == "doc-A"
     assert fetched.source_lineage[0].parse_version == "v1"
@@ -335,7 +335,7 @@ async def test_two_documents_cite_same_entity_preserves_both_lineage(lineage_sto
 
     record_base = EntityRecord(
         name="Python",
-        type="language",
+        entity_type="language",
         description="",
         source_chunk_ids=(),
     )
@@ -366,7 +366,7 @@ async def test_doc_re_parse_replaces_old_parse_version_member(lineage_store):
 
     record = EntityRecord(
         name="Rust",
-        type="language",
+        entity_type="language",
         description="memory-safe",
         source_chunk_ids=(),
     )
@@ -407,7 +407,7 @@ async def test_remove_then_gc_orphan_entity(lineage_store):
     """Case 4: §D.3.2 phase-1 strip → phase-2 GC. Orphan-only deletion;
     other-doc citations protect the row from GC."""
 
-    record = EntityRecord(name="ApeRAG", type="project", description="", source_chunk_ids=())
+    record = EntityRecord(name="ApeRAG", entity_type="project", description="", source_chunk_ids=())
     await lineage_store.upsert_entity_with_lineage(
         record=EntityRecord(**{**record.__dict__, "description": "RAG framework"}),
         lineage=_make_member(doc="doc-A", version="v1"),
@@ -441,7 +441,7 @@ async def test_relation_lineage_set_independent_from_entity(lineage_store):
     rel = RelationRecord(
         source="Linus Torvalds",
         target="Linux",
-        type="created",
+        relation_type="created",
         description="Linus created Linux in 1991.",
         source_chunk_ids=("c-1",),
     )
@@ -489,7 +489,7 @@ async def test_tenant_isolation_collection_id_filters_all_queries(lineage_store,
     try:
         record = EntityRecord(
             name="Shared Entity",
-            type="thing",
+            entity_type="thing",
             description="from other tenant",
             source_chunk_ids=(),
         )
@@ -639,7 +639,7 @@ async def test_cross_event_loop_construct_then_call(backend: str):
         await store.ensure_schema()
         record = EntityRecord(
             name="XLoop Entity",
-            type="thing",
+            entity_type="thing",
             description="cross-loop ok",
             source_chunk_ids=(),
         )

--- a/tests/integration/test_nebula_lineage_graph_store.py
+++ b/tests/integration/test_nebula_lineage_graph_store.py
@@ -158,7 +158,7 @@ async def test_roundtrip_entity_with_one_lineage_member(store):
 
     record = EntityRecord(
         name="Linus Torvalds",
-        type="person",
+        entity_type="person",
         description="Created Linux.",
         source_chunk_ids=("chunk-1",),
     )
@@ -168,7 +168,7 @@ async def test_roundtrip_entity_with_one_lineage_member(store):
     fetched = await store.get_entity("Linus Torvalds")
     assert fetched is not None
     assert fetched.name == "Linus Torvalds"
-    assert fetched.type == "person"
+    assert fetched.entity_type == "person"
     assert len(fetched.source_lineage) == 1
     assert fetched.source_lineage[0].document_id == "doc-A"
     assert fetched.source_lineage[0].parse_version == "v1"
@@ -183,7 +183,7 @@ async def test_two_documents_cite_same_entity_preserves_both_lineage(store):
     both members coexist; one's retry must not drop the other.
     """
 
-    record_base = EntityRecord(name="Python", type="language", description="", source_chunk_ids=())
+    record_base = EntityRecord(name="Python", entity_type="language", description="", source_chunk_ids=())
     await store.upsert_entity_with_lineage(
         record=EntityRecord(**{**record_base.__dict__, "description": "Created by Guido."}),
         lineage=_make_member(doc="doc-A", version="v1", chunks=("a-1",)),
@@ -215,7 +215,7 @@ async def test_doc_re_parse_replaces_old_parse_version_member(store):
     composite as the SET dedup key on Nebula too.
     """
 
-    record = EntityRecord(name="Rust", type="language", description="memory-safe", source_chunk_ids=())
+    record = EntityRecord(name="Rust", entity_type="language", description="memory-safe", source_chunk_ids=())
     await store.upsert_entity_with_lineage(
         record=record,
         lineage=_make_member(doc="doc-A", version="v1", chunks=("v1-1",)),
@@ -254,7 +254,7 @@ async def test_remove_then_gc_orphan_entity(store):
     it eligible for GC. Stripping all → GC actually deletes.
     """
 
-    record = EntityRecord(name="ApeRAG", type="project", description="", source_chunk_ids=())
+    record = EntityRecord(name="ApeRAG", entity_type="project", description="", source_chunk_ids=())
     await store.upsert_entity_with_lineage(
         record=EntityRecord(**{**record.__dict__, "description": "RAG framework"}),
         lineage=_make_member(doc="doc-A", version="v1"),
@@ -289,7 +289,7 @@ async def test_relation_lineage_set_independent_from_entity(store):
     rel = RelationRecord(
         source="Linus Torvalds",
         target="Linux",
-        type="created",
+        relation_type="created",
         description="Linus created Linux in 1991.",
         source_chunk_ids=("c-1",),
     )
@@ -345,7 +345,7 @@ async def test_tenant_isolation_collection_id_filters_all_queries(store):
     try:
         record = EntityRecord(
             name="Shared Entity",
-            type="thing",
+            entity_type="thing",
             description="from other tenant",
             source_chunk_ids=(),
         )

--- a/tests/integration/test_neo4j_lineage_graph_store.py
+++ b/tests/integration/test_neo4j_lineage_graph_store.py
@@ -119,7 +119,7 @@ async def test_roundtrip_entity_with_one_lineage_member(store):
 
     record = EntityRecord(
         name="Linus Torvalds",
-        type="person",
+        entity_type="person",
         description="Created Linux.",
         source_chunk_ids=("chunk-1",),
     )
@@ -129,7 +129,7 @@ async def test_roundtrip_entity_with_one_lineage_member(store):
     fetched = await store.get_entity("Linus Torvalds")
     assert fetched is not None
     assert fetched.name == "Linus Torvalds"
-    assert fetched.type == "person"
+    assert fetched.entity_type == "person"
     assert len(fetched.source_lineage) == 1
     assert fetched.source_lineage[0].document_id == "doc-A"
     assert fetched.source_lineage[0].parse_version == "v1"
@@ -146,7 +146,7 @@ async def test_two_documents_cite_same_entity_preserves_both_lineage(store):
 
     record_base = EntityRecord(
         name="Python",
-        type="language",
+        entity_type="language",
         description="",
         source_chunk_ids=(),
     )
@@ -189,7 +189,7 @@ async def test_doc_re_parse_replaces_old_parse_version_member(store):
 
     record = EntityRecord(
         name="Rust",
-        type="language",
+        entity_type="language",
         description="memory-safe",
         source_chunk_ids=(),
     )
@@ -239,7 +239,7 @@ async def test_remove_then_gc_orphan_entity(store):
     the entity must NOT make it eligible for GC.
     """
 
-    record = EntityRecord(name="ApeRAG", type="project", description="", source_chunk_ids=())
+    record = EntityRecord(name="ApeRAG", entity_type="project", description="", source_chunk_ids=())
     await store.upsert_entity_with_lineage(
         record=EntityRecord(**{**record.__dict__, "description": "RAG framework"}),
         lineage=_make_member(doc="doc-A", version="v1"),
@@ -276,7 +276,7 @@ async def test_relation_lineage_set_independent_from_entity(store):
     rel = RelationRecord(
         source="Linus Torvalds",
         target="Linux",
-        type="created",
+        relation_type="created",
         description="Linus created Linux in 1991.",
         source_chunk_ids=("c-1",),
     )
@@ -331,7 +331,7 @@ async def test_tenant_isolation_collection_id_filters_all_queries(store):
     try:
         record = EntityRecord(
             name="Shared Entity",
-            type="thing",
+            entity_type="thing",
             description="from other tenant",
             source_chunk_ids=(),
         )

--- a/tests/unit_test/domains/retrieval/test_graph_search_migration.py
+++ b/tests/unit_test/domains/retrieval/test_graph_search_migration.py
@@ -74,13 +74,13 @@ def test_render_graph_context_renders_lightrag_style_sections():
     entities = [
         EntityWithLineage(
             name="Alice",
-            type="person",
+            entity_type="person",
             source_lineage=members,
             description_parts=parts_a,
         ),
         EntityWithLineage(
             name="Acme",
-            type="organization",
+            entity_type="organization",
             source_lineage=members,
             description_parts=parts_b,
         ),
@@ -90,7 +90,7 @@ def test_render_graph_context_renders_lightrag_style_sections():
         RelationWithLineage(
             source="Alice",
             target="Acme",
-            type="founded",
+            relation_type="founded",
             evidence_lineage=members,
             description_parts=rel_parts,
         )
@@ -119,7 +119,7 @@ def test_render_graph_context_joins_multiple_description_parts():
         DescriptionPart(document_id="doc-1", parse_version="v1", text="   "),  # whitespace skipped
     )
     entities = [
-        EntityWithLineage(name="X", type="thing", source_lineage=members, description_parts=parts),
+        EntityWithLineage(name="X", entity_type="thing", source_lineage=members, description_parts=parts),
     ]
     text = _render_graph_context_text(entities, [])
     assert "- [thing] X — frag-1 | frag-2" in text
@@ -137,7 +137,7 @@ def test_render_graph_context_falls_back_to_no_description_marker():
     entities = [
         EntityWithLineage(
             name="Y",
-            type="",
+            entity_type="",
             source_lineage=members,
             description_parts=(),
         ),
@@ -191,20 +191,20 @@ def test_graph_search_composes_text_from_anchors_and_neighbors(monkeypatch):
     )
     alice = EntityWithLineage(
         name="Alice",
-        type="person",
+        entity_type="person",
         source_lineage=members,
         description_parts=(DescriptionPart(document_id="doc-1", parse_version="v1", text="Lead engineer"),),
     )
     bob = EntityWithLineage(
         name="Bob",
-        type="person",
+        entity_type="person",
         source_lineage=members,
         description_parts=(DescriptionPart(document_id="doc-1", parse_version="v1", text="CFO"),),
     )
     alice_bob = RelationWithLineage(
         source="Alice",
         target="Bob",
-        type="reports_to",
+        relation_type="reports_to",
         evidence_lineage=members,
         description_parts=(DescriptionPart(document_id="doc-1", parse_version="v1", text="Alice reports to Bob"),),
     )

--- a/tests/unit_test/indexing/test_lineage_query_protocol.py
+++ b/tests/unit_test/indexing/test_lineage_query_protocol.py
@@ -93,7 +93,7 @@ def _seed_minimal_graph(store: InMemoryLineageGraphStore) -> None:
             await store.upsert_entity_with_lineage(
                 record=EntityRecord(
                     name=name,
-                    type="person",
+                    entity_type="person",
                     description=f"{name} description",
                     source_chunk_ids=("chunk-1",),
                 ),
@@ -103,7 +103,7 @@ def _seed_minimal_graph(store: InMemoryLineageGraphStore) -> None:
             record=RelationRecord(
                 source="Alice",
                 target="Bob",
-                type="knows",
+                relation_type="knows",
                 description="knows",
                 source_chunk_ids=("chunk-1",),
             ),
@@ -113,7 +113,7 @@ def _seed_minimal_graph(store: InMemoryLineageGraphStore) -> None:
             record=RelationRecord(
                 source="Bob",
                 target="Carol",
-                type="manages",
+                relation_type="manages",
                 description="manages",
                 source_chunk_ids=("chunk-1",),
             ),
@@ -158,7 +158,7 @@ def test_in_memory_expand_neighbors_one_hop_includes_seed_and_neighbours():
         entities, relations = await store.expand_neighbors_n_hops(entity_names=["Alice"], hops=1)
         names = {e.name for e in entities}
         assert names == {"Alice", "Bob"}
-        rel_keys = {(r.source, r.target, r.type) for r in relations}
+        rel_keys = {(r.source, r.target, r.relation_type) for r in relations}
         assert rel_keys == {("Alice", "Bob", "knows")}
 
     asyncio.run(_run())
@@ -173,7 +173,7 @@ def test_in_memory_expand_neighbors_two_hops_walks_further():
         names = {e.name for e in entities}
         # 2-hop reaches Carol via Alice→Bob→Carol.
         assert names == {"Alice", "Bob", "Carol"}
-        rel_keys = {(r.source, r.target, r.type) for r in relations}
+        rel_keys = {(r.source, r.target, r.relation_type) for r in relations}
         assert rel_keys == {("Alice", "Bob", "knows"), ("Bob", "Carol", "manages")}
 
     asyncio.run(_run())

--- a/tests/unit_test/indexing/test_t1_2_graph.py
+++ b/tests/unit_test/indexing/test_t1_2_graph.py
@@ -248,7 +248,7 @@ async def test_d3_6_step1_doc_a_v1_inserts_initial_lineage(store, entity_lock, o
         "doc_A": [
             EntityRecord(
                 name="Linus",
-                type="Person",
+                entity_type="Person",
                 description="kernel hacker per doc_A",
                 source_chunk_ids=("doc_A-v1-c0",),
             )
@@ -675,14 +675,17 @@ class _RaceProvocateurStore(InMemoryLineageGraphStore):
         async with self._guard:
             row = self._entities.get(record.name)
             if row is None:
-                row = type(row)(name=record.name, type=record.type) if row is not None else None
+                # Note: the outer ``type(row)(...)`` call uses Python's
+                # builtin ``type()``; the ``entity_type=`` kwarg is the
+                # new dataclass field name (Wave 6 #36).
+                row = type(row)(name=record.name, entity_type=record.entity_type) if row is not None else None
             from aperag.indexing.graph import _InMemoryEntityRow  # noqa: PLC0415
 
             if row is None:
-                row = _InMemoryEntityRow(name=record.name, type=record.type)
+                row = _InMemoryEntityRow(name=record.name, entity_type=record.entity_type)
                 self._entities[record.name] = row
             else:
-                row.type = record.type
+                row.entity_type = record.entity_type
             # Without the ``EntityLock`` the second writer's
             # ``current_keys`` may have been computed before the
             # first writer's mutation, but since we still merge into
@@ -869,9 +872,9 @@ def test_kg_jsonl_skips_unknown_kinds_gracefully():
     # Forward-compatible: an older worker reads a newer artifact and
     # silently skips kinds it does not know yet.
     body = (
-        b'{"kind": "entity", "name": "X", "type": "Y", "description": "", "source_chunk_ids": []}\n'
+        b'{"kind": "entity", "name": "X", "entity_type": "Y", "description": "", "source_chunk_ids": []}\n'
         b'{"kind": "future_kind", "data": "..."}\n'
-        b'{"kind": "relation", "source": "X", "target": "Z", "type": "rel", "description": "", "source_chunk_ids": []}\n'
+        b'{"kind": "relation", "source": "X", "target": "Z", "relation_type": "rel", "description": "", "source_chunk_ids": []}\n'
     )
     entities, relations = parse_kg_jsonl(body)
     assert len(entities) == 1
@@ -1046,7 +1049,7 @@ async def test_end_to_end_with_real_parser_chunks():
             [
                 EntityRecord(
                     name=f"E_{c['chunk_id']}",
-                    type="Test",
+                    entity_type="Test",
                     description=c["text"],
                     source_chunk_ids=(c["chunk_id"],),
                 )


### PR DESCRIPTION
## Summary

Wave 6 #36 — rename `type` → `entity_type` / `relation_type` across the §D.3 `LineageGraphStore` Protocol surface and all 3 backend storage layers (Postgres / Neo4j / Nebula). Frees the bare `type` name from shadow conflicts with Python's builtin / Cypher's `TYPE()` keyword.

Hard-cut per earayu2 directive (no production data on legacy `type` shape — Wave 4 graph indexing was gated `enable_knowledge_graph=False` by default).

## Scope

* `EntityRecord.type` → `entity_type`; `RelationRecord.type` → `relation_type`; `EntityWithLineage` / `RelationWithLineage` follow.
* `_InMemoryEntityRow.type` → `entity_type`, `_InMemoryRelationRow.type` → `relation_type`.
* Postgres: ORM column rename + alembic migration `f8a4c5b9d3e1` + all SQL queries rewritten.
* Neo4j: Cypher `n.type` / `r.type` property rename + bind parameters + RETURN aliases.
* Nebula: tag-prop DDL rewrite + FETCH PROP / INSERT VERTEX nGQL.
* Retrieval pipeline: `_render_graph_context_text` reads `e.entity_type`.
* Extractor: accepts both `entity_type` (canonical) and `type` (legacy LightRAG prompt format) JSON keys.

## Test plan

- [x] 205/205 unit + integration tests pass (indexing + retrieval + extractor + model_platform)
- [x] ruff check + format clean across `aperag/` and `tests/`
- [x] Alembic head advanced to `f8a4c5b9d3e1`
- [x] Pattern 2 state-binding pre-check ran on `aperag_lineage_*.type` columns
- [x] Pattern 3 Protocol-method-state pre-check ran on `EntityRecord.type` / `RelationRecord.type` accessors
- [x] Method param names (`gc_relation_if_orphan(source, target, type)`) left as `type` to avoid breaking every caller — only data fields renamed

🤖 Generated with [Claude Code](https://claude.com/claude-code)