### PR TITLE
fix(indexing): batch vector embeddings

### DIFF
--- a/aperag/config.py
+++ b/aperag/config.py
@@ -179,6 +179,7 @@ class Config(BaseSettings):
 
     # Embedding
     embedding_max_chunks_in_batch: int = Field(10, alias="EMBEDDING_MAX_CHUNKS_IN_BATCH")
+    embedding_max_workers: int = Field(1, alias="EMBEDDING_MAX_WORKERS")
 
     # Memory backend
     memory_redis_url: Optional[str] = Field(None, alias="MEMORY_REDIS_URL")

--- a/aperag/indexing/vector.py
+++ b/aperag/indexing/vector.py
@@ -166,6 +166,7 @@ class VectorModality(ModalityWorker):
         backend: VectorBackend,
         store: _SyncObjectStore,
         embedder: callable | None = None,
+        batch_embedder: callable | None = None,
     ) -> None:
         self._backend = backend
         self._store = store
@@ -173,6 +174,7 @@ class VectorModality(ModalityWorker):
         # for the real embedding service without changing the
         # ``ModalityWorker`` interface.
         self._embedder = embedder or _placeholder_embedding
+        self._batch_embedder = batch_embedder
 
     async def derive(
         self,
@@ -221,10 +223,13 @@ class VectorModality(ModalityWorker):
             )
             return
 
-        for chunk in chunks:
+        texts = [chunk.get("text", "") for chunk in chunks]
+        embeddings = self._batch_embedder(texts) if self._batch_embedder is not None else None
+
+        for index, chunk in enumerate(chunks):
             chunk_id = chunk["chunk_id"]
-            text = chunk.get("text", "")
-            embedding = self._embedder(text)
+            text = texts[index]
+            embedding = embeddings[index] if embeddings is not None else self._embedder(text)
             payload = {
                 "document_id": document_id,
                 "parse_version": parse_version,

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -234,10 +234,12 @@ def _build_vector_worker(*, collection: Any, object_store: Any) -> ModalityWorke
     adaptor, embedding_service, _ = _build_collection_qdrant_connector(collection)
     backend = _QdrantPointBackend(connector=adaptor.connector)
 
-    def _embed(text: str) -> list[float]:
-        return embedding_service.embed_query(text)
-
-    return VectorModality(backend=backend, store=object_store, embedder=_embed)
+    return VectorModality(
+        backend=backend,
+        store=object_store,
+        embedder=embedding_service.embed_query,
+        batch_embedder=embedding_service.embed_documents,
+    )
 
 
 def _build_fulltext_worker(*, collection: Any, object_store: Any) -> ModalityWorker:

--- a/aperag/llm/embed/base_embedding.py
+++ b/aperag/llm/embed/base_embedding.py
@@ -65,6 +65,7 @@ def get_embedding_service(model_id: str, user_id: str) -> tuple[EmbeddingService
         embedding_service_url=invocation.base_url,
         embedding_service_api_key=invocation.api_key,
         embedding_max_chunks_in_batch=settings.embedding_max_chunks_in_batch,
+        embedding_max_workers=settings.embedding_max_workers,
         multimodal=multimodal,
     )
     return embedding_svc, _get_embedding_dimension(embedding_svc, model_id, invocation.embedding_dimensions)

--- a/aperag/llm/embed/embedding_service.py
+++ b/aperag/llm/embed/embedding_service.py
@@ -41,6 +41,7 @@ class EmbeddingService:
         embedding_service_url: str,
         embedding_service_api_key: str,
         embedding_max_chunks_in_batch: int,
+        embedding_max_workers: int = 1,
         multimodal: bool = False,
         caching: bool = True,
     ):
@@ -49,7 +50,7 @@ class EmbeddingService:
         self.api_base = embedding_service_url
         self.api_key = embedding_service_api_key
         self.max_chunks = embedding_max_chunks_in_batch
