### PR TITLE
fix: restore knowledge graph page loading

### DIFF
--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -156,9 +156,12 @@ class GraphService:
         if entities and max_depth > 0:
             search = build_graph_search_service_for(db_collection)
             seed_names = [entity.name for entity in entities]
-            subgraph = await search.get_subgraph(entity_names=seed_names, hops=max_depth)
+            _, subgraph_relations = await search.get_subgraph(
+                entity_names=seed_names,
+                hops=max_depth,
+            )
             allowed = set(seed_names)
-            relations = [rel for rel in subgraph.relations if rel.source in allowed and rel.target in allowed]
+            relations = [rel for rel in subgraph_relations if rel.source in allowed and rel.target in allowed]
 
         raw_nodes = _adapt_lineage_entities(entities)
         raw_edges = _adapt_lineage_relations(relations)

--- a/tests/unit_test/domains/knowledge_graph/test_service.py
+++ b/tests/unit_test/domains/knowledge_graph/test_service.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from aperag.domains.knowledge_graph.service import GraphService
+
+
+def _entity(name: str, entity_type: str = "entity") -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        entity_type=entity_type,
+        compacted_description=None,
+        description_parts=[],
+        source_lineage=[],
+    )
+
+
+def _relation(source: str, target: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        source=source,
+        target=target,
+        relation_type="related_to",
+        compacted_description=None,
+        description_parts=[],
+        evidence_lineage=[],
+    )
+
+
+async def test_get_knowledge_graph_unpacks_graph_search_subgraph_tuple(monkeypatch):
+    class FakeStore:
+        async def list_entities(self, *, label, limit):
+            assert label is None
+            assert limit == 20
+            return [_entity("A", "person"), _entity("B", "organization")]
+
+    class FakeSearch:
+        async def get_subgraph(self, *, entity_names, hops):
+            assert entity_names == ["A", "B"]
+            assert hops == 2
+            return (
+                [_entity("A", "person"), _entity("B", "organization")],
+                [
+                    _relation("A", "B"),
+                    _relation("A", "outside"),
+                ],
+            )
+
+    from aperag.indexing import graph_search_service, worker_factory
+
+    monkeypatch.setattr(worker_factory, "_resolve_graph_backend_type", lambda collection: "postgres")
+    monkeypatch.setattr(
+        worker_factory,
+        "_build_lineage_graph_store",
+        lambda *, backend_type, collection: FakeStore(),
+    )
+    monkeypatch.setattr(
+        graph_search_service,
+        "build_graph_search_service_for",
+        lambda collection: FakeSearch(),
+    )
+
+    service = GraphService()
+    service._get_and_validate_collection = AsyncMock(return_value=SimpleNamespace(id="col1"))
+
+    graph = await service.get_knowledge_graph(
+        user_id="user1",
+        collection_id="col1",
+        label="*",
+        max_depth=2,
+        max_nodes=10,
+    )
+
+    assert [node.id for node in graph.nodes] == ["A", "B"]
+    assert [(edge.source, edge.target) for edge in graph.edges] == [("A", "B")]

--- a/web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-merge.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph/collection-graph-node-merge.tsx
@@ -46,14 +46,10 @@ const SuggestionItem = ({
         accept: action === 'accept',
         reject: action === 'reject',
       });
-      const res = await dispatchSuggestionAction(
-        item.collection_id,
-        item.id,
-        {
-          action,
-          target_entity_data: item.suggested_target_entity,
-        },
-      );
+      const res = await dispatchSuggestionAction(item.collection_id, item.id, {
+        action,
+        target_entity_data: item.suggested_target_entity,
+      });
       if (res?.status === 'success' && action === 'reject') {
         await afterRejectMergeSuggestion();
       }
