### PR TITLE
feat(agent-runtime): persist user-facing tool summary on ToolPart

### DIFF
--- a/aperag/domains/agent_runtime/runtime.py
+++ b/aperag/domains/agent_runtime/runtime.py
@@ -166,6 +166,69 @@ class _PersistedToolCall:
     state: Literal["input-available", "output-available", "output-error"] = "input-available"
     output: Any = None
     error_text: Optional[str] = None
+    # User-facing one-line summary extracted from the tool's input args
+    # (e.g. "搜索：张飞牛肉" / "阅读：example.com/page"). Persisted as
+    # ``ToolPart.summary`` so the FE can render the activity subtitle
+    # post-refresh, when the raw ``input`` is intentionally NOT
+    # persisted (D9 §A7). Bounded to ``_TOOL_SUMMARY_MAX_LEN`` chars.
+    summary: Optional[str] = None
+
+
+# Maximum length of the user-facing tool-call summary written to
+# ``ToolPart.summary``. Keeps ``agent_message.parts`` size bounded (per
+# architect msg=2639aeea size-budget concern); long URLs / queries
+# truncate with an ellipsis at extraction.
+_TOOL_SUMMARY_MAX_LEN: int = 200
+
+
+def _truncate_summary(value: str) -> str:
+    if len(value) <= _TOOL_SUMMARY_MAX_LEN:
+        return value
+    keep = max(_TOOL_SUMMARY_MAX_LEN - 1, 1)
+    return value[:keep] + "…"
+
+
+def _compact_url_label(value: str) -> str:
+    """Mirror the FE ``compactUrlLabel`` (agent-turn-renderer.tsx) so
+    the persisted summary reads identical to live SSE rendering — same
+    user-visible string in both paths."""
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(value)
+        if not parsed.scheme or not parsed.netloc:
+            return value
+        path = "" if parsed.path in ("", "/") else parsed.path
+        label = f"{parsed.netloc}{path}".rstrip("/")
+        return label or value
+    except Exception:
+        return value
+
+
+def _extract_tool_summary(args: Any) -> Optional[str]:
+    """Project the raw tool input into a small user-facing summary.
+
+    Recognises common tool-input shapes and returns ``"搜索：…"`` /
+    ``"阅读：…"`` style copy. Returns ``None`` when the args don't fit
+    a recognised shape — the FE falls back to its generic per-tool
+    label in that case.
+
+    Bounded to ``_TOOL_SUMMARY_MAX_LEN`` chars so persisted rows stay
+    small. Raw args are NEVER persisted in full (D9 §A7) — this
+    function intentionally reads only the keys needed for the visible
+    summary.
+    """
+    if not isinstance(args, dict):
+        return None
+    for key in ("query", "q", "keyword", "keywords"):
+        value = args.get(key)
+        if isinstance(value, str) and value.strip():
+            return _truncate_summary(f"搜索:{value.strip()}")
+    for key in ("url", "uri", "link"):
+        value = args.get(key)
+        if isinstance(value, str) and value.strip():
+            return _truncate_summary(f"阅读:{_compact_url_label(value.strip())}")
+    return None
 
 
 def _tool_part_type(tool_name: str) -> str:
@@ -204,6 +267,7 @@ def _compose_assistant_parts(
                 state=call.state,
                 output=call.output,
                 error_text=call.error_text,
+                summary=call.summary,
                 metadata={"mcpToolName": call.tool_name},
             )
         )
@@ -501,6 +565,7 @@ class PydanticAIRuntime(AgentRuntime):
                             tool_call_id=tool_call_id,
                             tool_name=tool_name,
                             state="input-available",
+                            summary=_extract_tool_summary(self._normalize_jsonish(event.part.args)),
                         )
                         persisted_tool_calls.append(tool_call)
                         persisted_tool_index[tool_call_id] = tool_call

