### PR TITLE
fix(kb): document status/preview, hide retrieval UI, model labels

### DIFF
--- a/aperag/domains/knowledge_base/service/document_service.py
+++ b/aperag/domains/knowledge_base/service/document_service.py
@@ -82,6 +82,7 @@ from aperag.exceptions import (
 )
 from aperag.indexing.models import (
     DocumentIndex,
+    IndexStatus,
     Modality,
 )
 from aperag.objectstore.base import get_async_object_store
@@ -99,6 +100,27 @@ from aperag.utils.uncompress import SUPPORTED_COMPRESSED_EXTENSIONS
 from aperag.utils.utils import calculate_file_hash, generate_vector_db_collection_name, utc_now
 
 logger = logging.getLogger(__name__)
+
+
+def _index_statuses_to_document_status(indexes: dict, fallback: DocumentStatus) -> DocumentStatus:
+    enabled_indexes = [index for index in indexes.values() if index]
+    if not enabled_indexes:
+        return fallback
+
+    statuses = [index.get("status") for index in enabled_indexes]
+    if any(status == IndexStatus.FAILED.value for status in statuses):
+        return DocumentStatus.FAILED
+    if any(status in (IndexStatus.PENDING.value, IndexStatus.RUNNING.value) for status in statuses):
+        return DocumentStatus.RUNNING
+    if all(index.get("status") == IndexStatus.ACTIVE.value and index.get("is_serving") for index in enabled_indexes):
+        return DocumentStatus.COMPLETE
+    return fallback
+
+
+def _markdown_path_from_derived_artifact(derived_artifact_path: str | None) -> str | None:
+    if not derived_artifact_path:
+        return None
+    return f"{os.path.dirname(derived_artifact_path)}/markdown.md"
 
 
 # ---------------------------------------------------------------------
@@ -515,6 +537,7 @@ class DocumentService:
                     DocumentIndex.created_at.label("index_created_at"),
                     DocumentIndex.updated_at.label("index_updated_at"),
                     DocumentIndex.error_message.label("index_error_message"),
