### PR TITLE
test(web): align bot/types contract gate with #1774 FE-local ChatMessage/Reference

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -542,13 +542,23 @@ def test_bot_feature_uses_v2_typed_api_boundary():
     # Positive: features/bot/types exposes the schema-derived chat shell
     # aliases + the runtime `FEEDBACK_TAGS` const (constrained by
     # `satisfies readonly FeedbackTag[]`), matching the locked gate.
+    #
+    # ``ChatMessage`` and ``Reference`` were originally schema-derived
+    # but the underlying OpenAPI components were removed/refactored in
+    # Wave 8 D8.5+ (history → ``AgentTurnSnapshot``; reference →
+    # ``DataCitationPart`` / ``SourceDocumentPart`` / ``SourceUrlPart``).
+    # PR #1774 swept the broken ``components['schemas'][...]`` lookups
+    # and replaced them with FE-local types pending a proper renderer
+    # migration (TODO W9-3). Pin the FE-local shape so a future
+    # contributor doesn't silently re-introduce the broken schema
+    # lookup.
     bot_types = (REPO_ROOT / "web/src/features/bot/types.ts").read_text()
-    assert "components['schemas']['ChatMessage']" in bot_types
     assert "components['schemas']['Feedback']" in bot_types
-    assert "components['schemas']['Reference']" in bot_types
     assert "NonNullable<Feedback['tag']>" in bot_types
     assert "NonNullable<Feedback['type']>" in bot_types
     assert "satisfies readonly FeedbackTag[]" in bot_types
+    assert "export type ChatMessage = {" in bot_types
+    assert "export type Reference = {" in bot_types
 
 
 def test_collection_feature_uses_v2_typed_api_boundary():


### PR DESCRIPTION
PR #1774 (W9-1b CI tsc gate) swept \`ChatMessage\` and \`Reference\` from \`web/src/features/bot/types.ts\` — the underlying OpenAPI \`schemas\` were removed/refactored in Wave 8 D8.5+ (\`AgentTurnSnapshot\` / \`DataCitationPart\` / \`SourceDocumentPart\` / \`SourceUrlPart\`), so the FE replaced the broken \`components['schemas'][...]\` lookups with FE-local types pending a proper renderer migration (TODO W9-3).

The contract test \`test_bot_feature_uses_v2_typed_api_boundary\` still asserted the old schema-derived shape and started failing on every PR once #1774 landed:

\`\`\`
assert "components['schemas']['ChatMessage']" in bot_types
AssertionError
\`\`\`

**This is a CR drift on my own #1774** — I should have updated the contract test in the same PR. Hot-fix here so all PR CI (including @earayu #1775 V3→V2 rename in_review) goes green.

## Fix

- Drop the two stale schema-lookup assertions (\`ChatMessage\` / \`Reference\`).
- Pin the FE-local fallback shape (\`export type ChatMessage = {\` / \`export type Reference = {\`) so a future contributor can't silently re-introduce a broken schema lookup.
- Comment block explains the W8 D8.5 history + W9-3 follow-up.
- \`Feedback\` + \`FeedbackTag\` + \`FEEDBACK_TAGS\` assertions kept unchanged (still schema-derived; the gate intent there is unchanged).

## Test plan

- [x] \`uv run pytest tests/unit_test/test_web_typed_api_contract.py\` — **16 passed** (was 15 passed + 1 failed before this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)