### PR TITLE
fix(web_search): drop misnamed X-Return-Format header on Jina providers

### DIFF
--- a/aperag/domains/web_access/reader/providers/jina_read_provider.py
+++ b/aperag/domains/web_access/reader/providers/jina_read_provider.py
@@ -103,9 +103,14 @@ class JinaReaderProvider(BaseReaderProvider):
                 # Set X-Locale for browser rendering (important for region-specific content)
                 request_headers["X-Locale"] = locale
 
-            # Add Jina Reader specific headers based on documentation
-            # X-Return-Format controls response format (json, text, markdown)
-            request_headers["X-Return-Format"] = "json"
+            # Add Jina Reader specific headers based on documentation.
+            # ``Accept: application/json`` (set in ``__init__``) is the
+            # canonical signal; ``X-Return-Format: json`` is misnamed
+            # and on ``s.jina.ai`` it actually triggers a markdown
+            # response (huangheng empirical matrix). The reader
+            # endpoint historically tolerated it, but mirror the
+            # search-provider hot-fix and rely on ``Accept`` here too
+            # to keep the two providers consistent.
             # X-Retain-Images set to none to remove all images from response
             request_headers["X-Retain-Images"] = "none"
             # X-With-Links-Summary for link extraction

--- a/aperag/domains/web_access/search/providers/jina_search_provider.py
+++ b/aperag/domains/web_access/search/providers/jina_search_provider.py
@@ -121,10 +121,15 @@ class JinaSearchProvider(BaseSearchProvider):
                 accept_language = locale.replace("_", "-")
                 request_headers["Accept-Language"] = accept_language
 
-            # Add Jina-specific headers for better control
-            # X-Return-Format controls response format
-            request_headers["X-Return-Format"] = "json"
-            # X-Target-Selector for better content extraction (if supported)
+            # ``Accept: application/json`` (set in ``__init__``) is what
+            # Jina actually honours to return JSON. The previously-set
+            # ``X-Return-Format: json`` header was misnamed: with a
+            # valid API key Jina interprets it as a markdown-format hint
+            # and serves ``text/plain`` instead, which then fails
+            # ``await response.json()`` below → silent fallback. Per
+            # huangheng empirical curl matrix, removing it lets Accept
+            # win and Jina returns ``application/json``.
+            # X-Target-Domain still applies for site-specific search.
             if target_domain:
                 request_headers["X-Target-Domain"] = target_domain
 

