### PR TITLE
chore(makefile): remove residual add-license no-op target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ serve-web:
 ##################################################
 
 # Code quality checks
-.PHONY: format lint static-check add-license
+.PHONY: format lint static-check
 format:
 	uvx ruff check --fix ./aperag ./tests
 	uvx ruff format ./aperag ./tests
@@ -197,9 +197,6 @@ lint:
 
 static-check:
 	uvx mypy ./aperag
-
-add-license:
-	@echo "License headers are maintained in source files."
 
 # Testing suite
 .PHONY: test-all test-unit test-integration test-e2e test-e2e-perf \


### PR DESCRIPTION
## Summary

The license-check infrastructure (`check-license`, `install-addlicense`, `install-hooks`, the bundled `addlicense` binary, the git-hook installer) was already removed in commit `00ae644f` (PR #1729). The only remaining piece in `Makefile` is a no-op `add-license` target that just echoes a single line and does nothing else. This PR drops that stub along with its `.PHONY` entry.

License headers inside source files are not touched — every `aperag/**.py` keeps its Apache 2.0 header verbatim. The `LICENSE` file at the repo root is also untouched.

## Why

- `make add-license` runs `@echo "License headers are maintained in source files."` and that is its entire body. Keeping a stub for documentation purposes is dead weight; readers grep `add-license` and find nothing real.
- No CI workflow, pre-commit hook, or script invokes the target — it has zero callers in `.github/workflows/`, `scripts/`, or anywhere else (verified with grep).

## Test plan

- [x] `git diff Makefile` shows only the `add-license` target + its `.PHONY` listing removed
- [x] `make -n add-license` now reports `No rule to make target 'add-license'` (target gone)
- [x] `make -n format` still expands to the ruff commands (sibling targets intact)
- [x] No remaining `add-license` / `addlicense` / `install-addlicense` / `check-license` / `install-hooks` references anywhere in the repo
- [x] LICENSE file unchanged; license headers in source files unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)