+                    DocumentIndex.is_serving.label("index_is_serving"),
                 )
                 .select_from(
                     outerjoin(
@@ -564,6 +587,7 @@ class DocumentService:
                         "created_at": row.index_created_at,
                         "updated_at": row.index_updated_at,
                         "error_message": row.index_error_message,
+                        "is_serving": row.index_is_serving,
                         "index_data": None,
                     }
 
@@ -594,7 +618,7 @@ class DocumentService:
         return DocumentSchema(
             id=document.id,
             name=document.name,
-            status=document.status,
+            status=_index_statuses_to_document_status(indexes, document.status),
             # Per-modality status: ``None`` when the row does not exist
             # (modality not enabled for this collection — the dispatcher
             # never created a document_index row). Wave 3 §F.2 hard-cut
@@ -800,6 +824,7 @@ class DocumentService:
                         "created_at": index.created_at,
                         "updated_at": index.updated_at,
                         "error_message": index.error_message,
+                        "is_serving": index.is_serving,
                         "index_data": None,
                     }
 
@@ -1198,10 +1223,15 @@ class DocumentService:
             # 3. Get markdown content
             async_obj_store = get_async_object_store()
             markdown_content = ""
-            # The parsed markdown file is stored with the name "parsed.md"
-            markdown_path = f"{document.object_store_base_path()}/parsed.md"
+            vector_index_stmt = select(DocumentIndex.derived_artifact_path).filter(
+                DocumentIndex.document_id == document_id,
+                DocumentIndex.modality == Modality.VECTOR.value,
+                DocumentIndex.is_serving.is_(True),
+            )
+            vector_index_result = await session.execute(vector_index_stmt)
+            markdown_path = _markdown_path_from_derived_artifact(vector_index_result.scalars().first())
             try:
-                md_obj_result = await async_obj_store.get(markdown_path)
+                md_obj_result = await async_obj_store.get(markdown_path) if markdown_path else None
                 if md_obj_result:
                     md_stream, _ = md_obj_result
                     content = b""

--- a/tests/unit_test/test_document_service_index_state.py
+++ b/tests/unit_test/test_document_service_index_state.py
@@ -1,0 +1,51 @@
+from aperag.domains.knowledge_base.db.models import DocumentStatus
+from aperag.domains.knowledge_base.service.document_service import (
+    _index_statuses_to_document_status,
+    _markdown_path_from_derived_artifact,
+)
+
+
+def test_document_response_status_uses_active_serving_indexes():
+    assert (
+        _index_statuses_to_document_status(
+            {
+                "VECTOR": {"status": "ACTIVE", "is_serving": True},
+                "FULLTEXT": {"status": "ACTIVE", "is_serving": True},
+                "GRAPH": {"status": "ACTIVE", "is_serving": True},
+                "SUMMARY": None,
+                "VISION": None,
+            },
+            fallback=DocumentStatus.PENDING,
+        )
+        == DocumentStatus.COMPLETE
+    )
+
+
+def test_document_response_status_preserves_running_and_failed_indexes():
+    assert (
+        _index_statuses_to_document_status(
+            {
+                "VECTOR": {"status": "ACTIVE", "is_serving": True},
+                "FULLTEXT": {"status": "RUNNING", "is_serving": False},
+            },
+            fallback=DocumentStatus.PENDING,
+        )
+        == DocumentStatus.RUNNING
+    )
+    assert (
+        _index_statuses_to_document_status(
+            {
+                "VECTOR": {"status": "ACTIVE", "is_serving": True},
+                "FULLTEXT": {"status": "FAILED", "is_serving": False},
+            },
+            fallback=DocumentStatus.PENDING,
+        )
+        == DocumentStatus.FAILED
+    )
+
+
+def test_markdown_preview_uses_parse_artifact_directory():
+    assert (
+        _markdown_path_from_derived_artifact("collections/col/documents/doc/derived/parse_abcd/chunks.jsonl")
+        == "collections/col/documents/doc/derived/parse_abcd/markdown.md"
+    )

--- a/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
@@ -45,6 +45,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
+import { showRetrievalTestModule } from '../feature-visibility';
 import { CollectionDelete } from './collection-delete';
 
 export const CollectionHeader = ({ className }: { className?: string }) => {
@@ -111,12 +112,14 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
               label: page_graph('metadata.title'),
             }
           : null,
-        {
-          href: urls.search,
-          active: Boolean(pathname.match(urls.search)),
-          icon: FolderSearch,
-          label: page_search('metadata.title'),
-        },
+        showRetrievalTestModule
+          ? {
+              href: urls.search,
+              active: Boolean(pathname.match(urls.search)),
+              icon: FolderSearch,
+              label: page_search('metadata.title'),
+            }
+          : null,
         {
           href: urls.settings,
           active: Boolean(pathname.match(urls.settings)),

--- a/web/src/app/workspace/collections/[collectionId]/search/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/search/page.tsx
@@ -5,6 +5,8 @@ import {
 } from '@/components/page-container';
 import { listSearches } from '@/features/retrieval/server-api';
 import { getTranslations } from 'next-intl/server';
+import { redirect } from 'next/navigation';
+import { showRetrievalTestModule } from '../../feature-visibility';
 import { CollectionHeader } from '../collection-header';
 import { SearchTable } from './search-table';
 
@@ -13,9 +15,14 @@ export default async function Page({
 }: Readonly<{
   params: Promise<{ collectionId: string }>;
 }>) {
+  const { collectionId } = await params;
+
+  if (!showRetrievalTestModule) {
+    redirect(`/workspace/collections/${collectionId}/documents`);
+  }
+
   const page_collections = await getTranslations('page_collections');
   const page_search = await getTranslations('page_search');
-  const { collectionId } = await params;
 
   const searchRes = await listSearches(collectionId);
 

--- a/web/src/app/workspace/collections/collection-form.tsx
+++ b/web/src/app/workspace/collections/collection-form.tsx
@@ -56,6 +56,9 @@ import { toast } from 'sonner';
 import * as z from 'zod';
 import { isVisibleCollectionConfigKey } from './feature-visibility';
 
+const modelSelectLabel = (m: ModelSpec) =>
+  (m.display_name?.trim() || m.model_id || '').trim();
+
 const collectionModelSchema = z
   .object({
     model_id: z.string(),
@@ -197,10 +200,36 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
   const loadModels = useCallback(async () => {
     const models = await getAvailableModels(['chat', 'embedding']);
     setCompletionModels(
-      [{ label: page_collections('completion_model'), name: 'chat', models: models.filter((m) => m.capability === 'chat').map((m) => ({ model_id: m.id, temperature: 0.1, tags: [] })) }],
+      [
+        {
+          label: page_collections('completion_model'),
+          name: 'chat',
+          models: models
+            .filter((m) => m.capability === 'chat')
+            .map((m) => ({
+              model_id: m.id,
+              display_name: m.display_name,
+              temperature: 0.1,
+              tags: [],
+            })),
+        },
+      ],
     );
     setEmbeddingModels(
-      [{ label: page_collections('embedding_model'), name: 'embedding', models: models.filter((m) => m.capability === 'embedding').map((m) => ({ model_id: m.id, temperature: 0.1, tags: [] })) }],
+      [
+        {
+          label: page_collections('embedding_model'),
+          name: 'embedding',
+          models: models
+            .filter((m) => m.capability === 'embedding')
+            .map((m) => ({
+              model_id: m.id,
+              display_name: m.display_name,
+              temperature: 0.1,
+              tags: [],
+            })),
+        },
+      ],
     );
   }, [page_collections]);
 
@@ -510,7 +539,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
                                           key={model.model_id}
                                           value={model.model_id || ''}
                                         >
-                                          {model.model_id}
+                                          {modelSelectLabel(model)}
                                         </SelectItem>
                                       );
                                     })}
@@ -562,7 +591,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
                                         key={model.model_id}
                                         value={model.model_id || ''}
                                       >
-                                        {model.model_id}
+                                        {modelSelectLabel(model)}
                                       </SelectItem>
                                     );
                                   })}