@@ -161,6 +157,13 @@ export const CollectionGraphNodeMerge = ({
   const [activeStatus, setActiveStatus] =
     useState<MergeSuggestionStatus>('PENDING');
   const page_graph = useTranslations('page_graph');
+  const suggestions = Array.isArray(dataSource.suggestions)
+    ? dataSource.suggestions
+    : [];
+  const filteredSuggestions = suggestions.filter(
+    (suggestion) => suggestion.status === activeStatus,
+  );
+
   return (
     <Drawer
       direction="right"
@@ -193,9 +196,12 @@ export const CollectionGraphNodeMerge = ({
           </Tabs>
         </DrawerHeader>
         <div className="flex flex-1 flex-col gap-2 overflow-auto p-2 select-text">
-          {dataSource.suggestions
-            .filter((s) => s.status === activeStatus)
-            .map((suggestion) => {
+          {filteredSuggestions.length === 0 ? (
+            <div className="text-muted-foreground flex flex-1 items-center justify-center px-6 text-center text-sm">
+              {page_graph('no_nodes_found')}
+            </div>
+          ) : (
+            filteredSuggestions.map((suggestion) => {
               return (
                 <SuggestionItem
                   key={suggestion.id}
@@ -205,7 +211,8 @@ export const CollectionGraphNodeMerge = ({
                   afterAcceptMergeSuggestion={onRefresh}
                 />
               );
-            })}
+            })
+          )}
         </div>
       </DrawerContent>
     </Drawer>

--- a/web/src/app/workspace/collections/[collectionId]/graph/collection-graph.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph/collection-graph.tsx
@@ -12,6 +12,7 @@ import type {
   KnowledgeGraph,
   MergeSuggestionsResponse,
 } from '@/features/knowledge-graph/types';
+import { ApiClientError } from '@/lib/api/typed/errors';
 import { cn } from '@/lib/utils';
 
 import { Badge } from '@/components/ui/badge';
@@ -29,6 +30,12 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Tooltip, TooltipContent } from '@/components/ui/tooltip';
+import {
+  CANVAS_DARK,
+  COLORS,
+  ENTITY_PALETTE,
+  entityTypeToPaletteKey,
+} from '@/lib/design-tokens';
 import { TooltipTrigger } from '@radix-ui/react-tooltip';
 import _ from 'lodash';
 import {
@@ -43,12 +50,6 @@ import { useTheme } from 'next-themes';
 import dynamic from 'next/dynamic';
 import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  CANVAS_DARK,
-  COLORS,
-  ENTITY_PALETTE,
-  entityTypeToPaletteKey,
-} from '@/lib/design-tokens';
 import { CollectionGraphNodeDetail } from './collection-graph-node-detail';
 import { CollectionGraphNodeMerge } from './collection-graph-node-merge';
 
@@ -61,6 +62,13 @@ const ForceGraph2D = dynamic(
 
 const resolveEntityColor = (entityType: string | null | undefined): string =>
   ENTITY_PALETTE[entityTypeToPaletteKey(entityType)];
+
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof ApiClientError || error instanceof Error) {
+    return error.message || fallback;
+  }
+  return fallback;
+};
 
 export const CollectionGraph = ({
   marketplace = false,
@@ -80,6 +88,7 @@ export const CollectionGraph = ({
     nodes: GraphNode[];
     links: GraphEdge[];
   }>();
+  const [graphError, setGraphError] = useState<string>();
   const [mergeSuggestion, setMergeSuggestion] =
     useState<MergeSuggestionsResponse>();
   const [mergeSuggestionOpen, setMergeSuggestionOpen] =
@@ -108,39 +117,51 @@ export const CollectionGraph = ({
   const getGraphData = useCallback(async () => {
     if (typeof params.collectionId !== 'string') return;
     setLoading(true);
+    setGraphError(undefined);
 
-    const data: KnowledgeGraph | undefined = marketplace
-      ? await getMarketplaceKnowledgeGraph(params.collectionId)
-      : await getKnowledgeGraph(params.collectionId);
+    try {
+      const data: KnowledgeGraph | undefined = marketplace
+        ? await getMarketplaceKnowledgeGraph(params.collectionId)
+        : await getKnowledgeGraph(params.collectionId);
 
-    if (!data) {
+      if (!data) {
+        setGraphData({ nodes: [], links: [] });
+        return;
+      }
+
+      const edges = data.edges || [];
+      const nodes =
+        data.nodes?.map((n) => {
+          const targetCount = edges.filter((edg) => edg.target === n.id).length;
+          const sourceCount = edges.filter((edg) => edg.source === n.id).length;
+          return {
+            ...n,
+            value: Math.max(targetCount, sourceCount, NODE_MIN),
+          };
+        }) || [];
+      const links = edges;
+
+      setGraphData({ nodes, links });
+
+      setAllEntities(_.groupBy(nodes, (n) => n.properties.entity_type));
+    } catch (error: unknown) {
+      setGraphData({ nodes: [], links: [] });
+      setAllEntities({});
+      setActiveEntities([]);
+      setGraphError(getErrorMessage(error, page_graph('load_failed')));
+    } finally {
       setLoading(false);
-      return;
     }
-
-    const edges = data.edges || [];
-    const nodes =
-      data.nodes?.map((n) => {
-        const targetCount = edges.filter((edg) => edg.target === n.id).length;
-        const sourceCount = edges.filter((edg) => edg.source === n.id).length;
-        return {
-          ...n,
-          value: Math.max(targetCount, sourceCount, NODE_MIN),
-        };
-      }) || [];
-    const links = edges;
-
-    setGraphData({ nodes, links });
-
-    setAllEntities(_.groupBy(nodes, (n) => n.properties.entity_type));
-
-    setLoading(false);
-  }, [NODE_MIN, marketplace, params.collectionId]);
+  }, [NODE_MIN, marketplace, page_graph, params.collectionId]);
 
   const getMergeSuggestions = useCallback(async () => {
     if (typeof params.collectionId !== 'string' || marketplace) return;
-    const suggestionRes = await runMergeSuggestions(params.collectionId);
-    setMergeSuggestion(suggestionRes);
+    try {
+      const suggestionRes = await runMergeSuggestions(params.collectionId);
+      setMergeSuggestion(suggestionRes);
+    } catch {
+      setMergeSuggestion(undefined);
+    }
   }, [marketplace, params.collectionId]);
 
   const handleCloseDetail = useCallback(() => {
@@ -249,7 +270,11 @@ export const CollectionGraph = ({
         <div className="flex flex-row items-center gap-2">
           <Popover>
             <PopoverTrigger asChild>
-              <Button variant="outline" size="sm" className="w-40 justify-between">
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-40 justify-between"
+              >
                 {page_graph('node_search')}
                 <ChevronDown />
               </Button>
@@ -343,7 +368,7 @@ export const CollectionGraph = ({
         ref={containerRef}
         className="bg-card/0 relative flex flex-1 gap-0 overflow-hidden py-0"
       >
-        {graphData === undefined && (
+        {graphData === undefined && !graphError && (
           <div className="absolute top-4/12 left-6/12">
             <div className="flex flex-row gap-2 py-2">
               <div className="bg-muted-foreground animate-caret-blink size-2 rounded-full delay-0"></div>
@@ -353,13 +378,28 @@ export const CollectionGraph = ({
           </div>
         )}
 
-        {graphData !== undefined && _.isEmpty(graphData?.nodes) && (
-          <div className="absolute top-4/12 w-full">
-            <div className="text-muted-foreground text-center">
-              {page_graph('no_nodes_found')}
+        {graphError && (
+          <div className="absolute top-4/12 w-full px-6">
+            <div className="mx-auto max-w-md text-center">
+              <div className="text-foreground text-sm font-medium">
+                {page_graph('load_failed')}
+              </div>
+              <div className="text-muted-foreground mt-2 text-xs">
+                {graphError}
+              </div>
             </div>
           </div>
         )}
+
+        {!graphError &&
+          graphData !== undefined &&
+          _.isEmpty(graphData?.nodes) && (
+            <div className="absolute top-4/12 w-full">
+              <div className="text-muted-foreground text-center">
+                {page_graph('no_nodes_found')}
+              </div>
+            </div>
+          )}
 
         <ForceGraph2D
           graphData={graphData}
@@ -425,8 +465,7 @@ export const CollectionGraph = ({
             if (node === hoverNode) size += 1;
 
             const entityColor = resolveEntityColor(node.properties.entity_type);
-            const isDim =
-              highlightNodes.size > 0 && !highlightNodes.has(node);
+            const isDim = highlightNodes.size > 0 && !highlightNodes.has(node);
             const isActive = activeNode?.id === node.id;
 
             // soft halo under large / active nodes
@@ -470,7 +509,8 @@ export const CollectionGraph = ({
             // adaptive label
             let fontSize = 13;
             const offset = 2;
-            const fontFamily = 'var(--font-sans), Manrope, system-ui, sans-serif';
+            const fontFamily =
+              'var(--font-sans), Manrope, system-ui, sans-serif';
             ctx.font = `500 ${fontSize}px ${fontFamily}`;
             let textWidth = ctx.measureText(String(node.id)).width - offset;
             while (textWidth > size * 1.6 && fontSize > 1) {
@@ -526,7 +566,7 @@ export const CollectionGraph = ({
             className="bg-card absolute bottom-4 left-4 z-10 rounded-xl border p-3 shadow-sm"
             style={{ minWidth: 180 }}
           >
-            <div className="text-muted-foreground mb-2 font-mono text-[10px] uppercase tracking-wider">
+            <div className="text-muted-foreground mb-2 font-mono text-[10px] tracking-wider uppercase">
               {page_graph('node_group')}
             </div>
             <div className="grid grid-cols-1 gap-1.5">

--- a/web/src/features/knowledge-graph/client-api.ts
+++ b/web/src/features/knowledge-graph/client-api.ts
@@ -5,10 +5,64 @@ import { browserApiClient } from '@/lib/api/typed/browser';
 import type {
   GraphLabelsResponse,
   KnowledgeGraph,
+  MergeSuggestionItem,
   MergeSuggestionsResponse,
   SuggestionActionRequest,
   SuggestionActionResponse,
 } from './types';
+
+const createEmptyMergeSuggestionsResponse = (): MergeSuggestionsResponse => ({
+  suggestions: [],
+  total_analyzed_nodes: 0,
+  processing_time_seconds: 0,
+  from_cache: false,
+  generated_at: '',
+  total_suggestions: 0,
+  pending_count: 0,
+  accepted_count: 0,
+  rejected_count: 0,
+});
+
+const countSuggestionsByStatus = (
+  suggestions: MergeSuggestionItem[],
+  status: MergeSuggestionItem['status'],
+) => suggestions.filter((suggestion) => suggestion.status === status).length;
+
+const normalizeMergeSuggestionsResponse = (
+  data: unknown,
+): MergeSuggestionsResponse | undefined => {
+  if (!data || typeof data !== 'object') {
+    return undefined;
+  }
+
+  const raw = data as Partial<MergeSuggestionsResponse> &
+    Record<string, unknown>;
+  const suggestions = Array.isArray(raw.suggestions)
+    ? (raw.suggestions as MergeSuggestionItem[])
+    : [];
+
+  return {
+    ...createEmptyMergeSuggestionsResponse(),
+    ...raw,
+    suggestions,
+    total_suggestions:
+      typeof raw.total_suggestions === 'number'
+        ? raw.total_suggestions
+        : suggestions.length,
+    pending_count:
+      typeof raw.pending_count === 'number'
+        ? raw.pending_count
+        : countSuggestionsByStatus(suggestions, 'PENDING'),
+    accepted_count:
+      typeof raw.accepted_count === 'number'
+        ? raw.accepted_count
+        : countSuggestionsByStatus(suggestions, 'ACCEPTED'),
+    rejected_count:
+      typeof raw.rejected_count === 'number'
+        ? raw.rejected_count
+        : countSuggestionsByStatus(suggestions, 'REJECTED'),
+  };
+};
 
 export async function getGraphLabels(
   collectionId: string,
@@ -83,7 +137,7 @@ export async function getMergeSuggestions(
       params: { path: { collection_id: collectionId } },
     },
   );
-  return data as MergeSuggestionsResponse | undefined;
+  return normalizeMergeSuggestionsResponse(data);
 }
 
 export async function runMergeSuggestions(
@@ -96,7 +150,7 @@ export async function runMergeSuggestions(
       body: {},
     },
   );
-  return data as MergeSuggestionsResponse | undefined;
+  return normalizeMergeSuggestionsResponse(data);
 }
 
 export async function handleSuggestionAction(


### PR DESCRIPTION
## Summary

Fixes the workspace knowledge graph page failing to render after graph data or merge suggestion API calls return unexpected shapes.

## Root Cause

- The graph service called `GraphSearchService.get_subgraph()` and treated the return value as an object with `.relations`, but the current contract returns `(entities, relations)`.
- The merge suggestions start endpoint returns a run-start envelope (`run`, `started`, `message`) without `suggestions`, while the frontend cast it to `MergeSuggestionsResponse` and rendered `dataSource.suggestions.filter(...)` directly.

## Changes

- Unpack `get_subgraph()` as `(entities, relations)` in the graph service and keep filtering relations to the requested node set.
- Normalize merge suggestions responses in the browser API client so missing `suggestions` becomes an empty list with stable counters.
- Add defensive rendering and empty state handling in the merge suggestions drawer.
- Show graph load failures inside the graph panel instead of allowing runtime crashes.
- Add a unit test covering the graph service tuple contract.

## Validation

- `uv run ruff format aperag/domains/knowledge_graph/service.py tests/unit_test/domains/knowledge_graph/test_service.py`
- `uv run ruff check aperag/domains/knowledge_graph/service.py tests/unit_test/domains/knowledge_graph/test_service.py`
- `pytest tests/unit_test/domains/knowledge_graph/test_service.py -q`
- `yarn type-check`
- `yarn lint` (passes with existing warnings)
- Local API verification: graph endpoint returned 200 with 289 nodes and 348 edges for the affected collection.
