### PR TITLE
fix(web Wave 8 W8-8): documents-table polling stale enum strings

### DIFF
--- a/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
@@ -69,9 +69,7 @@ const NON_TERMINAL_DOCUMENT_STATUSES = new Set([
 
 const NON_TERMINAL_INDEX_STATUSES = new Set([
   'PENDING',
-  'CREATING',
-  'DELETING',
-  'DELETION_IN_PROGRESS',
+  'RUNNING',
 ]);
 
 const DOCUMENT_STATUS_CLASS: Record<string, string> = {


### PR DESCRIPTION
## Summary

Replace `NON_TERMINAL_INDEX_STATUSES` Set with the live four-value enum members so document polling actually identifies in-progress index work instead of silently never matching.

## Bug

`web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx` declared the Set as \`(PENDING, CREATING, DELETING, DELETION_IN_PROGRESS)\` — three of those four literals were retired when the backend simplified the per-modality index enum to \`(PENDING, RUNNING, ACTIVE, FAILED)\`. The Set is typed \`Set<string>\` so tsc never flagged the drift, but \`hasNonTerminalDocumentState\` would only ever match \`'PENDING'\` in practice; documents transitioning through the new \`'RUNNING'\` state were treated as terminal, so the table fell out of fast-poll mode while indexing was still active.

W8-8 sediment from PR #1766 (task #15) findings: type-drift fixed in #1766 is type-safe but did not catch behavior-drift hidden behind \`Set<string>\` / \`Array<string>\` literals. Architect msg=ec02b580 authorised this short-term follow-up at own cadence.

## §K.12 invariant cross-check

Largely n/a (frontend behavioral fix). Direct hit:
- **#12** (grep-zero LightRAG) — `rg -i lightrag web/src/` returns zero hits both before and after ✅.

## 4-pattern pre-check matrix

- **Pattern 1 v1** (legacy enum literals in this file): \`rg \"CREATING|DELETION_IN_PROGRESS\" documents-table.tsx\` returns zero. The remaining \`'DELETING'\` literal in the *other* Set (\`NON_TERMINAL_DOCUMENT_STATUSES\`, line 67) belongs to the separate eight-value \`Document.status\` enum (\`UPLOADED | EXPIRED | PENDING | RUNNING | COMPLETE | FAILED | DELETING | DELETED\`), which still includes \`DELETING\` — leave intact.
- **Pattern 1 v2** (consumers of the Set): only one call site, \`hasNonTerminalDocumentState\`, which polls based on Set membership; no other code reads the Set's contents directly.
- **Pattern 2** (response-shape change list): n/a, this PR does not touch any API surface or schema.
- **Pattern 3** (additive helpers): n/a, value-set narrowing only.

## simple-stable directive 4-guardrail

- **#1 不无限扩范围** — single-file two-string Set sweep, ~5 LOC diff. Did not extend to refactor the polling logic or re-derive the Set from the OpenAPI enum (future cleanup, not in scope for the immediate behavior fix).
- **#2 尽快上线** — small targeted fix, ~30 min after task #15 merge.
- **#3 简单稳定** — the Set now matches the live enum verbatim (\`PENDING\`, \`RUNNING\`); no fragile string-to-string mappings introduced.
- **#4 私有化部署免维护** — fix is invisible to operators; restores intended polling behaviour.

## Test plan

- [x] `yarn tsc --noEmit` shows the same 5 pre-existing errors as on main; no new errors introduced.
- [x] Static read: \`hasNonTerminalDocumentState\` Set membership now returns true for \`'PENDING'\` and \`'RUNNING'\` index states (the actual non-terminal states).
- [ ] Manual smoke (out of session env): create a fresh collection, upload a document, observe that \`documents-table\` stays in fast-poll while \`vector_index_status === 'RUNNING'\` instead of falling back to slow-poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)