--- a/web/src/app/workspace/collections/feature-visibility.ts
+++ b/web/src/app/workspace/collections/feature-visibility.ts
@@ -4,6 +4,9 @@ import type {
   SearchResultItem,
 } from '@/features/retrieval/types';
 
+/** When false, hide the collection "retrieval test" UI (nav tab + /search page). */
+export const showRetrievalTestModule = false;
+
 const hiddenCollectionConfigKeys = new Set([
   'config.enable_summary',
   'config.enable_vision',

--- a/web/src/features/providers/types.ts
+++ b/web/src/features/providers/types.ts
@@ -84,6 +84,8 @@ export type ModelPlatformViewModel = {
 
 export type ModelSpec = {
   model_id?: string | null;
+  /** UI label from model platform; form values stay `model_id`. */
+  display_name?: string | null;
   temperature?: number | null;
   max_tokens?: number | null;
   max_completion_tokens?: number | null;


### PR DESCRIPTION
## Summary

- **Backend**: Aggregate per-modality `DocumentIndex` status (including `is_serving`) into `DocumentSchema.status` for list/detail; derive markdown preview path from the serving vector index `derived_artifact_path`.
- **Tests**: Unit tests for status aggregation and markdown path helper.
- **Web**: Hide knowledge-base retrieval-test nav and redirect `/collections/:id/search` when disabled (`showRetrievalTestModule`).
- **Web**: Collection form embedding/completion selects show `display_name` with fallback to `model_id`.

## Test plan

- `uv run pytest tests/unit_test/test_document_service_index_state.py`
- Manual: document list shows COMPLETE when indexes ACTIVE; preview opens; collection form shows model names.

Made with [Cursor](https://cursor.com)