### PR TITLE
chore(infra Wave 9 audit): batch cleanup — Critical ×3 + Medium ×3 (+ W9-1 partial)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,11 +20,10 @@ dmypy.json
 aperag.egg-info/
 
 # Frontend development files (keep dist and deploy for production builds)
-frontend/node_modules
-frontend/.umi
-frontend/.umi-production
-frontend/yarn-error.log
-frontend/npm-debug.log*
+web/node_modules
+web/.next
+web/yarn-error.log
+web/npm-debug.log*
 
 # Development and build artifacts
 *.egg-info/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+envs/env.template

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ celerybeat.pid
 
 # Environments
 .env*
+!.env.example
 
 .venv
 .docker-env

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ env-dev: env-install
 	@echo "   1. Activate virtual environment: source .venv/bin/activate"
 	@echo "   2. Start databases: make infra-up"
 	@echo "   3. Apply migrations: make db-migrate"
-	@echo "   4. Run services: make serve-api, make serve-worker"
+	@echo "   4. Run services: make serve-api, make serve-web"
 
 # Environment cleanup
 env-clean:
@@ -146,23 +146,23 @@ endif
 .PHONY: stack-up stack-down stack-logs infra-up
 # Full application startup
 stack-up:
-	$(_EXTRA_ENVS) docker-compose $(_PROFILES_TO_ACTIVATE) -f docker-compose.yml up -d
+	$(_EXTRA_ENVS) docker compose $(_PROFILES_TO_ACTIVATE) -f docker-compose.yml up -d
 
 # Infrastructure only (databases + supporting services)
 # Optional services like Neo4j and Nebula will ONLY start if explicitly enabled:
 #   make infra-up WITH_NEO4J=1    # adds Neo4j
 #   make infra-up WITH_NEBULA=1   # adds Nebula Graph
 infra-up:
-	docker-compose $(_PROFILES_TO_ACTIVATE) -f docker-compose.yml up -d \
+	docker compose $(_PROFILES_TO_ACTIVATE) -f docker-compose.yml up -d \
 		postgres redis qdrant es \
 		$(if $(filter 1,$(WITH_NEO4J)),neo4j,) \
 		$(if $(filter 1,$(WITH_NEBULA)),nebula-metad nebula-storaged nebula-graphd nebula-storage-activator,)
 
 stack-down:
-	docker-compose --profile neo4j --profile nebula -f docker-compose.yml down $(_COMPOSE_DOWN_FLAGS)
+	docker compose --profile neo4j --profile nebula -f docker-compose.yml down $(_COMPOSE_DOWN_FLAGS)
 
 stack-logs:
-	docker-compose -f docker-compose.yml logs -f
+	docker compose -f docker-compose.yml logs -f
 
 ##################################################
 # Development Services

--- a/aperag/config.py
+++ b/aperag/config.py
@@ -96,14 +96,6 @@ class Config(BaseSettings):
     logto_domain: str = Field("aperag.authing.cn", alias="LOGTO_DOMAIN")
     logto_app_id: str = Field("", alias="LOGTO_APP_ID")
 
-    # Celery
-    celery_broker_url: Optional[str] = Field(None, alias="CELERY_BROKER_URL")
-    celery_result_backend: Optional[str] = None  # Will be set in __post_init__
-    celery_beat_scheduler: str = "django_celery_beat.schedulers:DatabaseScheduler"
-    celery_worker_send_task_events: bool = True
-    celery_task_send_sent_event: bool = True
-    celery_task_track_started: bool = True
-
     local_queue_name: str = Field("", alias="LOCAL_QUEUE_NAME")
 
     # Indexing mode (Wave 3 T3.1 — replaces Celery dispatch path).
@@ -339,16 +331,6 @@ class Config(BaseSettings):
                 f"postgresql://{self.postgres_user}:{self.postgres_password}"
                 f"@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
             )