--- a/aperag/domains/agent_runtime/uimessage.py
+++ b/aperag/domains/agent_runtime/uimessage.py
@@ -145,6 +145,15 @@ class ToolPart(BaseModel):
     input: Optional[Any] = None
     output: Optional[Any] = None
     error_text: Optional[str] = Field(default=None, alias="errorText")
+    # First-class user-facing one-line summary (e.g. "搜索:张飞牛肉",
+    # "阅读:example.com/page"). Per-tool-call free-form ≤ 200 chars
+    # extracted by the runtime from the raw input dict. Rendered by the
+    # FE as the activity-step subtitle so users see "what was searched
+    # / read" even after refresh — when raw ``input`` is intentionally
+    # not persisted (D9 §A7). Architect ratify msg=2639aeea pinned this
+    # as a first-class field rather than nested under ``metadata`` so
+    # FE doesn't fish through a catch-all dict for user-facing copy.
+    summary: Optional[str] = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(populate_by_name=True)

--- a/tests/unit_test/agent_runtime/test_runtime_persistence.py
+++ b/tests/unit_test/agent_runtime/test_runtime_persistence.py
@@ -1,5 +1,7 @@
 from aperag.domains.agent_runtime.runtime import (
+    _TOOL_SUMMARY_MAX_LEN,
     _compose_assistant_parts,
+    _extract_tool_summary,
     _PersistedToolCall,
 )
 from aperag.domains.agent_runtime.schemas import ReferenceBundleItem
@@ -72,3 +74,64 @@ def test_compose_assistant_parts_persists_tool_error_state():
     assert parts[0].type == "tool-knowledge_base_read_document"
     assert parts[0].state == "output-error"
     assert parts[0].error_text == "read timed out"
+
+
+def test_compose_assistant_parts_persists_tool_summary():
+    """Reload paths must surface the user-visible activity subtitle
+    (e.g. "搜索:张飞牛肉") via ``ToolPart.summary``. Without it the FE
+    can only show generic "已完成网页搜索" copy after refresh because
+    ``input`` is intentionally not persisted (D9 §A7)."""
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="",
+        references=[],
+        tool_calls=[
+            _PersistedToolCall(
+                tool_call_id="call-1",
+                tool_name="web.search",
+                state="output-available",
+                summary="搜索:张飞牛肉",
+            )
+        ],
+    )
+    assert len(parts) == 1
+    assert isinstance(parts[0], ToolPart)
+    assert parts[0].summary == "搜索:张飞牛肉"
+    assert parts[0].input is None, "raw tool args must not be persisted (D9 §A7)"
+
+
+def test_extract_tool_summary_search_query():
+    assert _extract_tool_summary({"query": "张飞牛肉"}) == "搜索:张飞牛肉"
+    assert _extract_tool_summary({"q": "beekeeping"}) == "搜索:beekeeping"
+    assert _extract_tool_summary({"keyword": "wave 9"}) == "搜索:wave 9"
+    # Whitespace-only / missing → None (FE falls back to generic copy)
+    assert _extract_tool_summary({"query": "   "}) is None
+    assert _extract_tool_summary({"unrelated": "x"}) is None
+
+
+def test_extract_tool_summary_url_fields_compact_to_host_path():
+    assert _extract_tool_summary({"url": "https://example.com/foo/bar"}) == "阅读:example.com/foo/bar"
+    assert _extract_tool_summary({"uri": "https://example.com/"}) == "阅读:example.com"
+    # Schemeless string passes through unchanged (still useful for FE).
+    assert _extract_tool_summary({"link": "example.com/page"}) == "阅读:example.com/page"
+
+
+def test_extract_tool_summary_truncates_long_values_with_ellipsis():
+    long_query = "x" * (_TOOL_SUMMARY_MAX_LEN + 50)
+    out = _extract_tool_summary({"query": long_query})
+    assert out is not None
+    assert len(out) == _TOOL_SUMMARY_MAX_LEN
+    assert out.endswith("…")
+
+
+def test_extract_tool_summary_query_takes_precedence_over_url():
+    """A tool that takes both ``query`` and ``url`` (e.g. a hybrid
+    search-with-fallback) prefers the human-readable query string."""
+    out = _extract_tool_summary({"query": "张飞牛肉", "url": "https://example.com"})
+    assert out == "搜索:张飞牛肉"
+
+
+def test_extract_tool_summary_non_dict_returns_none():
+    assert _extract_tool_summary(None) is None
+    assert _extract_tool_summary("just a string") is None
+    assert _extract_tool_summary(["a", "b"]) is None


