### PR TITLE
fix(web i18n): nest flat dot-notation status / source_type keys

### DIFF
--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -340,12 +340,14 @@
     "actions": "Actions",
     "retry_item": "Retry item",
     "open_chat": "Open chat",
-    "status.queued": "Queued",
-    "status.pending": "Pending",
-    "status.running": "Running",
-    "status.completed": "Completed",
-    "status.failed": "Failed",
-    "status.cancelled": "Cancelled"
+    "status": {
+      "queued": "Queued",
+      "pending": "Pending",
+      "running": "Running",
+      "completed": "Completed",
+      "failed": "Failed",
+      "cancelled": "Cancelled"
+    }
   },
   "page_chat": {
     "metadata": {
@@ -525,9 +527,11 @@
     "dataset_created_at": "Created at",
     "dataset_item_count": "Questions",
     "dataset_source_type": "Source",
-    "source_type.manual": "Manual",
-    "source_type.import": "Import",
-    "source_type.generated": "Generated",
+    "source_type": {
+      "manual": "Manual",
+      "import": "Import",
+      "generated": "Generated"
+    },
     "open_dataset": "Manage questions",
     "manage_dataset_items": "Manage questions",
     "delete_dataset": "Delete dataset",

--- a/web/src/i18n/en-US/page_bot_evaluation.json
+++ b/web/src/i18n/en-US/page_bot_evaluation.json
@@ -51,10 +51,12 @@
   "actions": "Actions",
   "retry_item": "Retry item",
   "open_chat": "Open chat",
-  "status.queued": "Queued",
-  "status.pending": "Pending",
-  "status.running": "Running",
-  "status.completed": "Completed",
-  "status.failed": "Failed",
-  "status.cancelled": "Cancelled"
+  "status": {
+    "queued": "Queued",
+    "pending": "Pending",
+    "running": "Running",
+    "completed": "Completed",
+    "failed": "Failed",
+    "cancelled": "Cancelled"
+  }
 }

--- a/web/src/i18n/en-US/page_collection_evaluations.json
+++ b/web/src/i18n/en-US/page_collection_evaluations.json
@@ -25,9 +25,11 @@
   "dataset_created_at": "Created at",
   "dataset_item_count": "Questions",
   "dataset_source_type": "Source",
-  "source_type.manual": "Manual",
-  "source_type.import": "Import",
-  "source_type.generated": "Generated",
+  "source_type": {
+    "manual": "Manual",
+    "import": "Import",
+    "generated": "Generated"
+  },
   "open_dataset": "Manage questions",
   "manage_dataset_items": "Manage questions",
   "delete_dataset": "Delete dataset",

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -340,12 +340,14 @@
     "actions": "操作",
     "retry_item": "重试条目",
     "open_chat": "打开聊天",
-    "status.queued": "排队中",
-    "status.pending": "待处理",
-    "status.running": "运行中",
-    "status.completed": "已完成",
-    "status.failed": "失败",
-    "status.cancelled": "已取消"
+    "status": {
+      "queued": "排队中",
+      "pending": "待处理",
+      "running": "运行中",
+      "completed": "已完成",
+      "failed": "失败",
+      "cancelled": "已取消"
+    }
   },
   "page_chat": {
     "metadata": {
@@ -525,9 +527,11 @@
     "dataset_created_at": "创建时间",
     "dataset_item_count": "问题数",
     "dataset_source_type": "来源",
-    "source_type.manual": "手动录入",
-    "source_type.import": "文件导入",
-    "source_type.generated": "自动生成",
+    "source_type": {
+      "manual": "手动录入",
+      "import": "文件导入",
+      "generated": "自动生成"
+    },
     "open_dataset": "管理问题",
     "manage_dataset_items": "管理问题",
     "delete_dataset": "删除数据集",

--- a/web/src/i18n/zh-CN/page_bot_evaluation.json
+++ b/web/src/i18n/zh-CN/page_bot_evaluation.json
@@ -51,10 +51,12 @@
   "actions": "操作",
   "retry_item": "重试条目",
   "open_chat": "打开聊天",
-  "status.queued": "排队中",
-  "status.pending": "待处理",
-  "status.running": "运行中",
-  "status.completed": "已完成",
-  "status.failed": "失败",
-  "status.cancelled": "已取消"
+  "status": {
+    "queued": "排队中",
+    "pending": "待处理",
+    "running": "运行中",
+    "completed": "已完成",
+    "failed": "失败",
+    "cancelled": "已取消"
+  }
 }

--- a/web/src/i18n/zh-CN/page_collection_evaluations.json
+++ b/web/src/i18n/zh-CN/page_collection_evaluations.json
@@ -25,9 +25,11 @@
   "dataset_created_at": "创建时间",
   "dataset_item_count": "问题数",
   "dataset_source_type": "来源",
-  "source_type.manual": "手动录入",
-  "source_type.import": "文件导入",
-  "source_type.generated": "自动生成",
+  "source_type": {
+    "manual": "手动录入",
+    "import": "文件导入",
+    "generated": "自动生成"
+  },
   "open_dataset": "管理问题",
   "manage_dataset_items": "管理问题",
   "delete_dataset": "删除数据集",


### PR DESCRIPTION
## Summary

`<NextIntlClientProvider>` boots through `next-intl`'s strict key validator, which interprets `.` as a namespace nesting separator. Two evaluation namespaces shipped flat dot-notation keys (\`\"status.queued\": \"...\"\`, \`\"source_type.manual\": \"...\"\`); the validator rejected them, the provider raised \`INVALID_KEY\` from the root layout, and **every page** that mounted the layout (incl. \`/workspace/collections/{id}/graph\`) crashed with a client-side exception.

Convert the two namespaces to nested objects matching the convention the rest of `web/src/i18n/**` already uses (sibling `page_prompts.status.{...}` was already nested). Aggregate files regenerated via `yarn i18n:sync`. **Caller code is unchanged** — `next-intl` resolves the dotted lookup against the nested object identically to how it used to resolve against the flat key.

Diagnosis credit: @冬柏 via #前后端整合 msg=6876b4e5 (2026-04-28 13:51).

## §K.12 invariant cross-check

Largely n/a (frontend i18n behaviour fix). Direct hit:
- **#12** (grep-zero LightRAG) — `rg -i lightrag web/src/` returns zero hits both before and after ✅.

## 4-pattern pre-check matrix

- **Pattern 1 v1** (other flat dot-notation keys): \`rg '\"(status|source_type)\\.(\\w+)\":' web/src/i18n/zh-CN/ web/src/i18n/en-US/\` returns zero remaining hits after the fix. Sibling namespace `page_prompts` was already nested, so no other call sites needed touching.
- **Pattern 1 v2** (consumers of the touched keys): `status-badge.tsx:30` builds \`status.${status.toLowerCase()}\` and `evaluation-datasets-panel.tsx:47` `sourceTypeLabelKey()` returns \`source_type.<value>\`; `next-intl` walks both segments against the nested object the same way it walked the flat key, so no JS change is required.
- **Pattern 2** (response-shape change list): n/a, this PR does not touch any backend or generated schema.
- **Pattern 3** (additive helpers): n/a, key-shape sweep only.

## simple-stable directive 4-guardrail

- **#1 不无限扩范围** — touches the two namespaces named in the console error plus the regenerated aggregates. Other namespaces were swept and verified clean.
- **#2 尽快上线** — small targeted fix unblocking the entire app layout (graph page was the symptom, but the layout crash affected every route).
- **#3 简单稳定** — converges these namespaces on the already-prevailing nested-key convention; no new pattern, no fragile dotted-key special case.
- **#4 私有化部署免维护** — operator-invisible; restores intended behaviour.

## Test plan

- [x] `yarn i18n:sync` regenerated aggregates without warnings
- [x] `yarn tsc --noEmit` reports **0 errors** (incl. clearing 5 unrelated pre-existing errors that the regen surfaced earlier in PR #1764 — those traced back to other namespaces being out of date relative to the aggregate. Their fix in this regen is incidental but confirmed locally.)
- [x] `rg '\"(status|source_type)\\.(\\w+)\":' web/src/i18n/zh-CN/ web/src/i18n/en-US/` → zero hits
- [ ] Manual: hit `/workspace/collections/{id}/graph` in dev — RootLayout no longer raises \`INVALID_KEY\`; status badges + dataset source-type column render localized text. (deferred to reviewer-side smoke since I don't have the local dev stack running.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)