### PR TITLE
fix(ui): remove duplicate collection create actions

### DIFF
--- a/web/src/app/workspace/collections/collection-list.tsx
+++ b/web/src/app/workspace/collections/collection-list.tsx
@@ -108,7 +108,7 @@ export const CollectionList = ({
 
   return (
     <div className="flex flex-col gap-5">
-      <div className="border-border/70 bg-card grid gap-4 rounded-xl border p-4 shadow-sm md:grid-cols-[1fr_auto] md:items-center">
+      <div className="border-border/70 bg-card rounded-xl border p-4 shadow-sm">
         <div className="relative max-w-xl">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
           <Input
@@ -117,14 +117,6 @@ export const CollectionList = ({
             value={searchValue}
             onChange={(e) => setSearchValue(e.currentTarget.value)}
           />
-        </div>
-        <div className="flex flex-wrap items-center gap-2 md:justify-end">
-          <Button asChild>
-            <Link href="/workspace/collections/new">
-              <Plus className="size-4" />
-              {page_collection_new('metadata.title')}
-            </Link>
-          </Button>
         </div>
       </div>
 

--- a/web/src/app/workspace/collections/page.tsx
+++ b/web/src/app/workspace/collections/page.tsx
@@ -3,15 +3,13 @@ import {
   PageContent,
   PageHeader,
 } from '@/components/page-container';
-import { Button } from '@/components/ui/button';
 
 import { listCollections } from '@/features/collection/server-api';
 import type { CollectionView } from '@/features/collection/types';
 import { toJson } from '@/lib/utils';
-import { Database, Plus } from 'lucide-react';
+import { Database } from 'lucide-react';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import Link from 'next/link';
 import { CollectionList } from './collection-list';
 
 export const dynamic = 'force-dynamic';
@@ -45,8 +43,8 @@ export default async function Page() {
         breadcrumbs={[{ title: page_collections('metadata.title') }]}
       />
       <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
-        <div className="mb-9 flex flex-col gap-5 lg:flex-row lg:items-end">
-          <div className="min-w-0 flex-1">
+        <div className="mb-9">
+          <div className="min-w-0">
             <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
               {page_collections('workspace_label')}
             </div>
@@ -56,14 +54,6 @@ export default async function Page() {
             <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
               {page_collections('metadata.description')}
             </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Button asChild>
-              <Link href="/workspace/collections/new">
-                <Plus className="size-4" />
-                {page_collections('create_collection')}
-              </Link>
-            </Button>
           </div>
         </div>
         <div className="border-border/70 bg-card mb-6 flex items-center gap-3 rounded-xl border px-4 py-3 shadow-sm">


### PR DESCRIPTION
## Summary
- remove duplicate create collection actions from the workspace collections page header and search toolbar
- keep the grid add-card as the single create entry when collections exist

## Verification
- yarn lint
- git diff --check HEAD~1 HEAD