### PR DESCRIPTION
## Summary

After PR #1798 fixed tool-call persistence, refresh still showed generic "已完成网页搜索 / 已把结果用于回答" for every step — the user-visible per-step subtitle (search query / URL) wasn't surviving the round-trip because raw `input` is intentionally not persisted (D9 §A7).

This PR persists a small user-facing summary on a new first-class `ToolPart.summary` field (architect ratify msg=2639aeea — first-class field, not buried under `metadata` catch-all). The FE (PR #1801, dongdong) reads `part.summary` first and shows `"搜索:张飞牛肉"` / `"阅读:example.com/page"` both during live SSE and post-refresh — same user-visible string in both paths.

## Implementation

- New `_extract_tool_summary(args)` recognises common tool-input shapes:
  - `query` / `q` / `keyword` / `keywords` → `"搜索:{value}"`
  - `url` / `uri` / `link` → `"阅读:{compacted-url}"` (URL compacted to host+path, mirroring FE `compactUrlLabel`)
  - Other shapes → `None` (FE falls back to generic per-tool label — no regression)
- Bounded to `_TOOL_SUMMARY_MAX_LEN=200` chars; longer values truncate with `…`. Keeps `agent_message.parts` size bounded (architect size-budget concern).
- **Raw `input` is NEVER persisted in full** — the extractor reads only the keys needed to render the summary (D9 §A7 preserved). Existing `test_compose_assistant_parts_persists_tool_lifecycle_for_reload` continues to assert `parts[0].input is None`.
- New `_PersistedToolCall.summary` field flows through to `ToolPart.summary` in `_compose_assistant_parts`.
- Wired in `run_turn` `FunctionToolCallEvent` handler — extracted at tool-start time from `event.part.args` so the summary is available before the tool finishes (live SSE benefits too).

## Test plan

8 unit cases pass (`uv run pytest tests/unit_test/agent_runtime/test_runtime_persistence.py -v`):

- Existing 2 cases retained (lifecycle + error state).
- New: `test_compose_assistant_parts_persists_tool_summary` — summary roundtrips through `ToolPart.summary`; `input` still `None`.
- New: `test_extract_tool_summary_search_query` — `query` / `q` / `keyword` recognised; whitespace / unrelated keys return `None`.
- New: `test_extract_tool_summary_url_fields_compact_to_host_path` — full URL → `host/path` compaction; schemeless string passes through.
- New: `test_extract_tool_summary_truncates_long_values_with_ellipsis` — `_TOOL_SUMMARY_MAX_LEN` cap with `…` suffix.
- New: `test_extract_tool_summary_query_takes_precedence_over_url` — when both fields present, prefer human-readable query.
- New: `test_extract_tool_summary_non_dict_returns_none` — defensive against non-dict args (string / list / None).

`ruff check` + `ruff format --check` clean.

## Coordination

- Architect ratify: msg=2639aeea (first-class field, not under `metadata`; size cap acknowledged)
- FE counterpart: PR #1801 (dongdong) reads `part.summary` first; falls back to live input/output extraction; finally falls back to generic per-tool label

## References

- Wave bug thread: `#AgentChat:4fb0b0f7` (earayu2 reported "正在搜索网页 ✓" without showing what was searched after refresh)
- Depends on: PR #1798 merged (`_PersistedToolCall` infrastructure)
- Pairs with: PR #1801 (FE renderer reads `summary`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)