### PR TITLE
Wave 11: dynamic graph entity types

### DIFF
--- a/aperag/indexing/entity_types.py
+++ b/aperag/indexing/entity_types.py
@@ -1,0 +1,162 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collection graph entity-type string helpers.
+
+Wave 11 keeps entity types as collection-local strings instead of a
+registry table. This module owns the small amount of normalization,
+i18n prompt mapping, and atomic config merge needed to keep that list
+stable while allowing LLM-proposed types.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Sequence
+from contextlib import asynccontextmanager
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aperag.domains.knowledge_base.db.models import Collection
+from aperag.schema.common import KnowledgeGraphConfig
+from aperag.schema.utils import dumpCollectionConfig, parseCollectionConfig
+
+logger = logging.getLogger(__name__)
+
+
+MAX_ENTITY_TYPE_CHARS = 64
+
+_PROMPT_LANGUAGE_NAMES: dict[str, str] = {
+    "zh-CN": "Chinese (Simplified)",
+    "en-US": "English",
+    "ja-JP": "Japanese",
+    "ko-KR": "Korean",
+}
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def prompt_language_name(language: str | None) -> str:
+    """Return the stable human-readable language name used in prompts."""
+    return _PROMPT_LANGUAGE_NAMES.get(language or "", language or "Chinese (Simplified)")
+
+
+def normalize_entity_type(raw: Any) -> str:
+    """Clean one LLM/user entity-type string.
+
+    This deliberately does not slugify, translate, hash, or semantically
+    merge labels. The stored value is the collection-language display
+    value. Overlong/empty values return ``""`` so callers can keep the
+    entity row while avoiding config pollution.
+    """
+    value = _WHITESPACE_RE.sub(" ", str(raw or "").strip())
+    if not value or len(value) > MAX_ENTITY_TYPE_CHARS:
+        return ""
+    return value
+
+
+def merge_entity_type_values(current_types: Sequence[Any], new_types: Sequence[Any]) -> list[str]:
+    """Merge two type lists with first-write-wins de-duplication."""
+    merged: list[str] = []
+    seen: set[str] = set()
+    for raw in [*current_types, *new_types]:
+        value = normalize_entity_type(raw)
+        if not value:
+            continue
+        key = _dedupe_key(value)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(value)
+    return merged
+
+
+def collect_entity_types_from_entities(entities: Sequence[Any]) -> list[str]:
+    """Return first-seen entity_type values from entity-like objects."""
+    values: list[str] = []
+    for entity in entities:
+        values.append(getattr(entity, "entity_type", ""))
+    return merge_entity_type_values((), values)
+
+
+def format_entity_types_for_prompt(entity_types: Sequence[Any]) -> str:
+    """Render every cleaned entity type for the prompt."""
+    cleaned = merge_entity_type_values((), entity_types)
+    return json.dumps(cleaned, ensure_ascii=False)
+
+
+async def merge_entity_types(
+    session: AsyncSession,
+    collection_id: str,
+    new_types: Sequence[str],
+) -> list[str]:
+    """Atomically merge new entity types into collection config.
+
+    The production path passes a fresh ``AsyncSession`` and this helper
+    opens the transaction. Tests may pass an already-open transaction;
+    in that case we still issue the required ``SELECT ... FOR UPDATE``
+    row lock and leave commit ownership to the caller.
+    """
+    normalized_new = merge_entity_type_values((), new_types)
+    if not normalized_new:
+        return []
+
+    async with _session_transaction(session):
+        stmt = select(Collection).where(Collection.id == collection_id).with_for_update()
+        result = await session.execute(stmt)
+        collection = result.scalar_one_or_none()
+        if collection is None:
+            logger.warning("entity type merge skipped: collection_id=%s not found", collection_id)
+            return []
+
+        config = parseCollectionConfig(collection.config)
+        if config.knowledge_graph_config is None:
+            config.knowledge_graph_config = KnowledgeGraphConfig(entity_types=[])
+
+        current = config.knowledge_graph_config.entity_types or []
+        merged = merge_entity_type_values(current, normalized_new)
+        if merged != merge_entity_type_values((), current):
+            config.knowledge_graph_config.entity_types = merged
+            collection.config = dumpCollectionConfig(config)
+            session.add(collection)
+        return merged
+
+
+@asynccontextmanager
+async def _session_transaction(session: AsyncSession):
+    if session.in_transaction():
+        yield
+    else:
+        async with session.begin():
+            yield
+
+
+def _dedupe_key(value: str) -> str:
+    if value.isascii():
+        return value.lower()
+    return value
+
+
+__all__ = [
+    "MAX_ENTITY_TYPE_CHARS",
+    "collect_entity_types_from_entities",
+    "format_entity_types_for_prompt",
+    "merge_entity_type_values",
+    "merge_entity_types",
+    "normalize_entity_type",
+    "prompt_language_name",
+]

--- a/aperag/indexing/graph.py
+++ b/aperag/indexing/graph.py
@@ -1136,6 +1136,16 @@ T2.x; tests pass deterministic stubs so the §D.3.6 self-test does not
 depend on any LLM.
 """
 
+EntityTypeMerger = Callable[
+    [str, Sequence[str]],
+    Awaitable[list[str]],
+]
+"""Per-document hook that persists newly observed entity_type strings.
+
+The first argument is ``document_id`` for diagnostics; the second is
+the first-seen list of entity type strings extracted for that document.
+"""
+
 
 # ---------------------------------------------------------------------
 # kg.jsonl serialization
@@ -1244,6 +1254,7 @@ class GraphModalityWorker(ModalityWorker):
         embedder: Callable[[str], list[float]] | None = None,
         vector_connector: "VectorStoreConnector | None" = None,
         merge_detector: "MergeCandidateDetector | None" = None,
+        entity_type_merger: EntityTypeMerger | None = None,
     ) -> None:
         """Construct a graph worker bound to a single tenant scope.
 
@@ -1286,6 +1297,7 @@ class GraphModalityWorker(ModalityWorker):
         self._embedder = embedder
         self._vector_connector = vector_connector
         self._merge_detector = merge_detector
+        self._entity_type_merger = entity_type_merger
 
     # ---- derive -----------------------------------------------------
 
@@ -1318,6 +1330,7 @@ class GraphModalityWorker(ModalityWorker):
             filename=KG_ARTIFACT_FILENAME,
         )
         await write_atomic_async(self._object_store, kg_path, body)
+        await self._merge_document_entity_types(document_id=document_id, entities=entities)
         logger.info(
             "graph.derive collection=%s document=%s parse_version=%s entities=%d relations=%d",
             self._collection_id,
@@ -1327,6 +1340,25 @@ class GraphModalityWorker(ModalityWorker):
             len(relations),
         )
         return DeriveResult(derived_artifact_path=kg_path)
