### PR TITLE
test(w7-task#10): grep-zero verification helper for legacy graphindex elimination

### DIFF
--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -343,9 +343,7 @@ class GraphService:
 
         db_collection = await self._get_and_validate_collection(user_id, collection_id)
         backend_type = _resolve_graph_backend_type(db_collection)
-        store = await asyncio.to_thread(
-            _build_lineage_graph_store, backend_type=backend_type, collection=db_collection
-        )
+        store = await asyncio.to_thread(_build_lineage_graph_store, backend_type=backend_type, collection=db_collection)
         entity = await store.get_entity(entity_name)
         if entity is None:
             return None

--- a/aperag/graph_curation/lineage_merge.py
+++ b/aperag/graph_curation/lineage_merge.py
@@ -518,9 +518,7 @@ def build_lineage_entity_merger_for(collection: Any) -> "LineageEntityMerger":
     try:
         llm = build_collection_llm_callable(collection)
     except Exception as exc:  # noqa: BLE001 — surface as factory failure.
-        raise WorkerFactoryError(
-            f"merge_entities: LLM not configured for collection {collection.id!r}: {exc}"
-        ) from exc
+        raise WorkerFactoryError(f"merge_entities: LLM not configured for collection {collection.id!r}: {exc}") from exc
 
     # Compactor is best-effort — the merger still runs without it
     # (description stays uncompacted; embedding falls back to unified).

--- a/aperag/mcp/server.py
+++ b/aperag/mcp/server.py
@@ -567,11 +567,6 @@ def get_api_key() -> str:
 # existing ``aperag.mcp.server.web_search`` access path for backward
 # compatibility with callers (e.g. ``tests/unit_test/test_mcp_server.py``)
 # that read attributes off the server module directly.
-from aperag.mcp.tools.search_fulltext import fulltext_search  # noqa: E402, F401
-from aperag.mcp.tools.search_graph import graph_search  # noqa: E402, F401
-from aperag.mcp.tools.search_vector import vector_search  # noqa: E402, F401
-from aperag.mcp.tools.search_web import web_search  # noqa: E402, F401
-
 # Wave 7 §K.12.6 — graph entity search / subgraph expand / detail.
 # Importing the module is what registers the three ``@mcp_server.tool``
 # decorators with the FastMCP instance above.
@@ -580,6 +575,10 @@ from aperag.mcp.tools.graph_tools import (  # noqa: E402, F401
     get_entity_detail,
     query_graph_entities,
 )
+from aperag.mcp.tools.search_fulltext import fulltext_search  # noqa: E402, F401
+from aperag.mcp.tools.search_graph import graph_search  # noqa: E402, F401
+from aperag.mcp.tools.search_vector import vector_search  # noqa: E402, F401
+from aperag.mcp.tools.search_web import web_search  # noqa: E402, F401
 
 # Export the server instance
 __all__ = ["mcp_server"]

--- a/tests/integration/test_w7_grep_zero_legacy_graphindex.py
+++ b/tests/integration/test_w7_grep_zero_legacy_graphindex.py
@@ -1,0 +1,302 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Wave 7 task #10 close-out — grep-zero verification helper.
+
+Per @Bryce's pre-check matrix (msg=11dd3b1b) + spec §K.12.10: once
+task #10 deletes the legacy ``aperag/domains/knowledge_graph/
+graphindex/`` package + drops the ``graphindex_*`` tables + cleans up
+the residual call sites, the repository must contain **zero** hits
+for a documented set of legacy patterns. This file pins those grep
+contracts as runnable assertions so:
+
+  * a future maintainer can `pytest` the close-out invariant locally;
+  * CI catches any accidental re-introduction (e.g. a copy-paste from
+    Wave-6-or-earlier docs / older branches);
+  * task #10's PR has a binary, automatable "did the cleanup land?"
+    gate beyond eyeballing 1000+ LOC of deletes.
+
+Layered the same way the Wave 7 task #11 narrative scaffold (PR #1760)
+is — module-level skip behind ``_TASK10_LEGACY_DELETED = False`` until
+task #10 actually deletes the package, at which point the flag flips
+True and these assertions become the close-out gate. Same PR that
+flips the flag (or a same-author follow-up) is responsible for ensuring
+all 10 patterns return 0.
+
+Patterns enumerated per @Bryce's task #10 plan + §K.12.10 spec:
+
+  1. ``from aperag.domains.knowledge_graph.graphindex`` — primary
+     legacy import surface. Production callers (6 files / 11 sites
+     per Bryce msg=11dd3b1b Pattern 1 v1) must all migrate.
+  2. ``graphindex_nodes`` / ``graphindex_edges`` — table names. After
+     alembic drop the only allowed mention is the migration script
+     itself (excluded via path filter).
+  3. ``import graphindex`` — bare ``import`` form (separate from
+     ``from ... import``).
+  4. ``_sync_entity_relation_vectors`` — Wave 6 vector-sync helper
+     superseded by GraphModalityWorker.sync() Phase 3 (W7-3).
+  5. ``_compact_oversized_descriptions`` — Wave 6 compactor entry
+     superseded by GraphCompactor (W7-2).
+  6. ``_summarize_description`` — Wave 6 summariser superseded by
+     LLM unified-description path inside GraphCompactor.
+  7. ``_fallback_truncate`` — Wave 6 fallback path superseded by
+     GraphCompactor's graceful-degrade branch (renamed inside the new
+     module — exception below allows the new name).
+  8. ``_delete_removed_shadow_vectors`` — Wave 6 shadow-vector
+     deletion superseded by Phase 3 snapshot-diff.
+  9. ``query_context`` — Wave 6 retrieval entry superseded by
+     ``GraphSearchService.compose_context`` (W7-5). Exception below
+     allows the new ``compose_context`` mention itself.
+ 10. ``merge_entities`` — Wave 6 legacy method must NOT remain on
+     ``GraphIndexService``; only allowed mention is on the new
+     ``GraphCurationService.merge_entities`` (W7-6).
+
+Each test runs the corresponding ``rg`` invocation and asserts that
+the matched-line count, after subtracting the documented exception
+paths, is 0.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------
+# Gate. Until task #10 deletes the legacy package, every test would
+# fail (because legacy code is intentionally still present). The flag
+# flips True in the same PR that lands task #10's deletes.
+# ---------------------------------------------------------------------
+
+_TASK10_LEGACY_DELETED = False  # flip True in the task #10 close-out
+# PR (Bryce). This file's contract: when the flag is True, every
+# pattern below MUST return 0 hits (modulo the documented exception
+# paths). When False, the file collects + skips so it never blocks
+# pre-#10 PRs.
+
+# Repository root, derived from this test file's location so the
+# subprocess invocations work whether pytest is run from the repo
+# root, the tests/ dir, or any other CWD.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _have_ripgrep() -> bool:
+    return shutil.which("rg") is not None
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _TASK10_LEGACY_DELETED,
+        reason=(
+            "task #10 (legacy graphindex package delete) has not landed yet; "
+            "grep-zero contract starts when the close-out PR flips "
+            "_TASK10_LEGACY_DELETED to True."
+        ),
+    ),
+    pytest.mark.skipif(
+        not _have_ripgrep(),
+        reason="ripgrep (rg) binary not on PATH — needed for the grep-zero contract.",
+    ),
+]
+
+
+def _rg_count(
+    pattern: str,
+    *,
+    extra_paths: list[str] | None = None,
+    exclude_globs: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
+) -> tuple[int, list[str]]:
+    """Run ``rg`` and return ``(line_count, matched_lines)``.
+
+    ``extra_paths`` (default: ``aperag/`` + ``tests/``) limits the
+    search root. ``exclude_globs`` is forwarded to ``rg --glob`` to
+    skip patterns like ``!**/migrations/**``. ``exclude_paths`` is a
+    post-filter applied to the matched lines (path-prefix or
+    substring match against the line) to drop documented exceptions
+    that ``--glob`` cannot express precisely.
+    """
+    paths = extra_paths or ["aperag", "tests"]
+    cmd: list[str] = ["rg", "--with-filename", "--line-number", "--no-heading", pattern]
+    for glob in exclude_globs or []:
+        cmd.extend(["--glob", glob])
+    cmd.extend(paths)
+
+    result = subprocess.run(
+        cmd,
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # rg exit code: 0 = matches found, 1 = no matches, 2 = error.
+    if result.returncode == 1:
+        return 0, []
+    if result.returncode != 0:
+        raise RuntimeError(f"rg failed for pattern {pattern!r}: stderr={result.stderr!r}")
+
+    lines = [line for line in result.stdout.splitlines() if line]
+    if exclude_paths:
+        kept = []
+        for line in lines:
+            if not any(exc in line for exc in exclude_paths):
+                kept.append(line)
+        lines = kept
+    return len(lines), lines
+
+
+def _assert_zero(
+    pattern: str,
+    *,
+    exclude_globs: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
+    note: str = "",
+) -> None:
+    count, hits = _rg_count(
+        pattern,
+        exclude_globs=exclude_globs,
+        exclude_paths=exclude_paths,
+    )
+    assert count == 0, (
+        f"Wave 7 task #10 grep-zero violated for pattern {pattern!r}.\n"
+        f"{note}\n"
+        f"Matches ({count}):\n  " + "\n  ".join(hits)
+    )
+
+
+# ---------------------------------------------------------------------
+# 10 grep-zero patterns. Each test names the pattern + the intended
+# Wave 7 successor so a maintainer hitting a failure knows where the
+# call should have moved to.
+# ---------------------------------------------------------------------
+
+
+def test_no_from_aperag_domains_knowledge_graph_graphindex_imports():
+    """Pattern 1 — primary legacy import surface. Per Bryce
+    msg=11dd3b1b Pattern 1 v1, 6 production files / 11 sites all
+    migrate during task #10."""
+    _assert_zero(
+        r"from aperag\.domains\.knowledge_graph\.graphindex",
+        note=(
+            "Migrate to one of the new Wave 7 surfaces: "
+            "GraphSearchService (retrieval reads), "
+            "GraphCurationService (user merges), "
+            "LineageEntityMerger (atomic merge orchestration), "
+            "or LineageGraphStore (write path)."
+        ),
+    )
+
+
+def test_no_graphindex_table_name_references():
+    """Pattern 2 — ``graphindex_nodes`` / ``graphindex_edges`` table
+    names. After the alembic drop in task #10's close-out migration,
+    the only place these names may appear is the migration script
+    itself."""
+    _assert_zero(
+        r"graphindex_(nodes|edges)",
+        exclude_globs=["!aperag/migration/**"],
+        note=(
+            "After task #10's alembic drop migration, no production "
+            "code may reference these table names. The migration "
+            "script itself is excluded."
+        ),
+    )
+
+
+def test_no_bare_import_graphindex():
+    """Pattern 3 — bare ``import graphindex`` form. Catches any
+    leftover module-level imports that the wider Pattern 1 v1 grep
+    would miss (e.g. ``import aperag.domains.knowledge_graph.graphindex``)."""
+    _assert_zero(
+        r"^\s*import\s+aperag\.domains\.knowledge_graph\.graphindex",
+        note=("Same migration targets as Pattern 1 — the bare import form is just a different code shape."),
+    )
+
+
+def test_no_legacy_sync_entity_relation_vectors():
+    """Pattern 4 — Wave 6 helper superseded by
+    GraphModalityWorker.sync() Phase 3 (W7-3, PR #1757)."""
+    _assert_zero(
+        r"_sync_entity_relation_vectors",
+        note="Use GraphModalityWorker.sync() Phase 3 (Wave 7 W7-3).",
+    )
+
+
+def test_no_legacy_compact_oversized_descriptions():
+    """Pattern 5 — Wave 6 compactor entry superseded by GraphCompactor
+    (W7-2)."""
+    _assert_zero(
+        r"_compact_oversized_descriptions",
+        note="Use GraphCompactor (Wave 7 W7-2).",
+    )
+
+
+def test_no_legacy_summarize_description():
+    """Pattern 6 — Wave 6 summariser superseded by the LLM unified-
+    description path inside GraphCompactor (W7-2)."""
+    _assert_zero(
+        r"_summarize_description",
+        note=("Use GraphCompactor's LLM unified-description path (Wave 7 W7-2)."),
+    )
+
+
+def test_no_legacy_fallback_truncate():
+    """Pattern 7 — Wave 6 fallback path superseded by
+    GraphCompactor's graceful-degrade branch. The new module may
+    expose a renamed helper; if so, document the new name as an
+    explicit allowed substring under ``exclude_paths``.
+
+    Today this is a strict zero — flip the exception list here only
+    if task #10 (or a follow-up) intentionally renames-and-keeps the
+    fallback under a new namespace."""
+    _assert_zero(
+        r"_fallback_truncate",
+        note=(
+            "Use GraphCompactor's graceful-degrade branch (Wave 7 "
+            "W7-2). If renamed-and-kept, add the new path to the "
+            "exception list."
+        ),
+    )
+
+
+def test_no_legacy_delete_removed_shadow_vectors():
+    """Pattern 8 — Wave 6 shadow-vector deletion superseded by Phase 3
+    snapshot-diff (W7-3)."""
+    _assert_zero(
+        r"_delete_removed_shadow_vectors",
+        note=("Use GraphModalityWorker.sync() Phase 3 snapshot-diff (Wave 7 W7-3)."),
+    )
+
+
+def test_no_legacy_query_context_except_compose_context():
+    """Pattern 9 — Wave 6 retrieval entry superseded by
+    ``GraphSearchService.compose_context``. The legacy method name
+    is ``query_context``; the new method is ``compose_context``. We
+    grep the old name explicitly so the new method's mention does
+    not need an exception."""
+    _assert_zero(
+        r"\bquery_context\b",
+        note=(
+            "Use GraphSearchService.compose_context (Wave 7 W7-5). "
+            "Note: the new method intentionally has a different name."
+        ),
+    )
+
+
+def test_no_legacy_merge_entities_on_graphindex():
+    """Pattern 10 — Wave 6 ``GraphIndexService.merge_entities`` must
+    NOT remain. The new home is ``GraphCurationService.merge_entities``
+    (W7-6) called via ``LineageEntityMerger`` (W7-6 chunk 2). Since
+    the new method shares the name, this grep targets the legacy
+    class binding only."""
+    _assert_zero(
+        r"GraphIndexService\.merge_entities",
+        note=("Use GraphCurationService.merge_entities via LineageEntityMerger (Wave 7 W7-6)."),
+    )

--- a/tests/unit_test/mcp/test_graph_tools.py
+++ b/tests/unit_test/mcp/test_graph_tools.py
@@ -56,9 +56,7 @@ def test_graph_tools_are_re_exported_on_server_module():
     """Importing ``aperag.mcp.server`` must register the 3 tools (the
     decorators run at module import time)."""
     for name in ("query_graph_entities", "expand_graph_subgraph", "get_entity_detail"):
-        assert hasattr(mcp_server_module, name), (
-            f"aperag.mcp.server must re-export {name} (decorator registration)."
-        )
+        assert hasattr(mcp_server_module, name), f"aperag.mcp.server must re-export {name} (decorator registration)."
 
 
 # --- 2. Signature locks ---------------------------------------------
@@ -69,11 +67,7 @@ def _params(func) -> dict[str, inspect.Parameter]:
 
 
 def _kw_only(func) -> set[str]:
-    return {
-        name
-        for name, p in inspect.signature(func).parameters.items()
-        if p.kind is inspect.Parameter.KEYWORD_ONLY
-    }
+    return {name for name, p in inspect.signature(func).parameters.items() if p.kind is inspect.Parameter.KEYWORD_ONLY}
 
 
 def test_query_graph_entities_signature():

--- a/tests/unit_test/service/test_graph_search_service_layer.py
+++ b/tests/unit_test/service/test_graph_search_service_layer.py
@@ -69,8 +69,7 @@ def _make_entity(
             for doc, ver, cs in chunks
         ),
         description_parts=tuple(
-            DescriptionPart(document_id=doc, parse_version=ver, text=text)
-            for doc, ver, text in parts
+            DescriptionPart(document_id=doc, parse_version=ver, text=text) for doc, ver, text in parts
         ),
         compacted_description=compacted,
     )


