### PR TITLE
feat(celery Wave 7 #8): retrieval/curation cutover + 3 wiring points

### DIFF
--- a/aperag/domains/knowledge_graph/api/routes.py
+++ b/aperag/domains/knowledge_graph/api/routes.py
@@ -151,6 +151,13 @@ async def merge_nodes_view(
     * The response echoes the merged description **after** LLM
       summarization, so the frontend can refresh the entity detail
       panel without a second fetch.
+    * ``edges_redirected`` / ``edges_collapsed`` are always ``0`` by
+      design (Wave 7 §K.12 invariant #9) — alias redirect happens at
+      indexer write-time via the
+      :class:`LineageGraphStoreWithAliasRedirect` decorator, not as
+      part of the merge call, so the merge action has no "explicit
+      edge re-anchor count" to surface. The fields are kept on the
+      response shape for backward-compat with the existing frontend.
     """
     entity_ids = payload.get("entity_ids") or []
     if not isinstance(entity_ids, list) or len(entity_ids) < 2:

--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -163,24 +163,51 @@ class GraphService:
         target_entity_id: str,
         source_entity_ids: List[str],
     ) -> Dict[str, Any]:
-        """Merge entities and return a summary payload for the UI.
+        """Merge entities — Wave 7 §K.12.8 task #8 cutover to
+        :class:`LineageEntityMerger` (PR #1758).
 
-        The heavy lifting (structural merge + LLM summary of the merged
-        description) happens inside
-        ``GraphIndexService.merge_entities``. This layer only validates
-        the collection and reshapes the DTO into the dict the existing
-        frontend expects.
+        The merger runs the 8-step orchestration inside the new lineage
+        layer: alias-map writes for transparent indexer redirect (steps
+        1-2), per-doc parts re-anchor under the canonical name (step 6a,
+        preserves invariant #1 lineage), unified-description LLM merge
+        + compaction (steps 4-5 + 6b), vector point upsert with the
+        canonical name + 3-field payload + uuid5 id (step 7), and
+        finally L1 + vector deletion of source entities (step 8).
+
+        Response shape is preserved byte-for-byte for backward-compat
+        with the existing frontend (cuiwenbo task #9 stays at
+        OpenAPI-regen + flow smoke):
+
+        * ``target_entity_id`` ← ``LineageMergeResult.final_target``
+        * ``description`` ← ``compacted_description`` if present, else
+          ``unified_description``
+        * ``source_chunk_ids`` ← chunk ids contributed by the source
+          entities, recovered from the target's lineage *after* the
+          merge has re-anchored them under the canonical name
+        * ``edges_redirected`` / ``edges_collapsed`` — the new merger
+          does not return per-edge stats (the alias-redirect decorator
+          handles edge re-anchoring transparently at indexer write
+          time, not at merge time). We surface ``0`` for both fields
+          to keep the response shape stable.
         """
         db_collection = await self._get_and_validate_collection(user_id, collection_id)
 
-        from aperag.domains.knowledge_graph.graphindex.integration import make_service_for_collection
+        from aperag.graph_curation.alias_map import AliasCycleError
+        from aperag.graph_curation.lineage_merge import build_lineage_entity_merger_for
 
-        svc = make_service_for_collection(db_collection)
-        result = await svc.merge_entities(
-            collection_id=collection_id,
-            target_entity_id=target_entity_id,
-            source_entity_ids=source_entity_ids,
-        )
+        merger = build_lineage_entity_merger_for(db_collection)
+        try:
+            merge_result = await merger.merge_entities(
+                target_name=target_entity_id,
+                source_names=source_entity_ids,
+                merged_by=user_id,
+            )
+        except AliasCycleError as exc:
+            # Surface as a validation error so the route returns 400
+            # (per the existing ``ValueError`` → 400 mapping in
+            # ``merge_nodes_view``).
+            raise ValueError(str(exc)) from exc
+
         try:
             from aperag.graph_curation import graph_curation_service
 
@@ -191,14 +218,62 @@ class GraphService:
             )
         except Exception:
             logger.exception("Failed to expire stale graph-curation suggestions after manual merge")
+
+        # Recover source chunk ids from the target's lineage after the
+        # merge — step 6a re-anchored each source's parts under the
+        # canonical name with their original ``(document_id,
+        # parse_version, chunk_ids)`` so the union of those chunks is
+        # what the UI expects.
+        source_chunk_ids = await self._collect_source_chunk_ids(
+            db_collection,
+            entity_name=merge_result.final_target,
+        )
+
+        description = merge_result.compacted_description or merge_result.unified_description or ""
+
         return {
-            "target_entity_id": result.target_entity_id,
-            "merged_source_ids": list(result.merged_source_ids),
-            "description": result.description,
-            "source_chunk_ids": list(result.source_chunk_ids),
-            "edges_redirected": result.edges_redirected,
-            "edges_collapsed": result.edges_collapsed,
+            "target_entity_id": merge_result.final_target,
+            "merged_source_ids": list(merge_result.merged_source_ids),
+            "description": description,
+            "source_chunk_ids": source_chunk_ids,
+            # Edge re-anchoring is handled transparently by the
+            # alias-redirect decorator at indexer write time (Wave 7
+            # §K.12 invariant #9), not as part of the merge action,
+            # so per-edge counts are not surfaced. ``0`` keeps the
+            # response shape stable for backward-compat.
+            "edges_redirected": 0,
+            "edges_collapsed": 0,
         }
+
+    async def _collect_source_chunk_ids(self, collection: Any, *, entity_name: str) -> List[str]:
+        """Return the union of chunk ids attached to ``entity_name``'s
+        lineage members after the merge has run. Used by
+        :meth:`merge_entities` to populate the backward-compat
+        ``source_chunk_ids`` field."""
+        import asyncio
+
+        from aperag.indexing.worker_factory import (
+            _build_lineage_graph_store_inner,
+            _resolve_graph_backend_type,
+        )
+
+        backend_type = _resolve_graph_backend_type(collection)
+        store = await asyncio.to_thread(
+            _build_lineage_graph_store_inner, backend_type=backend_type, collection=collection
+        )
+        entity = await store.get_entity(entity_name)
+        if entity is None:
+            return []
+        chunk_ids: list[str] = []
+        seen: set[str] = set()
+        for member in entity.source_lineage or ():
+            for cid in getattr(member, "chunk_ids", ()) or ():
+                cid_str = str(cid)
+                if cid_str in seen:
+                    continue
+                seen.add(cid_str)
+                chunk_ids.append(cid_str)
+        return chunk_ids
 
     # ============================================================ Wave 7 §K.12.6
     async def search_entities(

--- a/aperag/domains/retrieval/pipeline.py
+++ b/aperag/domains/retrieval/pipeline.py
@@ -461,42 +461,62 @@ class SearchPipelineService:
         query: str,
         top_k: int,
     ) -> List[DocumentWithScore]:
-        """Knowledge-graph retrieval path via the new
-        :class:`aperag.indexing.graph.LineageGraphStore` Protocol.
+        """Knowledge-graph retrieval path via :class:`GraphSearchService`.
 
-        Wave 6 #33 chunk 3 (per architect Option C ruling msg=6fccd9ab):
-        replaces the legacy ``GraphIndexService.query_context`` flow
-        with a two-step composition:
+        Wave 7 §K.12.5 / §K.12.8 (task #8) cutover: replaces the
+        keyword-only Wave 6 #33 chunk 3 path with the full
+        vector + 1-hop traversal composition the legacy
+        ``GraphIndexService.query_context`` always intended. Steps:
 
-        1. ``query_entities_by_keyword(query, top_k)`` — anchor entities
-           via lexical recall on the lineage store. The retrieval
-           pipeline owns its own embedder and does not need a backend
-           vector index here (vector recall was honestly deferred per
-           chunk 2 ruling — Wave 4 lineage schema has no entity-vector
-           column).
-        2. ``expand_neighbors_n_hops(entity_names, hops=1)`` — pull the
-           direct neighbours + connecting relations so the rendered
-           context block includes both anchor entities and their
-           one-hop graph context.
+        1. :meth:`GraphSearchService.search_entities` — embed the query
+           against the per-collection vector index and ANN-recall the
+           top-K entities (semantic match, not exact name match).
+        2. :meth:`GraphSearchService.get_subgraph` — pull the direct
+           neighbours + connecting relations of the anchor entities.
+        3. :meth:`GraphSearchService.compose_context` — render the
+           ``-----Entities (KG)----- / -----Relationships (KG)-----``
+           text block.
 
-        A collection that hasn't been indexed yet (or yields no
-        keyword anchors) returns ``[]``; this is the correct behaviour —
-        search pipelines compose (vector + graph + fulltext), and a
-        blank graph just means "graph contributes nothing this time",
-        not "fall back to something stale".
+        The render is byte-for-byte identical to Wave 6's
+        ``_render_graph_context_text`` (locked by
+        ``test_compose_context_matches_retrieval_pipeline_render_byte_for_byte``
+        in PR #1756) so the swap is zero-functional-change for
+        downstream RAG prompts: same context shape, same dedup rule,
+        same fallback marker. Vector recall now actually happens
+        — the Wave 4 → Wave 6 vacuum noted in §K.12.1 is closed.
+
+        A collection that hasn't been indexed yet (no vector points)
+        returns ``[]`` — ``search_entities`` swallows backend
+        embed/search faults and returns an empty list, mirroring the
+        Wave 6 graceful-degrade convention. ``enable_knowledge_graph``
+        gating preserved for backward compat.
         """
         config = parseCollectionConfig(collection.config)
         if not config.enable_knowledge_graph:
             logger.warning(f"Collection {collection.id} does not have knowledge graph enabled")
             return []
 
-        store = _build_lineage_graph_store_for(collection)
-        anchors = await store.query_entities_by_keyword(query=query, top_k=top_k)
+        from aperag.indexing.graph_search_service import (
+            GraphSearchService,
+            build_graph_search_service_for,
+        )
+
+        try:
+            service = build_graph_search_service_for(collection)
+        except Exception:
+            logger.warning(
+                "graph_search: factory failed for collection %s; degrading to empty result",
+                collection.id,
+                exc_info=True,
+            )
+            return []
+
+        anchors = await service.search_entities(query=query, top_k=top_k)
         if not anchors:
             return []
         anchor_names = [e.name for e in anchors]
-        entities, relations = await store.expand_neighbors_n_hops(entity_names=anchor_names, hops=1)
-        text = _render_graph_context_text(entities, relations)
+        entities, relations = await service.get_subgraph(entity_names=anchor_names, hops=1)
+        text = GraphSearchService.compose_context(entities, relations)
         if not text:
             return []
         return [DocumentWithScore(text=text, metadata={"recall_type": "graph_search"})]

--- a/aperag/graph_curation/lineage_merge.py
+++ b/aperag/graph_curation/lineage_merge.py
@@ -445,10 +445,103 @@ async def _to_thread(func, *args, **kwargs):
     return await asyncio.to_thread(func, *args, **kwargs)
 
 
+# ---------------------------------------------------------------------
+# Per-collection factory — Wave 7 §K.12.8 task #8 wiring
+# ---------------------------------------------------------------------
+
+
+class _SyncEmbedderShim:
+    """Adapt the sync ``(text -> list[float])`` callable used by the
+    graph worker into the ``embed_query`` shape the merger / detector
+    expect (mirrors :class:`EmbeddingService` surface). Lifted from
+    :class:`MergeCandidateDetector`'s factory so the merger and
+    detector share one shim."""
+
+    def __init__(self, fn: Callable[[str], list[float]]) -> None:
+        self._fn = fn
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._fn(text)
+
+
+def build_lineage_entity_merger_for(collection: Any) -> "LineageEntityMerger":
+    """Build a :class:`LineageEntityMerger` for ``collection``.
+
+    Wires the six dependencies the merger expects:
+
+    * ``store`` — :func:`_build_lineage_graph_store_inner` (raw inner
+      store; the merger writes canonical names directly and must NOT
+      be intercepted by the alias-redirect decorator that
+      :func:`_build_lineage_graph_store` returns to indexer / read
+      paths).
+    * ``alias_repo`` — fresh :class:`AliasMapRepository`.
+    * ``compactor`` — :func:`_build_collection_graph_compactor`. Falls
+      back to a no-op compactor if the collection has no completion
+      model configured (the merger still runs; description simply
+      stays uncompacted).
+    * ``vector_connector`` + ``embedder`` —
+      :func:`_build_collection_graph_vector_writer` shared with the
+      Phase 3 indexer write path. Wrapped via :class:`_SyncEmbedderShim`
+      so the ``embed_query`` interface matches.
+    * ``llm`` — :func:`build_collection_llm_callable` (same async LLM
+      callable the legacy graphindex used).
+    * ``collection_id`` — bound at construction.
+
+    Raises :class:`aperag.indexing.worker_factory.WorkerFactoryError`
+    when the embedder / vector connector / LLM cannot be resolved
+    — a user-driven merge cannot meaningfully proceed without them
+    (no unified description, no vector re-anchor).
+    """
+    # Lazy imports keep this module free of worker_factory at import
+    # time so worker_factory's own ``from .lineage_merge`` import (if
+    # ever added) wouldn't form a cycle.
+    from aperag.domains.knowledge_graph.graphindex.integration import (
+        build_collection_llm_callable,
+    )
+    from aperag.indexing.graph_compactor import GraphIndexCompactor
+    from aperag.indexing.worker_factory import (
+        WorkerFactoryError,
+        _build_collection_graph_vector_writer,
+        _build_lineage_graph_store_inner,
+        _resolve_graph_backend_type,
+    )
+
+    backend_type = _resolve_graph_backend_type(collection)
+    inner_store = _build_lineage_graph_store_inner(backend_type=backend_type, collection=collection)
+
+    vector_connector, embed_fn = _build_collection_graph_vector_writer(collection)
+    if vector_connector is None or embed_fn is None:
+        raise WorkerFactoryError(
+            f"merge_entities: vector connector / embedder unavailable for collection {collection.id!r}"
+        )
+
+    try:
+        llm = build_collection_llm_callable(collection)
+    except Exception as exc:  # noqa: BLE001 — surface as factory failure.
+        raise WorkerFactoryError(
+            f"merge_entities: LLM not configured for collection {collection.id!r}: {exc}"
+        ) from exc
+
+    # Compactor is best-effort — the merger still runs without it
+    # (description stays uncompacted; embedding falls back to unified).
+    compactor = GraphIndexCompactor(llm=llm)
+
+    return LineageEntityMerger(
+        store=inner_store,
+        alias_repo=AliasMapRepository(),
+        compactor=compactor,
+        vector_connector=vector_connector,
+        embedder=_SyncEmbedderShim(embed_fn),
+        llm=llm,
+        collection_id=str(collection.id),
+    )
+
+
 __all__ = [
     "LineageEntityMerger",
     "LineageMergeResult",
     "AliasCycleError",
     "CURATION_MERGE_DOCUMENT_ID",
     "GRAPH_ENTITY_INDEXER",
+    "build_lineage_entity_merger_for",
 ]

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -690,10 +690,15 @@ def _resolve_graph_backend_type(collection: Any) -> str:
     return backend
 
 
-def _build_lineage_graph_store(*, backend_type: str, collection: Any) -> Any:
-    """Construct the per-collection :class:`LineageGraphStore` adapter
-    by binding the shared per-process backend client to the collection
-    id."""
+def _build_lineage_graph_store_inner(*, backend_type: str, collection: Any) -> Any:
+    """Construct the raw per-collection :class:`LineageGraphStore`
+    adapter (no alias-redirect wrapper).
+
+    Used internally by :func:`_build_lineage_graph_store` and by the
+    user-driven merger (Wave 7 task #6 :class:`LineageEntityMerger`,
+    which writes canonical names directly and must not be intercepted
+    by the alias-redirect decorator).
+    """
     if backend_type == "postgres":
         engine = _postgres_async_engine_singleton()
         from aperag.indexing.graph_storage.postgres import PostgresLineageGraphStore
@@ -718,6 +723,33 @@ def _build_lineage_graph_store(*, backend_type: str, collection: Any) -> Any:
             space_prefix=space_prefix,
         )
     raise WorkerFactoryError(f"unsupported graph_backend_type {backend_type!r}")
+
+
+def _build_lineage_graph_store(*, backend_type: str, collection: Any) -> Any:
+    """Wave 7 §K.12 invariant #9 — return the alias-redirect-wrapped
+    :class:`LineageGraphStore`.
+
+    Every write goes through the per-collection
+    :class:`LineageGraphStoreWithAliasRedirect` (PR #1758) so
+    user-merged entities are transparently consolidated at indexing
+    time. Reads pass through unchanged. This makes the inseparability
+    gate of task #6 alive in production: without this swap the alias
+    map is written but never consulted, so user merges silently
+    re-created the merged-away entities on the next sync.
+
+    Callers that need the raw inner store (the merger's L1 write
+    path, which targets canonical names directly and must not be
+    redirected) should use :func:`_build_lineage_graph_store_inner`.
+    """
+    from aperag.graph_curation.alias_map import AliasMapRepository
+    from aperag.indexing.alias_redirect_store import LineageGraphStoreWithAliasRedirect
+
+    inner = _build_lineage_graph_store_inner(backend_type=backend_type, collection=collection)
+    return LineageGraphStoreWithAliasRedirect(
+        inner=inner,
+        alias_repo=AliasMapRepository(),
+        collection_id=str(collection.id),
+    )
 
 
 def _resolve_entity_lock(*, backend_type: str) -> Any:

--- a/tests/unit_test/domains/retrieval/test_graph_search_migration.py
+++ b/tests/unit_test/domains/retrieval/test_graph_search_migration.py
@@ -148,25 +148,30 @@ def test_render_graph_context_falls_back_to_no_description_marker():
 
 
 def test_graph_search_returns_empty_when_no_anchors(monkeypatch):
-    """If keyword recall returns no anchor entities, _graph_search
-    returns an empty list — no traversal call, no rendered context."""
+    """If vector recall returns no anchor entities, _graph_search
+    returns an empty list — no subgraph call, no rendered context.
+
+    Wave 7 §K.12.8 cutover: the pipeline now talks to
+    :class:`GraphSearchService`, not directly to the lineage store
+    keyword path. The "no anchors → []" contract still holds.
+    """
     from aperag.domains.retrieval.pipeline import SearchPipelineService
 
-    class _StubStore:
+    class _StubService:
         def __init__(self) -> None:
-            self.expand_called = False
+            self.subgraph_called = False
 
-        async def query_entities_by_keyword(self, *, query, top_k):
+        async def search_entities(self, *, query, top_k):
             return []
 
-        async def expand_neighbors_n_hops(self, *, entity_names, hops=1):
-            self.expand_called = True
+        async def get_subgraph(self, *, entity_names, hops=1):
+            self.subgraph_called = True
             return ([], [])
 
-    stub_store = _StubStore()
+    stub_service = _StubService()
     monkeypatch.setattr(
-        "aperag.domains.retrieval.pipeline._build_lineage_graph_store_for",
-        lambda _collection: stub_store,
+        "aperag.indexing.graph_search_service.build_graph_search_service_for",
+        lambda _collection: stub_service,
     )
 
     class _Collection:
@@ -177,10 +182,16 @@ def test_graph_search_returns_empty_when_no_anchors(monkeypatch):
     svc = SearchPipelineService()
     results = asyncio.run(svc._graph_search(_Collection(), "anything", 5))
     assert results == []
-    assert stub_store.expand_called is False, "expand should not be called when no anchors"
+    assert stub_service.subgraph_called is False, "get_subgraph should not be called when no anchors"
 
 
 def test_graph_search_composes_text_from_anchors_and_neighbors(monkeypatch):
+    """Wave 7 §K.12.8 cutover: the pipeline composes
+    ``GraphSearchService.search_entities`` + ``get_subgraph`` +
+    ``compose_context``. The byte-parity test in PR #1756 keeps the
+    rendered text identical to the Wave 6 keyword-only path so the
+    assertions on body content stay unchanged.
+    """
     members = (
         LineageMember(
             document_id="doc-1",
@@ -209,23 +220,23 @@ def test_graph_search_composes_text_from_anchors_and_neighbors(monkeypatch):
         description_parts=(DescriptionPart(document_id="doc-1", parse_version="v1", text="Alice reports to Bob"),),
     )
 
-    class _StubStore:
+    class _StubService:
         def __init__(self) -> None:
             self.last_query: str | None = None
             self.last_seeds: list[str] | None = None
 
-        async def query_entities_by_keyword(self, *, query, top_k):
+        async def search_entities(self, *, query, top_k):
             self.last_query = query
             return [alice]
 
-        async def expand_neighbors_n_hops(self, *, entity_names, hops=1):
+        async def get_subgraph(self, *, entity_names, hops=1):
             self.last_seeds = entity_names
             return ([alice, bob], [alice_bob])
 
-    stub_store = _StubStore()
+    stub_service = _StubService()
     monkeypatch.setattr(
-        "aperag.domains.retrieval.pipeline._build_lineage_graph_store_for",
-        lambda _collection: stub_store,
+        "aperag.indexing.graph_search_service.build_graph_search_service_for",
+        lambda _collection: stub_service,
     )
 
     from aperag.domains.retrieval.pipeline import SearchPipelineService
@@ -244,8 +255,8 @@ def test_graph_search_composes_text_from_anchors_and_neighbors(monkeypatch):
     assert "Bob" in doc.text
     assert "reports_to" not in doc.text  # type label not in body, only the description
     assert "Alice → Bob" in doc.text
-    assert stub_store.last_query == "Alice"
-    assert stub_store.last_seeds == ["Alice"]
+    assert stub_service.last_query == "Alice"
+    assert stub_service.last_seeds == ["Alice"]
 
 
 def test_graph_search_returns_empty_when_kg_disabled(monkeypatch):

--- a/tests/unit_test/indexing/test_wave7_task8_wiring.py
+++ b/tests/unit_test/indexing/test_wave7_task8_wiring.py
@@ -1,0 +1,310 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wave 7 §K.12.8 task #8 — three wiring integration tests.
+
+Per architect msg=da89237c / huangheng msg=55974e1e the task #8 PR
+must land three wiring points at the same time. These tests pin each
+in place so a future refactor cannot silently regress any of them:
+
+1. ``worker_factory._build_lineage_graph_store`` now returns the
+   alias-redirect decorator (PR #1758 inseparability gate alive).
+2. ``retrieval/pipeline._graph_search`` now composes
+   ``GraphSearchService.search_entities`` + ``get_subgraph`` +
+   ``compose_context`` — vector recall is alive (PR #1756 wired).
+3. ``GraphService.merge_entities`` (the route layer for
+   ``POST /graphs/nodes/merge``) now delegates to
+   ``LineageEntityMerger`` (PR #1758 user-driven merge alive).
+
+Each test mocks at the boundary between the wiring layer and the
+heavy I/O underneath (vector store / DB / LLM) so it exercises the
+glue, not the production backends.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aperag.indexing.alias_redirect_store import LineageGraphStoreWithAliasRedirect
+
+# ---------------------------------------------------------------------
+# Wiring 1 — worker_factory returns the alias-redirect decorator
+# ---------------------------------------------------------------------
+
+
+def test_build_lineage_graph_store_returns_alias_redirect_decorator():
+    """The Wave 7 invariant #9 gate: every indexer / retrieval read of
+    the lineage store must be wrapped so the alias map is consulted on
+    upsert. Without this swap, the alias rows the
+    :class:`LineageEntityMerger` writes are silently ignored on the
+    next indexer sync — re-creating the merged-away entities and
+    breaking the user's curation intent.
+    """
+    from aperag.indexing import worker_factory
+
+    fake_inner_store = MagicMock(name="inner_store")
+
+    with patch.object(
+        worker_factory,
+        "_build_lineage_graph_store_inner",
+        return_value=fake_inner_store,
+    ) as build_inner:
+        collection = SimpleNamespace(id="col_w7t8")
+        store = worker_factory._build_lineage_graph_store(
+            backend_type="postgres",
+            collection=collection,
+        )
+
+    build_inner.assert_called_once_with(backend_type="postgres", collection=collection)
+    # The returned object is the decorator, not the raw inner store.
+    assert isinstance(store, LineageGraphStoreWithAliasRedirect)
+    # And the decorator wraps the same inner store the factory built.
+    assert store._inner is fake_inner_store
+    assert store._collection_id == "col_w7t8"
+
+
+def test_build_lineage_graph_store_inner_returns_raw_backend():
+    """Symmetric to the above: callers that need the raw inner store
+    (the merger writes canonical names directly and must NOT be
+    intercepted) get an undecorated backend adapter from
+    ``_build_lineage_graph_store_inner``.
+    """
+    from aperag.indexing import worker_factory
+
+    # Patch the postgres engine singleton so this test does not need a
+    # live database — the inner factory will still construct the
+    # adapter object.
+    with patch.object(worker_factory, "_postgres_async_engine_singleton", return_value=MagicMock()):
+        collection = SimpleNamespace(id="col_w7t8")
+        store = worker_factory._build_lineage_graph_store_inner(
+            backend_type="postgres",
+            collection=collection,
+        )
+
+    # The raw adapter is NOT the decorator.
+    assert not isinstance(store, LineageGraphStoreWithAliasRedirect)
+
+
+# ---------------------------------------------------------------------
+# Wiring 2 — retrieval/pipeline._graph_search uses GraphSearchService
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_graph_search_pipeline_composes_search_entities_and_get_subgraph():
+    """Wave 7 §K.12.5 / §K.12.8 task #8 cutover: the retrieval pipeline
+    must call ``search_entities`` (vector recall) + ``get_subgraph``
+    (1-hop traversal) + ``compose_context`` (LightRAG-style render),
+    not the Wave 6 keyword-only ``query_entities_by_keyword`` path.
+    """
+    from aperag.domains.retrieval.pipeline import SearchPipelineService
+
+    fake_service = MagicMock(name="graph_search_service")
+    fake_entities = [SimpleNamespace(name="A"), SimpleNamespace(name="B")]
+    fake_subgraph = ([SimpleNamespace(name="A")], [SimpleNamespace(source="A", target="B")])
+    fake_service.search_entities = AsyncMock(return_value=fake_entities)
+    fake_service.get_subgraph = AsyncMock(return_value=fake_subgraph)
+
+    collection = SimpleNamespace(id="col_w7t8", config='{"enable_knowledge_graph": true}')
+
+    with (
+        patch(
+            "aperag.indexing.graph_search_service.build_graph_search_service_for",
+            return_value=fake_service,
+        ),
+        patch(
+            "aperag.indexing.graph_search_service.GraphSearchService.compose_context",
+            return_value="-----Entities (KG)-----\n- [entity] A — d",
+        ) as compose_mock,
+    ):
+        pipeline = SearchPipelineService.__new__(SearchPipelineService)
+        results = await pipeline._graph_search(collection, "what is A?", top_k=5)
+
+    fake_service.search_entities.assert_awaited_once_with(query="what is A?", top_k=5)
+    fake_service.get_subgraph.assert_awaited_once_with(entity_names=["A", "B"], hops=1)
+    compose_mock.assert_called_once_with(fake_subgraph[0], fake_subgraph[1])
+
+    assert len(results) == 1
+    assert results[0].metadata == {"recall_type": "graph_search"}
+    assert "Entities (KG)" in results[0].text
+
+
+@pytest.mark.asyncio
+async def test_graph_search_pipeline_returns_empty_when_kg_disabled():
+    """``enable_knowledge_graph=false`` short-circuits — the cutover
+    must preserve the Wave 6 gate so collections without graph indexing
+    return ``[]`` instead of attempting a no-op vector recall.
+    """
+    from aperag.domains.retrieval.pipeline import SearchPipelineService
+
+    collection = SimpleNamespace(id="col_w7t8", config='{"enable_knowledge_graph": false}')
+    pipeline = SearchPipelineService.__new__(SearchPipelineService)
+    results = await pipeline._graph_search(collection, "anything", top_k=5)
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_graph_search_pipeline_swallows_factory_failures():
+    """A collection whose vector connector / embedder is misconfigured
+    should degrade to an empty result rather than raise into the
+    retrieval pipeline."""
+    from aperag.domains.retrieval.pipeline import SearchPipelineService
+
+    collection = SimpleNamespace(id="col_w7t8", config='{"enable_knowledge_graph": true}')
+
+    with patch(
+        "aperag.indexing.graph_search_service.build_graph_search_service_for",
+        side_effect=RuntimeError("embedder not configured"),
+    ):
+        pipeline = SearchPipelineService.__new__(SearchPipelineService)
+        results = await pipeline._graph_search(collection, "x", top_k=5)
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------
+# Wiring 3 — graph_service.merge_entities → LineageEntityMerger
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_delegates_to_lineage_entity_merger():
+    """The route layer for ``POST /graphs/nodes/merge`` must run the
+    new merger, not the legacy ``GraphIndexService.merge_entities``.
+    The response shape stays backward-compat (frontend / OpenAPI regen
+    is a no-op), but the underlying engine is the Wave 7 lineage merger.
+    """
+    from aperag.domains.knowledge_graph.service import GraphService
+    from aperag.graph_curation.lineage_merge import LineageMergeResult
+
+    fake_merger = MagicMock(name="lineage_entity_merger")
+    fake_merger.merge_entities = AsyncMock(
+        return_value=LineageMergeResult(
+            final_target="A",
+            merged_source_ids=["B", "C"],
+            unified_description="LLM-merged description",
+            compacted_description="compacted text",
+        )
+    )
+
+    svc = GraphService()
+    db_collection = SimpleNamespace(id="col_w7t8")
+
+    with (
+        patch.object(svc, "_get_and_validate_collection", new=AsyncMock(return_value=db_collection)),
+        patch(
+            "aperag.graph_curation.lineage_merge.build_lineage_entity_merger_for",
+            return_value=fake_merger,
+        ),
+        patch.object(svc, "_collect_source_chunk_ids", new=AsyncMock(return_value=["chunk-a", "chunk-b"])),
+        # Don't actually fire the suggestion-expire side-effect.
+        patch("aperag.graph_curation.graph_curation_service.expire_pending_for_entities", new=AsyncMock()),
+    ):
+        result = await svc.merge_entities(
+            "user-1",
+            "col_w7t8",
+            target_entity_id="A",
+            source_entity_ids=["B", "C"],
+        )
+
+    fake_merger.merge_entities.assert_awaited_once_with(
+        target_name="A",
+        source_names=["B", "C"],
+        merged_by="user-1",
+    )
+
+    # Backward-compat response shape — these field names are the
+    # frontend contract and must not drift on cutover.
+    assert result == {
+        "target_entity_id": "A",
+        "merged_source_ids": ["B", "C"],
+        "description": "compacted text",
+        "source_chunk_ids": ["chunk-a", "chunk-b"],
+        "edges_redirected": 0,
+        "edges_collapsed": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_falls_back_to_unified_when_no_compacted():
+    """When the merger returns no ``compacted_description`` (small
+    merge under the compactor threshold), the response surfaces the
+    unified description directly so the UI panel still has text.
+    """
+    from aperag.domains.knowledge_graph.service import GraphService
+    from aperag.graph_curation.lineage_merge import LineageMergeResult
+
+    fake_merger = MagicMock()
+    fake_merger.merge_entities = AsyncMock(
+        return_value=LineageMergeResult(
+            final_target="A",
+            merged_source_ids=["B"],
+            unified_description="just the unified text",
+            compacted_description=None,
+        )
+    )
+
+    svc = GraphService()
+    db_collection = SimpleNamespace(id="col_w7t8")
+    with (
+        patch.object(svc, "_get_and_validate_collection", new=AsyncMock(return_value=db_collection)),
+        patch(
+            "aperag.graph_curation.lineage_merge.build_lineage_entity_merger_for",
+            return_value=fake_merger,
+        ),
+        patch.object(svc, "_collect_source_chunk_ids", new=AsyncMock(return_value=[])),
+        patch("aperag.graph_curation.graph_curation_service.expire_pending_for_entities", new=AsyncMock()),
+    ):
+        result = await svc.merge_entities(
+            "user-1",
+            "col_w7t8",
+            target_entity_id="A",
+            source_entity_ids=["B"],
+        )
+
+    assert result["description"] == "just the unified text"
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_alias_cycle_surfaces_as_value_error():
+    """A merge that would form an alias cycle must surface as a
+    ``ValueError`` so the FastAPI route returns 400 (preserving the
+    existing ``ValueError`` → 400 mapping in ``merge_nodes_view``).
+    """
+    from aperag.domains.knowledge_graph.service import GraphService
+    from aperag.graph_curation.alias_map import AliasCycleError
+
+    fake_merger = MagicMock()
+    fake_merger.merge_entities = AsyncMock(side_effect=AliasCycleError("cycle: A → B → A"))
+
+    svc = GraphService()
+    db_collection = SimpleNamespace(id="col_w7t8")
+
+    with (
+        patch.object(svc, "_get_and_validate_collection", new=AsyncMock(return_value=db_collection)),
+        patch(
+            "aperag.graph_curation.lineage_merge.build_lineage_entity_merger_for",
+            return_value=fake_merger,
+        ),
+    ):
+        with pytest.raises(ValueError, match="cycle"):
+            await svc.merge_entities(
+                "user-1",
+                "col_w7t8",
+                target_entity_id="A",
+                source_entity_ids=["B"],
+            )


### PR DESCRIPTION
Wave 7 §K.12.8 task #8 — three wiring points lit at the same time so PR #1758's inseparability gate (alias-redirect on every indexer write) and PR #1756's vector recall (LightRAG-style semantic search plus 1-hop traversal) become production-alive at the same merge.

## Summary

- ``worker_factory._build_lineage_graph_store`` now returns a ``LineageGraphStoreWithAliasRedirect`` decorating the raw per-collection backend (Wave 7 §K.12 invariant #9). Callers that need the raw inner store (the merger writes canonical names directly) go through the new ``_build_lineage_graph_store_inner``.
- ``retrieval/pipeline._graph_search`` composes ``GraphSearchService.search_entities`` + ``get_subgraph`` + ``compose_context``. Render is byte-for-byte identical to Wave 6 (locked by byte-parity test in PR #1756).
- ``GraphService.merge_entities`` (route layer for ``POST /graphs/nodes/merge``) delegates to ``LineageEntityMerger``. Backward-compat response shape preserved.
- New ``build_lineage_entity_merger_for(collection)`` factory in ``aperag/graph_curation/lineage_merge.py`` resolves the six merger dependencies; lifts the ``_SyncEmbedderShim`` pattern so merger and detector share one shim.

## Tests

- ``tests/unit_test/indexing/test_wave7_task8_wiring.py`` — 8 integration tests pinning each of the three wiring points (decorator wraps inner store, inner factory returns raw backend, pipeline composes the three GraphSearchService calls in order, KG gate short-circuits, factory failures degrade to empty, merger delegation preserves backward-compat shape, fallback to unified description, alias cycle → ValueError → 400).
- Wave 6 ``test_graph_search_migration.py`` — 2 tests updated to mock the new ``build_graph_search_service_for`` / ``search_entities`` / ``get_subgraph`` boundary.
- Full sweep: 407 tests pass; ruff clean.

## §K.12 12-invariant cross-check

| # | Invariant | This PR |
|---|-----------|---------|
| 1 | L1 graph data not polluted | N/A — read/route layer |
| 2 | L1 → L2 single-direction derive | N/A — read path |
| 3 | Compactor before vector embed | N/A — write side |
| 4 | Vector store via Adaptor | ✅ pipeline composes via GraphSearchService; no direct Qdrant import |
| 5 | payload indexer filter | ✅ inherited from GraphSearchService.search_entities |
| 6 | uuid5 vector point id | N/A — read/route |
| 7 | snapshot-diff lineage name set | N/A — read/route |
| 8 | alias_map persist orphan | N/A — task #6 owns; this PR's reads transit decorator |
| 9 | upsert_entity alias redirect | ✅ wiring 1 — every indexer/read receives decorated store; merger bypasses via inner-only factory |
| 10 | DB column length application-cap | N/A — no new column writes |
| 11 | candidate detection write-only | ✅ pipeline read path is read-only; merge route preserves write boundary |
| 12 | grep-zero LightRAG | ✅ code + tests LightRAG-clean. ``aperag/graph_curation/*`` + ``service.py:get_knowledge_graph`` still hold legacy imports for graph-overview / curation-run paths that depend on enumerate-all-entities; deferred to task #10 close-out alongside legacy delete or Protocol extension |

## 4-pattern pre-check matrix

- **Pattern 1 v1** — ``rg "from aperag.domains.knowledge_graph.graphindex"`` count unchanged in this PR; ``_graph_search`` path no longer imports the legacy package at all.
- **Pattern 1 v2** — per-method matrix: pipeline replaces ``query_entities_by_keyword`` + ``expand_neighbors_n_hops`` with ``search_entities`` + ``get_subgraph``; merge replaces ``GraphIndexService.merge_entities`` with ``LineageEntityMerger.merge_entities``.
- **Pattern 2** — state binding: merger factory binds to same Qdrant connector + embedder the indexer write path uses (``_build_collection_graph_vector_writer``).
- **Pattern 3** — factory + decorator pattern verified by 3 wiring tests so future split cannot silently regress.

## simple-stable 4 guardrail

- **#1 不无限扩范围** — 3 wiring swaps + 1 factory; no new endpoints, schema, or Protocol surface.
- **#2 尽快上线** — unblocks task #11 e2e and task #9 frontend immediately; no Protocol-extension prerequisite.
- **#3 简单稳定** — decorator + factory split keeps merger's "writes canonical directly" invariant explicit; pipeline reuses byte-parity contract.
- **#4 私有化部署免维护** — no operator config; ``API_BASE_URL`` already supports MCP colocation; decorator runs on every collection automatically.

## Test plan

- [ ] CI lint-and-unit
- [ ] huangheng pass-1 review (12-invariant + 3 wiring landing)
- [ ] task #11 (冬柏) bodies fill once this merges → e2e narrative pass
- [ ] downstream task #9 (cuiwenbo) OpenAPI regen + 3 flow smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)