### PR TITLE
feat(Wave 7 #2): port graph description compactor to new indexing pipeline

### DIFF
--- a/aperag/indexing/graph_compactor.py
+++ b/aperag/indexing/graph_compactor.py
@@ -77,25 +77,87 @@ spot rows that hit the LLM-unavailable path."""
 PART_SEPARATOR: str = "\n\n"
 
 
-_SUMMARIZE_PROMPT_TEMPLATE: str = (
-    "请将以下知识图谱节点 / 关系的多段描述压缩为一段连贯的中文总结，"
-    "目标长度约 {target} 字以内。要求：\n"
-    "1. 保留所有事实信息（实体、属性、时间、来源等），不要遗漏关键细节。\n"
-    "2. 去重重复表述，合并语义相近的句子。\n"
-    "3. 不要编造原文未出现的内容。\n"
-    "4. 直接输出总结正文，不要加任何前言、标题或解释。\n\n"
-    "原始描述片段：\n"
-    "{joined}\n"
-)
+DEFAULT_LANGUAGE: str = "Chinese"
+"""Default natural language for the summary output. Callers (worker /
+curation service) override per collection language config."""
+
+DESCRIPTION_SUMMARIZATION: str = """\
+You are consolidating a knowledge-graph entry.
+
+Below are {fragment_count} short descriptions of the same
+{subject_kind}, extracted from different chunks of a document. Your job
+is to produce ONE coherent summary in {language} that preserves every
+fact mentioned.
+
+**Rules**
+
+1. Output ONLY the summary text. No preamble, no JSON, no markdown.
+2. Target length: around {target_chars} characters (one or two
+   paragraphs). Go longer if the fragments genuinely require it; never
+   omit a fact to hit the target.
+3. Merge duplicate facts into one sentence. Keep conflicting facts
+   both — the downstream pipeline will flag contradictions, so do not
+   silently pick a winner.
+4. Do not add information that isn't in the fragments.
+5. For a relation, keep the subject–predicate–object framing clear
+   ("<source> <verb> <target> because ...").
+
+**Subject**: {subject_label}
+
+**Fragments** (separated by "---"):
+
+---
+{fragments_block}
+---
+
+Summary (plain text, {language}):"""
+"""Description summarization prompt — ported verbatim from legacy
+``aperag/domains/knowledge_graph/graphindex/prompts.py:DESCRIPTION_SUMMARIZATION``
+to preserve the five behaviours the legacy pipeline relied on:
+``subject_kind`` framing, ``subject_label`` anchoring, ``language``
+control, relation S-P-O guidance, and contradiction-keep-both. Per
+earayu2 ``msg=421c4223`` directive (新老对比，不要丢失好的算法)."""
+
+
+def render_summarization_prompt(
+    *,
+    subject_kind: str,
+    subject_label: str,
+    fragments: list[str],
+    language: str,
+    target_chars: int,
+) -> str:
+    """Render the description-summarization prompt for one entity or
+    relation.
+
+    Mirrors the legacy ``render_summarization_prompt`` so prompt-level
+    A/B testing can swap implementations without changing callers.
+    """
+    block = "\n---\n".join(f.strip() for f in fragments if f and f.strip())
+    cleaned_count = len([f for f in fragments if f and f.strip()])
+    return DESCRIPTION_SUMMARIZATION.format(
+        subject_kind=subject_kind,
+        subject_label=subject_label,
+        fragments_block=block,
+        fragment_count=cleaned_count,
+        language=language,
+        target_chars=target_chars,
+    )
 
 
 class GraphIndexCompactor:
     """Compact long description-part lists for one entity / relation.
 
-    Caller usage (task #3 ``GraphModalityWorker.sync()``)::
+    Caller usage (task #3 ``GraphModalityWorker.sync()`` and task #6
+    ``GraphCurationService.merge_entities``)::
 
         compactor = GraphIndexCompactor(llm)
-        compacted = await compactor.compact_if_oversized(entity.parts_text)
+        compacted = await compactor.compact_if_oversized(
+            entity.description_parts_text,
+            subject_kind="entity",
+            subject_label=entity.name,
+            language=collection.config.extraction_language,
+        )
         if compacted is not None:
             await store.set_compacted_description(entity_id, compacted)
 
@@ -108,9 +170,22 @@ class GraphIndexCompactor:
     def __init__(self, llm: LLMCall) -> None:
         self._llm = llm
 
-    async def compact_if_oversized(self, parts: list[str]) -> str | None:
+    async def compact_if_oversized(
+        self,
+        parts: list[str],
+        *,
+        subject_kind: str,
+        subject_label: str,
+        language: str = DEFAULT_LANGUAGE,
+    ) -> str | None:
         """Return a compacted description, or ``None`` if compaction is
         not warranted.
+
+        ``subject_kind`` is ``"entity"`` or ``"relation"``;
+        ``subject_label`` is the entity name (e.g. ``"OpenAI"``) or a
+        ``"<source> → <target>"`` rendering for a relation. Both flow
+        into the LLM prompt so the model can frame the summary
+        correctly. ``language`` controls the output natural language.
 
         Empty / whitespace-only parts are dropped before evaluation —
         an empty ``parts`` list returns ``None`` (nothing to compact).
@@ -124,22 +199,37 @@ class GraphIndexCompactor:
         if len(cleaned) < SUMMARIZE_AT_FRAGMENTS and len(joined) < MAX_DESCRIPTION_CHARS:
             return None
 
-        summary = await self._summarize_via_llm(joined)
+        summary = await self._summarize_via_llm(
+            cleaned,
+            subject_kind=subject_kind,
+            subject_label=subject_label,
+            language=language,
+        )
         if summary is not None:
             return summary
 
         return self._fallback_truncate(joined)
 
-    async def _summarize_via_llm(self, joined: str) -> str | None:
+    async def _summarize_via_llm(
+        self,
+        cleaned_parts: list[str],
+        *,
+        subject_kind: str,
+        subject_label: str,
+        language: str,
+    ) -> str | None:
         """Call the LLM to produce a compacted summary.
 
         Returns ``None`` if the call fails, returns empty text, or the
         response exceeds the hard char cap (so ``compact_if_oversized``
         falls through to the truncator instead of writing an oversize
         row)."""
-        prompt = _SUMMARIZE_PROMPT_TEMPLATE.format(
-            target=TARGET_SUMMARY_CHARS,
-            joined=joined,
+        prompt = render_summarization_prompt(
+            subject_kind=subject_kind,
+            subject_label=subject_label,
+            fragments=cleaned_parts,
+            language=language,
+            target_chars=TARGET_SUMMARY_CHARS,
         )
         try:
             raw = await self._llm(prompt)
@@ -189,4 +279,7 @@ __all__ = [
     "SUMMARIZE_AT_FRAGMENTS",
     "TARGET_SUMMARY_CHARS",
     "FALLBACK_TRUNCATE_MARK",
+    "DEFAULT_LANGUAGE",
+    "DESCRIPTION_SUMMARIZATION",
+    "render_summarization_prompt",
 ]

--- a/aperag/indexing/graph_compactor.py
+++ b/aperag/indexing/graph_compactor.py
@@ -1,0 +1,192 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Graph index description compactor — Wave 7 task #2.
+
+Per ``docs/modularization/indexing-redesign-design-pack.md`` §K.12.6:
+when an entity / relation accumulates many ``description_parts`` from
+multiple documents, the joined text grows past what the embedder can
+ingest cleanly and what the graph-DB column can hold. This component
+compacts the joined parts into a single bounded summary that the
+``GraphModalityWorker.sync()`` task #3 writes back into the new
+``compacted_description`` field (task #1) before vector embedding.
+
+Algorithm (mirrors legacy ``graphindex/service.py`` lines 158 / 456 /
+500 with renamed surface and tighter knobs):
+
+1. Join the parts with a paragraph separator.
+2. If neither the fragment count nor the total character length crosses
+   the threshold, return ``None`` (caller leaves the description as-is).
+3. Otherwise call the LLM with a summarization prompt.
+4. If the LLM call fails or returns empty, fall back to a hard
+   character cap with a ``" … [truncated]"`` marker so descriptions
+   never exceed the column budget even when the LLM is unreachable.
+
+The component is a pure compute helper: no coupling to
+``LineageGraphStore`` or any vector backend. It takes a list of
+``str`` and returns either a compacted ``str`` or ``None``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+LLMCall = Callable[[str], Awaitable[str]]
+
+
+# Threshold knobs are module-level constants per architect spec
+# (``msg=fc4b18ee``): not exposed via operator config so the
+# private-deploy "免维护" guardrail holds.
+
+MAX_DESCRIPTION_CHARS: int = 8000
+"""Upper bound for the persisted compacted description.
+
+Crossing this triggers compaction; the LLM target is well under this
+so the post-compact text stays within the cap. The fallback truncator
+also cuts at this length."""
+
+SUMMARIZE_AT_FRAGMENTS: int = 8
+"""When the joined ``parts`` list grows to this many fragments, compact
+even if the total character count is still below the char cap. Catches
+"high-frequency entity with many short mentions" cases."""
+
+TARGET_SUMMARY_CHARS: int = 3000
+"""Target length for the LLM summary prompt. The model is instructed to
+land near this number; we still verify the response is at most
+``MAX_DESCRIPTION_CHARS`` before accepting it."""
+
+FALLBACK_TRUNCATE_MARK: str = " … [truncated]"
+"""Marker appended to a fallback-truncated description so operators can
+spot rows that hit the LLM-unavailable path."""
+
+PART_SEPARATOR: str = "\n\n"
+
+
+_SUMMARIZE_PROMPT_TEMPLATE: str = (
+    "请将以下知识图谱节点 / 关系的多段描述压缩为一段连贯的中文总结，"
+    "目标长度约 {target} 字以内。要求：\n"
+    "1. 保留所有事实信息（实体、属性、时间、来源等），不要遗漏关键细节。\n"
+    "2. 去重重复表述，合并语义相近的句子。\n"
+    "3. 不要编造原文未出现的内容。\n"
+    "4. 直接输出总结正文，不要加任何前言、标题或解释。\n\n"
+    "原始描述片段：\n"
+    "{joined}\n"
+)
+
+
+class GraphIndexCompactor:
+    """Compact long description-part lists for one entity / relation.
+
+    Caller usage (task #3 ``GraphModalityWorker.sync()``)::
+
+        compactor = GraphIndexCompactor(llm)
+        compacted = await compactor.compact_if_oversized(entity.parts_text)
+        if compacted is not None:
+            await store.set_compacted_description(entity_id, compacted)
+
+    The component is stateless across calls; one instance per worker
+    invocation is fine. ``llm`` is the same async callable shape used
+    by the rest of the indexing pipeline (``aperag.indexing.llm.LLMCall``)
+    so it can be wired from ``build_collection_llm_callable`` directly.
+    """
+
+    def __init__(self, llm: LLMCall) -> None:
+        self._llm = llm
+
+    async def compact_if_oversized(self, parts: list[str]) -> str | None:
+        """Return a compacted description, or ``None`` if compaction is
+        not warranted.
+
+        Empty / whitespace-only parts are dropped before evaluation —
+        an empty ``parts`` list returns ``None`` (nothing to compact).
+        """
+        cleaned = [p for p in parts if p and p.strip()]
+        if not cleaned:
+            return None
+
+        joined = PART_SEPARATOR.join(cleaned)
+
+        if len(cleaned) < SUMMARIZE_AT_FRAGMENTS and len(joined) < MAX_DESCRIPTION_CHARS:
+            return None
+
+        summary = await self._summarize_via_llm(joined)
+        if summary is not None:
+            return summary
+
+        return self._fallback_truncate(joined)
+
+    async def _summarize_via_llm(self, joined: str) -> str | None:
+        """Call the LLM to produce a compacted summary.
+
+        Returns ``None`` if the call fails, returns empty text, or the
+        response exceeds the hard char cap (so ``compact_if_oversized``
+        falls through to the truncator instead of writing an oversize
+        row)."""
+        prompt = _SUMMARIZE_PROMPT_TEMPLATE.format(
+            target=TARGET_SUMMARY_CHARS,
+            joined=joined,
+        )
+        try:
+            raw = await self._llm(prompt)
+        except Exception:
+            logger.exception("graph_compactor: LLM summarization failed; falling back to truncation")
+            return None
+
+        summary = (raw or "").strip()
+        if not summary:
+            return None
+        if len(summary) > MAX_DESCRIPTION_CHARS:
+            logger.warning(
+                "graph_compactor: LLM returned %d chars > cap %d; falling back to truncation",
+                len(summary),
+                MAX_DESCRIPTION_CHARS,
+            )
+            return None
+        return summary
+
+    @staticmethod
+    def _fallback_truncate(joined: str) -> str:
+        """Hard-cap the joined text at ``MAX_DESCRIPTION_CHARS`` and
+        append the truncation marker.
+
+        Prefers a word boundary in the last 64 characters of the budget
+        so we don't cut mid-token; falls back to a hard slice if no
+        whitespace is found in that window."""
+        cap = MAX_DESCRIPTION_CHARS
+        if len(joined) <= cap:
+            return joined
+
+        budget = cap - len(FALLBACK_TRUNCATE_MARK)
+        if budget <= 0:
+            return joined[:cap]
+
+        window = joined[:budget]
+        cut = window.rfind(" ", max(0, len(window) - 64))
+        if cut <= 0:
+            cut = len(window)
+        return window[:cut].rstrip() + FALLBACK_TRUNCATE_MARK
+
+
+__all__ = [
+    "GraphIndexCompactor",
+    "LLMCall",
+    "MAX_DESCRIPTION_CHARS",
+    "SUMMARIZE_AT_FRAGMENTS",
+    "TARGET_SUMMARY_CHARS",
+    "FALLBACK_TRUNCATE_MARK",
+]

--- a/tests/unit_test/indexing/test_graph_compactor.py
+++ b/tests/unit_test/indexing/test_graph_compactor.py
@@ -15,28 +15,26 @@
 """Unit tests for ``aperag.indexing.graph_compactor`` — Wave 7 task #2.
 
 Pins the description-compaction contract: short input is left alone,
-oversize input goes through the LLM, and any LLM failure cleanly falls
-through to a hard-cap truncation that always carries the operator-
-visible marker.
+oversize input goes through the LLM, every LLM failure falls through to
+a hard-cap truncation that always carries the operator-visible marker,
+and the prompt the model receives carries the five legacy features
+(``subject_kind`` framing, ``subject_label`` anchor, ``language``
+control, relation S-P-O guidance, contradiction-keep-both).
 """
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from aperag.indexing.graph_compactor import (
+    DESCRIPTION_SUMMARIZATION,
     FALLBACK_TRUNCATE_MARK,
     MAX_DESCRIPTION_CHARS,
     SUMMARIZE_AT_FRAGMENTS,
     TARGET_SUMMARY_CHARS,
     GraphIndexCompactor,
+    render_summarization_prompt,
 )
-
-
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 class _RecordingLLM:
@@ -56,64 +54,125 @@ class _RecordingLLM:
         return self._response
 
 
+def _entity_kwargs(name: str = "OpenAI") -> dict:
+    return {"subject_kind": "entity", "subject_label": name}
+
+
 # ---------------------------------------------------------------------
 # Threshold logic
 # ---------------------------------------------------------------------
 
 
-def test_below_threshold_returns_none_without_llm():
+@pytest.mark.asyncio
+async def test_below_threshold_returns_none_without_llm():
     """No fragment cap hit + total chars under cap → no compaction."""
     parts = ["short A", "short B", "short C"]
     assert len(parts) < SUMMARIZE_AT_FRAGMENTS
     llm = _RecordingLLM(response="should-not-be-called")
 
-    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+    result = await GraphIndexCompactor(llm).compact_if_oversized(parts, **_entity_kwargs())
 
     assert result is None
     assert llm.prompts == []
 
 
-def test_empty_parts_returns_none():
+@pytest.mark.asyncio
+async def test_empty_parts_returns_none():
     """Empty list and whitespace-only entries collapse to nothing."""
     llm = _RecordingLLM(response="should-not-be-called")
     compactor = GraphIndexCompactor(llm)
 
-    assert _run(compactor.compact_if_oversized([])) is None
-    assert _run(compactor.compact_if_oversized(["", "   ", "\n"])) is None
+    assert await compactor.compact_if_oversized([], **_entity_kwargs()) is None
+    assert await compactor.compact_if_oversized(["", "   ", "\n"], **_entity_kwargs()) is None
     assert llm.prompts == []
 
 
 # ---------------------------------------------------------------------
-# LLM success path
+# LLM success path + prompt feature coverage
 # ---------------------------------------------------------------------
 
 
-def test_fragment_count_triggers_llm_summary():
-    """Fragment count >= SUMMARIZE_AT_FRAGMENTS triggers compaction
-    even when total chars are well below the cap."""
+@pytest.mark.asyncio
+async def test_fragment_count_triggers_llm_summary_with_entity_framing():
+    """Fragment count >= SUMMARIZE_AT_FRAGMENTS triggers compaction.
+
+    Also pins that the rendered prompt carries the five legacy
+    features required by ``feedback_announce_equals_landed.md`` /
+    earayu2 directive 'do not lose good legacy algorithms'.
+    """
     parts = [f"fragment-{i}" for i in range(SUMMARIZE_AT_FRAGMENTS)]
     summary = "compact summary"
     llm = _RecordingLLM(response=summary)
 
-    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+    result = await GraphIndexCompactor(llm).compact_if_oversized(
+        parts, subject_kind="entity", subject_label="OpenAI Inc."
+    )
 
     assert result == summary
     assert len(llm.prompts) == 1
-    # Prompt must include every fragment so the model sees full context.
     rendered = llm.prompts[0]
+
+    # Feature 1: subject_kind framing ("entity" appears in the prompt body).
+    assert "entity" in rendered
+    # Feature 2: subject_label anchoring ("OpenAI Inc." reaches the model).
+    assert "OpenAI Inc." in rendered
+    # Feature 3: default language is rendered.
+    assert "Chinese" in rendered
+    # Feature 5: contradiction-keep-both rule is included.
+    assert "Keep conflicting facts" in rendered
+    # All fragments make it into the prompt body.
     for p in parts:
         assert p in rendered
     # Sanity: prompt mentions the target length so the model knows the budget.
     assert str(TARGET_SUMMARY_CHARS) in rendered
 
 
-def test_char_count_triggers_llm_summary():
+@pytest.mark.asyncio
+async def test_relation_framing_uses_relation_kind():
+    """Relations carry the S-P-O framing rule (legacy feature 4)."""
+    parts = ["x" * 2000 for _ in range(SUMMARIZE_AT_FRAGMENTS + 1)]
+    llm = _RecordingLLM(response="merged relation summary")
+
+    result = await GraphIndexCompactor(llm).compact_if_oversized(
+        parts,
+        subject_kind="relation",
+        subject_label="Apple → Tim Cook",
+    )
+
+    assert result == "merged relation summary"
+    rendered = llm.prompts[0]
+    assert "relation" in rendered
+    assert "Apple → Tim Cook" in rendered
+    # The S-P-O framing rule must reach the model so relation summaries
+    # don't degenerate into entity-style listings.
+    assert "subject" in rendered.lower() and "predicate" in rendered.lower()
+
+
+@pytest.mark.asyncio
+async def test_language_kwarg_overrides_default():
+    """``language`` reaches the model so non-Chinese collections work."""
+    parts = ["x" * 2000 for _ in range(SUMMARIZE_AT_FRAGMENTS + 1)]
+    llm = _RecordingLLM(response="english summary")
+
+    result = await GraphIndexCompactor(llm).compact_if_oversized(
+        parts, subject_kind="entity", subject_label="OpenAI", language="English"
+    )
+
+    assert result == "english summary"
+    rendered = llm.prompts[0]
+    assert "English" in rendered
+    # Default language should NOT leak in when an override is supplied.
+    assert "Chinese" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_char_count_triggers_llm_summary():
     """Single huge part > MAX_DESCRIPTION_CHARS also triggers compaction."""
     big = "x" * (MAX_DESCRIPTION_CHARS + 100)
     summary = "compact summary of huge text"
     llm = _RecordingLLM(response=summary)
 
-    result = _run(GraphIndexCompactor(llm).compact_if_oversized([big]))
+    result = await GraphIndexCompactor(llm).compact_if_oversized([big], **_entity_kwargs())
 
     assert result == summary
     assert len(llm.prompts) == 1
@@ -124,11 +183,12 @@ def test_char_count_triggers_llm_summary():
 # ---------------------------------------------------------------------
 
 
-def test_llm_exception_falls_back_to_truncation():
+@pytest.mark.asyncio
+async def test_llm_exception_falls_back_to_truncation():
     parts = ["x" * 2000 for _ in range(SUMMARIZE_AT_FRAGMENTS + 2)]
     llm = _RecordingLLM(exc=RuntimeError("upstream provider 500"))
 
-    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+    result = await GraphIndexCompactor(llm).compact_if_oversized(parts, **_entity_kwargs())
 
     assert result is not None
     assert result.endswith(FALLBACK_TRUNCATE_MARK)
@@ -136,25 +196,27 @@ def test_llm_exception_falls_back_to_truncation():
     assert len(llm.prompts) == 1  # LLM was attempted before fallback
 
 
-def test_llm_empty_response_falls_back_to_truncation():
+@pytest.mark.asyncio
+async def test_llm_empty_response_falls_back_to_truncation():
     parts = ["x" * 2000 for _ in range(SUMMARIZE_AT_FRAGMENTS + 2)]
     llm = _RecordingLLM(response="   ")  # whitespace-only
 
-    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+    result = await GraphIndexCompactor(llm).compact_if_oversized(parts, **_entity_kwargs())
 
     assert result is not None
     assert result.endswith(FALLBACK_TRUNCATE_MARK)
     assert len(result) <= MAX_DESCRIPTION_CHARS
 
 
-def test_llm_oversize_response_falls_back_to_truncation():
+@pytest.mark.asyncio
+async def test_llm_oversize_response_falls_back_to_truncation():
     """LLM returns text longer than the hard cap → reject and truncate
     so the persisted description never exceeds column budget."""
     parts = ["x" * 2000 for _ in range(SUMMARIZE_AT_FRAGMENTS + 2)]
     too_long = "y" * (MAX_DESCRIPTION_CHARS + 50)
     llm = _RecordingLLM(response=too_long)
 
-    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+    result = await GraphIndexCompactor(llm).compact_if_oversized(parts, **_entity_kwargs())
 
     assert result is not None
     assert result.endswith(FALLBACK_TRUNCATE_MARK)
@@ -177,8 +239,7 @@ def test_fallback_truncate_prefers_word_boundary():
     assert truncated.endswith(FALLBACK_TRUNCATE_MARK)
     assert len(truncated) <= MAX_DESCRIPTION_CHARS
     body = truncated[: -len(FALLBACK_TRUNCATE_MARK)]
-    # The body should not end mid-word: either ends on a known token or
-    # is the hard fallback when no whitespace was reachable.
+    # The body should not end mid-word.
     assert body.rstrip() == body
 
 
@@ -202,13 +263,42 @@ def test_compactor_does_not_touch_external_state():
 
 
 # ---------------------------------------------------------------------
-# pytest-async harness
+# Prompt renderer surface (used by callers that want to log the prompt
+# without going through the LLM call)
 # ---------------------------------------------------------------------
 
-# All tests above wrap their coroutines via ``_run`` so this module
-# stays compatible with both bare ``unittest`` runners and pytest
-# without requiring ``pytest-asyncio`` to be configured. Direct test
-# discovery still works through pytest collection.
+
+def test_render_summarization_prompt_strips_blank_fragments():
+    rendered = render_summarization_prompt(
+        subject_kind="entity",
+        subject_label="OpenAI",
+        fragments=["alpha", "  ", "beta", "", "gamma"],
+        language="English",
+        target_chars=TARGET_SUMMARY_CHARS,
+    )
+    assert "alpha" in rendered and "beta" in rendered and "gamma" in rendered
+    # Blank entries shouldn't add empty separators that confuse the model.
+    assert "---\n\n---" not in rendered
+    # Fragment count reflects only non-blank fragments.
+    assert "3 short descriptions" in rendered
+
+
+def test_template_carries_legacy_five_features():
+    """Compile-time check on the template body, independent of caller
+    invocations. If anyone simplifies the template inline, this test
+    breaks before the per-feature behavioural tests do."""
+    body = DESCRIPTION_SUMMARIZATION
+    # Feature 1: subject_kind placeholder.
+    assert "{subject_kind}" in body
+    # Feature 2: subject_label placeholder.
+    assert "{subject_label}" in body
+    # Feature 3: language placeholder (rendered twice — body + final cue).
+    assert body.count("{language}") >= 2
+    # Feature 4: relation S-P-O framing rule.
+    assert "subject" in body.lower() and "predicate" in body.lower()
+    # Feature 5: contradiction-keep-both rule.
+    assert "Keep conflicting facts" in body
+
 
 if __name__ == "__main__":  # pragma: no cover - manual run convenience
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit_test/indexing/test_graph_compactor.py
+++ b/tests/unit_test/indexing/test_graph_compactor.py
@@ -1,0 +1,214 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``aperag.indexing.graph_compactor`` — Wave 7 task #2.
+
+Pins the description-compaction contract: short input is left alone,
+oversize input goes through the LLM, and any LLM failure cleanly falls
+through to a hard-cap truncation that always carries the operator-
+visible marker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from aperag.indexing.graph_compactor import (
+    FALLBACK_TRUNCATE_MARK,
+    MAX_DESCRIPTION_CHARS,
+    SUMMARIZE_AT_FRAGMENTS,
+    TARGET_SUMMARY_CHARS,
+    GraphIndexCompactor,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class _RecordingLLM:
+    """Async LLM stub that records each prompt and returns a scripted
+    response (or raises a scripted exception)."""
+
+    def __init__(self, response: str | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+        self.prompts: list[str] = []
+
+    async def __call__(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+# ---------------------------------------------------------------------
+# Threshold logic
+# ---------------------------------------------------------------------
+
+
+def test_below_threshold_returns_none_without_llm():
+    """No fragment cap hit + total chars under cap → no compaction."""
+    parts = ["short A", "short B", "short C"]
+    assert len(parts) < SUMMARIZE_AT_FRAGMENTS
+    llm = _RecordingLLM(response="should-not-be-called")
+
+    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+
+    assert result is None
+    assert llm.prompts == []
+
+
+def test_empty_parts_returns_none():
+    """Empty list and whitespace-only entries collapse to nothing."""
+    llm = _RecordingLLM(response="should-not-be-called")
+    compactor = GraphIndexCompactor(llm)
+
+    assert _run(compactor.compact_if_oversized([])) is None
+    assert _run(compactor.compact_if_oversized(["", "   ", "\n"])) is None
+    assert llm.prompts == []
+
+
+# ---------------------------------------------------------------------
+# LLM success path
+# ---------------------------------------------------------------------
+
+
+def test_fragment_count_triggers_llm_summary():
+    """Fragment count >= SUMMARIZE_AT_FRAGMENTS triggers compaction
+    even when total chars are well below the cap."""
+    parts = [f"fragment-{i}" for i in range(SUMMARIZE_AT_FRAGMENTS)]
+    summary = "compact summary"
+    llm = _RecordingLLM(response=summary)
+
+    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+
+    assert result == summary
+    assert len(llm.prompts) == 1
+    # Prompt must include every fragment so the model sees full context.
+    rendered = llm.prompts[0]
+    for p in parts:
+        assert p in rendered
+    # Sanity: prompt mentions the target length so the model knows the budget.
+    assert str(TARGET_SUMMARY_CHARS) in rendered
+
+
+def test_char_count_triggers_llm_summary():
+    """Single huge part > MAX_DESCRIPTION_CHARS also triggers compaction."""
+    big = "x" * (MAX_DESCRIPTION_CHARS + 100)
+    summary = "compact summary of huge text"
+    llm = _RecordingLLM(response=summary)
+
+    result = _run(GraphIndexCompactor(llm).compact_if_oversized([big]))
+
+    assert result == summary
+    assert len(llm.prompts) == 1
+
+
+# ---------------------------------------------------------------------
+# Fallback paths
+# ---------------------------------------------------------------------
+
+
+def test_llm_exception_falls_back_to_truncation():
+    parts = ["x" * 2000 for _ in range(SUMMARIZE_AT_FRAGMENTS + 2)]
+    llm = _RecordingLLM(exc=RuntimeError("upstream provider 500"))
+
+    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+
+    assert result is not None
+    assert result.endswith(FALLBACK_TRUNCATE_MARK)
+    assert len(result) <= MAX_DESCRIPTION_CHARS
+    assert len(llm.prompts) == 1  # LLM was attempted before fallback
+
+
+def test_llm_empty_response_falls_back_to_truncation():
+    parts = ["x" * 2000 for _ in range(SUMMARIZE_AT_FRAGMENTS + 2)]
+    llm = _RecordingLLM(response="   ")  # whitespace-only
+
+    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+
+    assert result is not None
+    assert result.endswith(FALLBACK_TRUNCATE_MARK)
+    assert len(result) <= MAX_DESCRIPTION_CHARS
+
+
+def test_llm_oversize_response_falls_back_to_truncation():
+    """LLM returns text longer than the hard cap → reject and truncate
+    so the persisted description never exceeds column budget."""
+    parts = ["x" * 2000 for _ in range(SUMMARIZE_AT_FRAGMENTS + 2)]
+    too_long = "y" * (MAX_DESCRIPTION_CHARS + 50)
+    llm = _RecordingLLM(response=too_long)
+
+    result = _run(GraphIndexCompactor(llm).compact_if_oversized(parts))
+
+    assert result is not None
+    assert result.endswith(FALLBACK_TRUNCATE_MARK)
+    assert len(result) <= MAX_DESCRIPTION_CHARS
+
+
+# ---------------------------------------------------------------------
+# Truncation shape
+# ---------------------------------------------------------------------
+
+
+def test_fallback_truncate_prefers_word_boundary():
+    """Truncator should land on whitespace inside the last-64-char
+    window to avoid cutting mid-token."""
+    head = "word " * (MAX_DESCRIPTION_CHARS // 5)  # plenty of word boundaries
+    joined = head + "z" * 200  # forces a cut somewhere
+
+    truncated = GraphIndexCompactor._fallback_truncate(joined)
+
+    assert truncated.endswith(FALLBACK_TRUNCATE_MARK)
+    assert len(truncated) <= MAX_DESCRIPTION_CHARS
+    body = truncated[: -len(FALLBACK_TRUNCATE_MARK)]
+    # The body should not end mid-word: either ends on a known token or
+    # is the hard fallback when no whitespace was reachable.
+    assert body.rstrip() == body
+
+
+def test_fallback_truncate_passes_through_when_under_cap():
+    short = "already small"
+    assert GraphIndexCompactor._fallback_truncate(short) == short
+
+
+# ---------------------------------------------------------------------
+# Pure-compute invariant
+# ---------------------------------------------------------------------
+
+
+def test_compactor_does_not_touch_external_state():
+    """Sanity: GraphIndexCompactor only depends on the LLM callable,
+    nothing else. This protects the §K.12.6 separation guarantee that
+    the compactor stays a pure helper (no LineageGraphStore /
+    VectorStore coupling)."""
+    sig_attrs = vars(GraphIndexCompactor(_RecordingLLM(response="ok")))
+    assert set(sig_attrs.keys()) == {"_llm"}
+
+
+# ---------------------------------------------------------------------
+# pytest-async harness
+# ---------------------------------------------------------------------
+
+# All tests above wrap their coroutines via ``_run`` so this module
+# stays compatible with both bare ``unittest`` runners and pytest
+# without requiring ``pytest-asyncio`` to be configured. Direct test
+# discovery still works through pytest collection.
+
+if __name__ == "__main__":  # pragma: no cover - manual run convenience
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Wave 7 task #2 — moves the description-length governance algorithm out of the legacy `graphindex/service.py` into a focused `aperag/indexing/graph_compactor.py` module so task #3 can wire it into `GraphModalityWorker.sync()` without dragging in the legacy package.

- New `GraphIndexCompactor.compact_if_oversized(parts, *, subject_kind, subject_label, language="Chinese") -> str | None` — single entry point. Returns `None` when no compaction is needed, an LLM summary when it is, or a hard-cap truncation (with `" … [truncated]"` marker) on every fallback branch.
- `DESCRIPTION_SUMMARIZATION` ported verbatim from legacy `aperag/domains/knowledge_graph/graphindex/prompts.py:45` — preserves the **five legacy features**: `subject_kind` framing, `subject_label` anchor, `language` control, S-P-O relation framing, contradiction-keep-both. Locked by @符炫炜 ratify (msg=c34e4e92) + earayu2 directive "不要丢失好的算法和设计" (msg=421c4223).
- LLM is the same async `LLMCall` shape (`aperag/indexing/llm.py:60`) the rest of the indexing pipeline already uses, so caller wiring (task #3) is one import.
- Threshold knobs are module-level constants — `MAX_DESCRIPTION_CHARS=8000`, `SUMMARIZE_AT_FRAGMENTS=8`, `TARGET_SUMMARY_CHARS=3000` — not exposed as operator config, per the Wave 7 simple-stable + 私有化免维护 guardrails.
- Pure compute helper: no `LineageGraphStore` / vector-store coupling, so the §K.12.6 separation guarantee holds.

## §K.12 invariant cross-check (12-item, per @符炫炜 msg=fcf580a6 + earayu2 msg=f19f9fc5)

| # | Invariant | This PR |
|---|---|---|
| 1 | L1 graph data 不污染 (raw extraction vs storage view 分层) | ✅ pure compute, never touches graph storage |
| 2 | L1 → L2 单向派生 (compacted_description / vector point are derived) | ✅ produces derived `compacted` string from input parts; no upstream mutation |
| 3 | Compactor 在 sync 末尾, vector embed 之前 | ✅ this PR ships the Compactor; task #3 owns the sync sequencing |
| 4 | Vector store 走 `VectorStoreConnectorAdaptor` | n/a (Compactor has zero vector coupling) |
| 5 | payload `indexer="graph_entity/graph_relation"` filter pattern | n/a (no vector payload writes in this PR) |
| 6 | uuid5 deterministic vector point id | n/a (no vector writes in this PR) |
| 7 | snapshot-diff via lineage entity name set | n/a (covered by task #3) |
| 8 | alias_map persistence independent of doc lifecycle | n/a (covered by task #6) |
| 9 | `upsert_entity_with_lineage` transparent alias redirect | n/a (covered by task #6) |
| 10 | DB column length application-layer cap (per-part 5K / per-entity 100 parts / **compacted ≤ 8K**) | ✅ **enforced here**: `MAX_DESCRIPTION_CHARS=8000`; LLM oversize / empty / exception all collapse to truncation, never raise; every fallback carries `FALLBACK_TRUNCATE_MARK` and stays ≤ cap |
| 11 | 候选检测仅写不自动合并 | n/a (covered by task #4) |
| 12 | 命名 grep-zero LightRAG | ✅ `grep -rn 'LightRAG\|lightrag' aperag/indexing/graph_compactor.py tests/unit_test/indexing/test_graph_compactor.py` → 0 hits |

## 4-pattern pre-check matrix

**Pattern 1 v1** — caller-grep for the legacy method:
```
$ grep -rn '_compact_oversized_descriptions' aperag/ tests/
aperag/domains/knowledge_graph/graphindex/service.py:158: await self._compact_oversized_descriptions(collection_id=collection_id)
aperag/domains/knowledge_graph/graphindex/service.py:517: async def _compact_oversized_descriptions(self, *, collection_id: str) -> None:
aperag/domains/knowledge_graph/graphindex/storage/postgres.py:149: ``GraphIndexService._compact_oversized_descriptions`` ...
```
→ legacy caller is `graphindex/service.py:158` (`run_index_document_sync` path), removed wholesale by Wave 7 task #10. No external callers.

**Pattern 1 v2** — n/a (new component, no in-tree replacements yet).

**Pattern 2** — dependency interface grep:
```
$ grep -n '^LLMCall' aperag/indexing/llm.py
60:LLMCall = Callable[[str], Awaitable[str]]
66:def build_collection_llm_callable(collection: CollectionRow) -> LLMCall:
```
→ `LLMCall` is async-native; direct `await self._llm(prompt)` is correct, no cross-loop wrapping needed.

**Pattern 3** — n/a (no per-collection vs per-tenant binding decisions in this PR; pure compute helper takes the `LLMCall` already bound by the caller).

## simple-stable 4-guardrail (earayu2 msg=421c4223)

1. 不无限扩范围 ✅ pure compute helper, no scope creep into worker / store.
2. 先做实尽快上线 ✅ smallest possible surface, callers (#3/#6) wire in one import.
3. 简单稳定优于复杂 ✅ legacy prompt ported verbatim — production-validated, no rewrite risk.
4. 私有化部署后免维护 ✅ thresholds are module constants (no operator config to drift).

## Test plan

- [x] 14-case unit suite in `tests/unit_test/indexing/test_graph_compactor.py` — all pass locally (`uv run pytest tests/unit_test/indexing/test_graph_compactor.py -v`).
- [x] Threshold logic: below-threshold returns `None`; empty list returns `None`; fragment trigger; char trigger.
- [x] Prompt feature pins: entity framing rendered, relation S-P-O framing rendered, `language="English"` overrides default, contradiction-keep-both appears, target-char hint appears, blank fragments stripped.
- [x] Template-level pin (`test_template_carries_legacy_five_features`) catches inline simplification before behavioural drift.
- [x] Fallback paths: LLM exception, empty response, oversize response — all hit truncation, all carry the marker, all stay ≤ `MAX_DESCRIPTION_CHARS`.
- [x] Truncation shape: word-boundary preference inside last-64-char window; pass-through when under the cap.
- [x] Pure-compute invariant: only attribute is the LLM callable.
- [x] Async harness: switched from `asyncio.get_event_loop().run_until_complete()` to native async + `pytest-asyncio` (`asyncio_mode=auto` already set in `pyproject.toml`).
- [x] `ruff check` + `ruff format --check` clean.

## References

- spec: §K.12 (PR #1751, commit `ffd79ed1`)
- thread: msg=69d0a7d2 in `#删除老graph` (CR `msg=7e962072`, ratify `msg=c34e4e92`, PM `msg=88720ab5`, 12-invariant directive `msg=fcf580a6`)
- legacy source: `aperag/domains/knowledge_graph/graphindex/service.py:158/456/500` + `prompts.py:45` (deleted by Wave 7 task #10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)