+
+    async def _merge_document_entity_types(self, *, document_id: str, entities: Sequence[EntityRecord]) -> None:
+        if self._entity_type_merger is None:
+            return
+        from aperag.indexing.entity_types import collect_entity_types_from_entities
+
+        entity_types = collect_entity_types_from_entities(entities)
+        if not entity_types:
+            return
+        try:
+            await self._entity_type_merger(document_id, entity_types)
+        except Exception as exc:  # noqa: BLE001 — config merge must not poison graph output
+            logger.warning(
+                "graph entity type merge failed collection=%s document=%s error=%r entity_types=%s",
+                self._collection_id,
+                document_id,
+                exc,
+                entity_types,
+            )
 
     # ---- sync -------------------------------------------------------
 
@@ -1799,6 +1831,7 @@ __all__ = [
     "InMemoryLineageGraphStore",
     # Extractor injection point
     "GraphExtractor",
+    "EntityTypeMerger",
     # kg.jsonl helpers
     "KG_ARTIFACT_FILENAME",
     "serialize_kg_jsonl",

--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -58,6 +58,11 @@ import logging
 import re
 from typing import Any, Awaitable, Callable, Mapping, Sequence
 
+from aperag.indexing.entity_types import (
+    merge_entity_type_values,
+    normalize_entity_type,
+    prompt_language_name,
+)
 from aperag.indexing.graph import (
     EntityRecord,
     GraphExtractor,
@@ -67,17 +72,7 @@ from aperag.indexing.graph import (
 logger = logging.getLogger(__name__)
 
 
-_DEFAULT_ENTITY_TYPES: tuple[str, ...] = (
-    "organization",
-    "person",
-    "geo",
-    "event",
-    "product",
-    "technology",
-    "date",
-    "category",
-)
-_DEFAULT_LANGUAGE = "en-US"
+_DEFAULT_LANGUAGE = "zh-CN"
 _DEFAULT_MAX_ENTITIES_PER_CHUNK = 32
 _DEFAULT_MAX_RELATIONS_PER_CHUNK = 32
 _DEFAULT_PER_CHUNK_TIMEOUT_SECONDS = 60.0
@@ -112,8 +107,8 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
             f"the collection's completion model"
         ) from exc
 
+    prompt_language = prompt_language_name(_resolve_language(collection))
     entity_types = tuple(_resolve_entity_types(collection))
-    language = _resolve_language(collection)
     max_entities = _resolve_int_kg_config(collection, "max_entities_per_chunk", _DEFAULT_MAX_ENTITIES_PER_CHUNK)
     max_relations = _resolve_int_kg_config(collection, "max_relations_per_chunk", _DEFAULT_MAX_RELATIONS_PER_CHUNK)
     per_chunk_timeout = _resolve_float_kg_config(
@@ -127,6 +122,7 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
 
         entities: list[EntityRecord] = []
         relations: list[RelationRecord] = []
+        active_entity_types = list(entity_types)
         for chunk in chunks:
             chunk_id = str(chunk.get("chunk_id") or chunk.get("id") or "")
             text = str(chunk.get("text") or "")
@@ -137,8 +133,8 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
                     llm=llm,
                     text=text,
                     chunk_id=chunk_id,
-                    entity_types=entity_types,
-                    language=language,
+                    entity_types=tuple(active_entity_types),
+                    language=prompt_language,
                     max_entities=max_entities,
                     max_relations=max_relations,
                     timeout_seconds=per_chunk_timeout,
@@ -153,6 +149,10 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
                 continue
             entities.extend(ents)
             relations.extend(rels)
+            active_entity_types = merge_entity_type_values(
+                active_entity_types,
+                [entity.entity_type for entity in ents],
+            )
         return entities, relations
 
     return _extractor
@@ -275,11 +275,9 @@ def _entity_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> EntityRecord:
     name = str(raw["name"]).strip()
     if not name:
         raise ValueError("entity name cannot be empty")
-    # The LLM extraction prompt still emits ``type`` in its JSON output
-    # (legacy template shape); we accept either the canonical
-    # ``entity_type`` field (post-Wave-6 #36 rename) or the legacy
-    # ``type`` field for backward compat with prompt templates.
-    entity_type = str(raw.get("entity_type") or raw.get("type") or "")
+    # Keep accepting legacy ``type`` for custom prompts, but store the
+    # canonical Wave 11 string field as ``entity_type``.
+    entity_type = normalize_entity_type(raw.get("entity_type") or raw.get("type") or "")
     description = str(raw.get("description") or "")
     return EntityRecord(
         name=name,
@@ -314,14 +312,14 @@ def _relation_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> RelationRec
 def _resolve_entity_types(collection: Any) -> Sequence[str]:
     cfg = _resolve_config(collection)
     if cfg is None:
-        return _DEFAULT_ENTITY_TYPES
+        return []
     kg_config: Any = None
     if hasattr(cfg, "knowledge_graph_config"):
         kg_config = cfg.knowledge_graph_config
     elif isinstance(cfg, Mapping):
         kg_config = cfg.get("knowledge_graph_config")
     if kg_config is None:
-        return _DEFAULT_ENTITY_TYPES
+        return []
     if hasattr(kg_config, "entity_types"):
         types = kg_config.entity_types
     elif isinstance(kg_config, Mapping):
@@ -329,8 +327,8 @@ def _resolve_entity_types(collection: Any) -> Sequence[str]:
     else:
         types = None
     if not types:
-        return _DEFAULT_ENTITY_TYPES
-    return [str(t) for t in types]
+        return []
+    return merge_entity_type_values((), types)
 
 
 def _resolve_language(collection: Any) -> str:

--- a/aperag/indexing/llm.py
+++ b/aperag/indexing/llm.py
@@ -133,18 +133,21 @@ object.
 
 1. Output language: {language}. Names keep their original script and
    case (e.g. English names capitalized, Chinese names unchanged).
-2. Use only these entity types: {entity_types}. If no provided type
-   fits, skip the entity rather than invent a new type.
-3. Every entity needs a short, self-contained description in
+2. Prefer existing entity types from this collection list:
+   {entity_types}
+3. If no existing entity type fits, create a concise new entity type
+   string in {language}. Do not skip a valid entity only because its
+   type is not already listed.
+4. Every entity needs a short, self-contained description in
    {language}. Do not add information that isn't in the text.
-4. Every relation must reference entities by the exact ``name`` you put
+5. Every relation must reference entities by the exact ``name`` you put
    in the ``entities`` list. No self-loops (source != target).
-5. ``weight`` is an integer 1-10 expressing how strongly the text
+6. ``weight`` is an integer 1-10 expressing how strongly the text
    supports the relation; default to 5 when unsure.
-6. Cap: at most {max_entities} entities and {max_relations} relations.
+7. Cap: at most {max_entities} entities and {max_relations} relations.
    If the text contains more, prefer the most specific and the
    most-mentioned.
-7. If the text has no extractable entities, return
+8. If the text has no extractable entities, return
    ``{{"entities": [], "relations": []}}``.
 
 **JSON schema**
@@ -152,17 +155,18 @@ object.
 ```
 {{
   "entities": [
-    {{"name": "<string>", "type": "<one of the allowed types>",
+    {{"name": "<string>", "entity_type": "<existing or new type string>",
       "description": "<string>"}}
   ],
   "relations": [
     {{"source": "<entity name>", "target": "<entity name>",
+      "relation_type": "<short relation type>",
       "description": "<string>", "weight": <int 1-10>}}
   ]
 }}
 ```
 
-**Example** (English, types=[person, organization]):
+**Example** (English):
 
 Text:
 ```
@@ -173,18 +177,20 @@ Output:
 ```
 {{
   "entities": [
-    {{"name": "Alice", "type": "person",
+    {{"name": "Alice", "entity_type": "Person",
       "description": "A researcher at Acme Labs."}},
-    {{"name": "Bob", "type": "person",
+    {{"name": "Bob", "entity_type": "Person",
       "description": "A collaborator on the project."}},
-    {{"name": "Acme Labs", "type": "organization",
+    {{"name": "Acme Labs", "entity_type": "Organization",
       "description": "Research organization where Alice works."}}
   ],
   "relations": [
     {{"source": "Alice", "target": "Bob",
+      "relation_type": "collaborated_with",
       "description": "Alice and Bob collaborated on a project.",
       "weight": 7}},
     {{"source": "Alice", "target": "Acme Labs",
+      "relation_type": "works_for",
       "description": "Alice is a researcher employed by Acme Labs.",
       "weight": 8}}
   ]
@@ -216,9 +222,11 @@ def render_extraction_prompt(
     identical to the legacy ``graphindex.prompts.ENTITY_RELATION_EXTRACTION``
     text (relocated here verbatim during Wave 5 P1).
     """
+    from aperag.indexing.entity_types import format_entity_types_for_prompt
+
     return ENTITY_RELATION_EXTRACTION.format(
         input_text=input_text,
-        entity_types=", ".join(entity_types),
+        entity_types=format_entity_types_for_prompt(entity_types),
         language=language,
         max_entities=max_entities,
         max_relations=max_relations,

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -60,7 +60,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session
@@ -467,7 +467,12 @@ def _build_vision_worker(*, collection: Any, object_store: Any) -> ModalityWorke
     return VisionModality(backend=backend, store=object_store, embedder=_embed)
 
 
-def _build_graph_worker(*, collection: Any, object_store: Any, payload: DispatchPayload) -> ModalityWorker:
+def _build_graph_worker(
+    *,
+    collection: Any,
+    object_store: Any,
+    payload: DispatchPayload,
+) -> ModalityWorker:
     """Wire :class:`GraphModalityWorker` for the §D.3 lineage pipeline.
 
     Wave 4 T1 lands the real LLM-driven graph extractor — the chunk
@@ -515,6 +520,7 @@ def _build_graph_worker(*, collection: Any, object_store: Any, payload: Dispatch
     lock = _resolve_entity_lock(backend_type=backend_type)
     extractor = build_collection_graph_extractor(collection)
     tenant_scope_key = _resolve_tenant_scope_key(payload=payload)
+    entity_type_merger = _build_graph_type_merger(collection)
 
     # Wave 7 W7-3 wiring: compactor + embedder + vector connector +
     # merge candidate detector. The Phase 3 sync extension is opt-in —
@@ -542,7 +548,22 @@ def _build_graph_worker(*, collection: Any, object_store: Any, payload: Dispatch
         embedder=embedder,
         vector_connector=vector_connector,
         merge_detector=merge_detector,
+        entity_type_merger=entity_type_merger,
     )
+
+
+def _build_graph_type_merger(collection: Any):
+    collection_id = str(getattr(collection, "id", ""))
+
+    async def _merge(_document_id: str, entity_types: Sequence[str]) -> list[str]:
+        from aperag.config import get_async_session
+        from aperag.indexing.entity_types import merge_entity_types
+
+        async for session in get_async_session():
+            return await merge_entity_types(session, collection_id, entity_types)
+        return []
+
+    return _merge
 
 
 def _build_collection_graph_compactor(collection: Any) -> Any:

--- a/aperag/schema/common.py
+++ b/aperag/schema/common.py
@@ -130,19 +130,10 @@ class KnowledgeGraphConfig(BaseModel):
     Configuration for knowledge graph generation
     """
 
-    entity_types: Optional[list[str]] = Field(
-        [
-            "organization",
-            "person",
-            "geo",
-            "event",
-            "product",
-            "technology",
-            "date",
-            "category",
-        ],
+    entity_types: list[str] = Field(
+        default_factory=list,
         description="List of entity types to extract during graph indexing",
-        examples=[["organization", "person", "geo", "event"]],
+        examples=[["人物", "组织", "疾病"]],
     )
     # Wave 5 P5A item 1 (per huangheng T1 obs A msg=6b349693): expose
     # the graph extractor's per-chunk caps + timeout as
@@ -226,22 +217,7 @@ class CollectionConfig(BaseModel):
     )
     enable_summary: Optional[bool] = Field(False, description="Whether to enable summary index")
     enable_vision: Optional[bool] = Field(False, description="Whether to enable vision index")
-    knowledge_graph_config: Optional[KnowledgeGraphConfig] = Field(
-        default_factory=lambda: KnowledgeGraphConfig.model_validate(
-            {
-                "entity_types": [
-                    "organization",
-                    "person",
-                    "geo",
-                    "event",
-                    "product",
-                    "technology",
-                    "date",
-                    "category",
-                ]
-            }
-        )
-    )
+    knowledge_graph_config: Optional[KnowledgeGraphConfig] = Field(default_factory=KnowledgeGraphConfig)
     index_prompts: Optional[IndexPrompts] = None
     language: Optional[Literal["zh-CN", "en-US", "ja-JP", "ko-KR"]] = Field(
         "zh-CN",

--- a/docs/modularization/wave11-graph-entity-types-i18n-design.md
+++ b/docs/modularization/wave11-graph-entity-types-i18n-design.md
@@ -1,0 +1,508 @@
+# Wave 11：Graph Entity Type 动态生成与 Collection 语言
+
+## 1. 当前结论
+
+这次 Wave 11 采用 **hard cut + 简单枚举** 方案。
+
+核心结论：
+
+1. 不做老数据迁移。
+2. 不建 `collection_entity_type` 新表。
+3. 不做 `type_id` / `label` 分离。
+4. 不保留 `_DEFAULT_ENTITY_TYPES` 作为默认兜底类型。
+5. 每个 collection 的 entity type 就是一个字符串列表：`entity_types: list[str]`。
+6. collection 语言固定后，graph 里新生成的 type、entity 描述、relation 描述都遵守这个语言。
+7. LLM 可以根据文档内容提出新的 entity type，系统把新 type 原子合并回 collection 配置。
+
+例子：
+
+- 中文 collection：`["人物", "组织", "疾病", "药物"]`
+- 英文 collection：`["Person", "Organization", "Disease", "Drug"]`
+
+同一个 collection 不切换语言，所以不需要再拆成内部 ID 和展示名。
+
+## 2. 要解决的问题
+
+现在 graph indexing 的 entity type 基本还是预定义列表：
+
+```python
+organization, person, geo, event, product, technology, date, category
+```
+
+这有几个问题：
+
+1. 不同 collection 的领域完全不同。医疗、法律、个人知识库不应该共用一套固定 type。
+2. Prompt 现在会让 LLM 只使用给定 type，不合适就跳过，这会丢掉有效 entity。
+3. Collection 已经有 `language` 配置，但 graph prompt 是否稳定遵守 collection language 还不够清楚。
+4. 用户希望系统少维护，最好让 type 随真实文档自然出现，而不是人工预先设计 ontology。
+
+Wave 11 的目标是把这些规则一次钉死。
+
+## 3. 当前代码入口
+
+主要涉及这些文件：
+
+- `aperag/schema/common.py`
+  - 已有 `CollectionConfig.language`
+  - 已有 `KnowledgeGraphConfig.entity_types`
+- `aperag/indexing/graph_extractor.py`
+  - 负责解析 collection config
+  - 负责调用 LLM 和解析 graph extraction 结果
+- `aperag/indexing/llm.py`
+  - graph extraction prompt 在这里
+- `aperag/indexing/graph.py`
+  - `EntityRecord.entity_type` 是最终写入 graph 的字符串字段
+- `aperag/indexing/graph_storage/*`
+  - Postgres / Neo4j / Nebula 后端都继续存 `entity_type` 字符串
+- `aperag/domains/knowledge_graph/service.py`
+  - `get_graph_labels()` 继续返回 graph 里已有的 type 字符串
+
+好消息是：schema 里已经有 `knowledge_graph_config.entity_types`，所以不需要新增 DB 表。
+
+## 4. 最终数据模型
+
+### 4.1 Collection 配置
+
+继续使用现有配置字段：
+
+```python
+Collection.config.knowledge_graph_config.entity_types: list[str]
+```
+
+规则：
+
+- 新 collection 初始值是空列表：`[]`
+- 如果用户手动配置了初始 type，就用用户配置
+- 如果没有配置，就让 LLM 从第一批文档里生成
+- LLM 后续发现新 type，就追加到这个列表
+
+不再使用硬编码默认值：
+
+```python
+_DEFAULT_ENTITY_TYPES = (...)
+```
+
+这个默认值要删掉，不允许再作为空 collection 的 fallback。
+
+### 4.2 Entity 存储
+
+Graph entity 仍然只存字符串：
+
+```python
+EntityRecord.entity_type = "疾病"
+```
+
+不改成：
+
+```python
+EntityRecord.type_id = "disease"
+```
+
+原因：
+
+- collection 语言不切换
+- 用户看到的 type 和系统存的 type 可以是同一个字符串
+- 这样 graph storage、graph label filter、graph curation 都不用大改
+
+### 4.3 不做 registry 表
+
+这次不建这种表：
+
+```text
+collection_entity_type
+- type_id
+- label
+- description
+- examples
+- status
+- source
+- created_from_document_id
+```
+
+这些字段以后如果真的需要管理、合并、禁用 entity type，可以再做。Wave 11 先只解决当前问题。
+
+## 5. 语言规则
+
+Collection 的 `language` 是 graph 输出语言的唯一来源。
+
+需要把代码里的语言 code 映射成 prompt 里更清楚的语言名：
+
+| collection language | prompt 语言 |
+| --- | --- |
+| `zh-CN` | `Chinese (Simplified)` |
+| `en-US` | `English` |
+| `ja-JP` | `Japanese` |
+| `ko-KR` | `Korean` |
+
+规则：
+
+1. Entity name 保留原文。
+   - `OpenAI` 不要翻译成 `开放人工智能`
+   - 人名、公司名、产品名、代码名尽量按原文保留
+2. Entity description 用 collection language。
+3. Relation description 用 collection language。
+4. 新生成的 entity type 用 collection language。
+5. 不引入 `auto` 语言检测。
+
+例子：
+
+英文文档里有：
+
+```text
+OpenAI released GPT-4o.
+```
+
+如果 collection language 是 `zh-CN`，graph extraction 可以输出：
+
+```json
+{
+  "entities": [
+    {
+      "name": "OpenAI",
+      "entity_type": "组织",
+      "description": "一家人工智能研究与产品公司。"
+    },
+    {
+      "name": "GPT-4o",
+      "entity_type": "产品",
+      "description": "OpenAI 发布的多模态模型。"
+    }
+  ]
+}
+```
+
+## 6. Prompt 规则
+
+旧规则：
+
+```text
+只能使用这些 entity types。如果没有合适 type，就跳过这个 entity。
+```
+
+新规则：
+
+```text
+优先复用已有 entity types。
+如果没有合适 type，可以创建一个新的、简短的 entity type。
+新 type 必须使用 collection language。
+不要因为 type 不在列表里就丢掉有效 entity。
+```
+
+Prompt 里传给 LLM 的内容包括：
+
+- collection language
+- 当前 `entity_types` 列表
+- 文档 chunk 内容
+
+如果 `entity_types=[]`，LLM 就从当前文档开始生成第一批 type。
+
+## 7. LLM 输出格式
+
+继续使用简单格式，不引入复杂 registry 对象。
+
+推荐输出：
+
+```json
+{
+  "entities": [
+    {
+      "name": "糖尿病",
+      "entity_type": "疾病",
+      "description": "一种慢性代谢性疾病。"
+    },
+    {
+      "name": "胰岛素",
+      "entity_type": "药物",
+      "description": "用于控制血糖的治疗药物。"
+    }
+  ],
+  "relations": [
+    {
+      "source": "胰岛素",
+      "target": "糖尿病",
+      "relation_type": "治疗",
+      "description": "胰岛素可用于治疗糖尿病。"
+    }
+  ]
+}
+```
+
+Parser 兼容已有字段：
+
+- `entity_type`
+- legacy `type`
+
+但最终内部统一成 `entity_type`。
+
+## 8. 新 type 如何追加
+
+每次 LLM 输出 entity 后，系统检查：
+
+```python
+entity.entity_type not in collection.config.knowledge_graph_config.entity_types
+```
+
+如果发现新 type，就合并回 collection 配置。
+
+例如当前列表是：
+
+```json
+["人物", "组织"]
+```
+
+LLM 新输出：
+
+```json
+{"name": "糖尿病", "entity_type": "疾病"}
+```
+
+那么合并后变成：
+
+```json
+["人物", "组织", "疾病"]
+```
+
+## 9. 字符串清理规则
+
+只做轻量清理，不做复杂语义合并。
+
+清理规则：
+
+1. 去掉前后空格。
+2. 多个连续空白合并成一个空格。
+3. 空字符串丢掉。
+4. 太长的 type 字段丢掉，初始上限 64 个字符；entity 本身保留，`entity_type=""`，这个空字符串不合并进 collection 配置。
+5. 英文 type 做大小写去重：
+   - `Person`
+   - `person`
+   - 只保留一个，规则是 first-write-wins：列表里已有的写法胜出，新来的大小写变体被忽略
+6. 中文、日文、韩文按原字符串去重：
+   - `疾病`
+   - `病症`
+   - 这两个不自动合并
+
+不做这些事情：
+
+- 不把 `疾病` 转成 `disease`
+- 不把 `Medical Condition` 转成 `medical_condition`
+- 不自动判断 `公司` 和 `组织` 是不是同义词
+
+## 10. 并发写入规则
+
+多个 worker 可能同时处理同一个 collection 的不同文档。
+
+例如两个 worker 都发现新 type：
+
+```json
+"疾病"
+```
+
+不能写出重复数据，也不能让其中一个 worker 因为重复 type 报错。
+
+所以需要一个异步原子合并函数：
+
+```python
+async def merge_entity_types(
+    session: AsyncSession,
+    collection_id: str,
+    new_types: Sequence[str],
+) -> list[str]
+```
+
+语义：
+
+1. 开启数据库事务。
+2. 用 `SELECT ... FOR UPDATE` 锁住 collection 这一行。
+3. 读取当前 `collection.config`。
+4. 解析出当前 `entity_types`。
+5. 合并新 type。
+6. 去重。
+7. 如果有变化，写回 collection config。
+8. 返回最终列表。
+
+这样两个 worker 同时写 `疾病`，最终列表里也只有一个 `疾病`。
+
+实现必须走 `SELECT ... FOR UPDATE` 这一条路径，不允许在 Wave 11 里改成 sync wrapper，也不允许改成乐观重试 fallback。
+
+如果 `merge_entity_types()` 失败：
+
+1. 记录 warning，包含 `collection_id`、`document_id`、失败原因、新 type 列表。
+2. 不阻塞已经完成的 graph entity 写入。
+3. 不在 indexing task 内无限重试。
+4. 后续文档再次出现同一个 type 时会重新尝试合并，形成轻量 self-healing。
+
+## 11. Runtime 流程
+
+一次 graph indexing 的流程：
+
+1. 读取 collection。
+2. 读取 collection language。
+3. 读取 `knowledge_graph_config.entity_types`。
+4. 把 language 和 entity_types 放进 prompt。
+5. LLM 提取 entities / relations。
+6. Parser 接受新旧字段格式。
+7. entity 写入 graph，`entity_type` 就是字符串。
+8. 以 document 为粒度收集本文档输出里出现的新 type。
+9. 一个文档处理完成、entity 已 flush 到 graph 后，调用一次 `merge_entity_types()` 合并回 collection config。
+
+调用粒度锁定为 **per-document**：
+
+- 不做 per-chunk 合并，避免一个文档内多次 DB 写。
+- 不做 per-indexing-run 合并，避免 worker 中途崩溃后 graph 里已有 entity type 没进 collection 配置。
+- per-document 合并失败不回滚已经写入 graph 的 entity。
+
+Graph backend 不需要知道这个 type 是用户手动配置的，还是 LLM 新生成的。
+
+## 12. API / UI 影响
+
+Wave 11 不要求新增 API。
+
+现有 graph labels API 可以继续返回字符串：
+
+```json
+["人物", "组织", "疾病"]
+```
+
+前端 filter 也继续按字符串过滤。
+
+如果以后要让用户编辑 type list，可以直接编辑：
+
+```json
+knowledge_graph_config.entity_types
+```
+
+但这不是第一版必须做的 UI。
+
+## 13. Graph Curation 兼容性
+
+Wave 7 的 graph curation 逻辑里也有 `entity_type`。
+
+这次不改字段形态，所以它继续是字符串：
+
+```python
+CurationEntity.entity_type: str
+```
+
+需要在实现 PR 里 grep 验证：
+
+- 没有引入 `type_id`
+- 没有引入 `collection_entity_type`
+- `_DEFAULT_ENTITY_TYPES` 没有剩余 caller
+- graph curation 仍然按字符串 entity_type 工作
+
+## 14. 实施计划
+
+### PR 1：文档 + language + dynamic type
+
+内容：
+
+1. 加这份设计文档。
+2. 加 centralized language mapping helper。
+3. 改 graph prompt：
+   - 不再说 unknown type 就 skip
+   - 允许 LLM 创建新 type
+   - 明确新 type 和 description 要遵守 collection language
+4. 删除 `_DEFAULT_ENTITY_TYPES` fallback。
+5. 允许 `entity_types=[]`。
+6. 改 parser：
+   - 接受 unknown `entity_type`
+   - 不再因为 type 不在列表里丢 entity
+   - 收集本次出现的新 type
+7. 加 `merge_entity_types()`。
+8. 每个 document graph indexing 完成后，把本文档新 type 合并回 collection config。
+9. 更新测试。
+
+### PR 2：可选 UI / API polish
+
+只有产品明确需要时再做：
+
+1. UI 上展示 / 编辑 entity_types。
+2. API 校验手动编辑的 type list。
+3. graph label 使用统计。
+
+不在 Wave 11 第一版做：
+
+- type 生命周期
+- approve / deprecated 状态
+- synonym merge
+- registry table
+
+## 15. 测试要求
+
+PR 1 必须覆盖：
+
+1. Language mapping：
+   - `zh-CN` 能映射成 `Chinese (Simplified)`
+   - prompt 里能看到这个语言要求
+2. Empty entity types：
+   - `entity_types=[]` 合法
+   - prompt 不崩
+3. Prompt contract：
+   - prompt 不再说 unknown type 必须跳过
+   - prompt 明确允许创建新 type
+4. Parser：
+   - unknown `entity_type` 不被丢掉
+   - legacy `type` 仍可解析
+5. Dynamic append：
+   - LLM 输出新 type 后，collection config 里能看到新 type
+6. Atomic merge：
+   - 重复 merge 同一个 type，最终只出现一次
+   - 并发 merge 不丢失 type
+7. Config preservation：
+   - merge entity_types 不破坏 collection config 里的其他字段
+8. i18n：
+   - 英文文档 + 中文 collection，可以输出中文 description 和中文 type
+   - entity name 保留原文
+9. Graph curation：
+   - `CurationEntity.entity_type` 仍然是字符串
+   - candidate pair 逻辑不因为 Wave 11 破坏
+10. Failure behavior：
+   - `merge_entity_types()` 失败时不阻塞已写入 graph 的 entity
+   - 有 warning 日志
+
+## 16. PR hard gate
+
+每个 Wave 11 PR 描述里必须写清楚：
+
+1. hard cut：没有老数据迁移。
+2. 没有新增 `collection_entity_type` 表。
+3. 没有 `type_id` / `label` 双层模型。
+4. `_DEFAULT_ENTITY_TYPES` 是否已经删除。
+5. `entity_types=[]` 是否合法。
+6. `merge_entity_types()` 是否是 async + `SELECT ... FOR UPDATE` + per-document 调用。
+7. grep 结果：
+   - `type_id`
+   - `collection_entity_type`
+   - `CurationEntity.entity_type`
+   - `_DEFAULT_ENTITY_TYPES`
+8. 测试命令和结果。
+
+同时继续沿用 Wave 7-10 的 hard-gate 三段：
+
+- 12-invariant cross-check
+- 4-pattern + 11 mini-pattern pre-check
+- simple-stable 4-guardrail
+
+## 17. 明确不做
+
+Wave 11 不做：
+
+- 老数据迁移
+- lazy seed
+- backfill
+- 新 DB 表
+- `type_id`
+- localized `label`
+- `description/examples/status/source` 等复杂字段
+- 默认 `_DEFAULT_ENTITY_TYPES`
+- 自动语言检测
+- 语义同义词合并
+- entity type 审批 / 禁用流程
+- 因为新增 type 自动触发 graph reindex
+- type 列表 size cap
+- type 列表 LRU 淘汰
+
+## 18. 最终一句话
+
+每个 collection 自己维护一个字符串列表 `entity_types`。LLM 先复用这个列表，不合适就按 collection
+语言生成新字符串。系统把新字符串原子合并回 collection 配置。Graph 里仍然只存 `entity_type` 字符串。

--- a/tests/integration/test_graph_extractor.py
+++ b/tests/integration/test_graph_extractor.py
@@ -124,6 +124,38 @@ def test_parse_extraction_response_skips_individual_malformed_records():
     assert relation_types == ["rel1"]
 
 
+def test_parse_extraction_response_accepts_unknown_entity_type():
+    raw = (
+        '{"entities": ['
+        '{"name": "糖尿病", "entity_type": "疾病", "description": "慢性代谢性疾病"},'
+        '{"name": "Bad Type", "entity_type": "' + ("x" * 65) + '"}'
+        "],"
+        '"relations": []}'
+    )
+    entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    assert [entity.name for entity in entities] == ["糖尿病", "Bad Type"]
+    assert entities[0].entity_type == "疾病"
+    assert entities[1].entity_type == ""
+    assert relations == []
+
+
+def test_render_prompt_allows_dynamic_entity_types():
+    from aperag.indexing.llm import render_extraction_prompt
+
+    prompt = render_extraction_prompt(
+        input_text="OpenAI released GPT-4o.",
+        entity_types=[],
+        language="Chinese (Simplified)",
+        max_entities=8,
+        max_relations=8,
+    )
+    assert "If no existing entity type fits" in prompt
+    assert "Do not skip a valid entity" in prompt
+    assert "Use only these entity types" not in prompt
+    assert "skip the entity rather than invent" not in prompt
+    assert "Chinese (Simplified)" in prompt
+
+
 def test_resolve_entity_types_uses_collection_kg_config():
     collection = _make_collection()
     types = ge._resolve_entity_types(collection)
@@ -135,9 +167,7 @@ def test_resolve_entity_types_falls_back_to_default():
         config = {"language": "en-US"}
 
     types = ge._resolve_entity_types(_NoKG())
-    assert "person" in types
-    assert "organization" in types
-    assert len(types) == len(ge._DEFAULT_ENTITY_TYPES)
+    assert list(types) == []
 
 
 def test_resolve_language_reads_from_config_dict():
@@ -225,7 +255,7 @@ def test_extractor_skips_chunks_with_empty_text():
         return '{"entities": [], "relations": []}'
 
     async def _run() -> None:
-        from aperag.indexing.graph_extractor import _DEFAULT_ENTITY_TYPES, _extract_one_chunk
+        from aperag.indexing.graph_extractor import _extract_one_chunk
 
         # Empty text ⇒ extract_one_chunk would call LLM, so we route
         # via the closure-style filter that lives inside the actual
@@ -245,8 +275,8 @@ def test_extractor_skips_chunks_with_empty_text():
                 llm=_stub_llm,
                 text=str(chunk["text"]),
                 chunk_id=str(chunk["chunk_id"]),
-                entity_types=_DEFAULT_ENTITY_TYPES,
-                language="en-US",
+                entity_types=(),
+                language="English",
                 max_entities=8,
                 max_relations=8,
                 timeout_seconds=60.0,
@@ -321,8 +351,6 @@ def test_extractor_returns_empty_on_empty_chunks():
     LLM calls — pin the no-op fast path."""
 
     async def _run() -> None:
-        from aperag.indexing.graph_extractor import _DEFAULT_ENTITY_TYPES
-
         # Bypass the builder by constructing a tiny extractor inline.
         async def _extractor(chunks):
             if not chunks:
@@ -332,9 +360,5 @@ def test_extractor_returns_empty_on_empty_chunks():
         entities, relations = await _extractor([])
         assert entities == []
         assert relations == []
-
-        # Also make sure the public API symbols exist (no need for
-        # production LLM here).
-        assert _DEFAULT_ENTITY_TYPES
 
     asyncio.run(_run())

--- a/tests/unit_test/indexing/test_entity_types.py
+++ b/tests/unit_test/indexing/test_entity_types.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+
+import pytest
+
+from aperag.indexing.entity_types import (
+    format_entity_types_for_prompt,
+    merge_entity_type_values,
+    merge_entity_types,
+    normalize_entity_type,
+    prompt_language_name,
+)
+from aperag.schema.common import CollectionConfig, KnowledgeGraphConfig
+from aperag.schema.utils import dumpCollectionConfig
+
+
+def test_knowledge_graph_config_defaults_to_no_entity_types():
+    assert KnowledgeGraphConfig().entity_types == []
+    assert CollectionConfig().knowledge_graph_config.entity_types == []
+
+
+def test_prompt_language_name_maps_collection_language():
+    assert prompt_language_name("zh-CN") == "Chinese (Simplified)"
+    assert prompt_language_name("en-US") == "English"
+
+
+def test_normalize_entity_type_keeps_entity_safe_empty_for_bad_type():
+    assert normalize_entity_type("  Medical   Condition  ") == "Medical Condition"
+    assert normalize_entity_type("") == ""
+    assert normalize_entity_type("x" * 65) == ""
+
+
+def test_merge_entity_type_values_uses_first_write_wins_for_ascii_case():
+    merged = merge_entity_type_values(["Person", "疾病"], [" person ", "疾病", "药物", "x" * 65])
+    assert merged == ["Person", "疾病", "药物"]
+
+
+def test_format_entity_types_for_prompt_allows_empty_list():
+    assert format_entity_types_for_prompt([]) == "[]"
+    assert format_entity_types_for_prompt(["人物", "组织"]) == '["人物", "组织"]'
+
+
+def test_format_entity_types_for_prompt_does_not_cap_type_list():
+    entity_types = [f"Type{i}" for i in range(75)]
+    rendered = json.loads(format_entity_types_for_prompt(entity_types))
+    assert rendered == entity_types
+
+
+@pytest.mark.asyncio
+async def test_merge_entity_types_uses_for_update_and_preserves_config():
+    config = CollectionConfig(
+        language="zh-CN",
+        enable_summary=True,
+        knowledge_graph_config=KnowledgeGraphConfig(entity_types=["Person", "疾病"]),
+    )
+    collection = _FakeCollection(config=dumpCollectionConfig(config))
+    session = _FakeSession(collection)
+
+    merged = await merge_entity_types(session, "col_w11", [" person ", "药物", "药物"])
+
+    assert session.saw_for_update is True
+    assert session.added is collection
+    assert merged == ["Person", "疾病", "药物"]
+    dumped = json.loads(collection.config)
+    assert dumped["language"] == "zh-CN"
+    assert dumped["enable_summary"] is True
+    assert dumped["knowledge_graph_config"]["entity_types"] == ["Person", "疾病", "药物"]
+
+
+@pytest.mark.asyncio
+async def test_merge_entity_types_serializes_concurrent_updates():
+    config = CollectionConfig(
+        language="zh-CN",
+        knowledge_graph_config=KnowledgeGraphConfig(entity_types=["人物"]),
+    )
+    row = _SharedCollectionRow(config=dumpCollectionConfig(config))
+
+    session_a = _FakeSession(row)
+    session_b = _FakeSession(row)
+
+    task_a = asyncio.create_task(merge_entity_types(session_a, "col_w11", ["组织", "person"]))
+    await asyncio.sleep(0)
+    task_b = asyncio.create_task(merge_entity_types(session_b, "col_w11", ["疾病", "Person", "药物"]))
+    merged_a, merged_b = await asyncio.gather(task_a, task_b)
+
+    assert session_a.saw_for_update is True
+    assert session_b.saw_for_update is True
+    assert row.max_active_transactions == 1
+    assert merged_a == ["人物", "组织", "person"]
+    assert merged_b == ["人物", "组织", "person", "疾病", "药物"]
+    dumped = json.loads(row.collection.config)
+    assert dumped["knowledge_graph_config"]["entity_types"] == ["人物", "组织", "person", "疾病", "药物"]
+
+
+class _FakeCollection:
+    id = "col_w11"
+
+    def __init__(self, *, config: str) -> None:
+        self.config = config
+
+
+class _FakeResult:
+    def __init__(self, collection: _FakeCollection) -> None:
+        self._collection = collection
+
+    def scalar_one_or_none(self):
+        return self._collection
+
+
+class _SharedCollectionRow:
+    def __init__(self, *, config: str) -> None:
+        self.collection = _FakeCollection(config=config)
+        self._lock = asyncio.Lock()
+        self._active_transactions = 0
+        self.max_active_transactions = 0
+
+    async def acquire_for_update(self) -> None:
+        await self._lock.acquire()
+        self._active_transactions += 1
+        self.max_active_transactions = max(self.max_active_transactions, self._active_transactions)
+        await asyncio.sleep(0)
+
+    def release_for_update(self) -> None:
+        self._active_transactions -= 1
+        self._lock.release()
+
+
+class _FakeSession:
+    def __init__(self, collection_or_row: _FakeCollection | _SharedCollectionRow) -> None:
+        if isinstance(collection_or_row, _SharedCollectionRow):
+            self._row = collection_or_row
+            self._collection = collection_or_row.collection
+        else:
+            self._row = None
+            self._collection = collection_or_row
+        self.saw_for_update = False
+        self.added = None
+        self._locked_row = None
+
+    def in_transaction(self) -> bool:
+        return False
+
+    @asynccontextmanager
+    async def begin(self):
+        try:
+            yield
+        finally:
+            if self._locked_row is not None:
+                self._locked_row.release_for_update()
+                self._locked_row = None
+
+    async def execute(self, stmt):
+        self.saw_for_update = getattr(stmt, "_for_update_arg", None) is not None
+        if self._row is not None:
+            await self._row.acquire_for_update()
+            self._locked_row = self._row
+        return _FakeResult(self._collection)
+
+    def add(self, item):
+        self.added = item

--- a/tests/unit_test/indexing/test_t1_2_graph.py
+++ b/tests/unit_test/indexing/test_t1_2_graph.py
@@ -51,6 +51,7 @@ this suite.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Sequence
 from typing import Any
 
@@ -182,6 +183,7 @@ def _make_worker(
     entities_per_doc: dict[str, list[EntityRecord]] | None = None,
     relations_per_doc: dict[str, list[RelationRecord]] | None = None,
     tenant_scope_key: str = DEFAULT_TENANT,
+    entity_type_merger=None,
 ) -> GraphModalityWorker:
     async def extractor(
         chunks: Sequence[dict[str, Any]],
@@ -199,6 +201,7 @@ def _make_worker(
         object_store=object_store,
         collection_id=COLLECTION_ID,
         tenant_scope_key=tenant_scope_key,
+        entity_type_merger=entity_type_merger,
     )
 
 
@@ -234,6 +237,59 @@ def _lineage_keys(entity: EntityWithLineage) -> set[tuple[str, str]]:
 
 def _description_keys(entity: EntityWithLineage) -> set[tuple[str, str]]:
     return {part.key() for part in entity.description_parts}
+
+
+@pytest.mark.asyncio
+async def test_derive_merges_entity_types_once_per_document(store, entity_lock, object_store):
+    calls: list[tuple[str, list[str]]] = []
+
+    async def _merge(document_id: str, entity_types: Sequence[str]) -> list[str]:
+        calls.append((document_id, list(entity_types)))
+        return list(entity_types)
+
+    worker = _make_worker(
+        store=store,
+        entity_lock=entity_lock,
+        object_store=object_store,
+        document_id="doc_A",
+        entities_per_doc={
+            "doc_A": [
+                EntityRecord(name="Alice", entity_type="Person", description="a", source_chunk_ids=("c0",)),
+                EntityRecord(name="Bob", entity_type="person", description="b", source_chunk_ids=("c1",)),
+                EntityRecord(name="Acme", entity_type="组织", description="o", source_chunk_ids=("c1",)),
+            ]
+        },
+        entity_type_merger=_merge,
+    )
+
+    _write_doc_chunks_jsonl(object_store=object_store, document_id="doc_A", parse_version="v1")
+    await worker.derive(document_id="doc_A", parse_version="v1", source_path="<irrelevant>")
+
+    assert calls == [("doc_A", ["Person", "组织"])]
+
+
+@pytest.mark.asyncio
+async def test_derive_entity_type_merge_failure_is_non_fatal(store, entity_lock, object_store, caplog):
+    async def _merge(_document_id: str, _entity_types: Sequence[str]) -> list[str]:
+        raise RuntimeError("merge unavailable")
+
+    worker = _make_worker(
+        store=store,
+        entity_lock=entity_lock,
+        object_store=object_store,
+        document_id="doc_A",
+        entities_per_doc={
+            "doc_A": [EntityRecord(name="Alice", entity_type="Person", description="a", source_chunk_ids=("c0",))]
+        },
+        entity_type_merger=_merge,
+    )
+
+    _write_doc_chunks_jsonl(object_store=object_store, document_id="doc_A", parse_version="v1")
+    with caplog.at_level(logging.WARNING):
+        result = await worker.derive(document_id="doc_A", parse_version="v1", source_path="<irrelevant>")
+
+    assert object_store.obj_exists(result.derived_artifact_path)
+    assert "graph entity type merge failed" in caplog.text
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Hard-cut graph entity types to collection-local `KnowledgeGraphConfig.entity_types: list[str]` with default `[]`.
- Remove the `_DEFAULT_ENTITY_TYPES` fallback and stop treating entity types as a closed enum in the extraction prompt.
- Add dynamic type helpers plus async `merge_entity_types(session, collection_id, new_types)` with `SELECT ... FOR UPDATE` and first-write-wins dedupe.
- Wire a per-document entity-type merge after `kg.jsonl` is written; merge failures log a warning and do not poison graph output.
- Keep graph storage and curation on `entity_type: str`; no `type_id` / `label` split and no registry table.
- Add the locked Chinese Wave 11 design doc under `docs/modularization/`.

## CR Fixes

- Removed the prompt-side 50-type cap; the prompt now renders every cleaned existing type.
- Added a concurrent merge test proving row-lock serialization keeps both writers' entity types.
- Expanded this PR body with the §16 hard-gate sections below.

## Spec Gates

- Hard cut only: no old-data migration, no lazy seed, no backfill.
- No DB schema change / alembic migration.
- New collections start with `entity_types=[]`; LLM can propose the first types from real documents.
- Invalid or overlong type clears only the type field (`entity_type=""`); the entity is preserved.
- ASCII case dedupe is first-write-wins.
- Prompt language comes from `collection.config.language`; entity names preserve source text.
- Prompt receives the full cleaned `entity_types` list; no prompt list cap, size cap, LRU, or fallback default.
- Per-document merge happens after graph derive writes `kg.jsonl`; no per-chunk or per-run merge.

## 12-Invariant Gate

1. `EntityRecord.entity_type` remains a string; no `type_id` field is introduced.
2. `kg.jsonl` entity/relation record shape remains compatible.
3. Graph storage backends continue storing/filtering string entity labels.
4. Graph curation continues using `CurationEntity.entity_type` string paths.
5. Wave 7 compacted entity/relation descriptions are untouched.
6. Wave 7 merge-candidate/vector sync hooks are untouched.
7. Wave 8 bulk-upsert entity type behavior remains covered by existing tests.
8. Tenant scope and parse-version artifact paths are unchanged.
9. Graph derive still writes `kg.jsonl` even if config merge fails.
10. Config merge never deletes or rewrites existing graph entities.
11. Empty or bad entity type values do not pollute collection config.
12. No production-data migration/backfill path is required for this hard cut.

## Pattern Gate

- Pattern 1: reuse the existing graph `entity_type: str` storage and API surface.
- Pattern 2: bind graph output language to `collection.config.language`; no `auto` language mode.
- Pattern 3: reuse existing `KnowledgeGraphConfig.entity_types`; no new registry table.
- Pattern 4: keep graph curation/search compatibility by preserving the string type surface.

## 11 Mini-Pattern Gate

1. `merge_entity_types()` is async and takes `AsyncSession`.
2. Atomic merge path uses `SELECT ... FOR UPDATE`.
3. No sync wrapper and no optimistic-retry fallback.
4. Merge call granularity is per-document after `kg.jsonl` flush.
5. `_DEFAULT_ENTITY_TYPES` is removed and no longer a fallback.
6. Unknown/new LLM type strings are accepted.
7. Overlong/bad type clears only the type field; entity row is preserved.
8. ASCII case dedupe is first-write-wins.
9. Merge failure logs warning and is non-fatal/self-healing.
10. Full existing type list is rendered into the prompt; no 50-item truncation.
11. Concurrent merge behavior is covered by a serialization test.

## Simple-Stable Guardrails

- No scope expansion: no lifecycle/status/source/audit registry model.
- Fastest safe path: one existing JSON config field and one merge helper.
- Simple stable behavior: strings are the storage/display contract within a fixed-language collection.
- Low maintenance: no schema table, no default ontology upkeep, no size-cap/LRU policy to tune.

## Validation

- `uv run ruff check aperag/indexing/entity_types.py aperag/indexing/graph.py aperag/indexing/graph_extractor.py aperag/indexing/llm.py aperag/indexing/worker_factory.py aperag/schema/common.py tests/unit_test/indexing/test_entity_types.py tests/integration/test_graph_extractor.py tests/unit_test/indexing/test_t1_2_graph.py`
- `uv run --extra test pytest tests/unit_test/indexing/test_entity_types.py tests/integration/test_graph_extractor.py tests/unit_test/indexing/test_t1_2_graph.py -q` → 84 passed, 1 warning
- `uv run python -m compileall -q aperag/indexing/entity_types.py aperag/indexing/graph.py aperag/indexing/graph_extractor.py aperag/indexing/llm.py aperag/indexing/worker_factory.py aperag/schema/common.py tests/unit_test/indexing/test_entity_types.py tests/integration/test_graph_extractor.py tests/unit_test/indexing/test_t1_2_graph.py`
- `git diff --check`
- `rg -n "type_id|collection_entity_type|_DEFAULT_ENTITY_TYPES" aperag tests` → no output
