### PR TITLE
perf(web): re-enable Turbopack dev — drop dead MDX JS plugin chain

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,18 +1,6 @@
 import createMDXPlugin from '@next/mdx';
-import { h } from 'hastscript';
 import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
-import remarkDirective from 'remark-directive';
-import remarkFrontmatter from 'remark-frontmatter';
-import remarkGfm from 'remark-gfm';
-import remarkGithubAdmonitionsToDirectives from 'remark-github-admonitions-to-directives';
-import remarkHeaderId from 'remark-heading-id';
-import { visit } from 'unist-util-visit';
-// import remarkMdxFrontmatter from "remark-mdx-frontmatter";
-// import rehypeToc from '@jsdevtools/rehype-toc';
-import rehypeHighlight from 'rehype-highlight';
-
-// import rehypeHighlightLines from 'rehype-highlight-code-lines';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 
@@ -57,51 +45,24 @@ const withNextIntl = createNextIntlPlugin({
 /**
  * https://nextjs.org/docs/app/guides/mdx
  * https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968
+ *
+ * No JS remark/rehype plugins are wired here on purpose: there are
+ * currently zero `.mdx` pages in the tree, so any plugin chain would be
+ * dead code at compile time. Runtime markdown rendering goes through
+ * `web/src/components/markdown.tsx`, which keeps its own React-side
+ * `react-markdown` plugin pipeline (gfm, highlight, directives,
+ * frontmatter, headerId).
+ *
+ * Keeping the chain empty makes the loader options worker-serializable,
+ * which is what `next dev --turbopack` requires (custom inline closures
+ * break the Turbopack worker pool with "loader options are not
+ * serializable"). If `.mdx` pages are introduced later, prefer
+ * `experimental.mdxRs: true` (Rust-based MDX) for Turbopack
+ * compatibility, or extract any JS plugins into their own modules so
+ * each one can be passed as an importable reference.
  */
 const withNextMDX = createMDXPlugin({
-  // Add markdown plugins here, as desired
   extension: /\.(md|mdx)$/,
-  options: {
-    remarkPlugins: [
-      remarkGfm,
-      remarkFrontmatter,
-      // remarkMdxFrontmatter,
-      remarkGithubAdmonitionsToDirectives,
-      remarkDirective,
-      () => {
-        return (tree) => {
-          visit(tree, (node) => {
-            if (node.type === 'containerDirective') {
-              const data = node.data || (node.data = {});
-              const tagName = 'div';
-              data.hName = tagName;
-              data.hProperties = h(tagName, {
-                ...node.attributes,
-                class: node.name,
-              }).properties;
-            }
-          });
-        };
-      },
-      [
-        remarkHeaderId,
-        {
-          defaults: true,
-        },
-      ],
-    ],
-    rehypePlugins: [
-      rehypeHighlight,
-      // rehypeHighlightLines,
-      // [
-      //   rehypeToc,
-      //   {
-      //     // position: 'beforebegin', // "beforebegin" | "afterbegin" | "beforeend" | "afterend"
-      //     headings: ['h2', 'h3', 'h4', 'h5', 'h6'],
-      //   },
-      // ],
-    ],
-  },
 });
 
 export default withNextMDX(withNextIntl(nextConfig));

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "api:build": "yarn api:v2:types",
     "api:v2:types": "mkdir -p ./src/api-v2 && openapi-typescript ../openapi.public.json -o ./src/api-v2/schema.d.ts",
     "build": "yarn install && yarn i18n:sync && next build && ts-node scripts/build.mjs",
-    "dev": "cp ./deploy/env.local.template ./.env && yarn install && yarn i18n:sync && next dev",
+    "dev": "cp ./deploy/env.local.template ./.env && yarn install && yarn i18n:sync && next dev --turbopack",
     "i18n:sync": "node scripts/i18n-watch.mjs",
     "lint": "next lint",
     "prettier": "prettier --cache --write ./ && yarn lint",


### PR DESCRIPTION
## Summary

`next dev --turbopack` is 10–50× faster than the Webpack default for HMR + per-route first-compile. PR #1667 disabled it because the inline `containerDirective` remark plugin in `next.config.ts` was a closure that Turbopack's worker pool cannot serialize. Empirically the **entire** JS plugin chain has the same problem — even after the inline closure is hoisted to its own module, `next dev --turbopack` still aborts with:

> Error: loader /node_modules/@next/mdx/mdx-js-loader.js for match \"#next-mdx\" does not have serializable options.

The unusual trade-off here: **this plugin chain is dead code at compile time**. There are zero `.mdx` pages in `web/src/**` (verified via `find` + `grep`). All runtime markdown rendering happens through `web/src/components/markdown.tsx`, which keeps its own React-side `react-markdown` pipeline (gfm, highlight, directives, frontmatter, headerId) — that path is untouched.

So: drop the JS plugin chain from `createMDXPlugin`. The `withNextMDX` wrapper is kept (so `mdx-components.tsx` stays wired) and `pageExtensions` keeps `'mdx'` (so the route resolver still recognises the extension). When `.mdx` pages are actually introduced, the recommended path is `experimental.mdxRs: true` (Rust-based, Turbopack-compatible) — comment in `next.config.ts` updated.

Re-enable the flag in `web/package.json:dev`. Local verification: `./node_modules/.bin/next dev --turbopack` reaches \"Ready\" in 1.5 s with zero loader-serialization errors; `yarn tsc --noEmit` reports zero errors.

## §K.12 invariant cross-check

Largely n/a (frontend dev tooling). Direct hit:
- **#12** (grep-zero LightRAG) — `rg -i lightrag web/src/` returns zero hits both before and after ✅.

## 4-pattern pre-check matrix

- **Pattern 1 v1** (`.mdx` page consumers): \`find web/src -name '*.mdx'\` returns zero. \`rg \"from '[^']*\\.mdx'\" web/src\` returns zero. Confirms the JS plugin chain has no live consumers.
- **Pattern 1 v2** (runtime markdown plugin chain): unchanged in `components/markdown.tsx`. Removing JS plugins from `next.config.ts` does not affect document rendering — react-markdown imports its own copies of remarkGfm / rehypeHighlight / etc. directly.
- **Pattern 2** (response-shape change list): n/a, this PR does not touch any backend or generated schema.
- **Pattern 3** (additive helpers): n/a, dev-tooling only.

## simple-stable directive 4-guardrail

- **#1 不无限扩范围** — 2 files / +16 / -55. Did not extract plugins to modules (would be future-only dead code given zero `.mdx` files); did not switch to `experimental.mdxRs` (kept current MDX setup empty-but-present so future adopters re-add plugins explicitly).
- **#2 尽快上线** — earayu2 directive: edit code → instant reload, no added manual burden. Turbopack ready in 1.5 s, HMR kicks in automatically; `dev` script still runs `yarn install && yarn i18n:sync` so engineers who pull dependency updates do not need any extra command.
- **#3 简单稳定** — fewer plugins is fewer moving parts. The runtime markdown path keeps the production-tested chain.
- **#4 私有化部署免维护** — operator-invisible; production builds unaffected (zero `.mdx` files means `next build` output is identical before/after).

## Test plan

- [x] `next dev --turbopack` reaches \"Ready in 1477ms\" cleanly (no loader-serialization error)
- [x] `yarn tsc --noEmit` → 0 errors
- [x] `find web/src -name '*.mdx'` → 0 files (confirms plugin chain was dead code)
- [x] `rg \"from '[^']*\\.mdx'\" web/src` → 0 imports (confirms no consumer)
- [ ] Manual: pull this branch + `yarn dev` + verify HMR feels instant on edit (deferred to reviewer-side; my session has no live dev stack running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)