### PR TITLE
feat(Wave 8 W8-3 #14): read-side alias resolution + flip task #11 trigger pin

### DIFF
--- a/aperag/indexing/alias_redirect_store.py
+++ b/aperag/indexing/alias_redirect_store.py
@@ -14,32 +14,60 @@
 
 """Lineage graph store decorator that applies user-driven alias redirect.
 
-Wave 7 §K.12.4 invariant #3: when the indexer writes
-``upsert_entity_with_lineage(record=EntityRecord(name="A"))`` and the
-user previously merged ``A → C``, the write should land on ``C``
-transparently — the indexer hot path is not aware of curation merges.
+Wave 7 §K.12.4 invariant #3 (write-side) + Wave 8 W8-3 (read-side):
+when the user has merged ``A → C``, every reference to ``A`` should
+silently resolve to ``C`` — both writes (indexer hot path) and reads
+(MCP / REST / curation surfaces).
 
-Implementation strategy (architect ratify msg=cf860ae4 + huangheng
-endorse msg=22816e0d / msg=93d9add1, **Option (b)**): write a thin
-decorator class that wraps any concrete
+Implementation strategy (architect ratify Wave 7 msg=cf860ae4 +
+huangheng endorse msg=22816e0d / msg=93d9add1, **Option (b)**): a
+thin decorator class wraps any concrete
 :class:`aperag.indexing.graph.LineageGraphStore` plus an
-:class:`aperag.graph_curation.alias_map.AliasMapRepository`, intercepts
-the write methods to rewrite entity names through the alias map, and
-forwards every other Protocol method unchanged. This keeps the three
-backend implementations (Postgres / Neo4j / Nebula) untouched —
-critical for landing task #6 in one PR without rippling into Bryce's
-storage territory.
+:class:`aperag.graph_curation.alias_map.AliasMapRepository`,
+intercepts the methods that take entity names as inputs (writes +
+direct reads + traversals seeded by entity names) and rewrites them
+through the alias map. Methods whose inputs aren't entity names
+(``query_entities_by_keyword``, ``list_entity_labels``,
+``find_*_with_lineage``) forward unchanged — they either operate on
+opaque tokens or already return canonical names.
+
+Read-side methods that DO redirect (Wave 8 task #14):
+
+* ``get_entity(name)`` — direct lookup by name.
+* ``get_relation(source, target, type)`` — both endpoints redirected
+  symmetrically (mirror :meth:`upsert_relation_with_lineage` write
+  redirect).
+* ``expand_neighbors_n_hops(entity_names, hops)`` — anchor names
+  redirected before traversal so an alias seed walks the canonical
+  neighbourhood.
+
+Read-side methods that do NOT redirect:
+
+* ``query_entities_by_keyword`` — keyword is not an entity name; the
+  matched rows are themselves canonical (alias rows live in
+  ``aperag_lineage_entity_alias``, not in the entity table).
+* ``list_entity_labels`` — returns a label set, not entity names.
+* ``find_entity_ids_with_lineage`` / ``find_relation_keys_with_lineage`` —
+  filter by ``document_id`` (lineage source), not by name.
+* ``gc_entity_if_orphan`` / ``gc_relation_if_orphan`` — gc operates on
+  the canonical row already; an alias name as input would no-op
+  silently (canonical row doesn't carry the alias as its name).
+* ``delete_entity`` / ``delete_relation`` — explicit user/admin
+  intent; redirecting would silently drop the canonical when the
+  caller asked for the alias. We surface ``False`` (no row deleted)
+  by passing through unchanged.
 
 Decorator passthrough invariant (huangheng CR lock,
 ``test_decorator_passthrough_for_non_upsert_methods``): every method
-declared on :class:`LineageGraphStore` that is NOT an ``upsert_*``
-write must forward to ``_inner`` byte-for-byte — no silent behaviour
-change. Tests pin this so a future Protocol method addition can't slip
-past without an explicit decorator update.
+declared on :class:`LineageGraphStore` that does NOT redirect must
+forward to ``_inner`` byte-for-byte — no silent behaviour change.
+Tests pin this so a future Protocol method addition can't slip past
+without an explicit decorator update.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import replace
 from typing import TYPE_CHECKING
@@ -136,8 +164,9 @@ class LineageGraphStoreWithAliasRedirect:
         )
 
     # ------------------------------------------------------------------
-    # Passthrough — forward every non-write Protocol method unchanged.
-    # Pinned by ``test_decorator_passthrough_for_non_upsert_methods``.
+    # Passthrough — forward every non-redirected Protocol method
+    # unchanged. Pinned by
+    # ``test_decorator_passthrough_for_non_redirected_methods``.
     # ------------------------------------------------------------------
 
     async def find_entity_ids_with_lineage(self, *, document_id: str) -> list[str]:
@@ -166,19 +195,76 @@ class LineageGraphStoreWithAliasRedirect:
     async def delete_relation(self, source: str, target: str, type: str) -> bool:
         return await self._inner.delete_relation(source, target, type)
 
+    # ------------------------------------------------------------------
+    # Intercepted read paths — Wave 8 W8-3 task #14
+    # ------------------------------------------------------------------
+
     async def get_entity(self, entity_name: str) -> EntityWithLineage | None:
-        return await self._inner.get_entity(entity_name)
+        canonical = await self._alias_repo.resolve_canonical(collection_id=self._collection_id, name=entity_name)
+        if canonical != entity_name:
+            logger.debug(
+                "alias_redirect: get_entity %r → %r (collection=%s)",
+                entity_name,
+                canonical,
+                self._collection_id,
+            )
+        return await self._inner.get_entity(canonical)
 
     async def get_relation(self, source: str, target: str, type: str) -> RelationWithLineage | None:
-        return await self._inner.get_relation(source, target, type)
-
-    async def query_entities_by_keyword(self, *, query: str, top_k: int) -> list[EntityWithLineage]:
-        return await self._inner.query_entities_by_keyword(query=query, top_k=top_k)
+        # Both endpoints may have been merged independently; resolve
+        # symmetrically (mirror write-side redirect in
+        # ``upsert_relation_with_lineage``).
+        new_source = await self._alias_repo.resolve_canonical(collection_id=self._collection_id, name=source)
+        new_target = await self._alias_repo.resolve_canonical(collection_id=self._collection_id, name=target)
+        if new_source != source or new_target != target:
+            logger.debug(
+                "alias_redirect: get_relation (%r→%r) → (%r→%r) (collection=%s)",
+                source,
+                target,
+                new_source,
+                new_target,
+                self._collection_id,
+            )
+        return await self._inner.get_relation(new_source, new_target, type)
 
     async def expand_neighbors_n_hops(
         self, *, entity_names: list[str], hops: int = 1
     ) -> tuple[list[EntityWithLineage], list[RelationWithLineage]]:
-        return await self._inner.expand_neighbors_n_hops(entity_names=entity_names, hops=hops)
+        if not entity_names:
+            return await self._inner.expand_neighbors_n_hops(entity_names=entity_names, hops=hops)
+        # Resolve every anchor through the alias map so a caller seeding
+        # ``["Alicia"]`` walks the canonical ``Alice`` neighbourhood.
+        # ``asyncio.gather`` keeps the per-anchor lookup cost flat —
+        # N is bounded by the caller (typically small).
+        resolved = await asyncio.gather(
+            *(self._alias_repo.resolve_canonical(collection_id=self._collection_id, name=n) for n in entity_names),
+            return_exceptions=False,
+        )
+        # De-dup so ``["Alicia", "Alice"]`` (alias + canonical mixed)
+        # doesn't double-traverse the same anchor; preserve input order
+        # for deterministic output.
+        seen: set[str] = set()
+        canonical_anchors: list[str] = []
+        for original, canonical in zip(entity_names, resolved):
+            if canonical not in seen:
+                seen.add(canonical)
+                canonical_anchors.append(canonical)
+            if canonical != original:
+                logger.debug(
+                    "alias_redirect: expand anchor %r → %r (collection=%s)",
+                    original,
+                    canonical,
+                    self._collection_id,
+                )
+        return await self._inner.expand_neighbors_n_hops(entity_names=canonical_anchors, hops=hops)
+
+    # ------------------------------------------------------------------
+    # Read paths that do NOT redirect — passthrough (see module
+    # docstring for the rationale per method).
+    # ------------------------------------------------------------------
+
+    async def query_entities_by_keyword(self, *, query: str, top_k: int) -> list[EntityWithLineage]:
+        return await self._inner.query_entities_by_keyword(query=query, top_k=top_k)
 
     async def list_entity_labels(self) -> list[str]:
         return await self._inner.list_entity_labels()

--- a/tests/integration/test_w7_e2e_graph_recall_and_merge.py
+++ b/tests/integration/test_w7_e2e_graph_recall_and_merge.py
@@ -499,23 +499,19 @@ async def test_step7_re_search_after_merge_returns_canonical():
 
 
 @pytest.mark.asyncio
-async def test_step8_get_entity_detail_alias_returns_404_w8_3_pin():
-    """W8-3 trigger pin (per huangheng msg=0b48af2b + architect ratify).
+async def test_step8_get_entity_detail_alias_returns_canonical_w8_3_landed():
+    """W8-3 landed (Wave 8 task #14, PR for this branch).
 
-    ``GraphService.get_entity_detail`` (the function the route
-    ``GET /collections/{cid}/graphs/entities/{name}`` delegates to,
-    per task #7) currently bypasses the alias_map on reads — looking
-    up ``Alicia`` returns ``None`` and the route surfaces 404.
+    ``GraphService.get_entity_detail`` delegates to the alias-redirect
+    decorator's ``get_entity``, which per Wave 8 W8-3 (task #14) now
+    resolves alias names to their canonical before reading the inner
+    store. Looking up ``Alicia`` returns the Alice row.
 
-    When Wave 8 W8-3 ships read-side alias resolution, this test will
-    fail (the lookup will start returning the Alice payload). The fix
-    is to flip the assertion: that flip is the physical evidence that
-    W8-3 shipped + the trigger condition is pinned in the repo.
-
-    Per architect ratify: the assertion shape is "today returns None
-    / 404; Wave 8 will flip to a real row" — encoding the future
-    expectation as a comment so the eventual fix is mechanical.
-    """
+    Flip history: this test was the **W8-3 trigger pin** (Wave 7 task
+    #11) — it asserted ``result is None`` to encode the deferred
+    behaviour as a future-flip marker. Wave 8 task #14 ships the
+    decorator extension; this test now pins the post-flip behaviour
+    so any regression in read-side redirect breaks here first."""
     from aperag.domains.knowledge_graph.service import GraphService
 
     svc = GraphService()
@@ -530,16 +526,16 @@ async def test_step8_get_entity_detail_alias_returns_404_w8_3_pin():
             entity_name="Alicia",
         )
 
-    # W8-3 trigger condition pinned in the assert message so the
-    # eventual fix is mechanical (per 冬柏 msg=8f488513): when Wave 8
-    # W8-3 ships read-side alias resolution, this assert fails and the
-    # traceback message tells the implementer exactly which line to
-    # flip.
-    assert result is None, (
-        "W8-3 trigger condition: get_entity_detail('Alicia') today "
-        "returns None because read-side alias resolution is deferred "
-        "to Wave 8 W8-3. When W8-3 ships, this assertion will fail; "
-        "flip to: `assert result is not None and result.name == 'Alice'`"
+    assert result is not None, (
+        "W8-3 read-side alias resolution should redirect 'Alicia' to "
+        "the canonical 'Alice' row — got None instead. Check that "
+        "``LineageGraphStoreWithAliasRedirect.get_entity`` is wrapping "
+        "``_inner.get_entity`` calls (Wave 8 task #14)."
+    )
+    assert result.name == "Alice", (
+        f"W8-3 redirect resolved to {result.name!r}; expected 'Alice'. "
+        "alias_map row may have been corrupted or the decorator's "
+        "redirect logic returned the wrong canonical."
     )
 
 

--- a/tests/unit_test/indexing/test_alias_redirect_store.py
+++ b/tests/unit_test/indexing/test_alias_redirect_store.py
@@ -12,21 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for ``aperag.indexing.alias_redirect_store`` — Wave 7 §K.12.4
-invariant #3 (transparent alias redirect on the indexer hot path).
+"""Unit tests for ``aperag.indexing.alias_redirect_store`` — Wave 7
+§K.12.4 invariant #3 (write-side) + Wave 8 W8-3 task #14 (read-side).
 
 Pinned cases:
 
-* Indexer write to an alias name lands on the canonical entity name
-  in the underlying lineage store. This is the core invariant —
-  ``test_indexer_upsert_after_merge_redirects_to_canonical``.
-* Relation writes redirect *both* endpoints when either has been
+* **Write-side redirect** (Wave 7): indexer write to an alias name
+  lands on the canonical entity name in the underlying lineage store
+  (``test_indexer_upsert_after_merge_redirects_to_canonical``).
+  Relation writes redirect *both* endpoints when either has been
   merged.
-* Decorator passthrough (huangheng CR lock,
-  ``test_decorator_passthrough_for_non_upsert_methods``): every
-  ``LineageGraphStore`` Protocol method that is NOT an
-  ``upsert_*`` write forwards to ``_inner`` byte-for-byte. Pin this
-  so a future Protocol method addition cannot slip past unnoticed.
+* **Read-side redirect** (Wave 8 task #14): ``get_entity`` /
+  ``get_relation`` / ``expand_neighbors_n_hops`` all rewrite anchor
+  names through the alias map before calling the inner store, so MCP
+  / REST / curation surfaces see canonical data even when the caller
+  passed the alias.
+* **Decorator passthrough** (huangheng CR lock,
+  ``test_decorator_passthrough_for_non_redirected_methods``): every
+  ``LineageGraphStore`` Protocol method that does NOT redirect must
+  forward to ``_inner`` byte-for-byte. Pinned so a future Protocol
+  method addition cannot slip past unnoticed. With an empty alias
+  map, the redirected methods also passthrough byte-for-byte (since
+  ``resolve_canonical`` returns the input unchanged) — this test
+  verifies BOTH groups in the no-alias steady state.
 """
 
 from __future__ import annotations
@@ -172,16 +180,135 @@ async def test_relation_write_redirects_only_one_endpoint():
 
 
 # ---------------------------------------------------------------------
+# Read-side redirect (Wave 8 W8-3 task #14)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_entity_after_alias_returns_canonical_data():
+    """Wave 8 W8-3: when user has merged ``Alicia → Alice``,
+    ``get_entity('Alicia')`` returns the canonical Alice entity. This
+    is the W8-3 trigger pin flipped: task #11 step 8 used to assert
+    ``result is None`` (Wave 7 decorator only intercepted writes); now
+    it asserts ``result.name == 'Alice'``."""
+    inner = AsyncMock()
+    canonical_entity = object()  # any sentinel — passthrough check
+    inner.get_entity = AsyncMock(return_value=canonical_entity)
+    decorator = LineageGraphStoreWithAliasRedirect(
+        inner=inner,
+        alias_repo=_FakeAliasRepo({"Alicia": "Alice"}),
+        collection_id="col-1",
+    )
+    result = await decorator.get_entity("Alicia")
+    assert result is canonical_entity
+    inner.get_entity.assert_awaited_once_with("Alice")
+
+
+@pytest.mark.asyncio
+async def test_get_entity_no_alias_passes_through_unchanged():
+    inner = AsyncMock()
+    inner.get_entity = AsyncMock(return_value=None)
+    decorator = LineageGraphStoreWithAliasRedirect(
+        inner=inner,
+        alias_repo=_FakeAliasRepo(),  # empty
+        collection_id="col-1",
+    )
+    await decorator.get_entity("Untouched")
+    inner.get_entity.assert_awaited_once_with("Untouched")
+
+
+@pytest.mark.asyncio
+async def test_get_relation_redirects_both_endpoints():
+    """Mirror the write-side
+    ``test_relation_write_redirects_both_endpoints`` — both endpoints
+    of a relation may have been merged independently; resolve
+    symmetrically before calling the inner store."""
+    inner = AsyncMock()
+    inner.get_relation = AsyncMock(return_value=None)
+    decorator = LineageGraphStoreWithAliasRedirect(
+        inner=inner,
+        alias_repo=_FakeAliasRepo({"Alicia": "Alice", "Bobby": "Bob"}),
+        collection_id="col-1",
+    )
+    await decorator.get_relation("Alicia", "Bobby", "knows")
+    inner.get_relation.assert_awaited_once_with("Alice", "Bob", "knows")
+
+
+@pytest.mark.asyncio
+async def test_get_relation_redirects_only_one_endpoint():
+    inner = AsyncMock()
+    inner.get_relation = AsyncMock(return_value=None)
+    decorator = LineageGraphStoreWithAliasRedirect(
+        inner=inner,
+        alias_repo=_FakeAliasRepo({"Alicia": "Alice"}),  # only source aliased
+        collection_id="col-1",
+    )
+    await decorator.get_relation("Alicia", "Bob", "knows")
+    inner.get_relation.assert_awaited_once_with("Alice", "Bob", "knows")
+
+
+@pytest.mark.asyncio
+async def test_expand_neighbors_redirects_alias_anchor():
+    """Anchor names in ``expand_neighbors_n_hops`` resolve through the
+    alias map before traversal so a caller seeding ``["Alicia"]``
+    walks the canonical Alice neighbourhood."""
+    inner = AsyncMock()
+    inner.expand_neighbors_n_hops = AsyncMock(return_value=([], []))
+    decorator = LineageGraphStoreWithAliasRedirect(
+        inner=inner,
+        alias_repo=_FakeAliasRepo({"Alicia": "Alice", "Bobby": "Bob"}),
+        collection_id="col-1",
+    )
+    await decorator.expand_neighbors_n_hops(entity_names=["Alicia", "Bobby", "Charlie"], hops=2)
+    inner.expand_neighbors_n_hops.assert_awaited_once_with(entity_names=["Alice", "Bob", "Charlie"], hops=2)
+
+
+@pytest.mark.asyncio
+async def test_expand_neighbors_dedupes_alias_and_canonical_in_anchors():
+    """If the caller passes both the alias and the canonical
+    (``["Alicia", "Alice"]``), redirect collapses to one anchor so
+    the traversal isn't double-walked."""
+    inner = AsyncMock()
+    inner.expand_neighbors_n_hops = AsyncMock(return_value=([], []))
+    decorator = LineageGraphStoreWithAliasRedirect(
+        inner=inner,
+        alias_repo=_FakeAliasRepo({"Alicia": "Alice"}),
+        collection_id="col-1",
+    )
+    await decorator.expand_neighbors_n_hops(entity_names=["Alicia", "Alice"], hops=1)
+    inner.expand_neighbors_n_hops.assert_awaited_once_with(entity_names=["Alice"], hops=1)
+
+
+@pytest.mark.asyncio
+async def test_expand_neighbors_empty_seeds_passes_through():
+    inner = AsyncMock()
+    inner.expand_neighbors_n_hops = AsyncMock(return_value=([], []))
+    decorator = LineageGraphStoreWithAliasRedirect(
+        inner=inner,
+        alias_repo=_FakeAliasRepo({"x": "y"}),
+        collection_id="col-1",
+    )
+    await decorator.expand_neighbors_n_hops(entity_names=[], hops=1)
+    inner.expand_neighbors_n_hops.assert_awaited_once_with(entity_names=[], hops=1)
+
+
+# ---------------------------------------------------------------------
 # Decorator passthrough invariant (huangheng CR lock)
 # ---------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_decorator_passthrough_for_non_upsert_methods():
-    """Every ``LineageGraphStore`` Protocol method that is NOT an
-    ``upsert_*`` write must forward to ``_inner`` byte-for-byte. Spelled
-    out one method at a time so a future Protocol addition can't slip
-    past without an explicit decorator update."""
+async def test_decorator_passthrough_for_non_redirected_methods():
+    """Every ``LineageGraphStore`` Protocol method that does NOT
+    redirect must forward to ``_inner`` byte-for-byte. Spelled out one
+    method at a time so a future Protocol addition can't slip past
+    without an explicit decorator update.
+
+    With an empty alias map, the redirected methods (``get_entity`` /
+    ``get_relation`` / ``expand_neighbors_n_hops``) ALSO passthrough
+    byte-for-byte (resolve_canonical returns input unchanged); we
+    re-assert that here so the no-alias steady state is pinned across
+    BOTH groups."""
     inner = AsyncMock()
     decorator = LineageGraphStoreWithAliasRedirect(
         inner=inner,


### PR DESCRIPTION
## Summary

Wave 8 W8-3 task #14. Extends `LineageGraphStoreWithAliasRedirect` to also intercept read-path methods that take entity names as input, so MCP / REST / curation surfaces resolve alias names to their canonical before hitting the inner store. Closes the W8-3 trigger pin Wave 7 task #11 left open (huangheng W8-3 sediment from task #7 PR CR msg=55974e1e). Architect ratify msg=486fc794 + decorator-extension Option (a).

## Changes

**Read-side methods that DO redirect** (mirror module docstring):

- `get_entity(name)` — resolve name through alias map before `inner.get_entity`.
- `get_relation(source, target, type)` — resolve **both** endpoints symmetrically (mirror write-side `upsert_relation_with_lineage`).
- `expand_neighbors_n_hops(entity_names, hops)` — resolve every anchor via `asyncio.gather`; dedupe so callers passing both alias and canonical (`["Alicia", "Alice"]`) don't double-walk.

**Methods that do NOT redirect** (documented in module docstring):

- `query_entities_by_keyword` — input is a keyword, not a name.
- `list_entity_labels` — returns labels, not names.
- `find_entity_ids_with_lineage` / `find_relation_keys_with_lineage` — filter by `document_id`.
- `gc_entity_if_orphan` / `gc_relation_if_orphan` — canonical-row-only operations.
- `delete_entity` / `delete_relation` — explicit user intent; redirect would silently drop the canonical when caller asked for the alias.

**Task #11 W8-3 trigger pin flip**:

`tests/integration/test_w7_e2e_graph_recall_and_merge.py` step 8 (`test_step8_get_entity_detail_alias_returns_404_w8_3_pin`) was the W8-3 trigger pin: it asserted `result is None` to encode the deferred behaviour as a future-flip marker. This PR flips it to assert `result.name == 'Alice'` and renames it to `test_step8_get_entity_detail_alias_returns_canonical_w8_3_landed`. The new assert messages document the redirect as the cause if it regresses, mirroring the Wave 7 task #11 future-flip pattern in reverse.

## §K.12 invariant cross-check (12-item)

| # | Invariant | This PR |
|---|---|---|
| 1 | L1 graph data 不污染 | ✅ read-only intercept; never writes |
| 2 | L1 → L2 单向派生 | n/a (read-only) |
| 3 | Compactor 在 sync 末尾 | n/a |
| 4 | Vector store via abstraction | n/a (alias_repo is SQL) |
| 5 | payload indexer filter | n/a |
| 6 | uuid5 deterministic id | n/a |
| 7 | snapshot-diff via lineage entity name set | n/a |
| 8 | alias_map orphan persist | ✅ read redirect surfaces canonical even when GC'd |
| 9 | `upsert_entity_with_lineage` transparent alias redirect | ✅ extended symmetrically to reads |
| 10 | DB column length cap | n/a |
| 11 | 候选检测仅写不自动合并 (D-3) | ✅ read-only |
| 12 | 命名 grep-zero LightRAG | ✅ `grep -rn 'LightRAG\|lightrag' aperag/indexing/alias_redirect_store.py tests/unit_test/indexing/test_alias_redirect_store.py` → 0 hits in new code |

## 4-pattern pre-check matrix

**Pattern 1 v1** — caller-grep:
```
$ grep -rn 'LineageGraphStoreWithAliasRedirect\|_build_lineage_graph_store\b' aperag/ | grep -v __pycache__
aperag/indexing/alias_redirect_store.py  # decorator class
aperag/indexing/worker_factory.py:_build_lineage_graph_store  # factory wraps with decorator (PR #1762)
```
→ all callers go through the wrapping factory; read-side redirect benefits any caller that uses `LineageGraphStore.get_entity` / `get_relation` / `expand_neighbors_n_hops` (retrieval pipeline, MCP graph tools, curation merger).

**Pattern 1 v2** — n/a (existing decorator extended, not replaced).

**Pattern 2** — dependency interface grep:
- `AliasMapRepository.resolve_canonical(*, collection_id, name) -> str` — async-native, returns input unchanged when no alias row present.
- `LineageGraphStore.get_entity / get_relation / expand_neighbors_n_hops` — Protocol unchanged from PR #1758; we just call them with redirected anchors.

**Pattern 3** — per-collection vs per-tenant binding:
→ unchanged from Wave 7. Decorator + alias_repo are both per-collection bound at construction.

## simple-stable 4-guardrail

1. 不无限扩范围 ✅ no Protocol method added; only intercepts existing methods. Methods that don't take entity-name inputs (keyword search, label list, lineage-filter queries) keep passing through.
2. 先做实尽快上线 ✅ ~70 LOC code change + 7 new tests + 1 integration test flip; small surface, ratified scope.
3. 简单稳定优于复杂 ✅ mirrors write-side redirect pattern symmetrically; reuses `asyncio.gather` for batch anchor resolution (same convention as `_batch_get_entities`).
4. 私有化部署后免维护 ✅ no operator config; deployment behaviour: alias names silently work everywhere they didn't before.

## Test plan

12/12 cases pass (`uv run pytest tests/unit_test/indexing/test_alias_redirect_store.py -v`):

7 new read-side cases:
- `test_get_entity_after_alias_returns_canonical_data` — the W8-3 invariant
- `test_get_entity_no_alias_passes_through_unchanged`
- `test_get_relation_redirects_both_endpoints`
- `test_get_relation_redirects_only_one_endpoint`
- `test_expand_neighbors_redirects_alias_anchor`
- `test_expand_neighbors_dedupes_alias_and_canonical_in_anchors`
- `test_expand_neighbors_empty_seeds_passes_through`

4 pre-existing write-side cases retained.

1 renamed `test_decorator_passthrough_for_non_redirected_methods` (was `test_decorator_passthrough_for_non_upsert_methods`) — verifies BOTH groups passthrough byte-for-byte under empty alias_map.

Integration test step 8 flip (`test_step8_get_entity_detail_alias_returns_canonical_w8_3_landed`) — assertion changed from `is None` to `not None and .name == 'Alice'`. The Wave 7 narrative test in PR #1760 will validate the e2e wiring once the next narrative run executes.

`ruff check` + `ruff format --check` clean.

## References

- Wave 7 sediment: huangheng task #7 PR CR msg=55974e1e (W8-3 surface), Wave 7 close-out W8-3 candidate `notes/wave8-candidate-list.md`
- Wave 8 task #14 thread: msg=6749e466 in `#删除老graph` (architect ratify msg=486fc794, decorator extension Option (a))
- depends on: PR #1758 (decorator) + PR #1762 (factory wiring) — both merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)