### PR TITLE
fix(web_access): aiohttp ClientSession needs trust_env=True for HTTPS_PROXY

### DIFF
--- a/aperag/domains/web_access/reader/providers/jina_read_provider.py
+++ b/aperag/domains/web_access/reader/providers/jina_read_provider.py
@@ -130,7 +130,11 @@ class JinaReaderProvider(BaseReaderProvider):
             logger.info(f"Jina reader request: {reader_url}")
             logger.debug(f"Request headers: {request_headers}")
 
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
+            # See ``jina_search_provider.py`` for the ``trust_env=True``
+            # rationale — same proxy-from-env story for ``r.jina.ai``.
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=timeout), trust_env=True
+            ) as session:
                 async with session.get(reader_url, headers=request_headers) as response:
                     if response.status != 200:
                         response_text = await response.text()

--- a/aperag/domains/web_access/reader/providers/jina_read_provider.py
+++ b/aperag/domains/web_access/reader/providers/jina_read_provider.py
@@ -132,9 +132,7 @@ class JinaReaderProvider(BaseReaderProvider):
 
             # See ``jina_search_provider.py`` for the ``trust_env=True``
             # rationale — same proxy-from-env story for ``r.jina.ai``.
-            async with aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=timeout), trust_env=True
-            ) as session:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout), trust_env=True) as session:
                 async with session.get(reader_url, headers=request_headers) as response:
                     if response.status != 200:
                         response_text = await response.text()

--- a/aperag/domains/web_access/reader/providers/trafilatura_read_provider.py
+++ b/aperag/domains/web_access/reader/providers/trafilatura_read_provider.py
@@ -184,7 +184,12 @@ class TrafilaturaProvider(BaseReaderProvider):
         }
 
         try:
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout), headers=headers) as session:
+            # See ``jina_search_provider.py`` for the ``trust_env=True``
+            # rationale — same proxy-from-env story for arbitrary URLs
+            # this provider fetches as a fallback to readability.
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=timeout), headers=headers, trust_env=True
+            ) as session:
                 async with session.get(url) as response:
                     if response.status == 200:
                         return await response.text()

--- a/aperag/domains/web_access/search/providers/jina_search_provider.py
+++ b/aperag/domains/web_access/search/providers/jina_search_provider.py
@@ -144,7 +144,16 @@ class JinaSearchProvider(BaseSearchProvider):
             logger.info(f"Jina search request: {search_url}")
             logger.debug(f"Request headers: {request_headers}")
 
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
+            # ``trust_env=True`` makes aiohttp honor ``HTTPS_PROXY`` /
+            # ``HTTP_PROXY`` env vars the way libcurl does by default.
+            # Without it, deployments behind a regional / corporate
+            # proxy (common for CN deploys reaching ``s.jina.ai``) get
+            # ``ClientConnectorError: Cannot connect to host ...
+            # [Connection reset by peer]`` on the direct route, while
+            # ``curl`` from the same host succeeds via the proxy.
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=timeout), trust_env=True
+            ) as session:
                 async with session.get(search_url, headers=request_headers) as response:
                     if response.status != 200:
                         response_text = await response.text()

--- a/aperag/domains/web_access/search/providers/jina_search_provider.py
+++ b/aperag/domains/web_access/search/providers/jina_search_provider.py
@@ -151,9 +151,7 @@ class JinaSearchProvider(BaseSearchProvider):
             # ``ClientConnectorError: Cannot connect to host ...
             # [Connection reset by peer]`` on the direct route, while
             # ``curl`` from the same host succeeds via the proxy.
-            async with aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=timeout), trust_env=True
-            ) as session:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout), trust_env=True) as session:
                 async with session.get(search_url, headers=request_headers) as response:
                     if response.status != 200:
                         response_text = await response.text()

