### PR TITLE
fix(graph): LineageGraphStoreWithAliasRedirect missing list_entities (W7-10 drift)

### DIFF
--- a/aperag/indexing/alias_redirect_store.py
+++ b/aperag/indexing/alias_redirect_store.py
@@ -47,6 +47,9 @@ Read-side methods that do NOT redirect:
   matched rows are themselves canonical (alias rows live in
   ``aperag_lineage_entity_alias``, not in the entity table).
 * ``list_entity_labels`` — returns a label set, not entity names.
+* ``list_entities`` (W7-10) — filter is by ``label`` + pagination,
+  not by name; rows are already canonical for the same reason as
+  ``query_entities_by_keyword``.
 * ``find_entity_ids_with_lineage`` / ``find_relation_keys_with_lineage`` —
   filter by ``document_id`` (lineage source), not by name.
 * ``gc_entity_if_orphan`` / ``gc_relation_if_orphan`` — gc operates on
@@ -296,6 +299,20 @@ class LineageGraphStoreWithAliasRedirect:
 
     async def list_entity_labels(self) -> list[str]:
         return await self._inner.list_entity_labels()
+
+    async def list_entities(
+        self,
+        *,
+        label: str | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> list[EntityWithLineage]:
+        # Filter is by ``label`` (entity type) + pagination, not by name —
+        # rows returned are already canonical (alias rows live in
+        # ``aperag_lineage_entity_alias``, not in the entity table).
+        # Same passthrough rationale as ``list_entity_labels`` /
+        # ``query_entities_by_keyword``.
+        return await self._inner.list_entities(label=label, limit=limit, offset=offset)
 
 
 __all__ = ["LineageGraphStoreWithAliasRedirect"]

--- a/tests/unit_test/indexing/test_alias_redirect_store.py
+++ b/tests/unit_test/indexing/test_alias_redirect_store.py
@@ -438,3 +438,41 @@ async def test_decorator_passthrough_for_non_redirected_methods():
     inner.list_entity_labels = AsyncMock(return_value=["a", "b"])
     assert await decorator.list_entity_labels() == ["a", "b"]
     inner.list_entity_labels.assert_awaited_once_with()
+
+    # list_entities (W7-10)
+    inner.list_entities = AsyncMock(return_value=[])
+    assert await decorator.list_entities(label="Person", limit=100, offset=0) == []
+    inner.list_entities.assert_awaited_once_with(label="Person", limit=100, offset=0)
+
+
+@pytest.mark.asyncio
+async def test_decorator_covers_every_lineage_graph_store_method():
+    """Meta-invariant: introspect ``LineageGraphStore`` Protocol and
+    assert the decorator class implements every public async method.
+
+    The spelled-out
+    ``test_decorator_passthrough_for_non_redirected_methods`` only
+    covers the methods that existed when it was written — adding a new
+    Protocol method without updating both decorator + spelled-out test
+    silently passes. This meta-test catches the "decorator missing
+    method" half of that gap (e.g. the W7-10 ``list_entities`` miss
+    that broke ``GET /collections/{id}/graphs`` on production).
+    """
+    from aperag.indexing.graph import LineageGraphStore
+
+    protocol_methods = {
+        name
+        for name in dir(LineageGraphStore)
+        if not name.startswith("_") and callable(getattr(LineageGraphStore, name))
+    }
+    decorator_methods = {
+        name
+        for name in dir(LineageGraphStoreWithAliasRedirect)
+        if not name.startswith("_") and callable(getattr(LineageGraphStoreWithAliasRedirect, name))
+    }
+    missing = protocol_methods - decorator_methods
+    assert not missing, (
+        f"LineageGraphStoreWithAliasRedirect missing Protocol method(s): {sorted(missing)}. "
+        f"Add either a redirect (if the input takes an entity name) or a passthrough "
+        f"(see module docstring rationale) to alias_redirect_store.py."
+    )


### PR DESCRIPTION
## What broke

Wave 7 task #10 (PR #1765) added \`list_entities\` to the \`LineageGraphStore\` Protocol + 4 backends. The \`LineageGraphStoreWithAliasRedirect\` decorator was NOT updated, and the spelled-out passthrough invariant test (\`test_decorator_passthrough_for_non_redirected_methods\`) only covers the methods that existed when it was written — so the gap landed silently.

Production crash on \`GET /api/v2/collections/{id}/graphs\`:

\`\`\`
AttributeError: 'LineageGraphStoreWithAliasRedirect' object has no attribute 'list_entities'
  File "aperag/domains/knowledge_graph/service.py", line 149,
       in get_knowledge_graph
    entities = await store.list_entities(label=normalized_label, limit=query_max_nodes)
\`\`\`

This is also the **e2e-http-provider failure visible on every Wave 7+8 PR** including the just-merged #1771 / #1772 — pre-existing on main since W7-10 close-out, masked because e2e-http-smoke shapes don't exercise the graph view endpoint.

## Fix

1. Add \`list_entities\` passthrough method on the decorator. Filter is by \`label\` (entity type) + pagination, not by name — rows are already canonical (alias rows live in \`aperag_lineage_entity_alias\`, not in the entity table). Same passthrough rationale as \`list_entity_labels\` / \`query_entities_by_keyword\`; module docstring updated.

2. Add \`list_entities\` row to the spelled-out passthrough test.

3. **NEW meta-invariant test**: \`test_decorator_covers_every_lineage_graph_store_method\` — introspect \`LineageGraphStore\` Protocol via \`dir()\` and assert the decorator implements every public method. Catches the "decorator missing method" half of the drift gap that the spelled-out test couldn't catch (because spelled-out tests only cover methods that existed when written). A future Protocol addition without a decorator update now fails CI immediately with a clear \`missing method(s): X\` assertion.

## Hard-gate format checklist (Wave 7+8 mirror)

### 4-pattern pre-check matrix
- [x] **#1 不丢失好的算法和设计**: passthrough rationale preserved per module docstring (filter-by-label not filter-by-name).
- [x] **#2 尽快上线**: 1 fix + 2 new tests (1 spelled-out row + 1 meta-test). No new abstraction.
- [x] **#3 简单稳定**: passthrough is byte-for-byte forward, mirror of \`list_entity_labels\`. Meta-test uses stdlib introspection, no new dep.
- [x] **#4 私有化部署免维护**: zero new env / config / dep. Backend-portable (decorator wraps the 4-backend Protocol; the actual \`list_entities\` implementation already covered by 4-backend compat tests).

### Simple-stable 4-guardrail
- [x] No new abstraction.
- [x] No backward-compat shim.
- [x] No silent behavior change — fix is additive (method that didn't exist now exists; behavior matches 4-backend Protocol contract).
- [x] Meta-test prevents this exact class of drift recurring.

## Test plan

- [x] \`uv run pytest tests/unit_test/indexing/test_alias_redirect_store.py\` — **16 passed** (was 15, +1 meta-test, +1 spelled-out \`list_entities\` row).
- [x] \`uvx ruff check\` — clean. \`uvx ruff format --check\` — clean.
- [ ] Production verify: \`GET /collections/{id}/graphs\` returns 200 after this lands (the original crash from main e2e-http-provider log) — will be visible on next PR's e2e-http-provider checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)