### PR TITLE
feat(celery Wave 7 #7): MCP graph tools — query_graph_entities / expand_graph_subgraph / get_entity_detail

### DIFF
--- a/aperag/domains/knowledge_graph/api/routes.py
+++ b/aperag/domains/knowledge_graph/api/routes.py
@@ -32,7 +32,11 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Request
 
 from aperag.domains.identity.service.auth_dependencies import required_user
 from aperag.domains.knowledge_graph.schemas import (
+    GraphEntitiesSearchResponse,
     GraphLabelsResponse,
+    GraphSearchEntity,
+    GraphSubgraphExpandRequest,
+    GraphSubgraphExpandResponse,
     KnowledgeGraph,
     MergeSuggestionsRequest,
     SuggestionActionRequest,
@@ -263,3 +267,105 @@ async def handle_suggestion_action_view(
 # the FastAPI level, matching every other v1 KG URL. The canonical v2
 # surface does not re-expose kg-eval. See
 # ``docs/zh-CN/design/graphindex_rewrite.md``.
+
+
+# ---------------------------------------------------------------------------
+# Wave 7 §K.12.6/§K.12.7 — internal-only graph search endpoints (task #7)
+#
+# These three endpoints back the ``query_graph_entities`` /
+# ``expand_graph_subgraph`` / ``get_entity_detail`` MCP tools defined in
+# ``aperag/mcp/tools/graph_tools.py``. They are mounted under the same
+# ``/api/v2`` prefix so the in-process MCP server can call them via
+# httpx with ``API_BASE_URL`` (mirroring the existing
+# ``aperag/mcp/tools/search_graph.py`` pattern).
+#
+# They are explicitly NOT user-facing: the frontend has no consumer
+# (cuiwenbo task #9 verified backward-compat unaffected). They appear
+# in OpenAPI regen so the SDK / agent runtime can bind to typed
+# request / response models.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/collections/{collection_id}/graphs/entities/search",
+    tags=["graph"],
+    response_model=GraphEntitiesSearchResponse,
+)
+async def graph_entities_search_view(
+    request: Request,
+    collection_id: str,
+    q: str,
+    top_k: int = 10,
+    user: AuthenticatedUser = Depends(required_user),
+) -> GraphEntitiesSearchResponse:
+    """Vector-recall the top-K entities matching ``q`` (Wave 7 §K.12.6).
+
+    Empty / whitespace ``q`` returns ``entities=[]`` — same convention as
+    the underlying :class:`GraphSearchService` so MCP tool callers see
+    consistent empty-state behaviour.
+    """
+    if not (1 <= top_k <= 100):
+        raise HTTPException(status_code=400, detail="top_k must be between 1 and 100")
+    try:
+        return await graph_service.search_entities(str(user.id), collection_id, query=q, top_k=top_k)
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post(
+    "/collections/{collection_id}/graphs/subgraph/expand",
+    tags=["graph"],
+    response_model=GraphSubgraphExpandResponse,
+)
+async def graph_subgraph_expand_view(
+    request: Request,
+    collection_id: str,
+    payload: GraphSubgraphExpandRequest = Body(...),
+    user: AuthenticatedUser = Depends(required_user),
+) -> GraphSubgraphExpandResponse:
+    """Expand neighbours from anchor entities (Wave 7 §K.12.6).
+
+    Backed by ``LineageGraphStore.expand_neighbors_n_hops`` via
+    ``GraphSearchService.get_subgraph``. Backend implementations cap
+    the result size — callers MUST not assume an unbounded subgraph.
+    """
+    try:
+        return await graph_service.expand_subgraph(
+            str(user.id),
+            collection_id,
+            entity_names=list(payload.entity_names),
+            hops=payload.hops,
+        )
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get(
+    "/collections/{collection_id}/graphs/entities/{name}",
+    tags=["graph"],
+    response_model=GraphSearchEntity,
+)
+async def graph_entity_detail_view(
+    request: Request,
+    collection_id: str,
+    name: str,
+    user: AuthenticatedUser = Depends(required_user),
+) -> GraphSearchEntity:
+    """Return the full record for a single entity (Wave 7 §K.12.6).
+
+    Returns 404 when the entity does not exist in the lineage store
+    (gc'd, never extracted, or wrong collection).
+    """
+    try:
+        result = await graph_service.get_entity_detail(str(user.id), collection_id, entity_name=name)
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if result is None:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    return result

--- a/aperag/domains/knowledge_graph/schemas.py
+++ b/aperag/domains/knowledge_graph/schemas.py
@@ -344,6 +344,102 @@ class SuggestionActionResponse(BaseModel):
     )
 
 
+# ----------------------------------------------------------------------
+# Wave 7 §K.12.6/§K.12.7 — internal-only graph search/expand/detail shapes
+# ----------------------------------------------------------------------
+#
+# These models back the three MCP-facing endpoints under
+# ``/collections/{id}/graphs/entities/...`` and ``/graphs/subgraph/...``.
+# They are explicitly NOT user-facing — frontend has no consumer for
+# them — but they appear in OpenAPI regen so SDK callers can bind to
+# them statically.
+#
+# Per §K.12 invariant #12 (grep-zero LightRAG) the names are
+# ``Graph*`` only; per invariant #11 (D-3 candidate detection writes
+# only) these are read-only shapes — no mutation surface.
+
+
+class GraphSearchEntity(BaseModel):
+    """Entity returned by ``/graphs/entities/search`` and
+    ``/graphs/entities/{name}``.
+
+    Mirrors :class:`aperag.indexing.graph.EntityWithLineage` projected
+    to the public-facing fields. The ``description`` field collapses
+    ``compacted_description`` (when present) and ``description_parts``
+    using the same rule as :func:`GraphSearchService.compose_context`,
+    so MCP callers see one stable text — independent of whether the
+    GraphIndexCompactor (task #2) has run yet.
+    """
+
+    name: str = Field(..., description="Canonical entity name", examples=["墨香居"])
+    entity_type: str = Field(..., description="Entity type", examples=["organization"])
+    description: str = Field(
+        ...,
+        description="Compacted description if available, otherwise joined description parts",
+        examples=["墨香居是这条老巷子里唯一的旧书店。"],
+    )
+    source_chunk_count: int = Field(
+        0,
+        description="Number of source chunks supporting this entity",
+        examples=[3],
+        ge=0,
+    )
+
+
+class GraphRelationView(BaseModel):
+    """Relation projection used by subgraph expansion responses."""
+
+    source: str = Field(..., description="Source entity name", examples=["李明华"])
+    target: str = Field(..., description="Target entity name", examples=["墨香居"])
+    description: str = Field(
+        ...,
+        description="Compacted description if available, otherwise joined description parts",
+        examples=["李明华经营墨香居"],
+    )
+
+
+class GraphEntitiesSearchResponse(BaseModel):
+    """Response for ``GET /graphs/entities/search``."""
+
+    entities: list[GraphSearchEntity] = Field(
+        ...,
+        description="Entities returned by vector recall, ordered by descending similarity score",
+    )
+
+
+class GraphSubgraphExpandRequest(BaseModel):
+    """Request body for ``POST /graphs/subgraph/expand``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entity_names: list[str] = Field(
+        ...,
+        description="Anchor entity names to expand from",
+        examples=[["墨香居", "李明华"]],
+        min_length=1,
+    )
+    hops: int = Field(
+        1,
+        description="Number of hops to expand (bounded by backend implementation)",
+        examples=[1],
+        ge=1,
+        le=3,
+    )
+
+
+class GraphSubgraphExpandResponse(BaseModel):
+    """Response for ``POST /graphs/subgraph/expand``."""
+
+    entities: list[GraphSearchEntity] = Field(
+        ...,
+        description="Entities reachable from the anchor names within ``hops``",
+    )
+    relations: list[GraphRelationView] = Field(
+        ...,
+        description="Relations connecting the returned entities",
+    )
+
+
 __all__ = [
     "GraphLabelsResponse",
     "GraphNodeProperties",
@@ -360,4 +456,9 @@ __all__ = [
     "SuggestionActionRequest",
     "SuggestionActionMergeResult",
     "SuggestionActionResponse",
+    "GraphSearchEntity",
+    "GraphRelationView",
+    "GraphEntitiesSearchResponse",
+    "GraphSubgraphExpandRequest",
+    "GraphSubgraphExpandResponse",
 ]

--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from aperag.db.ops import async_db_ops
 from aperag.domains.knowledge_graph.graphindex.dto import Entity as GraphIndexEntity
@@ -47,6 +47,14 @@ from aperag.domains.knowledge_graph.graphindex.dto import Relation as GraphIndex
 from aperag.domains.knowledge_graph.ports import CollectionRow
 from aperag.domains.knowledge_graph.schemas import GraphLabelsResponse, KnowledgeGraph
 from aperag.exceptions import CollectionNotFoundException
+
+if TYPE_CHECKING:
+    from aperag.domains.knowledge_graph.schemas import (
+        GraphEntitiesSearchResponse,
+        GraphRelationView,
+        GraphSearchEntity,
+        GraphSubgraphExpandResponse,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +199,82 @@ class GraphService:
             "edges_redirected": result.edges_redirected,
             "edges_collapsed": result.edges_collapsed,
         }
+
+    # ============================================================ Wave 7 §K.12.6
+    async def search_entities(
+        self,
+        user_id: str,
+        collection_id: str,
+        *,
+        query: str,
+        top_k: int = 10,
+    ) -> "GraphEntitiesSearchResponse":
+        """Vector-recall the top-K entities for ``query``.
+
+        Backed by :class:`GraphSearchService.search_entities`. Internal
+        endpoint serving the ``query_graph_entities`` MCP tool.
+        """
+        import asyncio
+
+        from aperag.domains.knowledge_graph.schemas import GraphEntitiesSearchResponse
+        from aperag.indexing.graph_search_service import build_graph_search_service_for
+
+        db_collection = await self._get_and_validate_collection(user_id, collection_id)
+        service = await asyncio.to_thread(build_graph_search_service_for, db_collection)
+        entities = await service.search_entities(query=query, top_k=top_k)
+        return GraphEntitiesSearchResponse(entities=[_entity_to_search_view(e) for e in entities])
+
+    async def expand_subgraph(
+        self,
+        user_id: str,
+        collection_id: str,
+        *,
+        entity_names: List[str],
+        hops: int = 1,
+    ) -> "GraphSubgraphExpandResponse":
+        """Expand neighbours from ``entity_names`` within ``hops``.
+
+        Backed by :class:`GraphSearchService.get_subgraph` (delegates to
+        :meth:`LineageGraphStore.expand_neighbors_n_hops`).
+        """
+        import asyncio
+
+        from aperag.domains.knowledge_graph.schemas import GraphSubgraphExpandResponse
+        from aperag.indexing.graph_search_service import build_graph_search_service_for
+
+        db_collection = await self._get_and_validate_collection(user_id, collection_id)
+        service = await asyncio.to_thread(build_graph_search_service_for, db_collection)
+        entities, relations = await service.get_subgraph(entity_names=entity_names, hops=hops)
+        return GraphSubgraphExpandResponse(
+            entities=[_entity_to_search_view(e) for e in entities],
+            relations=[_relation_to_view(r) for r in relations],
+        )
+
+    async def get_entity_detail(
+        self,
+        user_id: str,
+        collection_id: str,
+        *,
+        entity_name: str,
+    ) -> "GraphSearchEntity | None":
+        """Return the full record for a single entity.
+
+        Returns ``None`` when the entity is not found in the lineage
+        store — the route handler turns that into a 404.
+        """
+        import asyncio
+
+        from aperag.indexing.worker_factory import _build_lineage_graph_store, _resolve_graph_backend_type
+
+        db_collection = await self._get_and_validate_collection(user_id, collection_id)
+        backend_type = _resolve_graph_backend_type(db_collection)
+        store = await asyncio.to_thread(
+            _build_lineage_graph_store, backend_type=backend_type, collection=db_collection
+        )
+        entity = await store.get_entity(entity_name)
+        if entity is None:
+            return None
+        return _entity_to_search_view(entity)
 
     # --------------------------------------------------------- internal helpers
     def _optimize_graph_for_visualization(self, nodes, edges, max_nodes):
@@ -361,6 +445,57 @@ def _adapt_edges(edges: List[GraphIndexRelation]) -> List[SimpleNamespace]:
             )
         )
     return out
+
+
+# ---------------------------------------------------------------------------
+# Wave 7 §K.12.6 — EntityWithLineage / RelationWithLineage → public view
+# ---------------------------------------------------------------------------
+
+
+def _entity_to_search_view(entity: Any) -> "GraphSearchEntity":
+    """Project an :class:`EntityWithLineage` to the public search shape.
+
+    Uses the same compacted-or-fallback rule as
+    :func:`GraphSearchService.compose_context` so MCP callers see the
+    same description independent of which path (search vs subgraph
+    vs detail) returned it.
+    """
+    from aperag.domains.knowledge_graph.schemas import GraphSearchEntity
+    from aperag.indexing.graph_search_service import GraphSearchService
+
+    description = GraphSearchService._render_description(
+        getattr(entity, "compacted_description", None),
+        entity.description_parts or (),
+    )
+    # ``source_chunk_count`` aggregates chunk ids across all lineage
+    # members (per :class:`LineageMember.chunk_ids`). Description parts
+    # only carry text, not chunk ids — those live on the lineage side.
+    chunk_ids: set[str] = set()
+    for member in entity.source_lineage or ():
+        for cid in getattr(member, "chunk_ids", ()) or ():
+            chunk_ids.add(str(cid))
+    return GraphSearchEntity(
+        name=entity.name,
+        entity_type=entity.entity_type or "entity",
+        description=description,
+        source_chunk_count=len(chunk_ids),
+    )
+
+
+def _relation_to_view(relation: Any) -> "GraphRelationView":
+    """Project a :class:`RelationWithLineage` to the public view."""
+    from aperag.domains.knowledge_graph.schemas import GraphRelationView
+    from aperag.indexing.graph_search_service import GraphSearchService
+
+    description = GraphSearchService._render_description(
+        getattr(relation, "compacted_description", None),
+        relation.description_parts or (),
+    )
+    return GraphRelationView(
+        source=relation.source,
+        target=relation.target,
+        description=description,
+    )
 
 
 # Global service instance

--- a/aperag/indexing/graph_search_service.py
+++ b/aperag/indexing/graph_search_service.py
@@ -289,9 +289,54 @@ class GraphSearchService:
         return " | ".join(fragments) or "(no description)"
 
 
+# ----------------------------------------------------------------------
+# Per-collection factory — Wave 7 §K.12.6/§K.12.7/§K.12.8 task #7+#8
+# ----------------------------------------------------------------------
+
+
+def build_graph_search_service_for(collection: Any) -> GraphSearchService:
+    """Construct a :class:`GraphSearchService` bound to ``collection``.
+
+    Mirrors :func:`aperag.domains.retrieval.pipeline._build_lineage_graph_store_for`
+    factory pattern so MCP tool view handlers (task #7) and the
+    retrieval pipeline (task #8) share one wiring path. Lazy imports
+    keep the module free of indexing / config side-effects at import
+    time.
+
+    The four dependencies are resolved per-collection:
+
+    * ``store`` — :class:`LineageGraphStore` via existing
+      ``_build_lineage_graph_store`` (Wave 6 #33 / #40 pattern).
+    * ``vector_connector`` — Qdrant / pgvector via the shared
+      ``_build_collection_qdrant_connector`` helper (Wave 5 P5B).
+    * ``embedder`` — ``embedding_service`` returned by
+      ``get_collection_embedding_service_sync`` (the same model the
+      vector worker uses, so query-time embedding lives on the same
+      vector space as write-time).
+    * ``llm`` — ``None`` in v1 (kwarg reserved for follow-up
+      high-level / low-level keyword extraction; not invoked).
+    """
+    from aperag.indexing.worker_factory import (
+        _build_collection_qdrant_connector,
+        _build_lineage_graph_store,
+        _resolve_graph_backend_type,
+    )
+
+    backend_type = _resolve_graph_backend_type(collection)
+    store = _build_lineage_graph_store(backend_type=backend_type, collection=collection)
+    adaptor, embedder, _vector_size = _build_collection_qdrant_connector(collection)
+    return GraphSearchService(
+        store=store,
+        vector_connector=adaptor.connector,
+        embedder=embedder,
+        llm=None,
+    )
+
+
 __all__ = [
     "GraphSearchService",
     "DEFAULT_TOP_K",
     "DEFAULT_SCORE_THRESHOLD",
     "GRAPH_ENTITY_INDEXER",
+    "build_graph_search_service_for",
 ]

--- a/aperag/mcp/server.py
+++ b/aperag/mcp/server.py
@@ -572,5 +572,14 @@ from aperag.mcp.tools.search_graph import graph_search  # noqa: E402, F401
 from aperag.mcp.tools.search_vector import vector_search  # noqa: E402, F401
 from aperag.mcp.tools.search_web import web_search  # noqa: E402, F401
 
+# Wave 7 §K.12.6 — graph entity search / subgraph expand / detail.
+# Importing the module is what registers the three ``@mcp_server.tool``
+# decorators with the FastMCP instance above.
+from aperag.mcp.tools.graph_tools import (  # noqa: E402, F401
+    expand_graph_subgraph,
+    get_entity_detail,
+    query_graph_entities,
+)
+
 # Export the server instance
 __all__ = ["mcp_server"]

--- a/aperag/mcp/tools/graph_tools.py
+++ b/aperag/mcp/tools/graph_tools.py
@@ -1,0 +1,244 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Graph search MCP tools — Wave 7 §K.12.6 / §K.12.7 (task #7).
+
+Three discrete graph-recall primitives that let agents access the
+lineage graph through semantic vector search, neighbour expansion,
+and single-entity detail lookup. Mirrors the existing
+``aperag/mcp/tools/search_graph.py`` pattern: each tool calls an
+internal-only REST endpoint via httpx with ``API_BASE_URL`` so the
+MCP server can run colocated with — or detached from — the API
+service.
+
+Wire shape:
+
+* :func:`query_graph_entities` — vector recall over entity names /
+  descriptions; returns the top-K matching entities with
+  compacted-or-fallback descriptions.
+* :func:`expand_graph_subgraph` — n-hop expansion from anchor entity
+  names via :meth:`LineageGraphStore.expand_neighbors_n_hops`.
+* :func:`get_entity_detail` — single entity lookup by canonical name.
+
+Per spec §K.12 invariant #11 (D-3 candidate detection writes only)
+none of these tools mutate state — they are read-only. Per invariant
+#12 the tool names are LightRAG-grep-zero clean.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+import httpx
+
+from aperag.mcp.capabilities import ToolAnnotation
+from aperag.mcp.server import API_BASE_URL, get_api_key, mcp_server
+from aperag.mcp.tools._annotations import register as _register_tool_annotation
+
+logger = logging.getLogger(__name__)
+
+
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "query_graph_entities",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
+async def query_graph_entities(
+    collection_id: str,
+    query: str,
+    *,
+    top_k: int = 10,
+) -> Dict[str, Any]:
+    """Semantic search over knowledge-graph entities (§K.12.6).
+
+    Use this when:
+    - The query benefits from semantic similarity over entity names
+      and descriptions (e.g., "find entities related to renewable
+      energy companies").
+    - You want a ranked list of candidate anchor entities to feed
+      into ``expand_graph_subgraph``.
+
+    Do not use this when:
+    - You already know the exact entity name; use ``get_entity_detail``.
+    - You need free-text content rather than entities; use
+      ``vector_search`` or ``fulltext_search``.
+
+    What success means:
+    - You retrieved up to ``top_k`` entities ranked by descending
+      vector similarity.
+
+    What an empty result means:
+    - The collection has no graph index built yet.
+    - The query did not match any indexed entity within the score
+      threshold.
+
+    Args:
+        collection_id: The ID of the collection to search.
+        query: The natural-language search query.
+        top_k: Maximum number of entities to return (default 10, max 100).
+
+    Returns:
+        ``{"entities": [{"name", "entity_type", "description",
+        "source_chunk_count"}, ...]}``.
+    """
+    try:
+        api_key = get_api_key()
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.get(
+                f"{API_BASE_URL}/api/v2/collections/{collection_id}/graphs/entities/search",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                params={"q": query, "top_k": top_k},
+            )
+            return _parse_response(response, "query_graph_entities")
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "expand_graph_subgraph",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
+async def expand_graph_subgraph(
+    collection_id: str,
+    entity_names: List[str],
+    *,
+    hops: int = 1,
+) -> Dict[str, Any]:
+    """Expand neighbours from anchor entities (§K.12.6).
+
+    Use this when:
+    - You have anchor entity names (e.g., from
+      ``query_graph_entities``) and want their direct or n-hop
+      neighbours plus the connecting relations.
+
+    Do not use this when:
+    - You only need to look up a single entity; use
+      ``get_entity_detail``.
+    - You want chunk-level evidence; use ``vector_search`` or
+      ``fulltext_search`` against the original chunks.
+
+    Args:
+        collection_id: The ID of the collection to traverse.
+        entity_names: Anchor entity names to expand from (must be
+            non-empty).
+        hops: Number of hops to expand (default 1, max 3). Backend
+            implementations cap the result size — callers MUST not
+            assume an unbounded subgraph.
+
+    Returns:
+        ``{"entities": [...], "relations": [...]}`` where ``relations``
+        carries ``source`` / ``target`` entity names and a description.
+    """
+    try:
+        api_key = get_api_key()
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            response = await client.post(
+                f"{API_BASE_URL}/api/v2/collections/{collection_id}/graphs/subgraph/expand",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={"entity_names": list(entity_names), "hops": hops},
+            )
+            return _parse_response(response, "expand_graph_subgraph")
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+
+@mcp_server.tool(
+    annotations=_register_tool_annotation(
+        "get_entity_detail",
+        ToolAnnotation(
+            requires=("collection_access",),
+            capabilities={"long_context": False},
+        ),
+    ),
+)
+async def get_entity_detail(
+    collection_id: str,
+    name: str,
+) -> Dict[str, Any]:
+    """Return the full record for a single entity (§K.12.6).
+
+    Use this when:
+    - You already know the exact entity name and want its full
+      description and source-chunk reference count.
+
+    Do not use this when:
+    - You're not sure of the exact name; use ``query_graph_entities``
+      first.
+
+    Args:
+        collection_id: The ID of the collection.
+        name: The canonical entity name to look up.
+
+    Returns:
+        ``{"name", "entity_type", "description", "source_chunk_count"}``
+        on success, ``{"error": "Entity not found"}`` when the entity
+        is missing from the lineage store.
+    """
+    try:
+        api_key = get_api_key()
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            # Use ``urllib.parse.quote`` so entity names containing
+            # ``/`` or unicode characters survive path encoding.
+            from urllib.parse import quote
+
+            encoded = quote(name, safe="")
+            response = await client.get(
+                f"{API_BASE_URL}/api/v2/collections/{collection_id}/graphs/entities/{encoded}",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            return _parse_response(response, "get_entity_detail")
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+
+def _parse_response(response: httpx.Response, tool_name: str) -> Dict[str, Any]:
+    """Decode the API response into the tool's return shape.
+
+    Mirrors the convention in ``aperag/mcp/tools/search_graph.py``:
+    success → parsed JSON dict; non-2xx → ``{"error", "details"}``.
+    """
+    if response.status_code in (200, 201):
+        try:
+            return response.json()
+        except Exception as exc:  # noqa: BLE001 — defensive, surface message
+            logger.error("Failed to parse %s response: %s", tool_name, exc)
+            return {
+                "error": f"Failed to parse {tool_name} response",
+                "details": str(exc),
+            }
+    if response.status_code == 404:
+        return {"error": "Entity not found" if tool_name == "get_entity_detail" else "Collection not found"}
+    return {
+        "error": f"{tool_name} failed: {response.status_code}",
+        "details": response.text,
+    }

--- a/tests/unit_test/mcp/test_capability_negotiation.py
+++ b/tests/unit_test/mcp/test_capability_negotiation.py
@@ -244,6 +244,9 @@ class TestRegisterReregistrationGuard:
         importlib.reload(importlib.import_module("aperag.mcp.tools.search_graph"))
         importlib.reload(importlib.import_module("aperag.mcp.tools.search_fulltext"))
         importlib.reload(importlib.import_module("aperag.mcp.tools.search_web"))
+        # Wave 7 §K.12.6 task #7 — reload graph_tools so its 3 tool
+        # decorators re-register after the surgical _reset_for_tests().
+        importlib.reload(importlib.import_module("aperag.mcp.tools.graph_tools"))
         importlib.reload(importlib.import_module("aperag.mcp.server"))
         # Sanity: every snapshot entry is back.
         restored = _annotations.get_all()

--- a/tests/unit_test/mcp/test_graph_tools.py
+++ b/tests/unit_test/mcp/test_graph_tools.py
@@ -1,0 +1,245 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wave 7 §K.12.6 / §K.12.7 — graph MCP tool contract tests (task #7).
+
+Mirror of ``test_search_split.py`` for the three Wave 7 tools. Locks:
+
+1. The three tools exist and are registered as ``async`` MCP tools.
+2. Their signatures match the spec (collection_id positional, kw-only
+   knobs).
+3. The httpx call shape — verb / URL / params / body — matches the
+   internal-only REST endpoints implemented in
+   ``aperag/domains/knowledge_graph/api/routes.py``.
+4. Success / 404 / 5xx response paths return the right shape.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aperag.mcp import server as mcp_server_module
+from aperag.mcp.tools.graph_tools import (
+    expand_graph_subgraph,
+    get_entity_detail,
+    query_graph_entities,
+)
+
+API_BASE = "http://localhost:8000"
+
+
+# --- 1. Registration / surface ---------------------------------------
+
+
+def test_graph_tools_are_async_callables():
+    for tool in (query_graph_entities, expand_graph_subgraph, get_entity_detail):
+        assert callable(tool)
+        assert inspect.iscoroutinefunction(tool), f"{tool.__name__} must be async (MCP tool surface)."
+
+
+def test_graph_tools_are_re_exported_on_server_module():
+    """Importing ``aperag.mcp.server`` must register the 3 tools (the
+    decorators run at module import time)."""
+    for name in ("query_graph_entities", "expand_graph_subgraph", "get_entity_detail"):
+        assert hasattr(mcp_server_module, name), (
+            f"aperag.mcp.server must re-export {name} (decorator registration)."
+        )
+
+
+# --- 2. Signature locks ---------------------------------------------
+
+
+def _params(func) -> dict[str, inspect.Parameter]:
+    return dict(inspect.signature(func).parameters)
+
+
+def _kw_only(func) -> set[str]:
+    return {
+        name
+        for name, p in inspect.signature(func).parameters.items()
+        if p.kind is inspect.Parameter.KEYWORD_ONLY
+    }
+
+
+def test_query_graph_entities_signature():
+    params = _params(query_graph_entities)
+    assert list(params)[:2] == ["collection_id", "query"]
+    assert _kw_only(query_graph_entities) == {"top_k"}
+    assert params["top_k"].default == 10
+
+
+def test_expand_graph_subgraph_signature():
+    params = _params(expand_graph_subgraph)
+    assert list(params)[:2] == ["collection_id", "entity_names"]
+    assert _kw_only(expand_graph_subgraph) == {"hops"}
+    assert params["hops"].default == 1
+
+
+def test_get_entity_detail_signature():
+    params = _params(get_entity_detail)
+    assert list(params) == ["collection_id", "name"]
+
+
+# --- 3. httpx call shape ---------------------------------------------
+
+
+def _make_async_client(response_mock: Any) -> Any:
+    """Return a mock that mimics ``httpx.AsyncClient(...)`` async ctx."""
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(return_value=response_mock)
+    client.post = AsyncMock(return_value=response_mock)
+    return client
+
+
+def _ok_response(payload: dict[str, Any]) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(return_value=payload)
+    return resp
+
+
+def _err_response(status: int, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_query_graph_entities_httpx_call_shape():
+    payload = {"entities": [{"name": "X", "entity_type": "organization", "description": "d", "source_chunk_count": 2}]}
+    response = _ok_response(payload)
+    client = _make_async_client(response)
+
+    with (
+        patch("aperag.mcp.tools.graph_tools.httpx.AsyncClient", return_value=client),
+        patch("aperag.mcp.tools.graph_tools.get_api_key", return_value="kkey"),
+        patch("aperag.mcp.tools.graph_tools.API_BASE_URL", API_BASE),
+    ):
+        result = await query_graph_entities("col_abc", "what is X", top_k=5)
+
+    client.get.assert_awaited_once()
+    call = client.get.call_args
+    assert call.args[0] == f"{API_BASE}/api/v2/collections/col_abc/graphs/entities/search"
+    assert call.kwargs["params"] == {"q": "what is X", "top_k": 5}
+    assert call.kwargs["headers"]["Authorization"] == "Bearer kkey"
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_expand_graph_subgraph_httpx_call_shape():
+    payload = {"entities": [], "relations": []}
+    response = _ok_response(payload)
+    client = _make_async_client(response)
+
+    with (
+        patch("aperag.mcp.tools.graph_tools.httpx.AsyncClient", return_value=client),
+        patch("aperag.mcp.tools.graph_tools.get_api_key", return_value="kkey"),
+        patch("aperag.mcp.tools.graph_tools.API_BASE_URL", API_BASE),
+    ):
+        result = await expand_graph_subgraph("col_abc", ["A", "B"], hops=2)
+
+    client.post.assert_awaited_once()
+    call = client.post.call_args
+    assert call.args[0] == f"{API_BASE}/api/v2/collections/col_abc/graphs/subgraph/expand"
+    assert call.kwargs["json"] == {"entity_names": ["A", "B"], "hops": 2}
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_get_entity_detail_httpx_call_shape_url_encodes_name():
+    payload = {"name": "墨香居", "entity_type": "organization", "description": "...", "source_chunk_count": 3}
+    response = _ok_response(payload)
+    client = _make_async_client(response)
+
+    with (
+        patch("aperag.mcp.tools.graph_tools.httpx.AsyncClient", return_value=client),
+        patch("aperag.mcp.tools.graph_tools.get_api_key", return_value="kkey"),
+        patch("aperag.mcp.tools.graph_tools.API_BASE_URL", API_BASE),
+    ):
+        result = await get_entity_detail("col_abc", "墨香居")
+
+    client.get.assert_awaited_once()
+    url = client.get.call_args.args[0]
+    # Unicode entity name must be URL-encoded — no raw chinese in URL.
+    assert url.startswith(f"{API_BASE}/api/v2/collections/col_abc/graphs/entities/")
+    assert "%E5%A2%A8%E9%A6%99%E5%B1%85" in url
+    assert result == payload
+
+
+# --- 4. Error path response shapes -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_graph_entities_404_returns_error_dict():
+    response = _err_response(404, "not found")
+    client = _make_async_client(response)
+    with (
+        patch("aperag.mcp.tools.graph_tools.httpx.AsyncClient", return_value=client),
+        patch("aperag.mcp.tools.graph_tools.get_api_key", return_value="kkey"),
+        patch("aperag.mcp.tools.graph_tools.API_BASE_URL", API_BASE),
+    ):
+        result = await query_graph_entities("col_abc", "q")
+    assert result == {"error": "Collection not found"}
+
+
+@pytest.mark.asyncio
+async def test_get_entity_detail_404_distinguishes_entity_missing():
+    """``get_entity_detail`` 404 → 'Entity not found' (vs collection-level
+    'Collection not found' the other tools emit). The route already
+    distinguishes the two with a different ``HTTPException(detail=...)``;
+    this lock just ensures the tool surface preserves it."""
+    response = _err_response(404, "entity gone")
+    client = _make_async_client(response)
+    with (
+        patch("aperag.mcp.tools.graph_tools.httpx.AsyncClient", return_value=client),
+        patch("aperag.mcp.tools.graph_tools.get_api_key", return_value="kkey"),
+        patch("aperag.mcp.tools.graph_tools.API_BASE_URL", API_BASE),
+    ):
+        result = await get_entity_detail("col_abc", "missing")
+    assert result == {"error": "Entity not found"}
+
+
+@pytest.mark.asyncio
+async def test_expand_graph_subgraph_5xx_returns_error_dict_with_details():
+    response = _err_response(500, "boom")
+    client = _make_async_client(response)
+    with (
+        patch("aperag.mcp.tools.graph_tools.httpx.AsyncClient", return_value=client),
+        patch("aperag.mcp.tools.graph_tools.get_api_key", return_value="kkey"),
+        patch("aperag.mcp.tools.graph_tools.API_BASE_URL", API_BASE),
+    ):
+        result = await expand_graph_subgraph("col_abc", ["A"], hops=1)
+    assert result["error"].startswith("expand_graph_subgraph failed:")
+    assert result["details"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_query_graph_entities_missing_api_key_returns_error():
+    """When ``get_api_key`` raises ``ValueError``, the tool surfaces
+    the message as ``{"error": ...}`` instead of propagating the
+    exception (mirror ``aperag/mcp/tools/search_graph.py`` convention).
+    """
+    with (
+        patch("aperag.mcp.tools.graph_tools.get_api_key", side_effect=ValueError("missing key")),
+        patch("aperag.mcp.tools.graph_tools.API_BASE_URL", API_BASE),
+    ):
+        result = await query_graph_entities("col_abc", "q")
+    assert result == {"error": "missing key"}

--- a/tests/unit_test/service/test_graph_search_service_layer.py
+++ b/tests/unit_test/service/test_graph_search_service_layer.py
@@ -1,0 +1,268 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wave 7 §K.12.6 — :class:`GraphService` graph-search method tests (task #7).
+
+Covers the three new domain-service methods that back the internal-only
+REST endpoints under ``/collections/{id}/graphs/entities/...`` and
+``/graphs/subgraph/...``. Mocks the per-collection factory so the test
+exercises the projection + flow without touching Qdrant / Postgres.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aperag.domains.knowledge_graph.schemas import (
+    GraphEntitiesSearchResponse,
+    GraphRelationView,
+    GraphSearchEntity,
+    GraphSubgraphExpandResponse,
+)
+from aperag.domains.knowledge_graph.service import (
+    GraphService,
+    _entity_to_search_view,
+    _relation_to_view,
+)
+from aperag.indexing.graph import (
+    DescriptionPart,
+    EntityWithLineage,
+    LineageMember,
+    RelationWithLineage,
+)
+
+
+def _make_entity(
+    *,
+    name: str = "墨香居",
+    entity_type: str = "organization",
+    parts: list[tuple[str, str, str]] | None = None,
+    chunks: list[tuple[str, str, list[str]]] | None = None,
+    compacted: str | None = None,
+) -> EntityWithLineage:
+    parts = parts or [("doc1", "v1", "raw description")]
+    chunks = chunks or [("doc1", "v1", ["chunk-a", "chunk-b"])]
+    return EntityWithLineage(
+        name=name,
+        entity_type=entity_type,
+        source_lineage=tuple(
+            LineageMember(
+                document_id=doc,
+                parse_version=ver,
+                tenant_scope_key="user:test",
+                chunk_ids=tuple(cs),
+            )
+            for doc, ver, cs in chunks
+        ),
+        description_parts=tuple(
+            DescriptionPart(document_id=doc, parse_version=ver, text=text)
+            for doc, ver, text in parts
+        ),
+        compacted_description=compacted,
+    )
+
+
+def _make_relation(
+    *,
+    source: str = "李明华",
+    target: str = "墨香居",
+    relation_type: str = "owns",
+    parts: list[tuple[str, str, str]] | None = None,
+    compacted: str | None = None,
+) -> RelationWithLineage:
+    parts = parts or [("doc1", "v1", "李明华经营墨香居")]
+    return RelationWithLineage(
+        source=source,
+        target=target,
+        relation_type=relation_type,
+        evidence_lineage=(
+            LineageMember(document_id="doc1", parse_version="v1", tenant_scope_key="user:test", chunk_ids=("c1",)),
+        ),
+        description_parts=tuple(
+            DescriptionPart(document_id=doc, parse_version=ver, text=text) for doc, ver, text in parts
+        ),
+        compacted_description=compacted,
+    )
+
+
+# --- _entity_to_search_view / _relation_to_view ---------------------
+
+
+def test_entity_view_prefers_compacted_description():
+    e = _make_entity(parts=[("d", "v", "raw")], compacted="compacted text")
+    view = _entity_to_search_view(e)
+    assert isinstance(view, GraphSearchEntity)
+    assert view.description == "compacted text"
+    assert view.entity_type == "organization"
+
+
+def test_entity_view_falls_back_to_joined_parts():
+    e = _make_entity(
+        parts=[("doc1", "v1", "first"), ("doc2", "v2", "second")],
+        compacted=None,
+    )
+    view = _entity_to_search_view(e)
+    assert "first" in view.description and "second" in view.description
+
+
+def test_entity_view_source_chunk_count_dedupes_across_lineage():
+    e = _make_entity(
+        chunks=[
+            ("doc1", "v1", ["a", "b"]),
+            ("doc1", "v2", ["b", "c"]),  # 'b' appears twice — must dedup
+            ("doc2", "v1", ["d"]),
+        ]
+    )
+    view = _entity_to_search_view(e)
+    assert view.source_chunk_count == 4  # {a,b,c,d}
+
+
+def test_relation_view_uses_render_description_rule():
+    r = _make_relation(parts=[("d", "v", "primary")], compacted="compacted")
+    view = _relation_to_view(r)
+    assert isinstance(view, GraphRelationView)
+    assert view.source == "李明华"
+    assert view.target == "墨香居"
+    assert view.description == "compacted"
+
+
+# --- search_entities ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_entities_projects_graph_search_service_results():
+    e1 = _make_entity(name="A", parts=[("d1", "v1", "alpha")])
+    e2 = _make_entity(name="B", parts=[("d2", "v1", "beta")], compacted="B compact")
+
+    fake_search_service = MagicMock()
+    fake_search_service.search_entities = AsyncMock(return_value=[e1, e2])
+
+    svc = GraphService()
+    db_collection = SimpleNamespace(id="col1")
+    with (
+        patch.object(svc, "_get_and_validate_collection", new=AsyncMock(return_value=db_collection)),
+        patch(
+            "aperag.indexing.graph_search_service.build_graph_search_service_for",
+            return_value=fake_search_service,
+        ),
+    ):
+        result = await svc.search_entities("u", "col1", query="hello", top_k=5)
+
+    assert isinstance(result, GraphEntitiesSearchResponse)
+    fake_search_service.search_entities.assert_awaited_once_with(query="hello", top_k=5)
+    assert [e.name for e in result.entities] == ["A", "B"]
+    assert result.entities[1].description == "B compact"
+
+
+# --- expand_subgraph ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expand_subgraph_projects_entities_and_relations():
+    e_a = _make_entity(name="A")
+    e_b = _make_entity(name="B")
+    r_ab = _make_relation(source="A", target="B")
+
+    fake_search_service = MagicMock()
+    fake_search_service.get_subgraph = AsyncMock(return_value=([e_a, e_b], [r_ab]))
+
+    svc = GraphService()
+    db_collection = SimpleNamespace(id="col1")
+    with (
+        patch.object(svc, "_get_and_validate_collection", new=AsyncMock(return_value=db_collection)),
+        patch(
+            "aperag.indexing.graph_search_service.build_graph_search_service_for",
+            return_value=fake_search_service,
+        ),
+    ):
+        result = await svc.expand_subgraph("u", "col1", entity_names=["A"], hops=2)
+
+    assert isinstance(result, GraphSubgraphExpandResponse)
+    fake_search_service.get_subgraph.assert_awaited_once_with(entity_names=["A"], hops=2)
+    assert [e.name for e in result.entities] == ["A", "B"]
+    assert len(result.relations) == 1
+    assert result.relations[0].source == "A" and result.relations[0].target == "B"
+
+
+# --- get_entity_detail ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_entity_detail_returns_view_when_found():
+    entity = _make_entity(name="X")
+
+    fake_store = MagicMock()
+    fake_store.get_entity = AsyncMock(return_value=entity)
+
+    svc = GraphService()
+    db_collection = SimpleNamespace(id="col1")
+    with (
+        patch.object(svc, "_get_and_validate_collection", new=AsyncMock(return_value=db_collection)),
+        patch(
+            "aperag.indexing.worker_factory._resolve_graph_backend_type",
+            return_value="postgres",
+        ),
+        patch(
+            "aperag.indexing.worker_factory._build_lineage_graph_store",
+            return_value=fake_store,
+        ),
+    ):
+        result = await svc.get_entity_detail("u", "col1", entity_name="X")
+
+    assert isinstance(result, GraphSearchEntity)
+    assert result.name == "X"
+    fake_store.get_entity.assert_awaited_once_with("X")
+
+
+@pytest.mark.asyncio
+async def test_get_entity_detail_returns_none_when_missing():
+    fake_store = MagicMock()
+    fake_store.get_entity = AsyncMock(return_value=None)
+
+    svc = GraphService()
+    db_collection = SimpleNamespace(id="col1")
+    with (
+        patch.object(svc, "_get_and_validate_collection", new=AsyncMock(return_value=db_collection)),
+        patch(
+            "aperag.indexing.worker_factory._resolve_graph_backend_type",
+            return_value="postgres",
+        ),
+        patch(
+            "aperag.indexing.worker_factory._build_lineage_graph_store",
+            return_value=fake_store,
+        ),
+    ):
+        result = await svc.get_entity_detail("u", "col1", entity_name="missing")
+
+    assert result is None
+
+
+# --- byte-parity sanity (compose_context render rule reuse) ---------
+
+
+def test_entity_view_description_matches_compose_context_for_compacted():
+    """The MCP entity view description rule MUST match
+    :func:`GraphSearchService.compose_context` so an MCP caller chaining
+    ``query_graph_entities -> expand_graph_subgraph -> compose_context``
+    sees identical text per entity (no double-render drift).
+    """
+    from aperag.indexing.graph_search_service import GraphSearchService
+
+    e = _make_entity(parts=[("d", "v", "raw")], compacted="compacted via Compactor")
+    view = _entity_to_search_view(e)
+    composed = GraphSearchService.compose_context([e], [])
+    assert view.description in composed


### PR DESCRIPTION
Wave 7 §K.12.6 / §K.12.7 task #7. Architect ratify msg=da89237c locked Option A: 3 internal-only REST endpoints + 3 MCP tools, all REST-mediated (mirror existing ``aperag/mcp/tools/search_graph.py``).

## Summary

- Per-collection factory ``build_graph_search_service_for(collection)`` in ``aperag/indexing/graph_search_service.py`` (mirrors ``_build_lineage_graph_store_for``).
- 3 internal-only endpoints under ``/api/v2/collections/{id}/graphs/`` (``GET .../entities/search``, ``POST .../subgraph/expand``, ``GET .../entities/{name}``) — all read-only, all per-collection auth-scoped.
- 3 ``GraphService`` projection methods reusing ``GraphSearchService._render_description``.
- 3 MCP tools in ``aperag/mcp/tools/graph_tools.py`` wired at the bottom of ``aperag/mcp/server.py``.
- 21 new tests + 1 capability-negotiation teardown extension. Lint clean; 342 broad-sweep tests pass.

## §K.12 12-invariant cross-check

| # | Invariant | This PR |
|---|-----------|---------|
| 1 | L1 graph data 不污染 | N/A — read-only |
| 2 | L1 → L2 单向派生 | N/A — read-only |
| 3 | Compactor 在 vector embed 之前 | N/A (write-side, task #3) |
| 4 | Vector store via VectorStoreConnectorAdaptor | ✅ factory uses _build_collection_qdrant_connector; no direct Qdrant import in the new tool / route surface |
| 5 | payload indexer filter pattern | ✅ inherited from GraphSearchService.search_entities |
| 6 | uuid5 vector point id | N/A — read-only |
| 7 | snapshot-diff lineage name set | N/A — read-only |
| 8 | alias_map persist | N/A — task #6 owns; this PR's read paths transit LineageGraphStore so future alias decoration is transparent |
| 9 | upsert_entity alias redirect | N/A — task #6 owns |
| 10 | DB column length application-cap | ✅ reuses spec-bounded inputs (top_k cap 100, hops cap 3); no new column writes |
| 11 | 候选检测仅写不自动合并 | ✅ all 3 tools / endpoints are read-only |
| 12 | grep-zero LightRAG | ✅ tool names + URL paths + view models LightRAG-clean (borderline docstring sweep stays in task #10 batch) |

## 4-pattern pre-check matrix

- **Pattern 1 v1** — legacy import unchanged; cutover lives in task #8, deletion in task #10.
- **Pattern 1 v2 (architect own-up)** — MCPServerEntry (D9 remote-server URL registry) is NOT the in-process tool registry the original spec referenced; actual registration target is FastMCP via @mcp_server.tool. Architect ratify msg=da89237c locked Option A.
- **Pattern 2** — new endpoints reach lineage tables exclusively through LineageGraphStore / GraphSearchService.
- **Pattern 3** — Pydantic schemas appear in OpenAPI regen; frontend (cuiwenbo task #9) regen is a no-op.

## simple-stable 4 guardrail

- **#1 不无限扩范围** — new endpoints exist solely to back 3 spec-locked MCP tools.
- **#2 尽快上线** — task #7 ships independently of task #6 / #8.
- **#3 简单稳定** — same httpx-based pattern as the existing 8 D10 tools.
- **#4 私有化部署免维护** — API_BASE_URL env keeps MCP colocated-or-detached.

## Test plan

- [ ] CI lint-and-unit
- [ ] uv run pytest tests/unit_test/mcp/ tests/unit_test/service/ tests/unit_test/indexing/ — 342 pass
- [ ] uv run ruff check — clean
- [ ] @huangheng pass-1 review (12-invariant + ratify pattern lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)