--- a/tests/unit_test/web_access/test_jina_search_provider_headers.py
+++ b/tests/unit_test/web_access/test_jina_search_provider_headers.py
@@ -100,9 +100,10 @@ async def test_jina_search_does_not_send_x_return_format(stub_response_ok, monke
 
     captured: dict[str, Any] = {}
 
-    def _client_session_factory(timeout=None):
+    def _client_session_factory(**kwargs):
         session = _StubSession(stub_response_ok)
         captured["session"] = session
+        captured["session_kwargs"] = kwargs
         return session
 
     monkeypatch.setattr(aiohttp, "ClientSession", _client_session_factory)
@@ -128,7 +129,7 @@ async def test_jina_search_parses_valid_json_response(stub_response_ok, monkeypa
     parsed into ``WebSearchResultItem`` entries with ranks 1-N."""
     provider = JinaSearchProvider(config={"api_key": "test-key"})
 
-    def _client_session_factory(timeout=None):
+    def _client_session_factory(**kwargs):
         return _StubSession(stub_response_ok)
 
     monkeypatch.setattr(aiohttp, "ClientSession", _client_session_factory)
@@ -153,7 +154,7 @@ async def test_jina_search_propagates_target_domain_header(stub_response_ok, mon
 
     captured: dict[str, Any] = {}
 
-    def _client_session_factory(timeout=None):
+    def _client_session_factory(**kwargs):
         session = _StubSession(stub_response_ok)
         captured["session"] = session
         return session
@@ -166,3 +167,25 @@ async def test_jina_search_propagates_target_domain_header(stub_response_ok, mon
     assert headers is not None
     assert headers.get("X-Target-Domain") == "example.com"
     assert "X-Return-Format" not in headers
+
+
+@pytest.mark.asyncio
+async def test_jina_search_session_uses_trust_env(stub_response_ok, monkeypatch):
+    """``aiohttp.ClientSession(..., trust_env=True)`` is required so
+    deployments behind a regional proxy honour ``HTTPS_PROXY`` /
+    ``HTTP_PROXY`` env vars (libcurl-equivalent behaviour). Without
+    this flag, ``s.jina.ai`` direct route gets RST'd from CN deploys
+    while ``curl`` from the same host succeeds via the proxy."""
+    provider = JinaSearchProvider(config={"api_key": "test-key"})
+
+    captured: dict[str, Any] = {}
+
+    def _client_session_factory(**kwargs):
+        captured["session_kwargs"] = kwargs
+        return _StubSession(stub_response_ok)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _client_session_factory)
+
+    await provider.search(query="test", max_results=1, timeout=10)
+
+    assert captured["session_kwargs"].get("trust_env") is True


### PR DESCRIPTION
## Summary

aiohttp's `ClientSession` does NOT honor `HTTPS_PROXY` / `HTTP_PROXY` env vars by default — that requires explicit `trust_env=True`. libcurl (and `curl(1)`) honor those env vars by default, hence the asymmetry users hit on CN deploys: `curl https://s.jina.ai/?q=test` returns HTTP 401 in 0.7s while the same host's aiohttp client gets `ClientConnectorError: Cannot connect to host s.jina.ai:443 ssl:default [Connection reset by peer]`.

This is the **2nd layer** of the user-reported "web search 总是失败" bug (task #7). Layer 1 was the misnamed `X-Return-Format` header, fixed in #1799. Layer 2 (this PR) is the aiohttp env-proxy default.

## Root cause empirical proof (huangheng 4-config matrix)

Run from a host with `https_proxy=http://127.0.0.1:8118` set (matches user @earayu2's local dev):

| aiohttp config | result |
|---|---|
| `aiohttp.ClientSession(timeout=...)` (vanilla, **matches pre-fix code**) | ❌ FAIL `Connection reset by peer` 1490ms |
| `+ ssl=ssl.create_default_context()` | ❌ FAIL same |
| `+ TCPConnector(family=AF_INET)` IPv4 only | ❌ FAIL same |
| **`+ trust_env=True`** | ✅ **OK 401 application/json 807ms** (401 since test token, but TLS + connection complete) |

Compared to `curl https://s.jina.ai/?q=test` from same host: `HTTP 401` in 0.7s ✅.

## Scope

3 user-facing web_access providers gain `trust_env=True`:

- `aperag/domains/web_access/search/providers/jina_search_provider.py:147`
- `aperag/domains/web_access/reader/providers/jina_read_provider.py:133`
- `aperag/domains/web_access/reader/providers/trafilatura_read_provider.py:187`

The 2 internal `aperag/utils/weixin/client.py` ClientSessions are intentionally untouched — those run on internal corporate networks where a proxy is neither expected nor wanted.

## Behaviour

- **Production / public-internet deploys without `HTTPS_PROXY`**: 0 change (`trust_env=True` is a no-op when no env var is set).
- **Local dev or private-cloud deploys behind a corporate / regional proxy**: `export HTTPS_PROXY=...` is now sufficient — no code patch needed (aligns with simple-stable directive #4 "私有化部署免维护").

## Tests

- New regression test `test_jina_search_session_uses_trust_env` pins `trust_env=True` on the search provider's ClientSession kwargs.
- Existing 3 header-contract tests updated to use `**kwargs`-accepting stub factories (the call signature now passes a 2nd kwarg).
- All 4 tests pass locally.

## Test plan

- [x] Local 4-config aiohttp matrix proves `trust_env=True` is required + sufficient
- [x] 4/4 unit tests green
- [x] `uvx ruff check` clean
- [ ] CI all green (lint-and-unit + provider-preflight + e2e-http-smoke + e2e-http-provider)
- [ ] Post-merge: redeploy + re-test web search on @earayu2 local dev

## Related

- Closes task #7 ("@huangheng @Bryce 研究一下为什么我总是 web search 失败")
- Builds on #1799 (X-Return-Format header fix, layer 1 root cause)
- Long-term CN provider story tracked in #1800 (SearxNG/Tavily/Bing multi-provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)