### PR DESCRIPTION
## Summary

Per @Bryce's task #10 pre-check matrix (msg=11dd3b1b) + @符炫炜's ratify: once task #10 deletes the legacy ``aperag/domains/knowledge_graph/graphindex/`` package + drops the ``graphindex_*`` tables + cleans up the residual call sites, the repository must contain **zero** hits for a documented set of legacy patterns. This PR ships those grep contracts as runnable assertions so task #10's close-out has a binary, automatable "did the cleanup land?" gate beyond eyeballing 1000+ LOC of deletes.

## Layered the same way as task #11 scaffold (PR #1760)

```python
_TASK10_LEGACY_DELETED = False  # flip True in the task #10 close-out PR
```

- File collects + skips cleanly today (legacy still exists pre-#10).
- Bryce's task #10 PR (or a same-author follow-up) flips the flag → all 10 assertions become the close-out gate.
- Second skipif gates on ``rg`` availability so this file doesn't introduce a tooling requirement on dev machines without ripgrep.

## 10 patterns covered

| # | Pattern | Wave 7 successor |
|---|---|---|
| 1 | ``from aperag.domains.knowledge_graph.graphindex`` | GraphSearchService / GraphCurationService / LineageEntityMerger / LineageGraphStore |
| 2 | ``graphindex_nodes`` / ``graphindex_edges`` (table names; migration excluded) | dropped in task #10's alembic migration |
| 3 | bare ``import graphindex`` | same as #1 |
| 4 | ``_sync_entity_relation_vectors`` | GraphModalityWorker.sync() Phase 3 (W7-3) |
| 5 | ``_compact_oversized_descriptions`` | GraphCompactor (W7-2) |
| 6 | ``_summarize_description`` | GraphCompactor's LLM unified-description path |
| 7 | ``_fallback_truncate`` | GraphCompactor's graceful-degrade branch |
| 8 | ``_delete_removed_shadow_vectors`` | Phase 3 snapshot-diff (W7-3) |
| 9 | ``query_context`` (Wave 6 name) | new method intentionally renamed ``compose_context`` |
| 10 | ``GraphIndexService.merge_entities`` (legacy class binding) | GraphCurationService.merge_entities via LineageEntityMerger (W7-6) |

Each assertion shows the matched lines on failure + names the intended Wave 7 successor so a maintainer hitting a regression knows where the call should have moved to.

## Bundled lint sweep

Same post-#1762/#1759 ruff-format drift on 5 files that pre-commit catches. Format-only, zero behavior change. Bundling here so the PR can land cleanly through the repo-wide ``make lint`` gate (alternative is a separate format-only PR for code that just merged, more PR overhead than value).

## Test plan

- [x] ``pytest tests/integration/test_w7_grep_zero_legacy_graphindex.py -v`` collects 10 tests; all skip cleanly (default state, pre-#10).
- [ ] Once task #10 lands the deletes + flips ``_TASK10_LEGACY_DELETED``: 10/10 tests must pass.

## Why draft

The flag-flip + green-run validation belongs to task #10's close-out PR. This is the helper file Bryce can pull into / rely on for that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)