### PR TITLE
feat(web): graph-lab Cosmograph PoC menu page

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,8 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^2.0.0",
+    "@cosmograph/cosmograph": "^2.3.0",
+    "@cosmograph/react": "^2.3.0",
     "@diceui/mention": "^0.7.1",
     "@hookform/resolvers": "^5.2.1",
     "@jsdevtools/rehype-toc": "^3.0.2",

--- a/web/src/app/workspace/collections/[collectionId]/graph-lab/collection-graph-lab.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-lab/collection-graph-lab.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import { CosmographSemanticMap } from './cosmograph-semantic-map';
+import { CosmographTopology } from './cosmograph-topology';
+import { GraphLabNav } from './graph-lab-nav';
+import { DEFAULT_LAB_MODE, type LabMode } from './lab-modes';
+
+export function CollectionGraphLab() {
+  const [active, setActive] = useState<LabMode>(DEFAULT_LAB_MODE);
+  return (
+    <div className="flex h-full flex-1 gap-4 py-4">
+      <GraphLabNav active={active} onChange={setActive} />
+      <main className="flex-1 overflow-hidden">
+        {active === 'cosmograph-topology' ? (
+          <CosmographTopology />
+        ) : (
+          <CosmographSemanticMap />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/web/src/app/workspace/collections/[collectionId]/graph-lab/cosmograph-semantic-map.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-lab/cosmograph-semantic-map.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  buildSyntheticSemanticDataset,
+  type CosmographDataset,
+  type CosmographPoint,
+} from '@/features/knowledge-graph/cosmograph-adapter';
+import { cn } from '@/lib/utils';
+import dynamic from 'next/dynamic';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  SEMANTIC_SCALE_PRESETS,
+  type SemanticScale,
+} from './lab-modes';
+
+const Cosmograph = dynamic(
+  () => import('@cosmograph/react').then((m) => ({ default: m.Cosmograph })),
+  { ssr: false },
+);
+
+type Bench = {
+  scale: number;
+  generateMs: number;
+  renderMs: number | null;
+};
+
+export function CosmographSemanticMap() {
+  const [scale, setScale] = useState<SemanticScale>(SEMANTIC_SCALE_PRESETS[0]);
+  const [dataset, setDataset] = useState<CosmographDataset | null>(null);
+  const [bench, setBench] = useState<Bench | null>(null);
+  const [selected, setSelected] = useState<CosmographPoint | null>(null);
+  const renderStartRef = useRef<number>(0);
+
+  useEffect(() => {
+    const generateStart = performance.now();
+    const next = buildSyntheticSemanticDataset(scale, { clusterCount: 8 });
+    const generateMs = performance.now() - generateStart;
+    setDataset(next);
+    renderStartRef.current = performance.now();
+    setBench({ scale, generateMs, renderMs: null });
+    setSelected(null);
+  }, [scale]);
+
+  const cosmographConfig = useMemo(() => {
+    if (!dataset) return null;
+    return {
+      points: dataset.points,
+      pointIdBy: 'id',
+      pointLabelBy: 'label',
+      pointClusterBy: 'cluster',
+      pointColorBy: 'cluster',
+      pointXBy: 'x',
+      pointYBy: 'y',
+      backgroundColor: 'transparent',
+      // Semantic mode: positions are pre-baked, suppress the simulation.
+      enableSimulation: false,
+      pointSize: 4,
+      onPointClick: (index: number) => {
+        const point = dataset.points[index];
+        if (point) setSelected(point);
+      },
+    } as const;
+  }, [dataset]);
+
+  return (
+    <div className="grid h-full grid-cols-[1fr_18rem] gap-4">
+      <div className="bg-card relative flex h-full flex-col overflow-hidden rounded-lg border">
+        <div className="flex items-center gap-2 border-b px-3 py-2">
+          <span className="text-muted-foreground text-xs">Synthetic scale:</span>
+          {SEMANTIC_SCALE_PRESETS.map((preset) => (
+            <Button
+              key={preset}
+              size="sm"
+              variant={preset === scale ? 'default' : 'outline'}
+              className={cn('h-7 px-2 text-xs')}
+              onClick={() => setScale(preset)}
+            >
+              {preset.toLocaleString()}
+            </Button>
+          ))}
+        </div>
+        <div className="relative flex-1">
+          {cosmographConfig && (
+            <Cosmograph
+              {...cosmographConfig}
+              onMount={() => {
+                const ms = performance.now() - renderStartRef.current;
+                setBench((prev) =>
+                  prev ? { ...prev, renderMs: ms } : prev,
+                );
+              }}
+              style={{ width: '100%', height: '100%' }}
+            />
+          )}
+        </div>
+      </div>
+      <SemanticDetail
+        bench={bench}
+        clusterLabels={dataset?.clusterLabels ?? {}}
+        selected={selected}
+      />
+    </div>
+  );
+}
+
+function SemanticDetail({
+  bench,
+  clusterLabels,
+  selected,
+}: {
+  bench: Bench | null;
+  clusterLabels: Record<number, string>;
+  selected: CosmographPoint | null;
+}) {
+  return (
+    <aside className="bg-card flex h-full flex-col gap-3 overflow-y-auto rounded-lg border p-4">
+      <section>
+        <h3 className="text-sm font-medium">Bench</h3>
+        <dl className="text-muted-foreground mt-1 grid grid-cols-2 gap-y-1 text-xs">
+          <dt>points</dt>
+          <dd className="text-foreground">
+            {bench ? bench.scale.toLocaleString() : '–'}
+          </dd>
+          <dt>generate</dt>
+          <dd className="text-foreground">
+            {bench ? `${bench.generateMs.toFixed(1)} ms` : '–'}
+          </dd>
+          <dt>first frame</dt>
+          <dd className="text-foreground">
+            {bench?.renderMs ? `${bench.renderMs.toFixed(0)} ms` : '–'}
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h3 className="text-sm font-medium">Clusters</h3>
+        <ul className="text-muted-foreground mt-1 max-h-32 overflow-y-auto text-xs">
+          {Object.entries(clusterLabels).map(([id, label]) => (
+            <li key={id}>{label}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h3 className="text-sm font-medium">Selected</h3>
+        {selected ? (
+          <div className="mt-1 flex flex-col gap-1 text-xs">
+            <div>
+              <span className="text-muted-foreground">id: </span>
+              <span className="font-mono">{selected.id}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">label: </span>
+              <span>{selected.label}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">cluster: </span>
+              <span>{clusterLabels[selected.cluster] ?? selected.cluster}</span>
+            </div>
+            {typeof selected.x === 'number' && typeof selected.y === 'number' && (
+              <div>
+                <span className="text-muted-foreground">coords: </span>
+                <span className="font-mono">
+                  ({selected.x.toFixed(3)}, {selected.y.toFixed(3)})
+                </span>
+              </div>
+            )}
+            {selected.description && (
+              <p className="text-muted-foreground mt-1 line-clamp-6">
+                {selected.description}
+              </p>
+            )}
+          </div>
+        ) : (
+          <p className="text-muted-foreground mt-1 text-xs">
+            Click a point in the canvas.
+          </p>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/web/src/app/workspace/collections/[collectionId]/graph-lab/cosmograph-topology.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-lab/cosmograph-topology.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { getKnowledgeGraph } from '@/features/knowledge-graph/client-api';
+import {
+  toTopologyDataset,
+  type CosmographDataset,
+  type CosmographLink,
+  type CosmographPoint,
+} from '@/features/knowledge-graph/cosmograph-adapter';
+import dynamic from 'next/dynamic';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+// Cosmograph is a WebGL renderer; importing it directly breaks the SSR
+// pass with `window is not defined`. The dynamic import keeps the
+// bundle out of the server graph.
+const Cosmograph = dynamic(
+  () => import('@cosmograph/react').then((m) => ({ default: m.Cosmograph })),
+  { ssr: false },
+);
+
+type FrameStat = { renderMs?: number; pointCount: number; linkCount: number };
+
+export function CosmographTopology() {
+  const params = useParams<{ collectionId: string }>();
+  const collectionId = params?.collectionId ?? '';
+  const [dataset, setDataset] = useState<CosmographDataset | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<FrameStat | null>(null);
+  const [selected, setSelected] = useState<CosmographPoint | null>(null);
+  const renderStartRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!collectionId) return;
+    let cancelled = false;
+    setError(null);
+    setDataset(null);
+    getKnowledgeGraph(collectionId, {
+      label: '*',
+      maxNodes: 1000,
+      maxDepth: 3,
+    })
+      .then((graph) => {
+        if (cancelled) return;
+        if (!graph) {
+          setError('Empty graph response');
+          return;
+        }
+        renderStartRef.current = performance.now();
+        const next = toTopologyDataset(graph);
+        setDataset(next);
+        setStats({
+          pointCount: next.points.length,
+          linkCount: next.links.length,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [collectionId]);
+
+  const cosmographConfig = useMemo(() => {
+    if (!dataset) return null;
+    return {
+      points: dataset.points,
+      links: dataset.links,
+      pointIdBy: 'id',
+      pointLabelBy: 'label',
+      pointClusterBy: 'cluster',
+      pointColorBy: 'cluster',
+      linkSourceBy: 'source',
+      linkTargetBy: 'target',
+      backgroundColor: 'transparent',
+      enableSimulation: true,
+      simulationGravity: 0.25,
+      simulationRepulsion: 1.0,
+      pointSize: 6,
+      onPointClick: (index: number) => {
+        const point = dataset.points[index];
+        if (point) setSelected(point);
+      },
+    } as const;
+  }, [dataset]);
+
+  if (error) {
+    return (
+      <div className="text-destructive flex h-full items-center justify-center text-sm">
+        {error}
+      </div>
+    );
+  }
+
+  if (!cosmographConfig) {
+    return (
+      <div className="grid h-full grid-cols-[1fr_18rem] gap-4">
+        <Skeleton className="h-full w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid h-full grid-cols-[1fr_18rem] gap-4">
+      <div className="bg-card relative flex h-full overflow-hidden rounded-lg border">
+        <Cosmograph
+          {...cosmographConfig}
+          onMount={() => {
+            const ms = performance.now() - renderStartRef.current;
+            setStats((prev) =>
+              prev
+                ? { ...prev, renderMs: ms }
+                : { pointCount: 0, linkCount: 0, renderMs: ms },
+            );
+          }}
+          style={{ width: '100%', height: '100%' }}
+        />
+      </div>
+      <DetailPanel
+        stats={stats}
+        clusterLabels={dataset?.clusterLabels ?? {}}
+        selected={selected}
+        links={dataset?.links ?? []}
+      />
+    </div>
+  );
+}
+
+function DetailPanel({
+  stats,
+  clusterLabels,
+  selected,
+  links,
+}: {
+  stats: FrameStat | null;
+  clusterLabels: Record<number, string>;
+  selected: CosmographPoint | null;
+  links: CosmographLink[];
+}) {
+  const neighbours = useMemo(() => {
+    if (!selected) return [] as Array<{ direction: 'in' | 'out'; other: string }>;
+    const out: Array<{ direction: 'in' | 'out'; other: string }> = [];
+    for (const link of links) {
+      if (link.source === selected.id) {
+        out.push({ direction: 'out', other: link.target });
+      } else if (link.target === selected.id) {
+        out.push({ direction: 'in', other: link.source });
+      }
+    }
+    return out.slice(0, 20);
+  }, [selected, links]);
+
+  return (
+    <aside className="bg-card flex h-full flex-col gap-3 overflow-y-auto rounded-lg border p-4">
+      <section>
+        <h3 className="text-sm font-medium">Render</h3>
+        <dl className="text-muted-foreground mt-1 grid grid-cols-2 gap-y-1 text-xs">
+          <dt>points</dt>
+          <dd className="text-foreground">{stats?.pointCount ?? '–'}</dd>
+          <dt>links</dt>
+          <dd className="text-foreground">{stats?.linkCount ?? '–'}</dd>
+          <dt>first frame</dt>
+          <dd className="text-foreground">
+            {stats?.renderMs ? `${stats.renderMs.toFixed(0)} ms` : '–'}
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h3 className="text-sm font-medium">Clusters</h3>
+        <ul className="text-muted-foreground mt-1 max-h-32 overflow-y-auto text-xs">
+          {Object.entries(clusterLabels).map(([id, label]) => (
+            <li key={id}>{label}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h3 className="text-sm font-medium">Selected</h3>
+        {selected ? (
+          <div className="mt-1 flex flex-col gap-1 text-xs">
+            <div>
+              <span className="text-muted-foreground">id: </span>
+              <span className="font-mono">{selected.id}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">label: </span>
+              <span>{selected.label}</span>
+            </div>
+            {selected.entity_type && (
+              <div>
+                <span className="text-muted-foreground">type: </span>
+                <span>{selected.entity_type}</span>
+              </div>
+            )}
+            {selected.description && (
+              <p className="text-muted-foreground mt-1 line-clamp-6">
+                {selected.description}
+              </p>
+            )}
+            {neighbours.length > 0 && (
+              <div className="mt-1">
+                <div className="text-muted-foreground">neighbours</div>
+                <ul className="font-mono">
+                  {neighbours.map((n, i) => (
+                    <li key={`${n.direction}-${n.other}-${i}`}>
+                      {n.direction === 'in' ? '←' : '→'} {n.other}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-muted-foreground mt-1 text-xs">
+            Click a node in the canvas.
+          </p>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/web/src/app/workspace/collections/[collectionId]/graph-lab/graph-lab-nav.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-lab/graph-lab-nav.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import type { LabMode } from './lab-modes';
+
+type Props = {
+  active: LabMode;
+  onChange: (mode: LabMode) => void;
+};
+
+const MODES: Array<{
+  id: LabMode;
+  title: string;
+  description: string;
+}> = [
+  {
+    id: 'cosmograph-topology',
+    title: 'Cosmograph · Topology',
+    description: 'WebGL force-directed render of the live KG nodes/edges.',
+  },
+  {
+    id: 'cosmograph-semantic',
+    title: 'Cosmograph · Semantic Map',
+    description:
+      'Pre-computed (x, y) point cloud, synthetic fixture for FPS bench.',
+  },
+];
+
+const EXTERNAL_LINKS: Array<{
+  href: (collectionId: string) => string;
+  title: string;
+  description: string;
+}> = [
+  {
+    href: (id) => `/workspace/collections/${id}/graph`,
+    title: 'Current · /graph',
+    description: 'Production page, react-force-graph-2d.',
+  },
+  {
+    href: (id) => `/workspace/collections/${id}/graph-showcase`,
+    title: 'Showcase · /graph-showcase',
+    description: 'Existing alternate visual exploration page.',
+  },
+];
+
+export function GraphLabNav({ active, onChange }: Props) {
+  const params = useParams<{ collectionId: string }>();
+  const collectionId = params?.collectionId ?? '';
+  return (
+    <aside className="bg-card flex w-72 shrink-0 flex-col gap-4 border-r p-4">
+      <div>
+        <div className="text-muted-foreground mb-2 text-[10px] tracking-widest uppercase">
+          Embedded modes
+        </div>
+        <div className="flex flex-col gap-2">
+          {MODES.map((mode) => (
+            <Button
+              key={mode.id}
+              variant={mode.id === active ? 'default' : 'outline'}
+              className={cn('h-auto justify-start whitespace-normal py-3 text-left')}
+              onClick={() => onChange(mode.id)}
+            >
+              <div className="flex flex-col items-start gap-1">
+                <span className="text-sm font-medium">{mode.title}</span>
+                <span className="text-muted-foreground text-xs">
+                  {mode.description}
+                </span>
+              </div>
+            </Button>
+          ))}
+        </div>
+      </div>
+      <div className="border-t pt-4">
+        <div className="text-muted-foreground mb-2 text-[10px] tracking-widest uppercase">
+          External pages
+        </div>
+        <div className="flex flex-col gap-2">
+          {EXTERNAL_LINKS.map((link) => (
+            <Link
+              key={link.title}
+              href={link.href(collectionId)}
+              className="hover:bg-accent rounded-md border px-3 py-2"
+            >
+              <div className="text-sm font-medium">{link.title}</div>
+              <div className="text-muted-foreground text-xs">
+                {link.description}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+      <div className="border-t pt-4">
+        <div className="text-muted-foreground mb-2 text-[10px] tracking-widest uppercase">
+          POC notes
+        </div>
+        <p className="text-muted-foreground text-xs leading-relaxed">
+          Cosmograph (CC-BY-NC-4.0) is wired here as an exploratory PoC
+          only. Productionising the visual requires either a paid
+          Cosmograph licence or a switch to the MIT-licensed cosmos.gl
+          base library — neither is in scope for this PoC.
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/app/workspace/collections/[collectionId]/graph-lab/lab-modes.ts
+++ b/web/src/app/workspace/collections/[collectionId]/graph-lab/lab-modes.ts
@@ -1,0 +1,10 @@
+// Shared types between the lab page, the nav, and the renderers.
+// Pure module — kept separate so the server-component page.tsx can stay
+// import-light (no client-only references).
+
+export type LabMode = 'cosmograph-topology' | 'cosmograph-semantic';
+
+export const DEFAULT_LAB_MODE: LabMode = 'cosmograph-topology';
+
+export const SEMANTIC_SCALE_PRESETS = [1000, 5000, 10000] as const;
+export type SemanticScale = (typeof SEMANTIC_SCALE_PRESETS)[number];

--- a/web/src/app/workspace/collections/[collectionId]/graph-lab/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-lab/page.tsx
@@ -1,0 +1,38 @@
+import {
+  PageContainer,
+  PageContent,
+  PageHeader,
+} from '@/components/page-container';
+import { getTranslations } from 'next-intl/server';
+import { CollectionHeader } from '../collection-header';
+import { CollectionGraphLab } from './collection-graph-lab';
+
+export default async function Page() {
+  const pageCollections = await getTranslations('page_collections');
+  const pageGraph = await getTranslations('page_graph');
+
+  return (
+    <PageContainer>
+      <PageHeader
+        breadcrumbs={[
+          {
+            title: pageCollections('metadata.title'),
+            href: '/workspace/collections',
+          },
+          {
+            title: pageGraph('metadata.title'),
+          },
+          {
+            title: 'Lab',
+          },
+        ]}
+      />
+      <div className="flex h-[calc(100vh-48px)] flex-col px-0">
+        <CollectionHeader className="w-full" />
+        <PageContent className="flex w-full max-w-[1440px] flex-1 flex-col">
+          <CollectionGraphLab />
+        </PageContent>
+      </div>
+    </PageContainer>
+  );
+}

--- a/web/src/features/knowledge-graph/cosmograph-adapter.ts
+++ b/web/src/features/knowledge-graph/cosmograph-adapter.ts
@@ -1,0 +1,164 @@
+/**
+ * Adapter — translate ApeRAG `KnowledgeGraph` shape to the `points/links`
+ * shape that Cosmograph (`@cosmograph/react`) consumes. Pure data
+ * transform, no UI dependencies; lives outside the POC page so a future
+ * production-graph page can reuse the same mapping if Cosmograph wins
+ * the visual bake-off.
+ *
+ * The two output modes mirror the Cosmograph API surfaces:
+ *
+ * - `topology`  — graph mode: links carry source/target ids; layout is
+ *   computed by Cosmograph's force simulation. Used for the live
+ *   `/api/v2/collections/{id}/graphs` data.
+ * - `semantic`  — embedding mode: points carry pre-computed `x/y` and a
+ *   `cluster` index; no layout simulation. Used for the synthetic
+ *   fixture (and, eventually, a backend `/embedding-map` endpoint when
+ *   the POC results justify building one).
+ */
+
+import type {
+  GraphEdge,
+  GraphNode,
+  KnowledgeGraph,
+} from './types';
+
+export type CosmographPoint = {
+  id: string;
+  label: string;
+  /** Numeric cluster id Cosmograph uses for color quantization. */
+  cluster: number;
+  /** Original entity_type from the API; preserved for filter/legend UI. */
+  entity_type?: string | null;
+  /** Pre-computed coordinates for `semantic` mode; omitted in `topology`. */
+  x?: number;
+  y?: number;
+  /** Forwarded so the existing detail panel can render rich content. */
+  description?: string | null;
+};
+
+export type CosmographLink = {
+  source: string;
+  target: string;
+  /** Edge weight; falls back to 1 when the API does not surface one. */
+  weight?: number;
+  description?: string | null;
+};
+
+export type CosmographDataset = {
+  points: CosmographPoint[];
+  links: CosmographLink[];
+  /** Friendly cluster labels keyed by numeric `cluster` id. */
+  clusterLabels: Record<number, string>;
+};
+
+/**
+ * Convert a live `KnowledgeGraph` payload into Cosmograph topology mode
+ * data. Cluster id is derived from `entity_type` so points sharing a
+ * type land in the same color bucket — the API does not currently
+ * surface a real cluster signal.
+ */
+export function toTopologyDataset(graph: KnowledgeGraph): CosmographDataset {
+  const nodes = (graph.nodes ?? []) as GraphNode[];
+  const edges = (graph.edges ?? []) as GraphEdge[];
+
+  const typeToCluster = new Map<string, number>();
+  const clusterLabels: Record<number, string> = {};
+
+  const points: CosmographPoint[] = nodes.map((node) => {
+    const entityType = (node.properties?.entity_type ?? 'unknown') as string;
+    let cluster = typeToCluster.get(entityType);
+    if (cluster === undefined) {
+      cluster = typeToCluster.size;
+      typeToCluster.set(entityType, cluster);
+      clusterLabels[cluster] = entityType;
+    }
+    const description =
+      (node.properties?.description as string | undefined) ?? null;
+    return {
+      id: String(node.id),
+      label:
+        (node.labels?.[0] as string | undefined) ??
+        (node.properties?.entity_name as string | undefined) ??
+        String(node.id),
+      cluster,
+      entity_type: entityType,
+      description,
+    };
+  });
+
+  const validIds = new Set(points.map((p) => p.id));
+  const links: CosmographLink[] = edges
+    .filter((edge) => validIds.has(String(edge.source)) && validIds.has(String(edge.target)))
+    .map((edge) => ({
+      source: String(edge.source),
+      target: String(edge.target),
+      weight: 1,
+      description:
+        (edge.properties?.description as string | undefined) ?? null,
+    }));
+
+  return { points, links, clusterLabels };
+}
+
+/**
+ * Generate a deterministic synthetic semantic map at the requested
+ * scale. Points are scattered into `clusterCount` Gaussian blobs across
+ * a unit square. No links are produced — semantic mode is point-cloud
+ * only, mirroring the arXiv-map reference visual.
+ *
+ * Seeded with `seed` (default 1) so the same scale renders identically
+ * across reloads, which keeps performance benchmarking honest.
+ */
+export function buildSyntheticSemanticDataset(
+  pointCount: number,
+  options: { seed?: number; clusterCount?: number } = {},
+): CosmographDataset {
+  const seed = options.seed ?? 1;
+  const clusterCount = options.clusterCount ?? 8;
+
+  // Mulberry32 — small deterministic PRNG; avoids pulling a dep just for fixtures.
+  const prng = (() => {
+    let state = seed >>> 0;
+    return () => {
+      state = (state + 0x6d2b79f5) >>> 0;
+      let t = state;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  })();
+
+  const clusterCenters = Array.from({ length: clusterCount }, (_, k) => {
+    const angle = (k / clusterCount) * Math.PI * 2;
+    return {
+      cx: Math.cos(angle) * 0.6,
+      cy: Math.sin(angle) * 0.6,
+    };
+  });
+
+  const clusterLabels: Record<number, string> = {};
+  for (let k = 0; k < clusterCount; k += 1) {
+    clusterLabels[k] = `Cluster ${k}`;
+  }
+
+  const points: CosmographPoint[] = Array.from({ length: pointCount }, (_, i) => {
+    const cluster = i % clusterCount;
+    const center = clusterCenters[cluster];
+    // Box-Muller for a 2D Gaussian — gives the visually pleasing dense
+    // cluster cores with sparse outliers that the reference visual has.
+    const u1 = Math.max(prng(), 1e-9);
+    const u2 = prng();
+    const radius = Math.sqrt(-2 * Math.log(u1)) * 0.06;
+    const theta = u2 * Math.PI * 2;
+    return {
+      id: `synthetic-${i}`,
+      label: `Document ${i}`,
+      cluster,
+      x: center.cx + radius * Math.cos(theta),
+      y: center.cy + radius * Math.sin(theta),
+      description: `Synthetic point ${i} in ${clusterLabels[cluster]} — fixture data for FPS bench.`,
+    };
+  });
+
+  return { points, links: [], clusterLabels };
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -360,6 +360,73 @@
   resolved "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz#e39999307b102cff3645ec4f5b3665f5297a2224"
   integrity sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==
 
+"@cosmograph/cosmograph@2.3.0", "@cosmograph/cosmograph@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/@cosmograph/cosmograph/-/cosmograph-2.3.0.tgz#448326accd2f449c738128ebca5cdc15ad6a63c8"
+  integrity sha512-UgZifvhCMp7Eq6NLPnzgTlO7k8UYD5F6kg2Y75zysk3eC5tXBjD33wPjLcvTnwKy4aRy3mZ3o0xD8J1ldU70hg==
+  dependencies:
+    "@cosmograph/ui" "2.3.0"
+    "@cosmos.gl/graph" "3.0.0-beta.8"
+    "@duckdb/duckdb-wasm" "1.32.0"
+    "@interacta/css-labels" "^0.6.0"
+    "@supabase/supabase-js" "^2.98.0"
+    "@uwdata/mosaic-core" "^0.21.1"
+    "@uwdata/mosaic-plot" "^0.21.1"
+    "@uwdata/mosaic-sql" "^0.21.1"
+    "@uwdata/vgplot" "^0.21.1"
+    apache-arrow "17.0.0"
+    d3-array "^3.2.4"
+    d3-brush "^3.0.0"
+    d3-color "^3.1.0"
+    d3-interpolate "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-selection "^3.0.0"
+    dompurify "^3.2.6"
+
+"@cosmograph/react@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/@cosmograph/react/-/react-2.3.0.tgz#5869447b6a1e99a72579e1f90094e04cdad7dfdb"
+  integrity sha512-qV5RMCed6ISlXdCANiDOrLo+Sut+UGJNxFYQiW/eJ4GtWUg5G54vWEx6Vcz6KXZmLm8RvZzYTXVxarlrzYePMQ==
+  dependencies:
+    "@cosmograph/cosmograph" "2.3.0"
+
+"@cosmograph/ui@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/@cosmograph/ui/-/ui-2.3.0.tgz#714a1db665262ca486d32f8c3e3f12b375785ced"
+  integrity sha512-Umuoxy0m8HY6xOLxP5RZOdXS1WRESea8wrpobAw4QGvEidbWXyPQum3plXiYukXRE/7wqbkVt1Pc7/TBoKFyTA==
+  dependencies:
+    "@juggle/resize-observer" "^3.4.0"
+    d3-array "^3.2.4"
+    d3-axis "^3.0.0"
+    d3-brush "^3.0.0"
+    d3-format "^3.1.0"
+    d3-scale "^4.0.2"
+    d3-selection "^3.0.0"
+    d3-time-format "^4.1.0"
+    d3-transition "^3.0.1"
+
+"@cosmos.gl/graph@3.0.0-beta.8":
+  version "3.0.0-beta.8"
+  resolved "https://registry.npmjs.org/@cosmos.gl/graph/-/graph-3.0.0-beta.8.tgz#5bddfec1617311be90c54ed7ebe89c7a81f5389b"
+  integrity sha512-sxWgDtukeIXOe4Yi+Cl7/cTGufthpwu14iu3tAOUWnp4IdhaXtnclji1TkSyxLOEHgGKJ1p3k3T0VghD8MfdPA==
+  dependencies:
+    "@luma.gl/core" "~9.2.6"
+    "@luma.gl/engine" "~9.2.6"
+    "@luma.gl/shadertools" "~9.2.6"
+    "@luma.gl/webgl" "~9.2.6"
+    d3-array "^3.2.0"
+    d3-color "^3.1.0"
+    d3-drag "^3.0.0"
+    d3-ease "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-selection "^3.0.0"
+    d3-transition "^3.0.1"
+    d3-zoom "^3.0.0"
+    dompurify "^3.2.6"
+    gl-bench "^1.0.42"
+    gl-matrix "^3.4.3"
+    random "^4.1.0"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -384,6 +451,20 @@
   version "0.12.0"
   resolved "https://registry.npmjs.org/@diceui/shared/-/shared-0.12.0.tgz#bec74088807c9a9ebba2d8c340947458e54b4fd5"
   integrity sha512-aJ+gxHTleFD8b9DgXOb7G0sHymW8nMK4C3KXDMca4+PPl1NsfRG/Lnb2dN8vq44XOb/W7Wjn3gmgakXAOzgrJA==
+
+"@duckdb/duckdb-wasm@1.30.0":
+  version "1.30.0"
+  resolved "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.30.0.tgz#b6dcc228af441a38de2c54208f6f653d8342b38d"
+  integrity sha512-9aWrm+4ayl4sTlvGtl/b+LxrUyXaac3yyVqkoJ3F7Vkd62PoS8PcQIRJ/KjXBW36LP1CnPY5jjvFyIcTFLtcXA==
+  dependencies:
+    apache-arrow "^17.0.0"
+
+"@duckdb/duckdb-wasm@1.32.0":
+  version "1.32.0"
+  resolved "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz#199ebbca6c302eba7bb0a458aacd34ccf8518335"
+  integrity sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==
+  dependencies:
+    apache-arrow "^17.0.0"
 
 "@emnapi/core@^1.4.3", "@emnapi/core@^1.4.5":
   version "1.4.5"
@@ -754,6 +835,11 @@
   resolved "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz#efc293ba0ed91e90e6267f1aacc1c70d20b8b4e8"
   integrity sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==
 
+"@interacta/css-labels@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/@interacta/css-labels/-/css-labels-0.6.0.tgz#784da7023621b572004a19ee8f52fac08782342c"
+  integrity sha512-wY+UX6A1BP7MazIUkDl5rnLDETU0lhHGQsJ/Igf9BjH7ygGKvQ05348sCLbbJmsLMPoGD1P02WnTd8enYNZuHg==
+
 "@isaacs/fs-minipass@^4.0.0":
   version "4.0.1"
   resolved "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
@@ -807,6 +893,67 @@
   version "3.0.2"
   resolved "https://registry.npmjs.org/@jsdevtools/rehype-toc/-/rehype-toc-3.0.2.tgz#29c32e6b40cd4b5dafd96cb90d5057ac5dab4a51"
   integrity sha512-n5JEf16Wr4mdkRMZ8wMP/wN9/sHmTjRPbouXjJH371mZ2LEGDl72t8tEsMRNFerQN/QJtivOxqK1frdGa4QK5Q==
+
+"@juggle/resize-observer@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
+  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
+
+"@luma.gl/constants@9.2.6":
+  version "9.2.6"
+  resolved "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.2.6.tgz#19baa45cd3b1a24eec7371a0127899b37d2644e8"
+  integrity sha512-rvFFrJuSm5JIWbDHFuR4Q2s4eudO3Ggsv0TsGKn9eqvO7bBiPm/ANugHredvh3KviEyYuMZZxtfJvBdr3kzldg==
+
+"@luma.gl/core@~9.2.6":
+  version "9.2.6"
+  resolved "https://registry.npmjs.org/@luma.gl/core/-/core-9.2.6.tgz#28c9d7965d3ebf003e0c1db7f90b5d24bc6c87d8"
+  integrity sha512-d8KcH8ZZcjDAodSN/G2nueA9YE2X8kMz7Q0OxDGpCww6to1MZXM3Ydate/Jqsb5DDKVgUF6yD6RL8P5jOki9Yw==
+  dependencies:
+    "@math.gl/types" "^4.1.0"
+    "@probe.gl/env" "^4.0.8"
+    "@probe.gl/log" "^4.0.8"
+    "@probe.gl/stats" "^4.0.8"
+    "@types/offscreencanvas" "^2019.6.4"
+
+"@luma.gl/engine@~9.2.6":
+  version "9.2.6"
+  resolved "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.2.6.tgz#e61791b45a19fbff5a36c0dc8f85ec9492bd1c61"
+  integrity sha512-1AEDs2AUqOWh7Wl4onOhXmQF+Rz1zNdPXF+Kxm4aWl92RQ42Sh2CmTvRt2BJku83VQ91KFIEm/v3qd3Urzf+Uw==
+  dependencies:
+    "@math.gl/core" "^4.1.0"
+    "@math.gl/types" "^4.1.0"
+    "@probe.gl/log" "^4.0.8"
+    "@probe.gl/stats" "^4.0.8"
+
+"@luma.gl/shadertools@~9.2.6":
+  version "9.2.6"
+  resolved "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.6.tgz#850a69d3df37125c546d229651aa6936b8164ec7"
+  integrity sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w==
+  dependencies:
+    "@math.gl/core" "^4.1.0"
+    "@math.gl/types" "^4.1.0"
+    wgsl_reflect "^1.2.0"
+
+"@luma.gl/webgl@~9.2.6":
+  version "9.2.6"
+  resolved "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.2.6.tgz#41f6aa6b34690cbeefbb613024802f28d9924f1d"
+  integrity sha512-NGBTdxJMk7j8Ygr1zuTyAvr1Tw+EpupMIQo7RelFjEsZXg6pujFqiDMM+rgxex8voCeuhWBJc7Rs+MoSqd46UQ==
+  dependencies:
+    "@luma.gl/constants" "9.2.6"
+    "@math.gl/types" "^4.1.0"
+    "@probe.gl/env" "^4.0.8"
+
+"@math.gl/core@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz#2f4a1644c6f8fb50aacae57a02f1297f933aefbd"
+  integrity sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==
+  dependencies:
+    "@math.gl/types" "4.1.0"
+
+"@math.gl/types@4.1.0", "@math.gl/types@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz#ce28c06bcfe07d21311e00aeb25de82fecf7f393"
+  integrity sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==
 
 "@mdx-js/loader@^3.1.0":
   version "3.1.0"
@@ -1055,6 +1202,15 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
+"@observablehq/plot@^0.6.17":
+  version "0.6.17"
+  resolved "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.17.tgz#9a43f785e89e6d4413701e2b24d2ec8cc2700e02"
+  integrity sha512-/qaXP/7mc4MUS0s4cPPFASDRjtsWp85/TbfsciqDgU1HwYixbSbbytNuInD8AcTYC3xaxACgVX06agdfQy9W+g==
+  dependencies:
+    d3 "^7.9.0"
+    interval-tree-1d "^1.0.0"
+    isoformat "^0.2.0"
+
 "@open-draft/deferred-promise@^2.2.0":
   version "2.2.0"
   resolved "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
@@ -1171,6 +1327,23 @@
   version "0.2.9"
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
+
+"@probe.gl/env@4.1.1", "@probe.gl/env@^4.0.8":
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/@probe.gl/env/-/env-4.1.1.tgz#b683cfdfee5bf9456a2eeaf58c70978309f85fcd"
+  integrity sha512-+68seNDMVsEegRB47pFA/Ws1Fjy8agcFYXxzorKToyPcD6zd+gZ5uhwoLd7TzsSw6Ydns//2KEszWn+EnNHTbA==
+
+"@probe.gl/log@^4.0.8":
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/@probe.gl/log/-/log-4.1.1.tgz#9b916545fed02971a3ac05fdb620ad5bd4dadb4d"
+  integrity sha512-kcZs9BT44pL7hS1OkRGKYRXI/SN9KejUlPD+BY40DguRLzdC5tLG/28WGMyfKdn/51GT4a0p+0P8xvDn1Ez+Kg==
+  dependencies:
+    "@probe.gl/env" "4.1.1"
+
+"@probe.gl/stats@^4.0.8":
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.1.1.tgz#803a1e54732281e3198eef089b9fc0529a5ebdda"
+  integrity sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==
 
 "@radix-ui/number@1.1.1":
   version "1.1.1"
@@ -1694,6 +1867,61 @@
   resolved "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
   integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
+"@supabase/auth-js@2.105.0":
+  version "2.105.0"
+  resolved "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.0.tgz#2aecf243113288cc68f279fa074845b1e2b4cc53"
+  integrity sha512-cwNB9M4gClqOVJrlX+p2oPgqgRHiUm6hOQSRjgntplB/9XLP78/6MtvkhWdGeWpkP6npZxiLZ+VwNgeigk1wiw==
+  dependencies:
+    tslib "2.8.1"
+
+"@supabase/functions-js@2.105.0":
+  version "2.105.0"
+  resolved "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.0.tgz#9029b67d883119982ab7b1c59d9cb4db28019bb3"
+  integrity sha512-Q58EDZPb/3KM0Ksp4pUYPrShIAjoC12BRMIKlMOxcpVBYMQRZCDqr5ohRp1pKiCCvRbDD/bhiLIutdBmU5Nu6Q==
+  dependencies:
+    tslib "2.8.1"
+
+"@supabase/phoenix@^0.4.0":
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz#b851f5c6d0b588f624f185d78ddddfa2ce57dd82"
+  integrity sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==
+
+"@supabase/postgrest-js@2.105.0":
+  version "2.105.0"
+  resolved "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.0.tgz#4aaf99e3438c90178e16f76e2bc0446c7fd5c6e0"
+  integrity sha512-+M8mHTNEGlWXNvDEU14oL0aGQxAwGra19PO49/Gqco9iHKzgKL2xceE5CiqGOLQ547KMB/1uSFsETIKj8WQYmg==
+  dependencies:
+    tslib "2.8.1"
+
+"@supabase/realtime-js@2.105.0":
+  version "2.105.0"
+  resolved "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.0.tgz#9c1c65c5469886a14a26e87740aa02c424134f98"
+  integrity sha512-sU3bhcZnIT8rny4ZAR257JMjh6tBZVLvhTfczDXDKHaFZVje9Qaaqbl4O9UuuZmPsGWRfOfI1kUJ15uPeL0KhA==
+  dependencies:
+    "@supabase/phoenix" "^0.4.0"
+    "@types/ws" "^8.18.1"
+    tslib "2.8.1"
+    ws "^8.18.2"
+
+"@supabase/storage-js@2.105.0":
+  version "2.105.0"
+  resolved "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.0.tgz#08730d4c5541e4a260b0dbd271ad23c0ea8b5534"
+  integrity sha512-advo1qhRjeNLPYciUMpGeJTVFqaidPJq/6h4FoPF3XSo2SfecBUYQg/axcy26uon7y58QZoJxxguSmRZhuiRQA==
+  dependencies:
+    iceberg-js "^0.8.1"
+    tslib "2.8.1"
+
+"@supabase/supabase-js@^2.98.0":
+  version "2.105.0"
+  resolved "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.0.tgz#1ee95d16e5aa2980277b160732b062730194d49d"
+  integrity sha512-UUmh6KpStf2RdKpRUmzj0cPl6OXlo1hkRTNHdFHozbiJv2MIxR/7eWGKHAO8OgnaZt0gv52k7NL/bZXgPQbw/A==
+  dependencies:
+    "@supabase/auth-js" "2.105.0"
+    "@supabase/functions-js" "2.105.0"
+    "@supabase/postgrest-js" "2.105.0"
+    "@supabase/realtime-js" "2.105.0"
+    "@supabase/storage-js" "2.105.0"
+
 "@swc/core-darwin-arm64@1.15.30":
   version "1.15.30"
   resolved "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz#23447f1c30c9155fe35602de4392b4ecfa0a54cc"
@@ -1784,6 +2012,13 @@
   version "0.5.15"
   resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
   integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
+  dependencies:
+    tslib "^2.8.0"
+
+"@swc/helpers@^0.5.11":
+  version "0.5.21"
+  resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz#0b1b020317ee1282860ca66f7e9a7c7790f05ae0"
+  integrity sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==
   dependencies:
     tslib "^2.8.0"
 
@@ -1988,6 +2223,16 @@
   integrity sha512-6+xrIRImMtGAL2X3qYkd02Mgs+gFGs+WsK0b7VVMaO4mYRISwyTjcqNrO0mNSmYEoq++rSLDB2F5HDNmqfOe+A==
   dependencies:
     "@types/color-convert" "*"
+
+"@types/command-line-args@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz#553ce2fd5acf160b448d307649b38ffc60d39639"
+  integrity sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==
+
+"@types/command-line-usage@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz#374e4c62d78fbc5a670a0f36da10235af879a0d5"
+  integrity sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==
 
 "@types/cookie@^0.6.0":
   version "0.6.0"
@@ -2267,12 +2512,31 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
+"@types/node@*":
+  version "25.6.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
+  integrity sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==
+  dependencies:
+    undici-types "~7.19.0"
+
 "@types/node@^20":
   version "20.19.11"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz#728cab53092bd5f143beed7fbba7ba99de3c16c4"
   integrity sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==
   dependencies:
     undici-types "~6.21.0"
+
+"@types/node@^20.13.0":
+  version "20.19.39"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz#e98a3b575574070cd34b784bd173767269f95e99"
+  integrity sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==
+  dependencies:
+    undici-types "~6.21.0"
+
+"@types/offscreencanvas@^2019.6.4":
+  version "2019.7.3"
+  resolved "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz#90267db13f64d6e9ccb5ae3eac92786a7c77a516"
+  integrity sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==
 
 "@types/react-copy-to-clipboard@^5.0.7":
   version "5.0.7"
@@ -2338,6 +2602,13 @@
   version "2.0.11"
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
   integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
+
+"@types/ws@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version "8.40.0"
@@ -2539,6 +2810,53 @@
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
+"@uwdata/flechette@^2.2.5":
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/@uwdata/flechette/-/flechette-2.4.0.tgz#01c48f3adc1dc409078eaae433e8ef665c7361ef"
+  integrity sha512-cwxeYWe2iua4zPUopiqhYXkxaQWr0GK4Kbak7i0zemo3sgmNJ3IE+pNi6XD1dOK7q50SEXTLwieP5JycG6D56A==
+
+"@uwdata/mosaic-core@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.npmjs.org/@uwdata/mosaic-core/-/mosaic-core-0.21.1.tgz#56d069def9e8c4e8b77b3027c67c839b5cd367f1"
+  integrity sha512-nRh93+A7U/06x/6boSLUUaSCo4pkNAjOgV8P2Zl6ZZeF5pWynLcSqT30WLQPx+VewTvFgJGCymocymdbirFxYw==
+  dependencies:
+    "@duckdb/duckdb-wasm" "1.30.0"
+    "@uwdata/flechette" "^2.2.5"
+    "@uwdata/mosaic-sql" "^0.21.1"
+
+"@uwdata/mosaic-inputs@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.npmjs.org/@uwdata/mosaic-inputs/-/mosaic-inputs-0.21.1.tgz#43ab738bdb96c52c2af1ff7ae24c9de03df1e71a"
+  integrity sha512-9h/PFk71QL5+Nhqsai9pqVdnHUQb8OAemZrPossbfvb3q62o7RpU+jMwxcAId4uB/qRTAFxr0LgRfoPxrjfZYg==
+  dependencies:
+    "@uwdata/mosaic-core" "^0.21.1"
+    "@uwdata/mosaic-sql" "^0.21.1"
+
+"@uwdata/mosaic-plot@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.npmjs.org/@uwdata/mosaic-plot/-/mosaic-plot-0.21.1.tgz#0994481932c7f0932ec0031115721d1e5f5d8931"
+  integrity sha512-ZPBD0Km44VIexZ7l88n1yWh8QpVJakJnmkyq6zr8aujw2i2+MkrcI8Abc2aPJ74o2YiSb9hMKxno83nB/Mfy7A==
+  dependencies:
+    "@observablehq/plot" "^0.6.17"
+    "@uwdata/mosaic-core" "^0.21.1"
+    "@uwdata/mosaic-sql" "^0.21.1"
+    d3 "^7.9.0"
+
+"@uwdata/mosaic-sql@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.npmjs.org/@uwdata/mosaic-sql/-/mosaic-sql-0.21.1.tgz#888ec4dc1cd6e24f4341656245fa0cbfcc62e0fa"
+  integrity sha512-2B4Dle4odyxIaBaDVRfQchebH/CUZvUV8kIwKF3V2GksQoF8KYY/Q6zTLTJhYrDEdUkt8M0OIy4U/Ntw93CV1A==
+
+"@uwdata/vgplot@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.npmjs.org/@uwdata/vgplot/-/vgplot-0.21.1.tgz#8b3906dfbc9621bfea864c20152c2bea58ed2195"
+  integrity sha512-R+CFYeTPdNoMzMAxNwt7coTqcWWY6aOKUj28SqkQ4dbL3Ig37RjCnRDcpFzCqvxaSeOwZRXQ1Ld3WhnagqDh/Q==
+  dependencies:
+    "@uwdata/mosaic-core" "^0.21.1"
+    "@uwdata/mosaic-inputs" "^0.21.1"
+    "@uwdata/mosaic-plot" "^0.21.1"
+    "@uwdata/mosaic-sql" "^0.21.1"
+
 "@vercel/oidc@3.1.0":
   version "3.1.0"
   resolved "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz#066caee449b84079f33c7445fc862464fe10ec32"
@@ -2667,6 +2985,21 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+apache-arrow@17.0.0, apache-arrow@^17.0.0:
+  version "17.0.0"
+  resolved "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz#73d98566c86352c9a0314c03890dbd7211073827"
+  integrity sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==
+  dependencies:
+    "@swc/helpers" "^0.5.11"
+    "@types/command-line-args" "^5.2.3"
+    "@types/command-line-usage" "^5.0.4"
+    "@types/node" "^20.13.0"
+    command-line-args "^5.2.1"
+    command-line-usage "^7.0.1"
+    flatbuffers "^24.3.25"
+    json-bignum "^0.0.3"
+    tslib "^2.6.2"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -2688,6 +3021,16 @@ aria-query@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
+
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^6.2.2:
+  version "6.2.3"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz#d41e67598805e614f23b319b9e5960dfbcd72ae2"
+  integrity sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==
 
 array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
   version "1.0.2"
@@ -2863,6 +3206,11 @@ bezier-easing@^2.0.3:
   resolved "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz#c7828f6c8900562b69d5040afb881bcbdad82001"
   integrity sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==
 
+binary-search-bounds@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz#125e5bd399882f71e6660d4bf1186384e989fba7"
+  integrity sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==
+
 bl@^5.0.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz#183715f678c7188ecef9fe475d90209400624273"
@@ -2980,7 +3328,14 @@ ccount@^2.0.0:
   resolved "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
-chalk@^4.0.0:
+chalk-template@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz#692c034d0ed62436b9062c1707fadcd0f753204b"
+  integrity sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==
+  dependencies:
+    chalk "^4.1.2"
+
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3165,6 +3520,26 @@ comma-separated-tokens@^2.0.0:
   resolved "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
+command-line-args@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-usage@^7.0.1:
+  version "7.0.4"
+  resolved "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz#759449bac39c5410e23513f1f78551b669df1514"
+  integrity sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==
+  dependencies:
+    array-back "^6.2.2"
+    chalk-template "^0.4.0"
+    table-layout "^4.1.1"
+    typical "^7.3.0"
+
 commander@7:
   version "7.2.0"
   resolved "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
@@ -3306,14 +3681,14 @@ cytoscape@^3.29.3:
   dependencies:
     internmap "^1.0.0"
 
-"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.1.6, d3-array@^3.2.0:
+"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.1.6, d3-array@^3.2.0, d3-array@^3.2.4:
   version "3.2.4"
   resolved "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
   dependencies:
     internmap "1 - 2"
 
-d3-axis@3:
+d3-axis@3, d3-axis@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
   integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
@@ -3323,7 +3698,7 @@ d3-binarytree@1:
   resolved "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz#ed43ebc13c70fbabfdd62df17480bc5a425753cc"
   integrity sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==
 
-d3-brush@3:
+d3-brush@3, d3-brush@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
   integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
@@ -3341,7 +3716,7 @@ d3-chord@3:
   dependencies:
     d3-path "1 - 3"
 
-"d3-color@1 - 3", d3-color@3:
+"d3-color@1 - 3", d3-color@3, d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
@@ -3365,7 +3740,7 @@ d3-delaunay@6:
   resolved "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
 
-"d3-drag@2 - 3", d3-drag@3:
+"d3-drag@2 - 3", d3-drag@3, d3-drag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
@@ -3418,6 +3793,11 @@ d3-force@3:
   version "3.1.0"
   resolved "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
+d3-format@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
 
 d3-geo@3:
   version "3.1.1"
@@ -3495,7 +3875,7 @@ d3-sankey@^0.12.3:
     d3-time "2.1.1 - 3"
     d3-time-format "2 - 4"
 
-"d3-selection@2 - 3", d3-selection@3:
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
@@ -3514,7 +3894,7 @@ d3-shape@^1.2.0:
   dependencies:
     d3-path "1"
 
-"d3-time-format@2 - 4", d3-time-format@4:
+"d3-time-format@2 - 4", d3-time-format@4, d3-time-format@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
@@ -3533,7 +3913,7 @@ d3-shape@^1.2.0:
   resolved "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
-"d3-transition@2 - 3", d3-transition@3:
+"d3-transition@2 - 3", d3-transition@3, d3-transition@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
   integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
@@ -3544,7 +3924,7 @@ d3-shape@^1.2.0:
     d3-interpolate "1 - 3"
     d3-timer "1 - 3"
 
-"d3-zoom@2 - 3", d3-zoom@3:
+"d3-zoom@2 - 3", d3-zoom@3, d3-zoom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
   integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
@@ -3793,7 +4173,7 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
-dompurify@>=3.4.0, dompurify@^3.2.5:
+dompurify@>=3.4.0, dompurify@^3.2.5, dompurify@^3.2.6:
   version "3.4.1"
   resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz#521d04483ac12631b2aedf434a5f5390933b8789"
   integrity sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==
@@ -4502,6 +4882,13 @@ finalhandler@^2.1.0:
     parseurl "^1.3.3"
     statuses "^2.0.1"
 
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
+
 find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -4517,6 +4904,11 @@ flat-cache@^4.0.0:
   dependencies:
     flatted "^3.2.9"
     keyv "^4.5.4"
+
+flatbuffers@^24.3.25:
+  version "24.12.23"
+  resolved "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz#6eea59d2bcda0c5d59bcacefd6216348b3086883"
+  integrity sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==
 
 flatted@>=3.4.2, flatted@^3.2.9:
   version "3.4.2"
@@ -4707,6 +5099,16 @@ git-hooks-list@^4.0.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.1.1.tgz#ae340b82a9312354c73b48007f33840bbd83d3c0"
   integrity sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==
+
+gl-bench@^1.0.42:
+  version "1.0.42"
+  resolved "https://registry.npmjs.org/gl-bench/-/gl-bench-1.0.42.tgz#f82b9a1556bc89db2a7d095aec3f51f4eda85cfc"
+  integrity sha512-zuMsA/NCPmI8dPy6q3zTUH8OUM5cqKg7uVWwqzrtXJPBqoypM0XeFWEc8iFOqbf/1qtXieWOrbmgFEByKTQt4Q==
+
+gl-matrix@^3.4.3:
+  version "3.4.4"
+  resolved "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz#7789ee4982f62c7a7af447ee488f3bd6b0c77003"
+  integrity sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -5017,6 +5419,11 @@ human-signals@^4.3.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
   integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
 
+iceberg-js@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz#47d893468293a010385e1c70123f29d0fc1d9912"
+  integrity sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==
+
 iconv-lite@0.6, iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
@@ -5109,6 +5516,13 @@ intersection-observer@^0.12.0:
   version "0.12.2"
   resolved "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.2.tgz#4a45349cc0cd91916682b1f44c28d7ec737dc375"
   integrity sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==
+
+interval-tree-1d@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.4.tgz#b44f657de7ddae69ea3f98e0a9ad4bb046b07d11"
+  integrity sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ==
+  dependencies:
+    binary-search-bounds "^2.0.0"
 
 intl-messageformat@^11.1.0:
   version "11.2.1"
@@ -5410,6 +5824,11 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isoformat@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/isoformat/-/isoformat-0.2.1.tgz#2526344a4276a101b2881848dc337d1d2ae74494"
+  integrity sha512-tFLRAygk9NqrRPhJSnNGh7g7oaVWDwR0wKh/GM2LgmPa50Eg4UfyaCO4I8k6EqJHl1/uh2RAD6g06n5ygEnrjQ==
+
 iterator.prototype@^1.1.4:
   version "1.1.5"
   resolved "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz#12c959a29de32de0aa3bbbb801f4d777066dae39"
@@ -5463,6 +5882,11 @@ jsesc@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
+
+json-bignum@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz#41163b50436c773d82424dbc20ed70db7604b8d7"
+  integrity sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -5710,6 +6134,11 @@ lodash-es@4, lodash-es@4.17.21, lodash-es@>=4.18.0, lodash-es@^4.17.21:
   version "4.18.1"
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
   integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -7228,6 +7657,13 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+random@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/random/-/random-4.1.0.tgz#3e0fff0eea0d311e6a80fd2c91e72bb064dec363"
+  integrity sha512-6Ajb7XmMSE9EFAMGC3kg9mvE7fGlBip25mYYuSMzw/uUSrmGilvZo2qwX3RnTRjwXkwkS+4swse9otZ92VjAtQ==
+  dependencies:
+    seedrandom "^3.0.5"
+
 range-parser@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -7829,6 +8265,11 @@ section-matter@^1.0.0:
     extend-shallow "^2.0.1"
     kind-of "^6.0.0"
 
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
+
 semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -8320,6 +8761,14 @@ tabbable@^6.0.0:
   resolved "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
 
+table-layout@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz#0f72965de1a5c0c1419c9ba21cae4e73a2f73a42"
+  integrity sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==
+  dependencies:
+    array-back "^6.2.2"
+    wordwrapjs "^5.1.0"
+
 tailwind-merge@^3.3.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz#a7e7db7c714f6020319e626ecfb7e7dac8393a4b"
@@ -8472,7 +8921,7 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.8.0:
+tslib@2.8.1, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -8566,6 +9015,16 @@ typewriter-effect@^2.22.0:
     prop-types "^15.8.1"
     raf "^3.4.1"
 
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz#930376be344228709f134613911fa22aa09617a4"
+  integrity sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==
+
 ufo@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz#ac2db1d54614d1b22c1d603e3aef44a85d8f146b"
@@ -8585,6 +9044,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici-types@~7.19.0:
+  version "7.19.2"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz#1b67fc26d0f157a0cba3a58a5b5c1e2276b8ba2a"
+  integrity sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==
 
 unified@^11.0.0:
   version "11.0.5"
@@ -8919,6 +9383,11 @@ web-streams-polyfill@^3.0.3:
   resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
+wgsl_reflect@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.3.tgz#41985a661efdd00047e771ad7aa06ab131926a55"
+  integrity sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q==
+
 wheel@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/wheel/-/wheel-1.0.0.tgz#6cf46e06a854181adb8649228077f8b0d5c574ce"
@@ -8989,6 +9458,11 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+wordwrapjs@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz#bfd1eb426f0f7eec73b7df32cf7df1f618bfb3a9"
+  integrity sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==
+
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -9011,6 +9485,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.18.2:
+  version "8.20.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
+  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Summary

Per @earayu2 ask in #Graph可视化 (msg=4a8309e4): **one menu page** where the team can flip between visualisation experiments without leaving the production graph routes alone. Two embedded Cosmograph modes — topology (live KG) and semantic map (synthetic 1k/5k/10k fixture) — plus external-page links to `/graph` and `/graph-showcase` for side-by-side comparison.

**Why a sibling and not overwriting `graph-showcase/`**: `graph-showcase/` already carries 745 LOC of an earlier `react-force-graph-2d` exploration; replacing it would lose the prior probe. PM ratified the new sibling path in DM (msg=30e30aab).

**License caveat**: `@cosmograph/react` is CC-BY-NC-4.0. @earayu2 explicitly fine for PoC (msg=26e5530d), called out in the nav UI as a productionisation gate. The MIT-licensed `@cosmos.gl/graph` engine is the swap target if the visual sticks.

## Files

- `graph-lab/page.tsx` — server breadcrumbs + container
- `graph-lab/collection-graph-lab.tsx` — client shell, nav ↔ renderer wiring
- `graph-lab/graph-lab-nav.tsx` — left rail, mode tabs + external links + license note
- `graph-lab/cosmograph-topology.tsx` — live KG → Cosmograph Graph mode (`dynamic({ ssr: false })`)
- `graph-lab/cosmograph-semantic-map.tsx` — synthetic fixture → embedding mode + scale toggle + bench panel
- `graph-lab/lab-modes.ts` — shared types so `page.tsx` stays import-light
- `features/knowledge-graph/cosmograph-adapter.ts` — pure data transform (`toTopologyDataset` / `buildSyntheticSemanticDataset`)

## §K.12 invariant cross-check

- **#11** read-only ✅ — lab page is view-only, no merge/curate surface added.
- **#12** grep-zero LightRAG ✅ — `rg -i lightrag web/src` returns zero hits before and after.

## 4-pattern pre-check matrix

- **Pattern 1 v1** (existing graph routes): production `/graph` and `/graph-showcase` are unchanged; no imports moved/renamed.
- **Pattern 1 v2** (data-shape consumers): the new adapter consumes `KnowledgeGraph` / `GraphNode` / `GraphEdge` from `@/features/knowledge-graph/types` — same source the production graph uses. No type duplication.
- **Pattern 2** (response-shape change list): n/a, no API/schema touched.
- **Pattern 3** (additive helpers): adapter + fixture generator are pure functions; production graph page could adopt them later without circular imports.

## simple-stable directive 4-guardrail

- **#1 不无限扩范围** — explicit PoC scope per @ziang acceptance (msg=4db79b66). No backend changes; semantic mode uses front-end fixture data only.
- **#2 尽快上线** — single-PR ship, ~0.5 day work envelope.
- **#3 简单稳定** — production `/graph` and `/graph-showcase` byte-identical pre/post.
- **#4 私有化部署免维护** — no operator config introduced. License decision deferred to productionisation; surfaced in the nav UI for visibility.

## Acceptance items (per @ziang msg=4db79b66)

- [x] New `graph-lab/` route, `graph/` and `graph-showcase/` untouched
- [x] Topology mode reads live `/api/v2/collections/{id}/graphs`
- [x] Semantic mode uses front-end synthetic fixture (no API spec churn)
- [x] Search / select / detail / filter minimal closed loop (cluster legend + selected-node detail panel + topology shows neighbours)
- [x] Bench panel exposes 1k / 5k / 10k synthetic-scale generate + first-frame ms
- [ ] Screenshot / video + verbal feel comparison vs `react-force-graph-2d` — deferred to reviewer-side; bench numbers will be visible in the panel as soon as the page loads
- [x] License risk surfaced in PoC report — inline in the nav UI

## Test plan

- [x] `next dev --turbopack` reaches \"Ready in 1476ms\" cleanly post-add (SSR pass does not load `@cosmograph/react`)
- [x] `yarn tsc --noEmit` → zero errors in the new files. Five pre-existing errors remain in `graph/collection-graph*.tsx` (from PR #1789 dynamic-entity-types) and are out of scope.
- [ ] Manual: `cd web && yarn dev`, navigate to `/workspace/collections/<id>/graph-lab`, flip both modes, screenshot bench panel at each scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)