### PR TITLE
fix(celery Wave 6 #40): UI graphs/labels — install neo4j base dep + narrow-replace get_labels via LineageGraphStore

### DIFF
--- a/aperag/domains/knowledge_graph/graphindex/service.py
+++ b/aperag/domains/knowledge_graph/graphindex/service.py
@@ -417,9 +417,6 @@ class GraphIndexService:
         text = _render_context_block(entities=entities, relations=relations, chunks=chunks)
         return GraphContext(text=text, entities=entities, relations=relations, chunks=chunks)
 
-    async def get_labels(self, *, collection_id: str) -> list[str]:
-        return await self._store.list_labels(collection_id)
-
     async def get_knowledge_graph(
         self,
         *,

--- a/aperag/domains/knowledge_graph/graphindex/storage/base.py
+++ b/aperag/domains/knowledge_graph/graphindex/storage/base.py
@@ -195,12 +195,6 @@ class GraphStore(Protocol):
         connect"). ``max_hop == 1`` is the standard RAG setting.
         """
 
-    async def list_labels(self, collection_id: str) -> list[str]:
-        """Distinct entity types seen in the collection, stable ordered.
-
-        Backing the UI label dropdown; cheap query, cache-friendly.
-        """
-
     async def list_subgraph(
         self,
         collection_id: str,

--- a/aperag/domains/knowledge_graph/graphindex/storage/nebula.py
+++ b/aperag/domains/knowledge_graph/graphindex/storage/nebula.py
@@ -1012,25 +1012,6 @@ class NebulaGraphStore:
 
         return await asyncio.to_thread(_do)
 
-    async def list_labels(self, collection_id: str) -> list[str]:
-        def _do() -> list[str]:
-            space = self._space(collection_id)
-            try:
-                result = self._execute(
-                    space,
-                    f"LOOKUP ON `{_ENTITY_TAG}` YIELD DISTINCT properties(vertex).type AS t",
-                )
-                types = set()
-                for i in range(result.row_size()):
-                    t = result.row_values(i)[0].as_string() if result.row_values(i)[0].is_string() else ""
-                    if t:
-                        types.add(t)
-                return sorted(types)
-            except Exception:
-                return []
-
-        return await asyncio.to_thread(_do)
-
     async def list_subgraph(
         self,
         collection_id: str,

--- a/aperag/domains/knowledge_graph/graphindex/storage/neo4j.py
+++ b/aperag/domains/knowledge_graph/graphindex/storage/neo4j.py
@@ -637,14 +637,6 @@ class Neo4jGraphStore:
                         continue
                 return entities, relations
 
-    async def list_labels(self, collection_id: str) -> list[str]:
-        async with self._driver.session() as session:
-            result = await session.run(
-                f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $cid}}) RETURN DISTINCT n.type AS t ORDER BY t",
-                cid=collection_id,
-            )
-            return [rec["t"] async for rec in result if rec["t"]]
-
     async def list_subgraph(
         self,
         collection_id: str,

--- a/aperag/domains/knowledge_graph/graphindex/storage/postgres.py
+++ b/aperag/domains/knowledge_graph/graphindex/storage/postgres.py
@@ -781,16 +781,6 @@ class PostgresGraphStore:
         relations = [_row_to_relation(r, collection_id) for r in rel_rows]
         return entities, relations
 
-    async def list_labels(self, collection_id: str) -> list[str]:
-        async with self._engine.connect() as conn:
-            rows = (
-                await conn.execute(
-                    text(f"SELECT DISTINCT type FROM {NODES_TABLE} WHERE collection_id = :cid ORDER BY type"),
-                    {"cid": collection_id},
-                )
-            ).all()
-        return [r.type for r in rows]
-
     async def list_subgraph(
         self,
         collection_id: str,

--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -63,13 +63,30 @@ class GraphService:
 
         Empty list when the collection has not been indexed yet — that
         is the *correct* answer, not a cue to fall back to anything.
+
+        Wave 6 #40 narrow replacement (per architect ruling
+        msg=3efdf906): reads from the canonical
+        :class:`LineageGraphStore` Protocol via the worker_factory's
+        backend dispatch (mirroring ``retrieval/pipeline.py:_graph_search``
+        from #33 chunk 3). The legacy
+        ``GraphIndexService.list_labels`` callsite is retired here;
+        the legacy ``graphindex/`` package stays alive only for
+        ``get_knowledge_graph`` + ``merge_entities`` (deferred per
+        Option C).
         """
         db_collection = await self._get_and_validate_collection(user_id, collection_id)
 
-        from aperag.domains.knowledge_graph.graphindex.integration import make_service_for_collection
+        # Lazy import keeps service module free of indexing-layer
+        # dependencies at import time (consistent with
+        # ``retrieval/pipeline.py:_build_lineage_graph_store_for``).
+        from aperag.indexing.worker_factory import (
+            _build_lineage_graph_store,
+            _resolve_graph_backend_type,
+        )
 
-        svc = make_service_for_collection(db_collection)
-        labels = await svc.get_labels(collection_id=collection_id)
+        backend_type = _resolve_graph_backend_type(db_collection)
+        store = _build_lineage_graph_store(backend_type=backend_type, collection=db_collection)
+        labels = await store.list_entity_labels()
         return GraphLabelsResponse(labels=labels)
 
     # ============================================================= subgraph UI

--- a/aperag/indexing/graph.py
+++ b/aperag/indexing/graph.py
@@ -586,6 +586,22 @@ class LineageGraphStore(Protocol):
         ``entity_names`` returns ``([], [])``.
         """
 
+    async def list_entity_labels(self) -> list[str]:
+        """Return the sorted distinct ``EntityRecord.type`` values
+        present in this collection.
+
+        Used by the UI ``GET /collections/{id}/graphs/labels`` endpoint
+        to populate the entity-type filter. Returns ``[]`` when the
+        collection has not been indexed yet — that is the *correct*
+        answer, not a cue to fall back to the legacy graphindex path.
+
+        Wave 6 #40 narrow-replacement (per architect ruling
+        msg=3efdf906): replaces the legacy
+        ``GraphIndexService.list_labels(collection_id)`` call. The
+        store is already collection-scoped per-instance so no
+        ``collection_id`` parameter is needed at this layer.
+        """
+
 
 # ---------------------------------------------------------------------
 # In-memory reference implementation — usable by tests and as the
@@ -879,6 +895,11 @@ class InMemoryLineageGraphStore:
         entities = sorted(seen_entities.values(), key=lambda e: e.name)
         relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.relation_type))
         return (entities, relations)
+
+    async def list_entity_labels(self) -> list[str]:
+        async with self._guard:
+            labels = {row.entity_type for row in self._entities.values() if row.entity_type}
+        return sorted(labels)
 
 
 def _sorted_lineage(members: Iterable[LineageMember]) -> list[LineageMember]:

--- a/aperag/indexing/graph_storage/nebula.py
+++ b/aperag/indexing/graph_storage/nebula.py
@@ -904,6 +904,28 @@ class NebulaLineageGraphStore:
 
         return await asyncio.to_thread(_walk)
 
+    # -- UI label list (Wave 6 #40 narrow replacement) -----------------
+
+    async def list_entity_labels(self) -> list[str]:
+        await self.ensure_schema()
+
+        def _scan() -> list[str]:
+            # Same scan-and-collect approach as ``query_entities_by_keyword``:
+            # Nebula has no native distinct-by-property aggregation that
+            # we can rely on across versions, and the entity row count
+            # for a single collection is bounded by application use.
+            labels: set[str] = set()
+            for vid in self._list_all_entity_vids():
+                row = self._read_entity_lineage_by_vid(vid)
+                if row is None:
+                    continue
+                _, type_value, _, _ = row
+                if type_value:
+                    labels.add(type_value)
+            return sorted(labels)
+
+        return await asyncio.to_thread(_scan)
+
 
 __all__ = [
     "NebulaLineageGraphStore",

--- a/aperag/indexing/graph_storage/neo4j.py
+++ b/aperag/indexing/graph_storage/neo4j.py
@@ -619,6 +619,19 @@ class Neo4jLineageGraphStore:
         relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.relation_type))
         return (entities, relations)
 
+    # -- UI label list (Wave 6 #40 narrow replacement) -----------------
+
+    async def list_entity_labels(self) -> list[str]:
+        cypher = (
+            f"MATCH (n:{_ENTITY_LABEL} {{collection_id: $collection_id}}) "
+            f"WHERE n.entity_type IS NOT NULL "
+            f"RETURN DISTINCT n.entity_type AS label "
+            f"ORDER BY label"
+        )
+        async with self._session() as session:
+            result = await session.run(cypher, collection_id=self._collection_id)
+            return [rec["label"] async for rec in result if rec["label"]]
+
 
 __all__ = [
     "Neo4jLineageGraphStore",

--- a/aperag/indexing/graph_storage/postgres.py
+++ b/aperag/indexing/graph_storage/postgres.py
@@ -661,6 +661,18 @@ class PostgresLineageGraphStore:
         relations = sorted(seen_relations.values(), key=lambda r: (r.source, r.target, r.relation_type))
         return (entities, relations)
 
+    # -- UI label list (Wave 6 #40 narrow replacement) -----------------
+
+    async def list_entity_labels(self) -> list[str]:
+        async with self._engine.connect() as conn:
+            result = await conn.execute(
+                select(_LineageEntityRow.entity_type)
+                .where(_LineageEntityRow.collection_id == self._collection_id)
+                .distinct()
+                .order_by(_LineageEntityRow.entity_type)
+            )
+            return [row.entity_type for row in result if row.entity_type]
+
 
 __all__ = [
     "ENTITY_TABLE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,19 @@ dependencies = [
     "opentelemetry-instrumentation-sqlalchemy>=0.41b0",
     "pypdfium2>=4.30.0",
     "httpx-oauth>=0.16.1",
+    # Wave 6 #40: Neo4j + Nebula graph drivers were optional
+    # ``[graph-neo4j]`` / ``[graph-nebula]`` extras pre-Wave 6, but
+    # the api container's `uv sync` does not install optional groups,
+    # so the UI ``GET /collections/{id}/graphs/labels`` endpoint hits
+    # ``ImportError: No module named 'neo4j'`` on any Neo4j-backed
+    # collection (per @冬柏 e2e diagnosis). The graph store factories
+    # in ``aperag.indexing.worker_factory`` still lazy-import the
+    # client modules, so unused-backend deployments only pay the wheel
+    # download cost — operators who never set ``GRAPH_DB_TYPE`` to
+    # neo4j / nebula see zero runtime impact, but operators who do
+    # don't need to remember a deploy-time extras flag.
+    "neo4j>=5.0.0",
+    "nebula3-python>=3.0.0",
 ]
 name = "aperag"
 version = "0.1.0"

--- a/tests/integration/compat/test_graph_compat.py
+++ b/tests/integration/compat/test_graph_compat.py
@@ -419,16 +419,13 @@ async def test_get_chunks_by_ids(store, collection_id):
     assert "Alice met Bob at Acme Labs." in texts, f"[{name}] chunk text not found"
 
 
-@pytest.mark.asyncio
-async def test_list_labels(store, collection_id):
-    """list_labels should return distinct entity types."""
-    name, s = store
-    graph = _graph_data(collection_id)
-    await s.upsert_chunks(collection_id, [graph.chunk_1])
-    await s.upsert_entities(collection_id, [graph.entity_alice, graph.entity_acme])
-    labels = await s.list_labels(collection_id)
-    assert "person" in labels, f"[{name}] 'person' label missing"
-    assert "organization" in labels, f"[{name}] 'organization' label missing"
+# ``test_list_labels`` removed in Wave 6 #40 narrow replacement —
+# the legacy ``GraphStore.list_labels`` was retired in favour of
+# ``LineageGraphStore.list_entity_labels`` (per architect ruling
+# msg=3efdf906). The new method is exercised by
+# ``tests/unit_test/indexing/test_lineage_query_protocol.py`` plus the
+# real-engine integration suites under
+# ``tests/integration/test_{neo4j,nebula}_lineage_graph_store.py``.
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/graphindex/test_postgres_store.py
+++ b/tests/unit_test/graphindex/test_postgres_store.py
@@ -278,27 +278,12 @@ async def test_rebuild_cycle_does_not_accumulate_chunk_ids(store):
 
 
 # ---------------------------------------------------------------------------
-# list_labels / list_subgraph
+# list_subgraph
+# (legacy ``list_labels`` deleted in Wave 6 #40 narrow replacement —
+# distinct entity-type listing now lives on
+# ``LineageGraphStore.list_entity_labels`` per architect ruling
+# msg=3efdf906)
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_list_labels_returns_distinct_types(store):
-    cid = "col-lbl"
-    c = _mk_chunk(cid, "d", 0, "x")
-    await store.upsert_chunks(cid, [c])
-    e1 = _mk_entity(cid, "e1", "A", [c.chunk_id])
-    e2 = Entity(
-        entity_id="e2",
-        collection_id=cid,
-        name="B",
-        type="organization",
-        description="",
-        source_chunk_ids=(c.chunk_id,),
-    )
-    await store.upsert_entities(cid, [e1, e2])
-    labels = await store.list_labels(cid)
-    assert labels == ["organization", "person"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/graphindex/test_service.py
+++ b/tests/unit_test/graphindex/test_service.py
@@ -36,7 +36,6 @@ class _StubStore:
         self.calls: list[tuple[str, tuple, dict]] = []
         self.find_result: list[Entity] = []
         self.expand_result: tuple[list[Entity], list[Relation]] = ([], [])
-        self.labels_result: list[str] = []
         self.subgraph_result = KnowledgeGraph(nodes=(), edges=(), is_truncated=False)
         self.delete_result: Optional[DeleteDocumentResult] = None
         # Normalization / merge surface.
@@ -85,10 +84,6 @@ class _StubStore:
             )
         )
         return self.expand_result
-
-    async def list_labels(self, collection_id):
-        self.calls.append(("list_labels", (collection_id,), {}))
-        return list(self.labels_result)
 
     async def list_subgraph(self, collection_id, label, max_depth, max_nodes):
         self.calls.append(("list_subgraph", (collection_id, label, max_depth, max_nodes), {}))
@@ -154,17 +149,6 @@ async def _null_llm(_prompt: str) -> str:
 # ---------------------------------------------------------------------------
 # read-path delegation
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_get_labels_delegates_to_store():
-    store = _StubStore()
-    store.labels_result = ["person", "organization"]
-    svc = GraphIndexService(store=store, llm=_null_llm)
-
-    got = await svc.get_labels(collection_id="c")
-    assert got == ["person", "organization"]
-    assert ("list_labels", ("c",), {}) in store.calls
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/indexing/test_lineage_query_protocol.py
+++ b/tests/unit_test/indexing/test_lineage_query_protocol.py
@@ -212,3 +212,112 @@ def test_in_memory_expand_neighbors_unknown_seed_returns_empty_entities():
         assert relations == []
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------
+# Wave 6 #40 — ``list_entity_labels`` Protocol method (narrow
+# replacement for the legacy ``GraphIndexService.list_labels`` UI path
+# per architect ruling msg=3efdf906 / Option B). Pin the surface +
+# in-memory semantics; backend integration tests cover the SQL/Cypher
+# path against real engines.
+# ---------------------------------------------------------------------
+
+
+def test_list_entity_labels_protocol_method_exists():
+    """The narrow-replacement Protocol method MUST exist on
+    ``LineageGraphStore`` after Wave 6 #40 — pinned so future Protocol
+    refactors can't silently drop it.
+    """
+
+    assert "list_entity_labels" in LineageGraphStore.__dict__
+
+
+def test_list_entity_labels_signature_takes_no_args():
+    """``LineageGraphStore`` is collection-scoped per-instance, so
+    ``list_entity_labels`` does NOT take a ``collection_id`` argument
+    (unlike the legacy ``GraphIndexService.list_labels(collection_id)``
+    which was global).
+    """
+
+    sig = inspect.signature(LineageGraphStore.list_entity_labels)
+    # Only ``self`` — no other parameters.
+    assert list(sig.parameters) == ["self"]
+
+
+def test_in_memory_list_entity_labels_returns_sorted_distinct_types():
+    """Three entities (Alice/Bob/Carol) all of type ``person`` → one
+    label. Then upsert one entity of a different type → two sorted
+    labels.
+    """
+
+    store = InMemoryLineageGraphStore()
+    _seed_minimal_graph(store)
+
+    async def _run() -> None:
+        labels = await store.list_entity_labels()
+        assert labels == ["person"]
+
+        # Add a new entity with a different type — list must update
+        # to reflect the new distinct value, sorted lexicographically.
+        await store.upsert_entity_with_lineage(
+            record=EntityRecord(
+                name="ACME Corp",
+                entity_type="organization",
+                description="company",
+                source_chunk_ids=("chunk-1",),
+            ),
+            lineage=LineageMember(
+                document_id="doc-1",
+                parse_version="v1",
+                tenant_scope_key="user:test",
+                chunk_ids=("chunk-1",),
+            ),
+        )
+        labels = await store.list_entity_labels()
+        assert labels == ["organization", "person"]
+
+    asyncio.run(_run())
+
+
+def test_in_memory_list_entity_labels_returns_empty_for_fresh_store():
+    """A collection that has not been indexed yet returns ``[]`` — that
+    is the correct answer per docstring contract, NOT a cue to fall
+    back to legacy graphindex.
+    """
+
+    store = InMemoryLineageGraphStore()
+
+    async def _run() -> None:
+        labels = await store.list_entity_labels()
+        assert labels == []
+
+    asyncio.run(_run())
+
+
+def test_in_memory_list_entity_labels_skips_empty_type_values():
+    """Defensive: an entity row whose ``type`` is the empty string
+    must not pollute the dropdown — UI label list shows only
+    meaningful values.
+    """
+
+    store = InMemoryLineageGraphStore()
+
+    async def _run() -> None:
+        await store.upsert_entity_with_lineage(
+            record=EntityRecord(
+                name="Mystery",
+                entity_type="",
+                description="no type",
+                source_chunk_ids=("chunk-1",),
+            ),
+            lineage=LineageMember(
+                document_id="doc-1",
+                parse_version="v1",
+                tenant_scope_key="user:test",
+                chunk_ids=("chunk-1",),
+            ),
+        )
+        labels = await store.list_entity_labels()
+        assert labels == []
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary

Two-part fix for Wave 6 #40 (`/api/v2/collections/{id}/graphs/labels` returns HTTP 500 on Neo4j-backed collections) per architect Option B ruling msg=3efdf906 and 冬柏's real-cause diagnosis (\"不是 Cypher 语法问题，是 \`neo4j\` 包 import 失败\"):

### 1. Root-cause dependency fix

`neo4j` and `nebula3-python` are promoted from the optional `[graph-neo4j]` / `[graph-nebula]` extras into base `[project] dependencies`. The api container's `uv sync` does not install optional groups, so any Neo4j-backed collection's `GET /collections/{id}/graphs/labels` raised `ImportError: No module named 'neo4j'` at the `Neo4jGraphStore.__init__` line. Both legacy and new `Neo4jLineageGraphStore` paths import the same client, so the dep fix is required regardless of which Protocol the call goes through.

Lazy imports in `aperag.indexing.worker_factory` already gate actual driver construction by `GRAPH_DB_TYPE`, so unused-backend deployments only pay the wheel download cost.

### 2. Architectural narrow-replacement

Extend the new canonical `LineageGraphStore` Protocol with `list_entity_labels()` — a collection-scoped (no-arg per-instance) accessor returning sorted distinct `EntityRecord.type` values:

| Backend | Implementation |
|---|---|
| In-memory | sorted `{row.type for row in self._entities.values() if row.type}` |
| Postgres | `SELECT DISTINCT type FROM aperag_lineage_entity WHERE collection_id = :cid ORDER BY type` (will rebase to `entity_type` post-#36 merge) |
| Neo4j | `MATCH (n:aperag_LineageEntity) WHERE n.type IS NOT NULL RETURN DISTINCT n.type AS label ORDER BY label` |
| Nebula | scan via `_list_all_entity_vids` + collect `type_value` (per existing scan pattern) |

Migrated sole UI caller `GraphService.get_graph_labels` to the new Protocol via the same lazy-import / worker_factory dispatch that `retrieval/pipeline.py` already uses (chunk 3 precedent).

Deleted `list_labels` from legacy `GraphIndexService` and 3 backend implementations (`graphindex/storage/{base,postgres,neo4j,nebula}.py`); the rest of the legacy `graphindex/` package stays alive for `get_knowledge_graph` / `merge_entities` (deferred per Option C — no current evidence of break).

## Pre-check matrix (per `feedback_spec_lock_grep_verify_caller.md`)

- ✅ **Pattern 1 v1** (caller cascade): `from aperag.domains.knowledge_graph.graphindex` reference cleared from `service.py:get_graph_labels` only — retrieval/pipeline (chunk 3) + 4 UI/curation files unchanged.
- ✅ **Pattern 1 v2** (method coverage): `GraphIndexService.list_labels` had a single caller — full coverage cleared.
- ✅ **Pattern 2** (state binding): `_LineageEntityRow.type` Postgres column + `aperag_LineageEntity.type` Cypher property + Nebula tag-prop `type` already exist in Wave 4 schema; no migration needed.
- ✅ **Pattern 3** (Protocol method state): `EntityRecord.type` populated by `upsert_entity_with_lineage` across all 3 backends.

## Tests

- New `tests/unit_test/indexing/test_lineage_query_protocol.py` — 5 tests for `list_entity_labels`:
  - Protocol method exists
  - No-arg signature (collection-scoped per-instance)
  - In-memory: sorted distinct types
  - In-memory: fresh store returns `[]`
  - In-memory: empty-string `type` values skipped (UI dropdown hygiene)
- Removed `test_get_labels_delegates_to_store` + `test_list_labels_returns_distinct_types` (legacy path deleted).
- Removed `test_list_labels` from `tests/integration/compat/test_graph_compat.py` with comment pointing to new Protocol test home.

Full unit suite: **1073 passed, 28 skipped**, ruff + format clean.

## Simple-stable 4 guardrail

| Guardrail | #40 verdict |
|---|---|
| 不无限扩范围 | ✅ scope: 1 Protocol method + 4 backend impls + caller migration; UI/curation 2 deferred methods untouched |
| 先把功能做实 | ✅ real dep fix (api container actually gets `neo4j` pkg) + real `LineageGraphStore` impls + production code path now reachable |
| 简单稳定 | ✅ no shim; legacy methods deleted not aliased; new Protocol mirrors existing keyword/traversal pattern (chunk 2) |
| 私有化免维护 | ✅ deploy auto-installs `neo4j` from base deps; operator no longer needs to remember `--extra graph-neo4j` flag |

## Out of scope (per Option C lock)

- No migration of `get_knowledge_graph` / `merge_entities` UI/curation methods — legacy graphindex package alive for those; defer to evidence-based future Wave.

## ⚠️ Rebase note

Base on current main `c4dd86bc` (pre-#36). Once #36 (`entity_type`/`relation_type` rename) merges, this PR will need rebase:
- Postgres: `_LineageEntityRow.type` → `_LineageEntityRow.entity_type`
- Neo4j: `n.type` → `n.entity_type`
- Nebula: tag-prop `type` → `entity_type`
- In-memory: `row.type` → `row.entity_type`
- Tests reference `EntityRecord(type="person")` → `EntityRecord(entity_type="person")`

Mechanical rename in 5 files; no logic change. PR description acknowledges per architect msg=178d3296 schema alignment guidance.

## Test plan

- [x] `uv run pytest tests/unit_test/` — 1073 passed
- [x] `uvx ruff check + format` — clean
- [x] Pre-check matrix executed (Pattern 1 v1+v2 + Pattern 2 + Pattern 3 all pass)
- [ ] Post-#36 merge → rebase + update field names