### PR TITLE
fix(agent-runtime): persist tool calls in reload snapshots

### DIFF
--- a/aperag/domains/agent_runtime/runtime.py
+++ b/aperag/domains/agent_runtime/runtime.py
@@ -25,7 +25,7 @@ import os
 import uuid as _uuid
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic_ai import Agent, AgentRunResultEvent
 from pydantic_ai import messages as pai_messages
@@ -51,11 +51,13 @@ from aperag.domains.agent_runtime.services import (
     _parse_bot_config,
 )
 from aperag.domains.agent_runtime.storage import DEFAULT_AGENT_TURN_LEASE_TTL_SECONDS, AgentRuntimeRedisStore
+from aperag.domains.agent_runtime.tools.safe_name import sanitize_tool_name
 from aperag.domains.agent_runtime.uimessage import (
     CitationData,
     DataCitationPart,
     SourceUrlPart,
     TextPart,
+    ToolPart,
     UIMessage,
     UIMessagePart,
     UrlCitationLocation,
@@ -155,22 +157,56 @@ def _wrap_toolset_for_bot(toolset, bot):
     return FilteredToolset(toolset, _filter)
 
 
+@dataclass
+class _PersistedToolCall:
+    """Collapsed tool lifecycle for durable UIMessage reload."""
+
+    tool_call_id: str
+    tool_name: str
+    state: Literal["input-available", "output-available", "output-error"] = "input-available"
+    output: Any = None
+    error_text: Optional[str] = None
+
+
+def _tool_part_type(tool_name: str) -> str:
+    safe = sanitize_tool_name(tool_name or "tool") or "tool"
+    return f"tool-{safe}"
+
+
+def _is_tool_failure_status(status: Any) -> bool:
+    raw = getattr(status, "value", status)
+    return str(raw or "").lower() in {"error", "failed", "failure"}
+
+
 def _compose_assistant_parts(
     *,
     turn_id: str,
     answer_text: str,
     references: list[ReferenceBundleItem],
+    tool_calls: list[_PersistedToolCall] | None = None,
 ) -> list[UIMessagePart]:
     """Project the runtime's accumulated answer + references into a
     canonical at-rest ``UIMessagePart`` list for ``UIMessageStore.write``.
 
-    Order: ``TextPart`` (answer) first, then ``SourceUrlPart`` /
-    ``DataCitationPart`` pairs from each reference. Items without a
-    URI surface as ``DataCitationPart`` only — same shape the FE
-    renderer expects from the live SSE stream (D8 §2 byte-equal).
+    Order: collapsed ``ToolPart`` records first, ``TextPart`` (answer)
+    next, then ``SourceUrlPart`` / ``DataCitationPart`` pairs from
+    each reference. Items without a URI surface as ``DataCitationPart``
+    only — same shape the FE renderer expects from the live SSE stream
+    (D8 §2 byte-equal).
     """
 
     parts: list[UIMessagePart] = []
+    for call in tool_calls or []:
+        parts.append(
+            ToolPart(
+                type=_tool_part_type(call.tool_name),
+                tool_call_id=call.tool_call_id,
+                state=call.state,
+                output=call.output,
+                error_text=call.error_text,
+                metadata={"mcpToolName": call.tool_name},
+            )
+        )
     if answer_text:
         parts.append(TextPart(text=answer_text))
     for index, ref in enumerate(references):
@@ -374,6 +410,8 @@ class PydanticAIRuntime(AgentRuntime):
         text_chunks: list[str] = []
         reference_items: list[ReferenceBundleItem] = []
         tool_summaries: list[str] = []
+        persisted_tool_calls: list[_PersistedToolCall] = []
+        persisted_tool_index: dict[str, _PersistedToolCall] = {}
         lease_guard = TurnLeaseGuard(turn_service=self.turn_service, turn_id=turn.id, owner_token=lease_owner)
 
         async def emit(
@@ -459,6 +497,13 @@ class PydanticAIRuntime(AgentRuntime):
                     if isinstance(event, pai_messages.FunctionToolCallEvent):
                         tool_name = event.part.tool_name
                         tool_call_id = event.part.tool_call_id
+                        tool_call = _PersistedToolCall(
+                            tool_call_id=tool_call_id,
+                            tool_name=tool_name,
+                            state="input-available",
+                        )
+                        persisted_tool_calls.append(tool_call)
+                        persisted_tool_index[tool_call_id] = tool_call
                         tool_summaries.append(f"Calling tool: {tool_name}")
                         await emit(
                             "agent.state.changed",
@@ -494,6 +539,23 @@ class PydanticAIRuntime(AgentRuntime):
                         normalized = self._normalize_jsonish(event.result.content)
                         reference_items.extend(self._extract_reference_items(tool_name, normalized))
                         outcome = getattr(event.result, "outcome", "success")
+                        tool_call = persisted_tool_index.get(tool_call_id)
+                        if tool_call is None:
+                            tool_call = _PersistedToolCall(
+                                tool_call_id=tool_call_id,
+                                tool_name=tool_name,
+                            )
+                            persisted_tool_calls.append(tool_call)
+                            persisted_tool_index[tool_call_id] = tool_call
+                        if _is_tool_failure_status(outcome):
+                            tool_call.state = "output-error"
+                            tool_call.error_text = (
+                                normalized
+                                if isinstance(normalized, str)
+                                else json.dumps(normalized, ensure_ascii=False, default=str)
+                            )
+                        else:
+                            tool_call.state = "output-available"
                         tool_summaries.append(f"Tool {tool_name} finished with status: {outcome}")
                         await emit(
                             "tool.finished",
@@ -568,7 +630,10 @@ class PydanticAIRuntime(AgentRuntime):
                     id=f"msg-{turn.id}",
                     role="assistant",
                     parts=_compose_assistant_parts(
-                        turn_id=turn.id, answer_text=answer_text, references=reference_items
+                        turn_id=turn.id,
+                        answer_text=answer_text,
+                        references=reference_items,
+                        tool_calls=persisted_tool_calls,
                     ),
                 ),
             )

--- a/tests/unit_test/agent_runtime/test_runtime_persistence.py
+++ b/tests/unit_test/agent_runtime/test_runtime_persistence.py
@@ -1,0 +1,74 @@
+from aperag.domains.agent_runtime.runtime import (
+    _compose_assistant_parts,
+    _PersistedToolCall,
+)
+from aperag.domains.agent_runtime.schemas import ReferenceBundleItem
+from aperag.domains.agent_runtime.uimessage import DataCitationPart, SourceUrlPart, TextPart, ToolPart
+
+
+def test_compose_assistant_parts_persists_tool_lifecycle_for_reload():
+    """Reload snapshots must retain tool calls, not just answer text.
+
+    Live SSE renders tool lifecycle from timeline events. After a
+    browser refresh the FE reads ``AgentTurnSnapshot.parts`` from the
+    durable ``agent_message`` row, so the runtime must persist a
+    collapsed ``ToolPart`` for every tool call.
+    """
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="Answer body",
+        references=[
+            ReferenceBundleItem(
+                source_type="web",
+                source_id="src-1",
+                title="Doc A",
+                snippet="Reference text",
+                uri="https://example.com/doc-a",
+            )
+        ],
+        tool_calls=[
+            _PersistedToolCall(
+                tool_call_id="call-1",
+                tool_name="web.search",
+                state="output-available",
+            )
+        ],
+    )
+
+    assert [part.type for part in parts] == [
+        "tool-web_search",
+        "text",
+        "source-url",
+        "data-citation",
+    ]
+    assert isinstance(parts[0], ToolPart)
+    assert parts[0].tool_call_id == "call-1"
+    assert parts[0].state == "output-available"
+    assert parts[0].metadata == {"mcpToolName": "web.search"}
+    assert parts[0].input is None, "raw tool args must not be persisted"
+    assert isinstance(parts[1], TextPart)
+    assert isinstance(parts[2], SourceUrlPart)
+    assert isinstance(parts[3], DataCitationPart)
+
+
+def test_compose_assistant_parts_persists_tool_error_state():
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="",
+        references=[],
+        tool_calls=[
+            _PersistedToolCall(
+                tool_call_id="call-err",
+                tool_name="knowledge_base.read_document",
+                state="output-error",
+                error_text="read timed out",
+            )
+        ],
+    )
+
+    assert len(parts) == 1
+    assert isinstance(parts[0], ToolPart)
+    assert parts[0].type == "tool-knowledge_base_read_document"
+    assert parts[0].state == "output-error"
+    assert parts[0].error_text == "read timed out"


### PR DESCRIPTION
## Summary\n- persist collapsed agent tool lifecycle as at-rest UIMessage ToolPart entries\n- keep transient data-activity/thinking wire-only per existing design\n- add regression tests for reload snapshot tool lifecycle and tool error state\n\n## Tests\n- uv run ruff check aperag/domains/agent_runtime/runtime.py tests/unit_test/agent_runtime/test_runtime_persistence.py\n- uv run --extra test python -m pytest tests/unit_test/agent_runtime/test_runtime_persistence.py tests/unit_test/agent_runtime/test_uimessage_at_rest.py -q\n- uv run --extra test python -m pytest tests/unit_test/agent_runtime -q\n