### PR TITLE
docs(graph): W8-7 — replace LightRAG word references with neutral phrasing

### DIFF
--- a/aperag/domains/knowledge_graph/api/routes.py
+++ b/aperag/domains/knowledge_graph/api/routes.py
@@ -268,7 +268,7 @@ async def handle_suggestion_action_view(
 
 
 # Historical ``GET /api/v1/collections/{id}/graphs/export/kg-eval``
-# endpoint was removed together with the LightRAG-era graph workflow.
+# endpoint was removed together with the legacy graph workflow.
 # The ``aperag/views/graph.py`` 410-Gone shim that used to reply on the
 # v1 path was deleted by the Phase 2 hard-cut; v1 KG paths now 404 at
 # the FastAPI level, matching every other v1 KG URL. The canonical v2

--- a/aperag/domains/knowledge_graph/db/models.py
+++ b/aperag/domains/knowledge_graph/db/models.py
@@ -15,7 +15,7 @@
 """Knowledge-graph-domain SQLAlchemy models.
 
 Owns ``GraphCurationRun`` / ``GraphCurationSuggestion`` (the curation
-audit rows produced by the LightRAG-path graph-entity reviewer) plus
+audit rows produced by the graph-entity reviewer) plus
 their lifecycle enums. The table bodies were moved here from
 ``aperag.db.models`` in Phase 3 step 3 as part of the knowledge_graph
 domain split; the legacy aggregate module re-exports the three class

--- a/aperag/domains/knowledge_graph/schemas.py
+++ b/aperag/domains/knowledge_graph/schemas.py
@@ -354,7 +354,7 @@ class SuggestionActionResponse(BaseModel):
 # them — but they appear in OpenAPI regen so SDK callers can bind to
 # them statically.
 #
-# Per §K.12 invariant #12 (grep-zero LightRAG) the names are
+# Per §K.12 invariant #12 (grep-zero on legacy naming) the names are
 # ``Graph*`` only; per invariant #11 (D-3 candidate detection writes
 # only) these are read-only shapes — no mutation surface.
 

--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -484,8 +484,8 @@ class GraphService:
 # ---------------------------------------------------------------------------
 #
 # ``_to_ui_dict`` and ``_optimize_graph_for_visualization`` were originally
-# written for the LightRAG ``KnowledgeGraph`` schema. Rather than rewrite
-# the UI contract, we wrap graphindex DTOs in lightweight proxy objects
+# written for the legacy ``KnowledgeGraph`` schema. Rather than rewrite
+# the UI contract, we wrap lineage DTOs in lightweight proxy objects
 # that expose the attributes those helpers read. Keeps the frontend
 # contract unchanged and the adapter isolated in one place.
 
@@ -539,7 +539,7 @@ def _adapt_lineage_relations(relations: list[Any]) -> List[SimpleNamespace]:
     """Wave 7 W7-10: project ``RelationWithLineage`` rows into the
     ``SimpleNamespace`` shape ``_to_ui_dict`` consumes.
 
-    The lineage relation has no ``weight`` field (legacy LightRAG
+    The lineage relation has no ``weight`` field (legacy
     artefact) — we surface ``1.0`` constant so the UI dict builder
     keeps a stable shape. Description prefers ``compacted_description``
     over the joined per-doc parts (mirror ``_adapt_lineage_entities``).

--- a/aperag/domains/retrieval/pipeline.py
+++ b/aperag/domains/retrieval/pipeline.py
@@ -78,7 +78,7 @@ class CollectionRow(Protocol):
 
 
 def _render_graph_context_text(entities: list[Any], relations: list[Any]) -> str:
-    """Compose a LightRAG-style text block from entities + relations.
+    """Compose a graph-RAG text block from entities + relations.
 
     Mirrors the legacy ``GraphIndexService.query_context`` rendering
     convention so downstream RAG prompts that expect the
@@ -120,7 +120,7 @@ def _build_lineage_graph_store_for(collection: CollectionRow) -> Any:
     import tax unless a graph recall is actually requested.
 
     Wave 6 #33 chunk 3 (per architect Option C ruling msg=6fccd9ab):
-    retrieval-side LightRAG-style query routes through the new
+    retrieval-side graph-RAG query routes through the new
     LineageGraphStore Protocol (`query_entities_by_keyword` +
     `expand_neighbors_n_hops`) instead of the legacy
     ``GraphIndexService.query_context``.

--- a/aperag/indexing/graph.py
+++ b/aperag/indexing/graph.py
@@ -62,7 +62,7 @@ modality output — re-running ``derive`` would reissue every LLM
 extraction call. So ``derive`` writes once and ``sync`` only ever
 reads. The actual entity / relation extraction is provided by a
 :class:`GraphExtractor` callable injected at construction time so that
-T2.x can wire the production LightRAG-based extractor without
+T2.x can wire the production LLM-driven extractor without
 touching this module.
 
 T1.2 ships:
@@ -581,7 +581,7 @@ class LineageGraphStore(Protocol):
         """Read-path helper for relations."""
 
     # ------------------------------------------------------------------
-    # Wave 6 #33 — LightRAG-style retrieval query layer. The retrieval
+    # Wave 6 #33 — graph-RAG retrieval query layer. The retrieval
     # pipeline (§G.5) and graph-curation flows consume these to compose
     # a graph-recall context for a user query without going through the
     # legacy ``GraphIndexService.query_context``.
@@ -602,7 +602,7 @@ class LineageGraphStore(Protocol):
     #   carry an entity-vector column, so a Protocol method on this
     #   store would either invite a Qdrant cross-concern coupling or
     #   silently no-op. Wave 7+ may add it via a separate
-    #   ``LightRAGQueryService`` if real evidence surfaces; until then
+    #   dedicated query service if real evidence surfaces; until then
     #   no dead code lives here. See §K.11 amend.
     # ------------------------------------------------------------------
 
@@ -924,7 +924,7 @@ class InMemoryLineageGraphStore:
             )
 
     # ------------------------------------------------------------------
-    # Wave 6 #33 chunk 2 — LightRAG-style query layer real impls.
+    # Wave 6 #33 chunk 2 — graph-RAG query layer real impls.
     # ------------------------------------------------------------------
 
     async def query_entities_by_keyword(
@@ -1072,7 +1072,7 @@ GraphExtractor = Callable[
 ``chunks.jsonl`` and gets back the raw entity / relation list to
 serialise into ``kg.jsonl``.
 
-The production extractor (LightRAG-based, LLM-driven) is wired in
+The production extractor (LLM-driven, per-chunk) is wired in
 T2.x; tests pass deterministic stubs so the §D.3.6 self-test does not
 depend on any LLM.
 """

--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -15,7 +15,7 @@
 """Real LLM-driven graph extractor — Wave 4 T1.
 
 Replaces the chunk 4b ``_no_op_extractor`` placeholder with an actual
-LightRAG-style entity/relation extractor that calls the collection's
+LLM-driven entity/relation extractor that calls the collection's
 configured completion model for each chunk and parses the JSON output
 into the new ``aperag.indexing.graph.EntityRecord`` /
 ``RelationRecord`` shapes.
@@ -36,7 +36,7 @@ silently-lie):
   cryptic LLM-side error.
 * Per-chunk LLM call failures (malformed JSON, transient backend
   errors, etc.) log a warning and skip the chunk's entities/relations.
-  The other chunks still contribute. This matches the legacy LightRAG
+  The other chunks still contribute. This matches the prior reference
   extractor's failure semantics — one bad chunk does not poison the
   whole document.
 
@@ -276,7 +276,7 @@ def _entity_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> EntityRecord:
     if not name:
         raise ValueError("entity name cannot be empty")
     # The LLM extraction prompt still emits ``type`` in its JSON output
-    # (LightRAG-style template); we accept either the canonical
+    # (legacy template shape); we accept either the canonical
     # ``entity_type`` field (post-Wave-6 #36 rename) or the legacy
     # ``type`` field for backward compat with prompt templates.
     entity_type = str(raw.get("entity_type") or raw.get("type") or "")

--- a/aperag/indexing/graph_search_service.py
+++ b/aperag/indexing/graph_search_service.py
@@ -18,14 +18,14 @@ Activates vector recall against the lineage graph. The Wave 6 #33 chunk
 3 retrieval cutover only wired keyword recall via
 ``LineageGraphStore.query_entities_by_keyword`` (chunk 2 vector recall
 was deferred); this service finally adds the vector path and composes
-both into the LightRAG-style context block the retrieval pipeline
+both into the graph-RAG context block the retrieval pipeline
 already consumes (so task #8's wiring is a one-line swap).
 
 Per-collection bound — caller wires the four dependencies (lineage
 store, vector connector, embedder, optional LLM) to the collection
 being searched before constructing the service. The constructor does
 no I/O. ``llm`` is reserved for follow-up high-level / low-level
-keyword extraction (LightRAG hybrid recall); v1 PR does not invoke it.
+keyword extraction (hybrid keyword recall); v1 PR does not invoke it.
 """
 
 from __future__ import annotations
@@ -90,7 +90,7 @@ class GraphSearchService:
     * :meth:`get_subgraph` — wrap ``expand_neighbors_n_hops`` as a
       stable read primitive for MCP tools (task #7).
     * :meth:`compose_context` — render the ``EntityWithLineage`` /
-      ``RelationWithLineage`` lists into the legacy LightRAG-style
+      ``RelationWithLineage`` lists into the canonical graph-RAG
       ``-----Entities (KG)----- / -----Relationships (KG)-----`` text
       block so the retrieval pipeline (task #8) gets a drop-in
       replacement for the keyword-only path.
@@ -102,8 +102,8 @@ class GraphSearchService:
         store: LineageGraphStore,
         vector_connector: VectorStoreConnector,
         embedder: Any,
-        # Reserved for follow-up: LightRAG-style high/low-level
-        # keyword extraction from the user query. Not invoked in v1.
+        # Reserved for follow-up: hybrid high/low-level keyword
+        # extraction from the user query. Not invoked in v1.
         llm: Callable[[str], Awaitable[str]] | None = None,
         top_k: int = DEFAULT_TOP_K,
         score_threshold: float = DEFAULT_SCORE_THRESHOLD,
@@ -331,7 +331,7 @@ class GraphSearchService:
         entities: Sequence[EntityWithLineage],
         relations: Sequence[RelationWithLineage],
     ) -> str:
-        """Render entities + relations into the LightRAG-style block
+        """Render entities + relations into the graph-RAG context block
         the retrieval pipeline already expects.
 
         Mirrors :func:`aperag.domains.retrieval.pipeline._render_graph_context_text`

--- a/aperag/indexing/graph_storage/nebula.py
+++ b/aperag/indexing/graph_storage/nebula.py
@@ -921,7 +921,7 @@ class NebulaLineageGraphStore:
 
         return await asyncio.to_thread(_read)
 
-    # -- LightRAG-style query layer (Wave 6 #33 chunk 2) --------------
+    # -- Graph-RAG query layer (Wave 6 #33 chunk 2) -------------------
 
     async def query_entities_by_keyword(
         self,

--- a/aperag/indexing/graph_storage/neo4j.py
+++ b/aperag/indexing/graph_storage/neo4j.py
@@ -557,7 +557,7 @@ class Neo4jLineageGraphStore:
                 compacted_description=rec["compacted_description"],
             )
 
-    # -- LightRAG-style query layer (Wave 6 #33 chunk 2) --------------
+    # -- Graph-RAG query layer (Wave 6 #33 chunk 2) -------------------
 
     async def query_entities_by_keyword(
         self,

--- a/aperag/indexing/graph_storage/postgres.py
+++ b/aperag/indexing/graph_storage/postgres.py
@@ -617,7 +617,7 @@ class PostgresLineageGraphStore:
                 compacted_description=row.compacted_description,
             )
 
-    # -- LightRAG-style query layer (Wave 6 #33 chunk 2) --------------
+    # -- Graph-RAG query layer (Wave 6 #33 chunk 2) -------------------
 
     async def query_entities_by_keyword(
         self,

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -468,7 +468,7 @@ def _build_vision_worker(*, collection: Any, object_store: Any) -> ModalityWorke
 def _build_graph_worker(*, collection: Any, object_store: Any, payload: DispatchPayload) -> ModalityWorker:
     """Wire :class:`GraphModalityWorker` for the §D.3 lineage pipeline.
 
-    Wave 4 T1 lands the real LightRAG-style LLM extractor — the chunk
+    Wave 4 T1 lands the real LLM-driven graph extractor — the chunk
     4b "Wave 4 wiring T1" gate is now self-disabled because
     :func:`build_collection_graph_extractor` returns a real LLM-driven
     closure. A collection that has no completion model configured

--- a/aperag/mcp/tools/graph_tools.py
+++ b/aperag/mcp/tools/graph_tools.py
@@ -33,7 +33,7 @@ Wire shape:
 
 Per spec §K.12 invariant #11 (D-3 candidate detection writes only)
 none of these tools mutate state — they are read-only. Per invariant
-#12 the tool names are LightRAG-grep-zero clean.
+#12 the tool names are grep-zero clean for legacy naming.
 """
 
 from __future__ import annotations

--- a/aperag/migration/sql/extensions_init.sql
+++ b/aperag/migration/sql/extensions_init.sql
@@ -3,7 +3,7 @@
 -- Extensions must be created before schema tables that use them
 
 -- Create pgvector extension for vector operations
--- Used by LightRAG tables: lightrag_doc_chunks, lightrag_vdb_entity, lightrag_vdb_relation
+-- Used by chunk-vector / graph-entity-vector / fulltext sidecar tables
 CREATE EXTENSION IF NOT EXISTS vector;
 
 -- Optional: Create other useful extensions

--- a/aperag/schema/common.py
+++ b/aperag/schema/common.py
@@ -145,7 +145,7 @@ class KnowledgeGraphConfig(BaseModel):
         examples=[["organization", "person", "geo", "event"]],
     )
     # Wave 5 P5A item 1 (per huangheng T1 obs A msg=6b349693): expose
-    # the LightRAG-style extractor's per-chunk caps + timeout as
+    # the graph extractor's per-chunk caps + timeout as
     # per-collection overrides so deployments tuning a slow LLM provider
     # or extracting from very dense chunks can lift the defaults without
     # patching ``aperag/indexing/graph_extractor.py`` constants.
@@ -196,7 +196,7 @@ class CollectionConfig(BaseModel):
     # Wave 3 ships graph modality structurally implemented but gated
     # in :class:`aperag.indexing.worker_factory.ProductionWorkerFactory`
     # because the §D.3.6 Nebula / Postgres ``LineageGraphStore`` adapter
-    # + LightRAG-style LLM extractor are Wave 4 scope. Default flipped
+    # + LLM-driven graph extractor are Wave 4 scope. Default flipped
     # to False so new collections do not opt into the placeholder path
     # by accident; Wave 4 release flips it back to True. Per architect
     # msg=c79e9a3f.

--- a/aperag/service/prompt_template_service.py
+++ b/aperag/service/prompt_template_service.py
@@ -202,7 +202,7 @@ class PromptTemplateService:
 
     This service provides:
     1. User configuration management (for View layer)
-    2. Prompt resolution with 3-tier priority (for Agent/LightRAG)
+    2. Prompt resolution with 3-tier priority (for Agent / graph indexing)
     3. Helper utilities (preview, validate)
     """
 
@@ -399,7 +399,7 @@ class PromptTemplateService:
 
             return result
 
-    # === Prompt resolution (for Agent/LightRAG) ===
+    # === Prompt resolution (for Agent / graph indexing) ===
 
     async def resolve_agent_system_prompt(self, bot, user_id: str) -> str:
         """

--- a/tests/unit_test/indexing/test_graph_search_service.py
+++ b/tests/unit_test/indexing/test_graph_search_service.py
@@ -32,7 +32,7 @@ Pins the vector-recall contract:
   writing relation vectors.
 * ``get_subgraph`` is a thin pass-through to
   ``expand_neighbors_n_hops`` for MCP / retrieval callers.
-* ``compose_context`` renders byte-for-byte the same LightRAG-style
+* ``compose_context`` renders byte-for-byte the same graph-RAG context
   block ``aperag/domains/retrieval/pipeline.py:_render_graph_context_text``
   produces today (so task #8's swap is zero-functional-change), and
   prefers ``compacted_description`` when present.

--- a/tests/unit_test/indexing/test_lineage_query_protocol.py
+++ b/tests/unit_test/indexing/test_lineage_query_protocol.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Wave 6 #33 — Protocol surface + in-memory implementation for the
-LightRAG-style query layer on :class:`aperag.indexing.graph.LineageGraphStore`.
+graph-RAG query layer on :class:`aperag.indexing.graph.LineageGraphStore`.
 
 Pin the Protocol method signatures so chunk 3 caller migration can
 rely on a stable surface, and pin the in-memory query/traversal
@@ -26,7 +26,7 @@ Per architect ruling msg=54eac595 (Option A) the read API is:
 ``query_entities_by_vector`` was originally declared in chunk 1 but
 dropped in chunk 2 because the Wave 4 lineage schema does not carry an
 entity-vector column. Wave 7 may re-introduce vector recall via a
-separate ``LightRAGQueryService`` if real evidence surfaces.
+dedicated query service if real evidence surfaces.
 """
 
 from __future__ import annotations
@@ -45,7 +45,7 @@ from aperag.indexing.graph import (
 
 def test_lineage_query_protocol_exposes_two_read_methods():
     """The new query layer surface must declare exactly the two
-    LightRAG-style read methods agreed in §K.11.11 amend."""
+    graph-RAG read methods agreed in §K.11.11 amend."""
 
     members = set(LineageGraphStore.__dict__)
     assert "query_entities_by_keyword" in members

--- a/tests/unit_test/indexing/test_wave7_task8_wiring.py
+++ b/tests/unit_test/indexing/test_wave7_task8_wiring.py
@@ -108,7 +108,7 @@ def test_build_lineage_graph_store_inner_returns_raw_backend():
 async def test_graph_search_pipeline_composes_search_entities_and_get_subgraph():
     """Wave 7 §K.12.5 / §K.12.8 task #8 cutover: the retrieval pipeline
     must call ``search_entities`` (vector recall) + ``get_subgraph``
-    (1-hop traversal) + ``compose_context`` (LightRAG-style render),
+    (1-hop traversal) + ``compose_context`` (graph-RAG render),
     not the Wave 6 keyword-only ``query_entities_by_keyword`` path.
     """
     from aperag.domains.retrieval.pipeline import SearchPipelineService

--- a/tests/unit_test/test_modularization_boundaries.py
+++ b/tests/unit_test/test_modularization_boundaries.py
@@ -586,7 +586,7 @@ def test_no_legacy_retrieval_or_graph_routes_remain():
 
     The only explicitly allowed graph route left in ``views/graph.py``
     is the ``GET /collections/{id}/graphs/export/kg-eval`` 410-Gone
-    shim (kept for out-of-tree callers hitting the deleted LightRAG
+    shim (kept for out-of-tree callers hitting the deleted legacy
     endpoint). The regex above carves out that exception with a
     negative lookahead.
     """


### PR DESCRIPTION
## Summary

Wave 8 task #16 (W8-7) — sweeps ~30 historical-context "LightRAG" word mentions across 20 files in production code + tests, replacing each with neutral graph-RAG phrasing. 0 functional change.

## Why

Wave 7 close-out grep-zero contract (PR #1765's folded-in helper) is intent-driven — it asserts no legacy *callable code* binds to `GraphIndexService.*` / `graphindex_*` symbols, but doesn't check the literal word "LightRAG" because comments naming a prior reference implementation aren't a behavioural regression.

Spec §K.12.10 strict reading wants the legacy provenance fully neutralised, so this completes the last-mile naming sweep per huangheng's task #10 PR #1765 CR sediment (msg=23b17c4c).

## Scope

- **Production code (16 files)**: schema/common.py + service/prompt_template_service.py + migration/sql/extensions_init.sql + indexing/graph_storage/{postgres,neo4j,nebula}.py + indexing/graph_search_service.py + indexing/graph_extractor.py + indexing/graph.py + indexing/worker_factory.py + mcp/tools/graph_tools.py + domains/knowledge_graph/{api/routes,service,schemas,db/models}.py + domains/retrieval/pipeline.py
- **Tests (4 files)**: unit_test/test_modularization_boundaries.py + unit_test/indexing/{test_graph_search_service,test_wave7_task8_wiring,test_lineage_query_protocol}.py
- **Allowed retention** (per architect spec allow): docs/* (rewrite-plan, blueprint, modularization design pack), READMEs, spec §K.12 historical attribution

## Replacements

- `LightRAG-style` → `graph-RAG style` / `graph-RAG context block` / `Graph-RAG query layer` (section headers)
- `LightRAG-based` → `LLM-driven`
- `LightRAG hybrid recall` → `hybrid keyword recall`
- `LightRAG-grep-zero` → `grep-zero on legacy naming`
- `LightRAG-era` → `legacy`
- `Agent/LightRAG` → `Agent / graph indexing`
- `LightRAG ``KnowledgeGraph`` schema` → `legacy ``KnowledgeGraph`` schema`
- `LightRAG-path` → removed (`graph-entity reviewer`)
- `LightRAG ``query layer``` → `graph-RAG query layer`
- `LightRAGQueryService` → `dedicated query service`

## 12-invariant cross-check

- **#12 (grep-zero LightRAG word)**: ✅ `rg LightRAG aperag/ tests/` → 0 hits post-sweep
- All other invariants: n/a (pure docstring / comment edit, 0 functional change)

## 4-pattern pre-check matrix

- Pattern A (kg.jsonl shape): unchanged
- Pattern B (Lineage SET semantics): unchanged
- Pattern C (Cypher LIST<MAP>): unchanged
- Pattern D (vector 3-field payload): unchanged

## Simple-stable 4-guardrail

- No new public API surface
- No new dependency
- No frontend change
- No config change

## Test plan

- [x] `rg LightRAG aperag/ tests/` → 0 hits
- [x] `uv run pytest tests/unit_test/` — 1141 unit tests pass
- [x] `uv run pytest tests/integration/test_w7_grep_zero_legacy_graphindex.py` — 10/10 pass (intent-driven gate unaffected)
- [x] `uv run ruff format --check` / `ruff check` — clean
- [ ] CR by @huangheng (focus: grep-zero literal word + historical narrative meaning preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)