-        # CELERY_BROKER_URL
-        if not self.celery_broker_url:
-            self.celery_broker_url = (
-                f"redis://{self.redis_user}:{self.redis_password}@{self.redis_host}:{self.redis_port}/0"
-            )
-
-        # CELERY_RESULT_BACKEND
-        if not self.celery_result_backend:
-            self.celery_result_backend = self.celery_broker_url
-
         # MEMORY_REDIS_URL
         if not self.memory_redis_url:
             self.memory_redis_url = (

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -11,6 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-__all__ = "celery_app"

--- a/envs/docker.env.overrides
+++ b/envs/docker.env.overrides
@@ -6,7 +6,6 @@ NEO4J_URI=bolt://aperag-neo4j:7687
 NEBULA_HOSTS=aperag-nebula-graphd:9669
 NEBULA_USERNAME=root
 NEBULA_PASSWORD=nebula
-CELERY_BROKER_URL=redis://default:password@aperag-redis:6379/0
 DATABASE_URL="postgresql://postgres:postgres@aperag-postgres:5432/postgres"
 PGVECTOR_DATABASE_URL="postgresql://postgres:postgres@aperag-postgres:5432/postgres"
 VECTOR_DB_CONTEXT={"url":"http://aperag-qdrant", "port":6333, "distance":"Cosine", "timeout": 1000}

--- a/envs/env.template
+++ b/envs/env.template
@@ -92,10 +92,6 @@ REGISTER_MODE=unlimited
 # Logging
 DJANGO_LOG_LEVEL=INFO
 
-# Celery
-CELERY_FLOWER_USER=admin
-CELERY_FLOWER_PASSWORD=admin
-
 # Object Store
 # OBJECT_STORE_TYPE can be "local" or "s3".
 # "s3" is S3-API-compatible and works with MinIO, AWS S3, Alibaba Cloud

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint",
     "prettier": "prettier --cache --write ./ && yarn lint",
     "start": "next start",
+    "type-check": "tsc --noEmit",
     "i18n:watch": "node scripts/i18n-watch.mjs --watch"
   },
   "dependencies": {


### PR DESCRIPTION
Closes audit task #5 in #本地测试 (msg=98b614c5). 6 fixes ratified, 2 dropped per @earayu2 (alembic roundtrip → W8-4 candidate; pre-commit → not adding), 1 partially shipped (W9-1).

## Scope

### 🔴 CRITICAL #1a — Add `type-check` script (dev tool)
- `web/package.json`: `"type-check": "tsc --noEmit"`
- **W9-1b (CI hard gate) DEFERRED** to follow-up PR. Reason: `yarn type-check` fails on `main` with **5 pre-existing real type errors** (i18n template literal key, implicit-any index access, 3 missing module exports from `@aperag/types`). Shipping the gate now would block all PRs immediately; soft-warn is the anti-pattern. Follow-up vertical-slice PR will: (1) fix the 5 errors, (2) add the CI step.

### 🔴 CRITICAL #2 — Remove stale Celery dead code
Wave 3 T3.1 chunk 3 hard-deleted Celery infra (broker / worker / beat / flower) — but 6 config fields, 2 `__post_init__` fallbacks, 3 env vars, and 1 broken `__all__` stayed:
- `aperag/config.py`: drop 6 unused fields (`celery_broker_url`, `celery_result_backend`, `celery_beat_scheduler`, `celery_worker_send_task_events`, `celery_task_send_sent_event`, `celery_task_track_started`) + 2 fallback blocks in `__post_init__`
- `envs/env.template`: drop `CELERY_FLOWER_USER` / `CELERY_FLOWER_PASSWORD` (+ section header)
- `envs/docker.env.overrides`: drop `CELERY_BROKER_URL` line
- `config/__init__.py`: drop broken `__all__ = "celery_app"` (string, not iterable; would silently iterate single chars on `from config import *`)

Verified zero active code references via grep. Comments in `docker-compose.yml` / `Makefile` / observability docs preserved (historical context, per @earayu2 LOW #9 "context preservation 不必清").

### 🔴 CRITICAL #3 — Makefile help message stale `serve-worker` ref
- `Makefile` env-dev step 4 echo: `serve-worker` → `serve-web` (`serve-worker` target was deleted in Wave 3 T3.1 chunk 3)

### 🟡 MEDIUM #1 — Standardize to Docker Compose v2 syntax
- `Makefile` lines 149/156/162/165: `docker-compose` (binary) → `docker compose` (-f docker-compose.yml filename unchanged)
- v1 binary deprecated since 2023; v2 plugin is upstream default

### 🟡 MEDIUM #2 — Fix .dockerignore stale frontend paths
- `.dockerignore`: `frontend/*` → `web/*` (project renamed `frontend/` → `web/` pre-Wave-7); also `.umi*` → `.next` (Next.js build dir, not historical Umi)

### 🟡 MEDIUM #3 — Add .env.example symlink for onboarding
- New `.env.example` → `envs/env.template` (symlink — tracks template automatically)
- `.gitignore`: add `!.env.example` exception under `.env*` rule

## Hard-gate format checklist (Wave 7+8 mirror)

### 4-pattern pre-check matrix
- [x] **#1 不丢失好的算法和设计**: Wave 3 Celery deletion preserved `docker-compose.yml` + observability doc historical comments (context, not dead config). Only stale variable references and dead `__all__` line cleaned.
- [x] **#2 尽快上线**: 6 fixes batched as 1 PR (all small, cohesive, independently ratified — splitting would just be churn).
- [x] **#3 简单稳定**: each fix is mechanical. No semantic change to runtime behavior. Symlink for `.env.example` (not a copy) so it tracks `envs/env.template` automatically.
- [x] **#4 私有化部署免维护**: no new env var; no schema change; no new dependency. CI lint + ruff format + 19 config-related unit tests pass.

### Simple-stable 4-guardrail
- [x] No new abstraction introduced.
- [x] No backward-compat shim (Celery field removal is a clean delete).
- [x] No silent behavior change (only dead code removed; `make help` message corrected from impossible-to-run target name).
- [x] Future contributor onboarding improved (`.env.example` symlink + correct `make help` output + correct `.dockerignore` paths).

## Test plan

- [x] \`python3 -c "import ast; ast.parse(...)"\` — \`config.py\` + \`config/__init__.py\` syntax-valid.
- [x] \`from aperag.config import Config, settings\` — settings construction OK; \`database_url\` + \`local_queue_name\` resolve.
- [x] \`uvx ruff check aperag/config.py config/__init__.py\` — clean.
- [x] \`uvx ruff format --check ...\` — clean.
- [x] \`uv run pytest tests/unit_test/ -k "config or settings"\` — **19 passed**.
- [x] \`git ls-files .env.example\` — symlink visible to git after \`.gitignore\` exception.
- [x] \`readlink .env.example\` → \`envs/env.template\`; \`head\` resolves.
- [ ] CR by @earayu2 — follow-up: ratify W9-1b split (5 type-error sweep + CI tsc gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)