### PR TITLE
test(worker_factory): cover OpenSearch fulltext backend dispatch + ES_HOST gating

### DIFF
--- a/tests/integration/test_worker_factory.py
+++ b/tests/integration/test_worker_factory.py
@@ -529,3 +529,52 @@ def test_build_fulltext_backend_elasticsearch_requires_es_host(monkeypatch: pyte
         )
     assert "ES_HOST" in str(exc.value)
     assert "elasticsearch" in str(exc.value)
+
+
+def test_build_fulltext_backend_dispatches_to_opensearch(monkeypatch: pytest.MonkeyPatch):
+    """``backend_type=opensearch`` constructs an ``OpenSearch`` client
+    and wraps it in the **same** ``_ElasticsearchFulltextBackend``
+    adapter — the two backends share a wire-compatible HTTP API, so
+    the index/bulk/delete_by_query call sites do not branch by
+    backend. Patches the client builder so the test does not need a
+    live OpenSearch cluster.
+    """
+
+    import aperag.indexing.worker_factory as wf
+
+    class _FakeOS:
+        def __init__(self, host, **kwargs):
+            self.host = host
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(wf, "_build_opensearch_client", lambda: _FakeOS("http://os:9200"))
+
+    backend = wf._build_fulltext_backend(
+        backend_type="opensearch",
+        index_name="aperag_doc_col-1",
+    )
+    assert isinstance(backend, wf._ElasticsearchFulltextBackend)
+    assert backend._index == "aperag_doc_col-1"
+    assert isinstance(backend._client, _FakeOS)
+
+
+def test_build_fulltext_backend_opensearch_requires_es_host(monkeypatch: pytest.MonkeyPatch):
+    """Mirror of the elasticsearch ``ES_HOST`` gate — the OpenSearch
+    builder reads the same ``settings.es_host`` (operators run one
+    fulltext backend per deployment, so a single env var feeds either
+    driver). An unset ``ES_HOST`` raises a clear
+    :class:`WorkerFactoryError`.
+    """
+
+    import aperag.indexing.worker_factory as wf
+    from aperag.config import settings as _settings
+
+    monkeypatch.setattr(_settings, "es_host", "", raising=False)
+
+    with pytest.raises(WorkerFactoryError) as exc:
+        wf._build_fulltext_backend(
+            backend_type="opensearch",
+            index_name="aperag_doc_col-1",
+        )
+    assert "ES_HOST" in str(exc.value)
+    assert "opensearch" in str(exc.value)


### PR DESCRIPTION
## Summary

Backend-coverage audit (#测试 task #25) found that the **opensearch** fulltext backend had no test for the dispatch-success path and no test for the ``ES_HOST`` env gate, while the parallel elasticsearch tests existed for both. Adds the two missing tests so every supported fulltext backend has matched coverage of its three failure / success modes.

## Coverage matrix (after this PR)

| Test category | elasticsearch | opensearch |
|---|---|---|
| Config resolution (4 forms) | ✅ existing | ✅ existing (parametrized) |
| Dispatch success → wrapped backend | ✅ existing | ✅ **new in this PR** |
| ``ES_HOST`` unset → ``WorkerFactoryError`` | ✅ existing | ✅ **new in this PR** |
| Missing driver dependency → ``WorkerFactoryError`` | n/a (in deps) | ✅ existing |

## Why this matters

- The opensearch backend ships in production: ``fulltext_backend_type: Literal["elasticsearch", "opensearch"]`` per-collection field with a real ``_build_opensearch_client()`` in ``worker_factory.py``.
- Without the dispatch-success test, the wire-compat invariant ("both backends use the same ``_ElasticsearchFulltextBackend`` adapter — only the underlying driver differs") was not locked in by tests; a future refactor could silently branch the adapter class without anyone noticing.
- Without the ``ES_HOST`` gate test for opensearch, an operator misconfiguring the backend would have hit a half-built client with a less-friendly error.

## Test plan

- [x] `pytest tests/integration/test_worker_factory.py -k fulltext` → 11 passed (9 existing + 2 new)
- [x] No production code change; tests-only PR
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)