### PR TITLE
fix(e2e): neo4j compose healthcheck + api gate to avoid DNS flake (Wave 6 #41)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,9 @@ services:
         condition: service_healthy
       es:
         condition: service_healthy
+      neo4j:
+        condition: service_healthy
+        required: false
       # Vector backend is intentionally NOT in depends_on. ApeRAG's
       # VectorStoreConnectorAdaptor (aperag/vectorstore/connector.py) is
       # lazy-import + lazy-instantiate, so the api boots cleanly with
@@ -34,6 +37,11 @@ services:
       # qdrant, which masked "code accidentally still calls qdrant" bugs
       # in pgvector mode. Runners (tests/e2e_http/runners/compose/up.sh)
       # are responsible for starting the chosen vector backend.
+      #
+      # neo4j uses required:false so the dependency activates only when
+      # the neo4j profile is enabled (e2e Neo4j shape). Without it, the
+      # api can start before neo4j is reachable and the first /graphs
+      # call fails with ServiceUnavailable: DNS resolve aperag-neo4j:7687.
     volumes:
       - ~/.cache:/root/.cache
       - aperag-shared-data:/shared
@@ -165,6 +173,12 @@ services:
       - NEO4J_apoc_export_file_enabled=true
     volumes:
       - aperag-neo4j-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p password 'RETURN 1' || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 18  # 18 * 10s = 180s — Neo4j enterprise + apoc plugin takes time to boot
+      start_period: 20s
     profiles: ["neo4j"]
 
   nebula-metad:


### PR DESCRIPTION
## Summary

Fixes the e2e CI flake surfaced by PR #1746 merge cycle:
```
neo4j.exceptions.ServiceUnavailable: Failed to DNS resolve address aperag-neo4j:7687: [Errno -3] Temporary failure in name resolution
```
on `tests/e2e_http/hurl/full/14_graph_http.hurl:99 GET /graphs?label=*` in the e2e-http-provider Qdrant+Neo4j shape.

## Why it surfaced now

PR #1746 promoted `neo4j` + `nebula3-python` from optional `[graph-neo4j]` / `[graph-nebula]` extras into required base dependencies, so the api container can finally `from neo4j import AsyncGraphDatabase`. That fix unmasked a pre-existing e2e race:

- The `neo4j` compose service had **no healthcheck**, so the runner had no way to wait for it.
- The api's `depends_on` did **not** include neo4j, so the api was free to come up before neo4j's bolt port was accepting queries.
- The compose runner (`tests/e2e_http/runners/compose/up.sh`) only waits for `${E2E_BASE_URL}/health` (api), then immediately starts hurl tests.

Result: hurl hits the legacy `get_knowledge_graph` endpoint → `Neo4jGraphStore` → `session.run(...)` → DNS resolve `aperag-neo4j:7687` fails → 500.

## Fix

Two changes in `docker-compose.yml`:

1. Add a `cypher-shell -u neo4j -p password 'RETURN 1'` healthcheck to the `neo4j` service (start_period 20s + 18 retries × 10s = up to 200s warm-up tolerance for Neo4j enterprise + apoc plugin boot).
2. Wire the api's `depends_on` to neo4j with `required: false` so the dependency activates only when the `neo4j` profile is enabled (e2e Neo4j shape). Postgres / pgvector / nebula deploys remain unaffected.

The `required: false` choice mirrors the existing lazy-instantiate convention (qdrant intentionally NOT in depends_on per the inline comment): the dependency only gates when the operator actually starts neo4j.

## Test plan

- [ ] CI e2e-http-provider Qdrant+Neo4j shape now reaches hurl test phase only after neo4j healthcheck passes.
- [ ] e2e-http-provider Qdrant+Nebula shape unaffected (no neo4j profile started, `required: false` means dependency is skipped).
- [ ] e2e-http-smoke (lite + pgvector) unaffected (no graph profile started).
- [ ] Local docker compose up validates the config change (cypher-shell ping returns RETURN 1 from inside the neo4j container).

Wave 6 follow-up task #41. Out of scope: the `nebula-graphd` healthcheck already exists; no analogous race observed for Nebula in CI logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)