-        self.max_workers = 8
+        self.max_workers = max(1, embedding_max_workers)
         self.multimodal = multimodal
         self.caching = caching
 

--- a/tests/unit_test/indexing/test_t1_3_vector_fulltext.py
+++ b/tests/unit_test/indexing/test_t1_3_vector_fulltext.py
@@ -241,6 +241,47 @@ def test_vector_payload_carries_modality_discriminator():
         assert point["payload"]["modality"] == Modality.VECTOR.value
 
 
+def test_vector_sync_uses_batch_embedder_when_available():
+    """Production vector sync should batch embeddings instead of issuing one
+    external embedding request per chunk.
+
+    Large PDFs can produce hundreds of chunks; calling ``embed_query`` for
+    each chunk overwhelms OpenAI-compatible providers such as DashScope. The
+    vector modality keeps the single-item embedder for simulator tests, but
+    production wiring should be able to pass a batch embedder.
+    """
+
+    store = InMemoryObjectStore()
+    backend = InMemoryVectorBackend()
+    from aperag.indexing import ChunkingConfig, ParseConfig
+
+    parsed = parse_document(
+        store=store,
+        collection_id="col-1",
+        document_id="doc-batch",
+        source_bytes=SAMPLE_MARKDOWN.encode("utf-8"),
+        config=ParseConfig(chunking=ChunkingConfig(chunk_size=80, chunk_overlap=0)),
+    )
+    calls: list[list[str]] = []
+
+    def batch_embedder(texts: list[str]) -> list[list[float]]:
+        calls.append(list(texts))
+        return [[float(i)] for i, _ in enumerate(texts)]
+
+    asyncio.run(
+        VectorModality(backend=backend, store=store, batch_embedder=batch_embedder).sync(
+            document_id="doc-batch",
+            parse_version=parsed.parse_version,
+            derived_artifact_path=parsed.chunks_path,
+        )
+    )
+
+    points = backend.points_for_document("doc-batch", parsed.parse_version)
+    assert len(points) > 1
+    assert len(calls) == 1
+    assert len(calls[0]) == len(points)
+
+
 def test_fulltext_payload_carries_modality_discriminator():
     store = InMemoryObjectStore()
     backend = InMemoryFulltextBackend()

--- a/tests/unit_test/llm/test_embedding_encoding_format.py
+++ b/tests/unit_test/llm/test_embedding_encoding_format.py
@@ -114,3 +114,26 @@ def test_embedding_service_source_pins_encoding_format_float():
         'embedding_service.py must keep the literal encoding_format="float" '
         "pin in the litellm.embedding(...) call. See task #15."
     )
+
+
+def test_embedding_service_accepts_configurable_worker_count():
+    """Embedding concurrency must be configurable for providers that reset
+    connections under high parallel batch load.
+
+    DashScope-compatible embeddings can handle a single request but reset
+    connections when a large document fans out into many concurrent batches.
+    The service should not hard-code eight workers; callers need to pass a
+    safer concurrency value from settings.
+    """
+
+    service = EmbeddingService(
+        embedding_provider="alibabacloud",
+        embedding_model="text-embedding-v3",
+        embedding_service_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        embedding_service_api_key="sk-test-not-used",
+        embedding_max_chunks_in_batch=10,
+        embedding_max_workers=2,
+        caching=False,
+    )
+
+    assert service.max_workers == 2


### PR DESCRIPTION
## Summary
- Batch vector-index embedding calls instead of invoking the embedding provider once per chunk.
- Add configurable embedding worker concurrency with a conservative default for provider stability.
- Cover the vector batch path and embedding worker configuration with focused unit tests.

## Test plan
- `uv run pytest tests/unit_test/indexing/test_t1_3_vector_fulltext.py::test_vector_sync_uses_batch_embedder_when_available tests/unit_test/llm/test_embedding_encoding_format.py -q`
- Manually verified the previously failed document indexes reached `ACTIVE` for fulltext, graph, and vector.


Made with [Cursor](https://cursor.com)