--- a/tests/unit_test/web_access/test_jina_search_provider_headers.py
+++ b/tests/unit_test/web_access/test_jina_search_provider_headers.py
@@ -1,0 +1,168 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Regression test for JinaSearchProvider header configuration.
+
+The pre-fix provider sent ``X-Return-Format: json`` which Jina
+``s.jina.ai`` interprets as a markdown-format hint with a valid API
+key — the response body comes back as ``text/plain`` and
+``await response.json()`` then explodes, the provider returns ``[]``
+silently, and ``_search_with_jina_fallback`` cascades to DuckDuckGo
+(also unstable from the same network).
+
+Fix: rely on ``Accept: application/json`` (set in ``__init__``) and
+drop the misnamed ``X-Return-Format`` header. Pin the contract here
+so a future regression that re-adds the bad header is caught
+immediately.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+import pytest
+
+from aperag.domains.web_access.search.providers.jina_search_provider import (
+    JinaSearchProvider,
+)
+
+
+class _StubResponse:
+    def __init__(self, status: int, payload: Any, content_type: str = "application/json"):
+        self.status = status
+        self._payload = payload
+        self.content_type = content_type
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return str(self._payload)
+
+
+class _StubSession:
+    def __init__(self, response: _StubResponse):
+        self._response = response
+        self.captured_headers: dict[str, str] | None = None
+        self.captured_url: str | None = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    def get(self, url, headers):
+        self.captured_url = url
+        self.captured_headers = dict(headers)
+        return self._response
+
+
+@pytest.fixture
+def stub_response_ok():
+    return _StubResponse(
+        status=200,
+        payload={
+            "data": [
+                {
+                    "url": "https://example.com/zhang-fei-niurou",
+                    "title": "Zhang Fei beef intro",
+                    "description": "Sichuan smoked beef product overview.",
+                },
+                {
+                    "url": "https://example.com/sichuan-cuisine",
+                    "title": "Sichuan local specialties",
+                    "description": "Background on regional cured meats.",
+                },
+            ]
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_jina_search_does_not_send_x_return_format(stub_response_ok, monkeypatch):
+    """The misnamed ``X-Return-Format: json`` header must NEVER be
+    on the outbound request — Jina interprets it (with a valid API
+    key) as "respond in markdown" and the JSON parse below fails."""
+    provider = JinaSearchProvider(config={"api_key": "test-key"})
+
+    captured: dict[str, Any] = {}
+
+    def _client_session_factory(timeout=None):
+        session = _StubSession(stub_response_ok)
+        captured["session"] = session
+        return session
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _client_session_factory)
+
+    results = await provider.search(query="test", max_results=2, timeout=10, locale="zh-CN")
+
+    assert len(results) == 2
+    assert "session" in captured
+    headers = captured["session"].captured_headers
+    assert headers is not None
+
+    # The fix's invariant: no X-Return-Format header.
+    assert "X-Return-Format" not in headers
+    # And Accept must still be application/json so Jina returns JSON.
+    assert headers.get("Accept") == "application/json"
+    # Authorization should be present when an API key is configured.
+    assert headers.get("Authorization") == "Bearer test-key"
+
+
+@pytest.mark.asyncio
+async def test_jina_search_parses_valid_json_response(stub_response_ok, monkeypatch):
+    """End-to-end on the happy path: Accept-driven JSON response is
+    parsed into ``WebSearchResultItem`` entries with ranks 1-N."""
+    provider = JinaSearchProvider(config={"api_key": "test-key"})
+
+    def _client_session_factory(timeout=None):
+        return _StubSession(stub_response_ok)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _client_session_factory)
+
+    results = await provider.search(query="test", max_results=5, timeout=10)
+
+    assert [r.url for r in results] == [
+        "https://example.com/zhang-fei-niurou",
+        "https://example.com/sichuan-cuisine",
+    ]
+    assert results[0].rank == 1
+    assert results[1].rank == 2
+    assert provider.last_search_meta["search_status"] == "ok"
+    assert provider.last_search_meta["error_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_jina_search_propagates_target_domain_header(stub_response_ok, monkeypatch):
+    """``X-Target-Domain`` (the legitimate Jina header we still send
+    when ``source`` is set) must remain on the outbound request."""
+    provider = JinaSearchProvider(config={"api_key": "test-key"})
+
+    captured: dict[str, Any] = {}
+
+    def _client_session_factory(timeout=None):
+        session = _StubSession(stub_response_ok)
+        captured["session"] = session
+        return session
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _client_session_factory)
+
+    await provider.search(query="aperag", max_results=3, timeout=10, source="https://example.com/path")
+
+    headers = captured["session"].captured_headers
+    assert headers is not None
+    assert headers.get("X-Target-Domain") == "example.com"
+    assert "X-Return-Format" not in headers


### PR DESCRIPTION
## Summary

Web search through the agent fails with empty results (\"网络搜索：多次尝试均返回了空结果\") even with a valid Jina API key configured — root cause empirically located by @huangheng: Jina's \`s.jina.ai\` interprets \`X-Return-Format: json\` (with a valid key) as a markdown hint, returns \`text/plain\`, the provider's \`await response.json()\` fails, the provider returns \`[]\` silently, and \`_search_with_jina_fallback\` cascades to DuckDuckGo (which is anomaly-blocked from most non-residential IPs).

## Fix

- Drop the misnamed \`X-Return-Format: json\` header from \`JinaSearchProvider\` and \`JinaReaderProvider\`.
- The \`Accept: application/json\` header set in \`__init__\` is what Jina actually honours; with it alone the response is proper JSON.

## Test plan

- [x] New unit tests pin the contract: outbound request never contains \`X-Return-Format\`, contains \`Accept: application/json\` + \`Authorization\`, and a valid JSON response parses into ranked results (\`tests/unit_test/web_access/test_jina_search_provider_headers.py\`, 3 tests, all green).
- [x] \`uvx ruff check\` + \`uvx ruff format\` clean.
- [x] CI: lint-and-unit + e2e-http-smoke + e2e-http-provider expected to stay green (no behavior change for non-Jina paths).
- [ ] Manual e2e: with a Jina key configured and \`POST /api/v2/web/search\`, expect \`provider_used=[\"jina\"]\` with \`fallback_used=false\` and non-empty results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)