### PR TITLE
fix(web Wave 8 #15): sweep schema-drift tsc errors surfaced by #1764 regen

### DIFF
--- a/web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
@@ -8,12 +8,9 @@ import _ from 'lodash';
 const getIndexStatusBg = (status?: DocumentIndexStatusType | null) => {
   const data: Record<DocumentIndexStatusType, string> = {
     ACTIVE: 'bg-green-500',
-    CREATING: 'bg-sky-500',
-    DELETING: 'bg-pink-500',
-    DELETION_IN_PROGRESS: 'bg-cyan-500',
+    RUNNING: 'bg-sky-500',
     FAILED: 'bg-red-500',
     PENDING: 'bg-amber-500',
-    SKIPPED: 'bg-gray-500',
   };
   return status ? data[status] : 'bg-gray-500';
 };

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
@@ -8,12 +8,9 @@ import _ from 'lodash';
 const getIndexStatusBg = (status?: DocumentIndexStatusType | null) => {
   const data: Record<DocumentIndexStatusType, string> = {
     ACTIVE: 'bg-green-500',
-    CREATING: 'bg-sky-500',
-    DELETING: 'bg-pink-500',
-    DELETION_IN_PROGRESS: 'bg-cyan-500',
+    RUNNING: 'bg-sky-500',
     FAILED: 'bg-red-500',
     PENDING: 'bg-amber-500',
-    SKIPPED: 'bg-gray-500',
   };
   return status ? data[status] : 'bg-gray-500';
 };

--- a/web/src/app/workspace/collections/collection-form.tsx
+++ b/web/src/app/workspace/collections/collection-form.tsx
@@ -76,6 +76,8 @@ const collectionSchema = z
       enable_summary: z.boolean(),
       enable_vector: z.boolean(),
       enable_vision: z.boolean(),
+      graph_backend_type: z.enum(['postgres', 'neo4j', 'nebula']).nullable(),
+      fulltext_backend_type: z.enum(['elasticsearch', 'opensearch']).nullable(),
       completion: collectionModelSchema,
       embedding: collectionModelSchema,
       language: z.enum(TITLE_LANGUAGES),
@@ -138,6 +140,8 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
       enable_vector: true,
       enable_summary: false,
       enable_vision: false,
+      graph_backend_type: null,
+      fulltext_backend_type: null,
       completion: {
         model_id: '',
         temperature: 0.1,


### PR DESCRIPTION
## Summary

Resolves the 4 tsc errors PR #1764 surfaced as W8-6 sediment: index-status badge color map (`document-index-status.tsx` × 2) realigned with the four-value `DocumentIndexStatus` enum (`PENDING/RUNNING/ACTIVE/FAILED`), and `collection-form.tsx` zod schema + `defaultValues` thread the new nullable backend-selection fields (`graph_backend_type`, `fulltext_backend_type`).

## §K.12 invariant cross-check

- **#4** (`VectorStoreConnectorAdaptor` abstraction) — n/a at the frontend layer, no provider lock-in introduced.
- **#11** (candidate detection write-only) — n/a, this PR does not touch the curation surface.
- **#12** (grep-zero LightRAG) — `rg -i lightrag web/src/` returns zero hits both before and after the sweep ✅.

## 4-pattern pre-check matrix

- **Pattern 1 v1** (legacy enum string literals in graph paths): `rg "CREATING|DELETING|DELETION_IN_PROGRESS|SKIPPED" web/src` shows zero remaining hits in the two files this PR touches. Outside this PR's scope, `documents-table.tsx` (`NON_TERMINAL_INDEX_STATUSES` Set) and unrelated `Document.status` paths still reference these literals — see Findings.
- **Pattern 1 v2** (form submission compatibility): the regenerated `web/src/api-v2/schema.d.ts` already declares both new fields as \`… | null\`, so passing `null` from the form keeps server validation green. Verified by re-running `yarn tsc --noEmit` → zero errors in `collection-form.tsx` after the schema fix.
- **Pattern 2** (response-shape change list): the form change is on the *request* shape only — `Collection.config` was already carrying these fields on the response side after #1764, the drift was that the form never threaded them.
- **Pattern 3** (additive helpers): n/a, the PR is purely additive fields + value-set narrowing.

## simple-stable directive 4-guardrail

- **#1 不无限扩范围** — strictly the two files named in the W8-6 task description. Did *not* extend to the `documents-table.tsx` Set or to other pre-existing tsc errors that pre-date Wave 7.
- **#2 尽快上线** — three small files, ~15 LOC of diff.
- **#3 简单稳定** — the field defaults match the implicit pre-W7 behavior (server picks default backend, color map maps every enum value). No new UI; no new validation.
- **#4 私有化部署免维护** — \`null\` values mean operators do not need to pre-provision backend pickers in the form before they can create a collection.

## Findings (out of scope, sediment)

1. **`documents-table.tsx`** defines a \`NON_TERMINAL_INDEX_STATUSES = new Set([...])\` whose members (\`CREATING\`, \`DELETING\`, \`DELETION_IN_PROGRESS\`) correspond to the retired enum. The Set is \`Set<string>\` so tsc does not flag it, but the polling logic that asks \"is any document still indexing?\" will silently never match — the actual non-terminal values today are \`PENDING\` and \`RUNNING\`. Worth a follow-up PR (separate scope: behavioural polling fix, not type drift).

2. **`yarn tsc --noEmit` still reports five pre-existing errors** in `app/page.tsx` (i18n template literal), `collection-header.tsx` (\`Record<CollectionStatus, …>\` indexing), `bot/types.ts` (\`ChatMessage\` / \`Reference\`), and `features/collection/types.ts` (\`Collection\`). These pre-date the Wave 7 regen — they are not in W8-6 scope and are a deeper feature-by-feature investigation (translation namespace, type-namespace re-exports).

## Test plan

- [x] `yarn tsc --noEmit` baseline on `origin/main` → 9 errors (4 in W8-6 scope + 5 pre-existing)
- [x] After this PR → 5 errors (zero in W8-6 scope; 5 pre-existing untouched, sedimented)
- [x] Diff is local: `git diff --stat` shows 3 files / +6 / -8
- [x] No new dependency, no new UI surface — pure type/value sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)