### PR TITLE
feat(Wave 7 #4): MergeCandidateDetector — sync-driven candidate detection

### DIFF
--- a/aperag/indexing/merge_candidate_detector.py
+++ b/aperag/indexing/merge_candidate_detector.py
@@ -1,0 +1,406 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sync-driven merge candidate detection — Wave 7 §K.12.4 task #4.
+
+The detector runs at the end of :meth:`GraphModalityWorker.sync` (task #3
+will wire it in). For each entity touched in the sync run it embeds the
+description, ANN-searches the graph-entity vector index for similar
+neighbours, then scores ``(affected, neighbour)`` pairs with the existing
+:func:`aperag.graph_curation.candidate_generation.build_candidate_pairs`
+algorithm. Any pair scoring above the threshold is persisted as a
+``PENDING`` :class:`GraphCurationSuggestion` for human review — never
+auto-merged (D-3 invariant locked by earayu2).
+
+Per the §K.12.4 amend2 ratify (msg=6ab89fbb) this writes into the existing
+``GraphCurationSuggestion`` infrastructure rather than introducing a new
+table; auto-detected runs are tagged via
+``GraphCurationRun.config_json["source"] == "auto_detect"`` so admin UI
+can split user-triggered vs sync-driven curation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Iterable, Sequence
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aperag.db.repositories.base import AsyncBaseRepository
+from aperag.domains.knowledge_graph.db.models import (
+    GraphCurationRun,
+    GraphCurationRunStatus,
+    GraphCurationSuggestion,
+    GraphCurationSuggestionStatus,
+)
+from aperag.domains.knowledge_graph.graphindex.dto import Entity as LegacyEntity
+from aperag.graph_curation.candidate_generation import (
+    CandidatePair,
+    build_candidate_pairs,
+)
+from aperag.indexing.graph import EntityWithLineage, LineageGraphStore
+from aperag.utils.utils import utc_now
+from aperag.vectorstore.base import VectorStoreConnector
+from aperag.vectorstore.dto import QueryRequest
+from aperag.vectorstore.filters import Eq
+
+logger = logging.getLogger(__name__)
+
+
+# ``config_json["source"]`` discriminator + ``GraphCurationSuggestion.reason``
+# tag — both are how auto-detected rows are filtered out from
+# user-triggered curation runs in queries / supersede / admin UI.
+AUTO_DETECT_SOURCE: str = "auto_detect"
+AUTO_DETECT_REASON: str = "auto_detected"
+
+
+# Mirrors the user-triggered tunables in
+# :mod:`aperag.graph_curation.service` so sync-driven and user-driven
+# detection share the same scoring frontier — divergence here would let
+# one path silently surface candidates the other rejects.
+DEFAULT_VECTOR_TOP_K: int = 4
+DEFAULT_VECTOR_SCORE_THRESHOLD: float = 0.72
+DEFAULT_MAX_PAIRS_PER_ENTITY: int = 6
+DEFAULT_MAX_TOTAL_PAIRS: int = 240
+DEFAULT_MAX_SUGGESTIONS: int = 32
+
+
+# Embedder API: callers pass any object with a sync ``embed_query``
+# (matches :class:`EmbeddingService`); we offload the call to a worker
+# thread so the event loop stays free.
+EmbedQueryFn = Callable[[str], list[float]]
+
+
+class MergeCandidateDetector(AsyncBaseRepository):
+    """Detect and persist merge-candidate suggestions for one collection.
+
+    Per-collection bound — caller wires the four dependencies (lineage
+    store, vector connector, embedder, optional LLM) to the collection
+    being synced before constructing the detector. The constructor does
+    no I/O.
+
+    The detector is *write-only* with respect to lineage data — it
+    reads entities through ``store.get_entity`` but never writes lineage
+    rows back, preserving §K.12 invariant #1 (L1 graph data not polluted
+    by L2 derivatives).
+    """
+
+    def __init__(
+        self,
+        *,
+        store: LineageGraphStore,
+        vector_connector: VectorStoreConnector,
+        embedder: Any,
+        collection_id: str,
+        user_id: str,
+        # Optional LLM judge tier — reserved for follow-up, not invoked
+        # by the v1 PR. When wired, accepts an ``LLMCall`` async callable
+        # and runs the existing ``_adjudicate_pairs`` flow.
+        llm: Callable[[str], Awaitable[str]] | None = None,
+        vector_top_k: int = DEFAULT_VECTOR_TOP_K,
+        vector_score_threshold: float = DEFAULT_VECTOR_SCORE_THRESHOLD,
+        max_pairs_per_entity: int = DEFAULT_MAX_PAIRS_PER_ENTITY,
+        max_total_pairs: int = DEFAULT_MAX_TOTAL_PAIRS,
+        max_suggestions: int = DEFAULT_MAX_SUGGESTIONS,
+        session: AsyncSession | None = None,
+    ) -> None:
+        super().__init__(session)
+        self._store = store
+        self._vector_connector = vector_connector
+        self._embedder = embedder
+        self._collection_id = collection_id
+        self._user_id = user_id
+        self._llm = llm
+        self._vector_top_k = vector_top_k
+        self._vector_score_threshold = vector_score_threshold
+        self._max_pairs_per_entity = max_pairs_per_entity
+        self._max_total_pairs = max_total_pairs
+        self._max_suggestions = max_suggestions
+
+    # ------------------------------------------------------------------
+    # public surface
+    # ------------------------------------------------------------------
+
+    async def detect_for_sync(
+        self,
+        *,
+        sync_run_id: str,
+        affected_entity_names: Sequence[str],
+    ) -> int:
+        """Run candidate detection over ``affected_entity_names`` and
+        persist the result as ``PENDING`` ``GraphCurationSuggestion`` rows.
+
+        Returns the number of suggestions written. Always supersedes
+        prior auto-detected ``PENDING`` rows for this collection so
+        reviewers never see stale duplicates from earlier syncs.
+
+        Empty ``affected_entity_names`` short-circuits to ``0`` (no run
+        row, no DB write) — there is nothing to detect.
+
+        Cross-document full-collection sweep is *not* implemented here:
+        the user-triggered ``GraphCurationService.start_run`` path
+        owns full sweeps. A sync-driven detector that reaches every
+        entity in the collection would need a ``list_entities`` Protocol
+        method on :class:`LineageGraphStore`, which is intentionally
+        deferred (no caller needs it today; adding it would broaden the
+        Protocol surface for one consumer — earayu2 simple-stable
+        directive #1, 不无限扩范围).
+        """
+        if not affected_entity_names:
+            return 0
+
+        suggestions = await self._detect_suggestion_payloads(affected_entity_names)
+        capped = suggestions[: self._max_suggestions]
+
+        await self._persist_run_and_suggestions(
+            sync_run_id=sync_run_id,
+            suggestions=capped,
+            stats={
+                "affected_entities": len(affected_entity_names),
+                "raw_pair_suggestions": len(suggestions),
+                "suggestions": len(capped),
+            },
+        )
+        return len(capped)
+
+    # ------------------------------------------------------------------
+    # detection (pure compute except for store / vector / embedder I/O —
+    # no DB writes, fully testable with mock dependencies)
+    # ------------------------------------------------------------------
+
+    async def _detect_suggestion_payloads(
+        self,
+        affected_entity_names: Sequence[str],
+    ) -> list[dict[str, Any]]:
+        affected_entities = await self._fetch_entities(affected_entity_names)
+        if not affected_entities:
+            return []
+
+        entities_by_name: dict[str, EntityWithLineage] = {e.name: e for e in affected_entities}
+        vector_neighbors: dict[str, list[tuple[str, float]]] = {}
+
+        for entity in affected_entities:
+            neighbours = await self._vector_neighbours_for(entity)
+            if not neighbours:
+                continue
+            vector_neighbors[entity.name] = neighbours
+            extra_names = [name for name, _ in neighbours if name not in entities_by_name]
+            for fetched in await self._fetch_entities(extra_names):
+                entities_by_name.setdefault(fetched.name, fetched)
+
+        legacy_entities = [self._to_legacy_entity(e) for e in entities_by_name.values()]
+        pairs = build_candidate_pairs(
+            entities=legacy_entities,
+            vector_neighbors=vector_neighbors,
+            max_pairs_per_entity=self._max_pairs_per_entity,
+            max_total_pairs=self._max_total_pairs,
+        )
+        return self._pairs_to_suggestion_rows(pairs, entities_by_name)
+
+    async def _fetch_entities(self, names: Iterable[str]) -> list[EntityWithLineage]:
+        out: list[EntityWithLineage] = []
+        for name in names:
+            entity = await self._store.get_entity(name)
+            if entity is not None:
+                out.append(entity)
+        return out
+
+    async def _vector_neighbours_for(self, entity: EntityWithLineage) -> list[tuple[str, float]]:
+        text = self._description_text_for_scoring(entity)
+        if not text:
+            return []
+        try:
+            embedding = await asyncio.to_thread(self._embedder.embed_query, text)
+        except Exception:
+            logger.warning("merge_candidate_detector: embed failed for %r", entity.name, exc_info=True)
+            return []
+        # +1 to reserve a slot for the entity itself, which the search
+        # will return when its own vector is in the index.
+        request = QueryRequest(
+            embedding=embedding,
+            top_k=self._vector_top_k + 1,
+            flt=Eq("indexer", "graph_entity"),
+            score_threshold=self._vector_score_threshold,
+        )
+        try:
+            hits = await asyncio.to_thread(self._vector_connector.search, request)
+        except Exception:
+            logger.warning(
+                "merge_candidate_detector: vector search failed for %r",
+                entity.name,
+                exc_info=True,
+            )
+            return []
+        out: list[tuple[str, float]] = []
+        for hit in hits:
+            name = hit.payload.get("entity_name") or hit.payload.get("name")
+            if not name or name == entity.name:
+                continue
+            out.append((str(name), float(hit.score)))
+            if len(out) >= self._vector_top_k:
+                break
+        return out
+
+    @staticmethod
+    def _description_text_for_scoring(entity: EntityWithLineage) -> str:
+        # Prefer ``compacted_description`` once task #1 lands; fall back
+        # to the raw concatenated parts so scoring still works on
+        # entities the compactor hasn't touched yet (or compactor was
+        # below threshold).
+        compacted = getattr(entity, "compacted_description", None)
+        if compacted:
+            return str(compacted)
+        return "\n\n".join(p.text for p in entity.description_parts if p.text)
+
+    def _to_legacy_entity(self, entity: EntityWithLineage) -> LegacyEntity:
+        # ``build_candidate_pairs`` predates Wave 7 and consumes the
+        # legacy ``Entity`` DTO; we adapt rather than fork the scoring
+        # algorithm (simple-stable directive #3, 简单稳定优于复杂).
+        # ``name`` doubles as ``entity_id`` because the lineage shape
+        # uses name as the natural key (see
+        # ``LineageGraphStore.get_entity(entity_name)``).
+        chunk_ids: list[str] = []
+        for member in entity.source_lineage:
+            chunk_ids.extend(member.chunk_ids)
+        return LegacyEntity(
+            entity_id=entity.name,
+            collection_id=self._collection_id,
+            name=entity.name,
+            type=entity.entity_type,
+            description=self._description_text_for_scoring(entity),
+            source_chunk_ids=tuple(chunk_ids),
+        )
+
+    def _pairs_to_suggestion_rows(
+        self,
+        pairs: list[CandidatePair],
+        entities_by_name: dict[str, EntityWithLineage],
+    ) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for pair in pairs:
+            left = entities_by_name.get(pair.left_id)
+            right = entities_by_name.get(pair.right_id)
+            if left is None or right is None:
+                continue
+            # Deterministic alphabetical-first canonical pick — same
+            # ``(a, b)`` pair across syncs always points at the same
+            # surviving entity (architect ratify #3, msg=6ab89fbb).
+            ordered = sorted([pair.left_id, pair.right_id])
+            target = ordered[0]
+            rows.append(
+                {
+                    "entity_ids": ordered,
+                    "entity_snapshots": [self._snapshot(entities_by_name[name]) for name in ordered],
+                    "target_entity_id": target,
+                    "confidence_score": float(pair.score),
+                    "reason": AUTO_DETECT_REASON,
+                    "evidence": dict(pair.signals),
+                }
+            )
+        rows.sort(
+            key=lambda row: (
+                -float(row["confidence_score"]),
+                row["target_entity_id"],
+            )
+        )
+        return rows
+
+    @staticmethod
+    def _snapshot(entity: EntityWithLineage) -> dict[str, Any]:
+        return {
+            "entity_id": entity.name,
+            "entity_name": entity.name,
+            "entity_type": entity.entity_type,
+            "description": MergeCandidateDetector._description_text_for_scoring(entity),
+            "source_chunk_count": sum(len(member.chunk_ids) for member in entity.source_lineage),
+        }
+
+    # ------------------------------------------------------------------
+    # persistence
+    # ------------------------------------------------------------------
+
+    async def _persist_run_and_suggestions(
+        self,
+        *,
+        sync_run_id: str,
+        suggestions: list[dict[str, Any]],
+        stats: dict[str, int],
+    ) -> None:
+        async def _op(session: AsyncSession) -> None:
+            now = utc_now()
+            # Always supersede prior auto-detected ``PENDING`` rows for
+            # this collection — even when the new run yields zero
+            # suggestions — so reviewers don't see stale duplicates from
+            # an earlier sync that detected something this sync no
+            # longer agrees with (huangheng CR plan, msg=ee1a2c78).
+            await session.execute(
+                update(GraphCurationSuggestion)
+                .where(
+                    GraphCurationSuggestion.collection_id == self._collection_id,
+                    GraphCurationSuggestion.status == GraphCurationSuggestionStatus.PENDING,
+                    GraphCurationSuggestion.reason == AUTO_DETECT_REASON,
+                )
+                .values(
+                    status=GraphCurationSuggestionStatus.SUPERSEDED,
+                    resolution_note=f"superseded_by_sync_run:{sync_run_id}",
+                    gmt_updated=now,
+                    gmt_operated=now,
+                )
+            )
+            run = GraphCurationRun(
+                user_id=self._user_id,
+                collection_id=self._collection_id,
+                status=GraphCurationRunStatus.COMPLETED,
+                config_json={
+                    "source": AUTO_DETECT_SOURCE,
+                    "sync_run_id": sync_run_id,
+                },
+                stats=stats,
+                gmt_started=now,
+                gmt_finished=now,
+            )
+            session.add(run)
+            await session.flush()
+            for row in suggestions:
+                session.add(
+                    GraphCurationSuggestion(
+                        run_id=run.id,
+                        user_id=self._user_id,
+                        collection_id=self._collection_id,
+                        status=GraphCurationSuggestionStatus.PENDING,
+                        entity_ids=row["entity_ids"],
+                        entity_snapshots=row["entity_snapshots"],
+                        target_entity_id=row["target_entity_id"],
+                        confidence_score=row["confidence_score"],
+                        reason=row["reason"],
+                        evidence=row["evidence"],
+                    )
+                )
+
+        await self.execute_with_transaction(_op)
+
+
+__all__ = [
+    "MergeCandidateDetector",
+    "EmbedQueryFn",
+    "AUTO_DETECT_SOURCE",
+    "AUTO_DETECT_REASON",
+    "DEFAULT_VECTOR_TOP_K",
+    "DEFAULT_VECTOR_SCORE_THRESHOLD",
+    "DEFAULT_MAX_PAIRS_PER_ENTITY",
+    "DEFAULT_MAX_TOTAL_PAIRS",
+    "DEFAULT_MAX_SUGGESTIONS",
+]

--- a/tests/unit_test/indexing/test_merge_candidate_detector.py
+++ b/tests/unit_test/indexing/test_merge_candidate_detector.py
@@ -1,0 +1,445 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``aperag.indexing.merge_candidate_detector`` — Wave 7
+task #4.
+
+Pins the contract that:
+
+* Sync-driven detection writes ``GraphCurationSuggestion`` rows in the
+  same shape the user-triggered curation flow already uses (so the
+  existing UI / REST surface is zero-touch — task #9 / cuiwenbo).
+* Auto-detected runs are tagged via ``GraphCurationRun.config_json
+  ["source"] == "auto_detect"`` and the suggestions carry
+  ``reason == "auto_detected"`` so admin UIs can split user vs sync
+  triggered runs without a schema change.
+* Canonical pick is the alphabetical-first entity name — same
+  ``(entity_a, entity_b)`` pair across syncs always points at the same
+  surviving entity (architect ratify #3, msg=6ab89fbb).
+* Each sync supersedes the prior auto-detected ``PENDING`` rows for
+  the collection so reviewers never see stale duplicates.
+* Empty ``affected_entity_names`` short-circuits — no run row, no DB
+  write.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from aperag.indexing.graph import (
+    DescriptionPart,
+    EntityWithLineage,
+    LineageMember,
+)
+from aperag.indexing.merge_candidate_detector import (
+    AUTO_DETECT_REASON,
+    AUTO_DETECT_SOURCE,
+    MergeCandidateDetector,
+)
+from aperag.vectorstore.dto import SearchHit
+from aperag.vectorstore.filters import Eq
+
+# ---------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------
+
+
+def _entity(
+    name: str,
+    *,
+    entity_type: str = "organization",
+    description: str = "",
+    chunk_ids: tuple[str, ...] = ("c0",),
+    document_id: str = "doc1",
+) -> EntityWithLineage:
+    return EntityWithLineage(
+        name=name,
+        entity_type=entity_type,
+        source_lineage=(
+            LineageMember(
+                document_id=document_id,
+                parse_version="v1",
+                tenant_scope_key="tenant-1",
+                chunk_ids=chunk_ids,
+            ),
+        ),
+        description_parts=(
+            DescriptionPart(
+                document_id=document_id,
+                parse_version="v1",
+                text=description or f"description of {name}",
+            ),
+        ),
+    )
+
+
+class _FakeStore:
+    def __init__(self, entities: dict[str, EntityWithLineage]) -> None:
+        self._entities = entities
+
+    async def get_entity(self, entity_name: str) -> EntityWithLineage | None:
+        return self._entities.get(entity_name)
+
+
+class _FakeEmbedder:
+    """Returns a unique deterministic vector per text so tests can match
+    on ``(text, vector)`` pairs."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self._cache: dict[str, list[float]] = {}
+
+    def embed_query(self, text: str) -> list[float]:
+        self.calls.append(text)
+        if text not in self._cache:
+            self._cache[text] = [float(len(self._cache) + 1), 0.0, 0.0]
+        return self._cache[text]
+
+
+@dataclass
+class _RecordedSearch:
+    request: Any  # QueryRequest captured for filter / threshold assertion
+
+
+class _FakeVectorConnector:
+    def __init__(self, hits_by_query: dict[tuple[float, ...], list[SearchHit]]) -> None:
+        self._hits = hits_by_query
+        self.searches: list[_RecordedSearch] = []
+
+    def search(self, request) -> list[SearchHit]:
+        self.searches.append(_RecordedSearch(request=request))
+        return list(self._hits.get(tuple(request.embedding), []))
+
+
+class _RecordingPersistence:
+    """Capture what the detector would persist without standing up SQLA.
+
+    The real persistence path uses ``execute_with_transaction``; we
+    monkeypatch that on a per-detector basis to record the ``run`` /
+    ``suggestions`` payload the persistence ``_op`` would have written.
+    """
+
+    def __init__(self) -> None:
+        self.runs: list[Any] = []
+        self.suggestions: list[Any] = []
+        self.supersede_filters: list[dict[str, Any]] = []
+        self.flush_count = 0
+
+    def install(self, detector: MergeCandidateDetector) -> None:
+        recorder = self
+
+        async def _fake_execute(operation):
+            await operation(_FakeSession(recorder))
+
+        detector.execute_with_transaction = _fake_execute  # type: ignore[method-assign]
+
+
+class _FakeSession:
+    def __init__(self, recorder: _RecordingPersistence) -> None:
+        self._recorder = recorder
+        self._next_run_id = "gcr_test_0001"
+
+    async def execute(self, stmt) -> Any:
+        # Best-effort capture of the supersede UPDATE: store the WHERE
+        # criteria + the values dict so tests can assert on filter shape.
+        try:
+            criteria = [str(c) for c in stmt._where_criteria]  # type: ignore[attr-defined]
+        except Exception:
+            criteria = []
+        try:
+            values = dict(stmt._values)  # type: ignore[attr-defined]
+        except Exception:
+            values = {}
+        self._recorder.supersede_filters.append({"criteria": criteria, "values": values})
+        return None
+
+    def add(self, instance) -> None:
+        # Discriminate by class name to avoid importing internals.
+        cls_name = type(instance).__name__
+        if cls_name == "GraphCurationRun":
+            instance.id = self._next_run_id
+            self._recorder.runs.append(instance)
+        elif cls_name == "GraphCurationSuggestion":
+            self._recorder.suggestions.append(instance)
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected ORM type: {cls_name}")
+
+    async def flush(self) -> None:
+        self._recorder.flush_count += 1
+
+
+def _make_detector(
+    *,
+    entities: dict[str, EntityWithLineage],
+    hits_by_query: dict[tuple[float, ...], list[SearchHit]] | None = None,
+    embedder: _FakeEmbedder | None = None,
+    user_id: str = "user-1",
+    collection_id: str = "col-1",
+    vector_top_k: int = 4,
+    vector_score_threshold: float = 0.72,
+) -> tuple[MergeCandidateDetector, _RecordingPersistence, _FakeVectorConnector, _FakeEmbedder]:
+    embedder = embedder or _FakeEmbedder()
+    connector = _FakeVectorConnector(hits_by_query or {})
+    detector = MergeCandidateDetector(
+        store=_FakeStore(entities),
+        vector_connector=connector,
+        embedder=embedder,
+        collection_id=collection_id,
+        user_id=user_id,
+        vector_top_k=vector_top_k,
+        vector_score_threshold=vector_score_threshold,
+    )
+    recorder = _RecordingPersistence()
+    recorder.install(detector)
+    return detector, recorder, connector, embedder
+
+
+# ---------------------------------------------------------------------
+# Empty / no-op cases
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_affected_short_circuits_with_no_db_write():
+    detector, recorder, connector, embedder = _make_detector(entities={})
+
+    written = await detector.detect_for_sync(sync_run_id="sync-0", affected_entity_names=[])
+
+    assert written == 0
+    assert recorder.runs == []
+    assert recorder.suggestions == []
+    assert recorder.supersede_filters == []  # short-circuited before DB
+    assert embedder.calls == []
+    assert connector.searches == []
+
+
+@pytest.mark.asyncio
+async def test_affected_entity_gced_before_run_is_skipped():
+    """Caller hands us names; if the entity was GC'd between sync and
+    detect, ``store.get_entity`` returns ``None`` and we treat it as not
+    affected. We still create a run row so the audit trail records the
+    detector ran (with stats = 0)."""
+    detector, recorder, *_ = _make_detector(entities={})  # store empty
+
+    written = await detector.detect_for_sync(sync_run_id="sync-1", affected_entity_names=["GoneEntity"])
+
+    assert written == 0
+    # Detector still recorded the run for audit (stats reflect the GC).
+    assert len(recorder.runs) == 1
+    assert recorder.runs[0].stats["affected_entities"] == 1
+    assert recorder.runs[0].stats["suggestions"] == 0
+    assert recorder.suggestions == []
+
+
+# ---------------------------------------------------------------------
+# Run / suggestion shape pinning
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_and_suggestions_carry_auto_detect_tags():
+    a = _entity("OpenAI", description="AI lab founded in 2015 in San Francisco")
+    b = _entity("OpenAI Inc.", description="AI lab founded in 2015 in San Francisco")
+    detector, recorder, *_ = _make_detector(entities={a.name: a, b.name: b})
+
+    written = await detector.detect_for_sync(
+        sync_run_id="sync-42",
+        affected_entity_names=[a.name, b.name],
+    )
+
+    assert written == 1, "lexical near-duplicate should yield exactly one suggestion"
+    assert len(recorder.runs) == 1
+    run = recorder.runs[0]
+    assert run.config_json == {
+        "source": AUTO_DETECT_SOURCE,
+        "sync_run_id": "sync-42",
+    }
+    assert run.collection_id == "col-1"
+    assert run.user_id == "user-1"
+    # Run is created in COMPLETED state because the detection completes
+    # synchronously (no PENDING/RUNNING phase to expose).
+    assert run.status.value == "COMPLETED"
+    assert run.stats["affected_entities"] == 2
+    assert run.stats["suggestions"] == 1
+
+    suggestion = recorder.suggestions[0]
+    assert suggestion.reason == AUTO_DETECT_REASON
+    assert suggestion.collection_id == "col-1"
+    assert suggestion.user_id == "user-1"
+    assert suggestion.run_id == run.id
+    assert suggestion.status.value == "PENDING"
+
+
+# ---------------------------------------------------------------------
+# Canonical pick is alphabetical-first
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_target_entity_id_is_alphabetical_first():
+    """Architect ratify #3: deterministic, reproducible canonical pick.
+    ``min(name_a, name_b)`` so the same pair across syncs always points
+    at the same surviving entity."""
+    # Construct two entities where alphabetical order ≠ insertion order.
+    z = _entity("Zephyr Corp", description="A wind energy company headquartered in Berlin")
+    a = _entity("Aeolus Inc", description="A wind energy company headquartered in Berlin")
+    detector, recorder, *_ = _make_detector(entities={z.name: z, a.name: a})
+
+    await detector.detect_for_sync(
+        sync_run_id="sync-7",
+        affected_entity_names=[z.name, a.name],  # insertion order: Z first
+    )
+
+    suggestion = recorder.suggestions[0]
+    assert suggestion.target_entity_id == "Aeolus Inc"  # alphabetical-first
+    assert suggestion.entity_ids == ["Aeolus Inc", "Zephyr Corp"]
+    # Snapshot ordering also follows alphabetical-first.
+    assert [snap["entity_name"] for snap in suggestion.entity_snapshots] == [
+        "Aeolus Inc",
+        "Zephyr Corp",
+    ]
+
+
+# ---------------------------------------------------------------------
+# Vector ANN integration
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vector_neighbour_pulls_in_unsynced_existing_entity():
+    """The affected entity ``A`` has a vector ANN neighbour ``B`` that
+    was NOT in the sync batch — detector still scores ``(A, B)`` and
+    surfaces the candidate."""
+    affected = _entity("OpenAI", description="An AI research lab")
+    neighbour = _entity("OpenAI Foundation", description="An AI research lab")
+    embedder = _FakeEmbedder()
+    affected_text = MergeCandidateDetector._description_text_for_scoring(affected)
+    embedder.embed_query(affected_text)  # warm cache so we know the vector
+    affected_vec = tuple(embedder._cache[affected_text])
+    detector, recorder, connector, _ = _make_detector(
+        entities={affected.name: affected, neighbour.name: neighbour},
+        hits_by_query={
+            affected_vec: [
+                # First hit is self — must be filtered.
+                SearchHit(
+                    id="self",
+                    score=1.0,
+                    payload={"entity_name": affected.name, "indexer": "graph_entity"},
+                ),
+                SearchHit(
+                    id="nbr",
+                    score=0.91,
+                    payload={"entity_name": neighbour.name, "indexer": "graph_entity"},
+                ),
+            ],
+        },
+        embedder=embedder,
+    )
+
+    written = await detector.detect_for_sync(
+        sync_run_id="sync-vec",
+        affected_entity_names=[affected.name],
+    )
+
+    assert written == 1
+    suggestion = recorder.suggestions[0]
+    assert sorted(suggestion.entity_ids) == sorted([affected.name, neighbour.name])
+    # Evidence carries the vector signal so a reviewer can see *why*
+    # the pair was surfaced.
+    assert suggestion.evidence.get("vector_neighbor") is True
+    assert suggestion.evidence.get("vector_score") == pytest.approx(0.91, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_vector_search_uses_graph_entity_filter_and_threshold():
+    """§K.12 invariant #5 — vector search must filter by
+    ``Eq("indexer", "graph_entity")`` so the ANN never bleeds into
+    chunk / summary points sharing the physical collection."""
+    a = _entity("Acme")
+    embedder = _FakeEmbedder()
+    embedder.embed_query("description of Acme")  # warm
+    detector, _, connector, _ = _make_detector(
+        entities={a.name: a},
+        hits_by_query={},
+        embedder=embedder,
+        vector_score_threshold=0.5,
+        vector_top_k=3,
+    )
+    await detector.detect_for_sync(
+        sync_run_id="sync-flt",
+        affected_entity_names=[a.name],
+    )
+
+    assert len(connector.searches) == 1
+    request = connector.searches[0].request
+    assert request.flt == Eq("indexer", "graph_entity")
+    assert request.score_threshold == 0.5
+    assert request.top_k == 4  # vector_top_k + 1 (slot for self)
+
+
+# ---------------------------------------------------------------------
+# Supersede semantics
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_supersede_runs_even_when_no_suggestions():
+    """Reviewers must never see a stale auto-detected PENDING from a
+    prior sync that this sync no longer agrees with — so the supersede
+    UPDATE runs unconditionally before any new suggestion insert."""
+    detector, recorder, *_ = _make_detector(entities={})  # store empty
+
+    await detector.detect_for_sync(
+        sync_run_id="sync-empty",
+        affected_entity_names=["MissingEntity"],
+    )
+
+    assert recorder.suggestions == []
+    # Exactly one supersede UPDATE was recorded.
+    assert len(recorder.supersede_filters) == 1
+
+
+# ---------------------------------------------------------------------
+# Forward compat: detector tolerates compacted_description when present
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_uses_compacted_description_when_present():
+    """When task #1's ``compacted_description`` field is set, the
+    detector embeds / scores against the compacted text — not the raw
+    parts — so behaviour matches what task #3's worker writes."""
+    a = _entity("OpenAI", description="raw fragment 1")
+    b = _entity("OpenAI Inc.", description="raw fragment 2")
+    # Mimic task #1's optional kwarg via direct attr-set (the field is
+    # added in PR #1754; until merged, the dataclass tolerates it via
+    # the default-None pattern).
+    object.__setattr__(a, "compacted_description", "OpenAI is an AI research lab.")
+    embedder = _FakeEmbedder()
+    detector, _, _, embedder = _make_detector(
+        entities={a.name: a, b.name: b},
+        embedder=embedder,
+    )
+
+    await detector.detect_for_sync(
+        sync_run_id="sync-cmp",
+        affected_entity_names=[a.name, b.name],
+    )
+
+    # The embedder saw the compacted text for ``a``, not the raw parts.
+    assert "OpenAI is an AI research lab." in embedder.calls
+    assert "raw fragment 1" not in "".join(embedder.calls)


### PR DESCRIPTION
## Summary

Wave 7 §K.12.4 amend2 task #4. Sync-driven detector that runs at the end of `GraphModalityWorker.sync()` (task #3 will wire it in), finds merge candidates among the entities touched by the sync, and persists them as `PENDING` `GraphCurationSuggestion` rows for human review — never auto-merged (D-3 invariant locked).

Per architect ratify msg=6ab89fbb (5-point lock + msg=fcf580a6 12-invariant gate):

- **Thin wrapper** around the existing `aperag/graph_curation/candidate_generation.build_candidate_pairs` algorithm. No re-implementation.
- **Writes into existing `GraphCurationSuggestion`** — no new table, no alembic migration, no frontend / REST changes (cuiwenbo task #9 is zero-touch).
- **Per-sync `GraphCurationRun`** with `status=COMPLETED`, `config_json={"source": "auto_detect", "sync_run_id": ...}` so admin UI can split user-triggered vs sync-driven curation.
- **Deterministic alphabetical-first canonical pick** for `target_entity_id` so the same `(entity_a, entity_b)` pair across syncs always points at the same surviving entity.
- **Auto-detected supersede semantics**: each sync supersedes the prior auto-detected `PENDING` rows for the collection so reviewers never see stale duplicates.

## §K.12 invariant cross-check (12-item)

| # | Invariant | This PR |
|---|---|---|
| 1 | L1 graph data 不污染 | ✅ write-only on `GraphCurationSuggestion`; never writes back to lineage rows |
| 2 | L1 → L2 单向派生 | n/a (detector consumes lineage, doesn't produce derived L2 like compacted/vector) |
| 3 | Compactor 在 sync 末尾, vector embed 之前 | n/a (this is task #2/#3 — detector runs after; task #3 wiring concern) |
| 4 | Vector store 走 `VectorStoreConnectorAdaptor` | ✅ uses `VectorStoreConnector` abstract base; adaptor at task #3 wiring |
| 5 | payload `indexer="graph_entity"` filter | ✅ pinned in `test_vector_search_uses_graph_entity_filter_and_threshold` (`Eq("indexer", "graph_entity")`) |
| 6 | uuid5 deterministic vector point id | n/a (detector reads vectors, doesn't write) |
| 7 | snapshot-diff via lineage entity name set | n/a (covered by task #3) |
| 8 | alias_map persistence independent of doc lifecycle | n/a (covered by task #6) |
| 9 | `upsert_entity_with_lineage` transparent alias redirect | n/a (covered by task #6) |
| 10 | DB 列长度 application-layer cap | n/a (suggestion rows reuse existing `GraphCurationSuggestion` schema; no new column) |
| 11 | 候选检测仅写不自动合并 (D-3) | ✅ detector only writes `PENDING`; never invokes `merge_entities` / `accept_suggestion` |
| 12 | 命名 grep-zero LightRAG | ✅ `grep -rn 'LightRAG\|lightrag' aperag/indexing/merge_candidate_detector.py tests/unit_test/indexing/test_merge_candidate_detector.py` → 0 hits |

## 4-pattern pre-check matrix

**Pattern 1 v1** — caller-grep / similar-infra grep:
```
$ grep -rn 'class .*Detector\|class .*Candidate\|build_.*pairs\|adjudicate' aperag/ tests/ | grep -v __pycache__
aperag/graph_curation/candidate_generation.py:31:class CandidatePair:
aperag/graph_curation/candidate_generation.py:48:def build_candidate_pairs(...)
aperag/graph_curation/service.py:_adjudicate_pairs
```
→ existing `build_candidate_pairs` is the production-validated algorithm. Wrapper imports it (no fork). Existing `_adjudicate_pairs` for LLM judge is reachable via `llm` kwarg in follow-up.

**Pattern 1 v2** — n/a (new component, no in-tree replacements yet).

**Pattern 2** — dependency interface grep:
- `LineageGraphStore.get_entity(entity_name) -> EntityWithLineage | None` (`aperag/indexing/graph.py:516`) — async-native, direct await.
- `VectorStoreConnector.search(QueryRequest) -> list[SearchHit]` (`aperag/vectorstore/base.py:127`) — sync API, wrapped in `asyncio.to_thread(...)` per existing `aperag/domains/retrieval/pipeline.py:_summary_search` pattern.
- `EmbeddingService.embed_query(text) -> list[float]` (`aperag/llm/embed/embedding_service.py:128`) — sync API, wrapped in `asyncio.to_thread(...)`.
- `GraphCurationSuggestion` ORM (`aperag/domains/knowledge_graph/db/models.py:106`) — fields confirmed: `run_id` (FK NOT NULL), `entity_ids: JSON`, `entity_snapshots: JSON` (list shape per existing `_aggregate_positive_judgements`), `target_entity_id` (NOT NULL), `confidence_score`, `reason`, `evidence`. Mapping locked.

**Pattern 3** — per-collection vs per-tenant binding:
→ per-collection bound at construction (4 deps + `collection_id` + `user_id` in ctor), no `collection_id` parameter on entry. Mirrors task #5 ratify decision (msg=acbd0003).

## simple-stable 4-guardrail (earayu2 msg=421c4223)

1. 不无限扩范围 ✅ thin wrapper, no algorithm fork; full-collection sweep deferred until a caller actually needs it (today: only sync-driven scoped detection).
2. 先做实尽快上线 ✅ smallest surface that satisfies the task #4 contract; LLM judge tier reserved as `llm` kwarg for follow-up.
3. 简单稳定优于复杂 ✅ algorithm reused verbatim (production-validated since user-triggered curation shipped); deterministic alphabetical-first canonical pick avoids LLM nondeterminism.
4. 私有化部署后免维护 ✅ thresholds (`vector_top_k=4`, `vector_score_threshold=0.72`, etc.) are constructor kwargs with sensible defaults — matches user-triggered tunables in `aperag/graph_curation/service.py`. No operator config to drift.

## Scope notes (called out for reviewers)

- **LLM judge tier**: `llm` kwarg present on the constructor for forward-compat but NOT invoked in this PR. Follow-up will plumb it through to the existing `_adjudicate_pairs`-style logic. Documented in the constructor's inline comment.
- **Cross-document full sweep**: not implemented. The `LineageGraphStore` Protocol has no `list_entities` method (intentionally — broadening for one consumer hits earayu2 directive #1). Sync-driven detection only sees what the caller passes via `affected_entity_names`. Full-collection sweep continues to live in user-triggered `GraphCurationService.start_run`. Documented in the `detect_for_sync` docstring.

## Test plan

- [x] 8-case unit suite in `tests/unit_test/indexing/test_merge_candidate_detector.py` — all pass locally (`uv run pytest tests/unit_test/indexing/test_merge_candidate_detector.py -v`):
  - empty `affected_entity_names` short-circuits with no DB write
  - GC'd entity (store returns None) is silently skipped, audit run row still created
  - `GraphCurationRun` carries `config_json["source"] == "auto_detect"` + sync_run_id; suggestion carries `reason == "auto_detected"`
  - canonical `target_entity_id` is alphabetical-first regardless of insertion order
  - vector ANN pulls in unsynced existing entity (cross-batch detection)
  - vector search uses `Eq("indexer", "graph_entity")` filter + threshold + `top_k = vector_top_k + 1` (slot for self)
  - supersede UPDATE runs even when 0 suggestions written (no stale PENDING)
  - forward-compat: prefers `compacted_description` when set (task #1's field), falls back to joined `description_parts.text`
- [x] `ruff check` + `ruff format --check` clean.

## References

- spec: §K.12.4 + amend2 (PRs #1751 + #1753), commit `c1c48429` for prior task #2
- ratify thread: msg=4ceb9edb in `#删除老graph` (architect ratify msg=6ab89fbb 5-point lock)
- huangheng CR plan checklist: msg=ee1a2c78 (D-3, no auto-merge; supersede explicit; vector filter pinned; canonical alphabetical-first; mapping accuracy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)