### PR TITLE
feat(agent-runtime): persist reasoning chunks interleaved with tool calls (Claude-style timeline)

### DIFF
--- a/aperag/domains/agent_runtime/runtime.py
+++ b/aperag/domains/agent_runtime/runtime.py
@@ -727,16 +727,24 @@ class PydanticAIRuntime(AgentRuntime):
                         if isinstance(event.delta, pai_messages.ThinkingPartDelta):
                             delta_text = event.delta.content_delta or ""
                             if delta_text:
+                                # Pre-flight overflow check: flush
+                                # BEFORE appending if this delta would
+                                # push the buffer past the per-part
+                                # budget. Post-append flush would
+                                # produce a ReasoningPart whose text
+                                # exceeds ``MAX_REASONING_PART_CHARS``
+                                # and trip the Pydantic validator,
+                                # crashing the whole turn write
+                                # (huangheng PR #1804 BLOCKER fix
+                                # msg=e609d5c9). With the pre-check
+                                # the next ReasoningPart starts cleanly
+                                # at the boundary, no part overflows.
+                                if sum(len(s) for s in reasoning_buffer) + len(delta_text) > MAX_REASONING_PART_CHARS:
+                                    _flush_reasoning_chunk()
                                 # Capture the actual reasoning text so
                                 # we can persist it as a ReasoningPart
                                 # (not just emit a status badge).
                                 reasoning_buffer.append(delta_text)
-                                # Auto-flush when the chunk fills the
-                                # per-part budget — keeps any single
-                                # ReasoningPart small enough for
-                                # incremental FE rendering.
-                                if sum(len(s) for s in reasoning_buffer) >= MAX_REASONING_PART_CHARS:
-                                    _flush_reasoning_chunk()
                                 # Live SSE: emit a reasoning delta so
                                 # the FE renderer can stream the
                                 # current reasoning chunk text — same

--- a/aperag/domains/agent_runtime/runtime.py
+++ b/aperag/domains/agent_runtime/runtime.py
@@ -53,8 +53,10 @@ from aperag.domains.agent_runtime.services import (
 from aperag.domains.agent_runtime.storage import DEFAULT_AGENT_TURN_LEASE_TTL_SECONDS, AgentRuntimeRedisStore
 from aperag.domains.agent_runtime.tools.safe_name import sanitize_tool_name
 from aperag.domains.agent_runtime.uimessage import (
+    MAX_REASONING_PART_CHARS,
     CitationData,
     DataCitationPart,
+    ReasoningPart,
     SourceUrlPart,
     TextPart,
     ToolPart,
@@ -174,6 +176,24 @@ class _PersistedToolCall:
     summary: Optional[str] = None
 
 
+@dataclass
+class _PersistedReasoning:
+    """One reasoning chunk (the model's thinking text emitted between
+    tool calls). Lives on the chronological timeline alongside
+    :class:`_PersistedToolCall` entries so the FE can render
+    Claude/Cursor-style "思考1 → 工具a → 思考2 → 工具b" interleaving.
+
+    The runtime accumulates ``ThinkingPartDelta.content_delta`` into
+    a buffer; ``_close_reasoning_chunk`` flushes the buffer into a
+    ``_PersistedReasoning`` entry and appends it to the timeline:
+    when a tool call interrupts the reasoning stream, OR when the
+    buffer reaches ``MAX_REASONING_PART_CHARS``, OR when the turn
+    completes.
+    """
+
+    text: str
+
+
 # Maximum length of the user-facing tool-call summary written to
 # ``ToolPart.summary``. Keeps ``agent_message.parts`` size bounded (per
 # architect msg=2639aeea size-budget concern); long URLs / queries
@@ -247,30 +267,56 @@ def _compose_assistant_parts(
     answer_text: str,
     references: list[ReferenceBundleItem],
     tool_calls: list[_PersistedToolCall] | None = None,
+    timeline: list[Any] | None = None,
 ) -> list[UIMessagePart]:
     """Project the runtime's accumulated answer + references into a
     canonical at-rest ``UIMessagePart`` list for ``UIMessageStore.write``.
 
-    Order: collapsed ``ToolPart`` records first, ``TextPart`` (answer)
-    next, then ``SourceUrlPart`` / ``DataCitationPart`` pairs from
-    each reference. Items without a URI surface as ``DataCitationPart``
-    only — same shape the FE renderer expects from the live SSE stream
-    (D8 §2 byte-equal).
+    Order:
+    - ``timeline`` entries first, in their original chronological order
+      — interleaved ``ReasoningPart`` / ``ToolPart`` records so FE
+      renders Claude/Cursor-style "思考1 → 工具a → 思考2 → 工具b" flow
+      (Wave 9 task #2 followup #2, architect ratify msg=2639aeea).
+    - ``TextPart`` (final answer) next.
+    - ``SourceUrlPart`` / ``DataCitationPart`` pairs from each reference.
+
+    ``tool_calls`` is the legacy parameter (Wave 9 PR #1798); when
+    ``timeline`` is supplied it takes precedence and ``tool_calls`` is
+    ignored. Callers that don't track reasoning (older / test paths)
+    can keep using ``tool_calls`` for backward compat.
     """
 
     parts: list[UIMessagePart] = []
-    for call in tool_calls or []:
-        parts.append(
-            ToolPart(
-                type=_tool_part_type(call.tool_name),
-                tool_call_id=call.tool_call_id,
-                state=call.state,
-                output=call.output,
-                error_text=call.error_text,
-                summary=call.summary,
-                metadata={"mcpToolName": call.tool_name},
+    if timeline is not None:
+        for entry in timeline:
+            if isinstance(entry, _PersistedReasoning):
+                if entry.text and entry.text.strip():
+                    parts.append(ReasoningPart(text=entry.text))
+            elif isinstance(entry, _PersistedToolCall):
+                parts.append(
+                    ToolPart(
+                        type=_tool_part_type(entry.tool_name),
+                        tool_call_id=entry.tool_call_id,
+                        state=entry.state,
+                        output=entry.output,
+                        error_text=entry.error_text,
+                        summary=entry.summary,
+                        metadata={"mcpToolName": entry.tool_name},
+                    )
+                )
+    else:
+        for call in tool_calls or []:
+            parts.append(
+                ToolPart(
+                    type=_tool_part_type(call.tool_name),
+                    tool_call_id=call.tool_call_id,
+                    state=call.state,
+                    output=call.output,
+                    error_text=call.error_text,
+                    summary=call.summary,
+                    metadata={"mcpToolName": call.tool_name},
+                )
             )
-        )
     if answer_text:
         parts.append(TextPart(text=answer_text))
     for index, ref in enumerate(references):
@@ -476,6 +522,30 @@ class PydanticAIRuntime(AgentRuntime):
         tool_summaries: list[str] = []
         persisted_tool_calls: list[_PersistedToolCall] = []
         persisted_tool_index: dict[str, _PersistedToolCall] = {}
+        # Chronological timeline of reasoning chunks + tool calls.
+        # ``_compose_assistant_parts`` reads this in order so the FE
+        # gets Claude/Cursor-style "思考1 → 工具a → 思考2 → 工具b"
+        # interleaving (Wave 9 task #2 followup #2).
+        persisted_timeline: list[Any] = []
+        # Reasoning text accumulator: ThinkingPartDelta deltas append
+        # here; a flush (tool-call interrupt / size cap / turn end)
+        # converts the buffer into a ``_PersistedReasoning`` entry on
+        # ``persisted_timeline`` and resets the buffer.
+        reasoning_buffer: list[str] = []
+
+        def _flush_reasoning_chunk() -> None:
+            """Push the accumulated reasoning text onto the timeline as
+            a ``_PersistedReasoning`` entry, then reset the buffer.
+
+            Called on tool-call interrupt, size cap, and turn end —
+            the chunk boundaries are what give the FE its discrete
+            "思考N" blocks rather than one ever-growing reasoning
+            block at the bottom."""
+            text = "".join(reasoning_buffer).strip()
+            reasoning_buffer.clear()
+            if text:
+                persisted_timeline.append(_PersistedReasoning(text=text))
+
         lease_guard = TurnLeaseGuard(turn_service=self.turn_service, turn_id=turn.id, owner_token=lease_owner)
 
         async def emit(
@@ -561,6 +631,11 @@ class PydanticAIRuntime(AgentRuntime):
                     if isinstance(event, pai_messages.FunctionToolCallEvent):
                         tool_name = event.part.tool_name
                         tool_call_id = event.part.tool_call_id
+                        # Tool call interrupts the reasoning stream —
+                        # close the current chunk so the FE renders
+                        # this thinking block before the upcoming tool
+                        # action card.
+                        _flush_reasoning_chunk()
                         tool_call = _PersistedToolCall(
                             tool_call_id=tool_call_id,
                             tool_name=tool_name,
@@ -569,6 +644,7 @@ class PydanticAIRuntime(AgentRuntime):
                         )
                         persisted_tool_calls.append(tool_call)
                         persisted_tool_index[tool_call_id] = tool_call
+                        persisted_timeline.append(tool_call)
                         tool_summaries.append(f"Calling tool: {tool_name}")
                         await emit(
                             "agent.state.changed",
@@ -612,6 +688,7 @@ class PydanticAIRuntime(AgentRuntime):
                             )
                             persisted_tool_calls.append(tool_call)
                             persisted_tool_index[tool_call_id] = tool_call
+                            persisted_timeline.append(tool_call)
                         if _is_tool_failure_status(outcome):
                             tool_call.state = "output-error"
                             tool_call.error_text = (
@@ -648,12 +725,36 @@ class PydanticAIRuntime(AgentRuntime):
 
                     if isinstance(event, pai_messages.PartDeltaEvent):
                         if isinstance(event.delta, pai_messages.ThinkingPartDelta):
-                            await emit(
-                                "agent.state.changed",
-                                actor=AgentEventActor.AGENT,
-                                label=VisibleAgentState.THINKING.value,
-                                status="thinking",
-                            )
+                            delta_text = event.delta.content_delta or ""
+                            if delta_text:
+                                # Capture the actual reasoning text so
+                                # we can persist it as a ReasoningPart
+                                # (not just emit a status badge).
+                                reasoning_buffer.append(delta_text)
+                                # Auto-flush when the chunk fills the
+                                # per-part budget — keeps any single
+                                # ReasoningPart small enough for
+                                # incremental FE rendering.
+                                if sum(len(s) for s in reasoning_buffer) >= MAX_REASONING_PART_CHARS:
+                                    _flush_reasoning_chunk()
+                                # Live SSE: emit a reasoning delta so
+                                # the FE renderer can stream the
+                                # current reasoning chunk text — same
+                                # convention as ``text.delta``.
+                                await emit(
+                                    "reasoning.delta",
+                                    actor=AgentEventActor.AGENT,
+                                    label=VisibleAgentState.THINKING.value,
+                                    status="thinking",
+                                    data={"delta": delta_text},
+                                )
+                            else:
+                                await emit(
+                                    "agent.state.changed",
+                                    actor=AgentEventActor.AGENT,
+                                    label=VisibleAgentState.THINKING.value,
+                                    status="thinking",
+                                )
                             continue
 
                         if isinstance(event.delta, pai_messages.TextPartDelta):
@@ -688,6 +789,13 @@ class PydanticAIRuntime(AgentRuntime):
             lease_guard.ensure_owned()
             answer_text = "".join(text_chunks).strip()
 
+            # Final flush — the model may have emitted reasoning text
+            # after its last tool call (the close-out thinking that
+            # leads into the answer). Without this, that trailing
+            # block would be silently dropped from the persisted
+            # timeline.
+            _flush_reasoning_chunk()
+
             await self.uimessage_store.write(
                 turn_id=turn.id,
                 chat_id=chat.id,
@@ -698,7 +806,7 @@ class PydanticAIRuntime(AgentRuntime):
                         turn_id=turn.id,
                         answer_text=answer_text,
                         references=reference_items,
-                        tool_calls=persisted_tool_calls,
+                        timeline=persisted_timeline,
                     ),
                 ),
             )

--- a/aperag/domains/agent_runtime/uimessage.py
+++ b/aperag/domains/agent_runtime/uimessage.py
@@ -114,6 +114,40 @@ class TextPart(BaseModel):
     text: str
 
 
+# Per-part length budget for ReasoningPart. Keeps any single part
+# small enough to render incrementally on the FE; the runtime opens a
+# new part when the buffer fills (or when a tool call interrupts the
+# reasoning stream).
+MAX_REASONING_PART_CHARS: int = 4096
+
+
+class ReasoningPart(BaseModel):
+    """Persisted multi-step reasoning text the model emitted between
+    tool calls — the "how the agent got there" trace, distinct from
+    :class:`TextPart` (final answer body).
+
+    Architect ratify msg=2639aeea: separate first-class type vs reusing
+    ``TextPart`` with a ``role`` meta field. Keeping reasoning as its
+    own type makes downstream serialisation / aggregation / UI
+    rendering unambiguous (a reader can tell "this is reasoning" vs
+    "this is the final answer" by ``type`` alone).
+
+    ``transient=False`` (default) so reasoning survives reload — Wave 8
+    D8.6 chunk-3 design originally pinned reasoning as fully transient
+    via :class:`DataActivityPart`, but earayu2 explicitly asked for
+    Claude-style chronological timeline (思考1 → 工具a → 思考2 → 工具b
+    → 最终回答) so persistence is the canonical user-priority amend.
+
+    Length cap: ``MAX_REASONING_PART_CHARS`` per part — the runtime
+    opens a new ReasoningPart when the buffer fills OR when a tool
+    call interrupts, giving the chronological chunking the FE renders
+    as discrete thinking blocks interleaved with tool actions.
+    """
+
+    type: Literal["reasoning"] = "reasoning"
+    text: str = Field(max_length=MAX_REASONING_PART_CHARS)
+
+
 _TOOL_TYPE_PATTERN = r"^tool-[A-Za-z0-9_-]+$"
 
 
@@ -273,6 +307,7 @@ class DataElicitationPart(BaseModel):
 
 UIMessagePart = Union[
     TextPart,
+    ReasoningPart,
     ToolPart,
     SourceUrlPart,
     SourceDocumentPart,

--- a/aperag/domains/agent_runtime/wire/parts.py
+++ b/aperag/domains/agent_runtime/wire/parts.py
@@ -130,6 +130,38 @@ class TextEndPart(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Reasoning parts (live SSE only — at-rest persistence uses the
+# ``ReasoningPart`` UIMessagePart shape; see uimessage.py)
+# ---------------------------------------------------------------------------
+
+
+class ReasoningStartPart(BaseModel):
+    """Opens a streaming reasoning block; subsequent
+    ``reasoning-delta`` parts must reuse the same ``id`` until a
+    ``reasoning-end`` closes the block. Mirrors the AI SDK v5 reasoning
+    part shape so FE renderers that already consume that protocol can
+    drop the wire stream straight into the same code path."""
+
+    type: Literal["reasoning-start"] = "reasoning-start"
+    id: str
+
+
+class ReasoningDeltaPart(BaseModel):
+    """Incremental reasoning text chunk for an open reasoning block."""
+
+    type: Literal["reasoning-delta"] = "reasoning-delta"
+    id: str
+    delta: str
+
+
+class ReasoningEndPart(BaseModel):
+    """Closes the reasoning block opened by ``reasoning-start``."""
+
+    type: Literal["reasoning-end"] = "reasoning-end"
+    id: str
+
+
+# ---------------------------------------------------------------------------
 # Tool lifecycle parts
 # ---------------------------------------------------------------------------
 
@@ -388,6 +420,9 @@ StreamPart = Annotated[
         TextStartPart,
         TextDeltaPart,
         TextEndPart,
+        ReasoningStartPart,
+        ReasoningDeltaPart,
+        ReasoningEndPart,
         ToolInputStartPart,
         ToolInputDeltaPart,
         ToolInputAvailablePart,
@@ -457,6 +492,9 @@ __all__ = [
     "StreamPartAdapter",
     "TextDeltaPart",
     "TextEndPart",
+    "ReasoningStartPart",
+    "ReasoningDeltaPart",
+    "ReasoningEndPart",
     "TextStartPart",
     "ToolInputAvailablePart",
     "ToolInputDeltaPart",

--- a/aperag/domains/agent_runtime/wire/translator.py
+++ b/aperag/domains/agent_runtime/wire/translator.py
@@ -67,6 +67,9 @@ from aperag.domains.agent_runtime.wire.parts import (
     ErrorPart,
     FinishPart,
     FinishStepPart,
+    ReasoningDeltaPart,
+    ReasoningEndPart,
+    ReasoningStartPart,
     SourceUrlPart,
     StartPart,
     StartStepPart,
@@ -105,6 +108,13 @@ class TranslatorState:
 
     text_block_open: bool = False
     text_block_id: Optional[str] = None
+    # Reasoning block state — mirror of text-block bookkeeping. Open on
+    # first ``reasoning.delta``, closed when a non-reasoning event
+    # arrives (tool call / text delta / turn end). Lets the FE
+    # accumulate one chunk per "thinking N" block without each delta
+    # spawning a new one.
+    reasoning_block_open: bool = False
+    reasoning_block_id: Optional[str] = None
     safe_tool_name_resolver: Optional[SafeToolNameResolver] = None
     _user_activities: dict[int, UserActivityEnvelope] = field(default_factory=dict)
 
@@ -334,6 +344,12 @@ def _translate_tool_finished(envelope: AgentTimelineEventEnvelope) -> list[Strea
 def _translate_text_delta(envelope: AgentTimelineEventEnvelope, state: TranslatorState) -> list[StreamPart]:
     delta = (envelope.data or {}).get("delta") or ""
     parts: list[StreamPart] = []
+    # Close any open reasoning block before opening / continuing the
+    # text block. The runtime's chunk-on-tool-call boundary already
+    # handles closing reasoning at tool starts; this catches the
+    # transition from reasoning straight to the answer text (no tool
+    # call between them).
+    parts.extend(_close_reasoning_block_if_open(state))
     if not state.text_block_open:
         text_id = envelope.turn_id
         state.text_block_open = True
@@ -341,6 +357,50 @@ def _translate_text_delta(envelope: AgentTimelineEventEnvelope, state: Translato
         parts.append(TextStartPart(id=text_id))
     assert state.text_block_id is not None  # invariant: opened above
     parts.append(TextDeltaPart(id=state.text_block_id, delta=str(delta)))
+    return parts
+
+
+def _close_reasoning_block_if_open(state: TranslatorState) -> list[StreamPart]:
+    """Emit a ``reasoning-end`` if a reasoning block is currently open
+    and reset the state. Called by anything that interrupts reasoning
+    (text delta, tool start, turn end, artifact, ...). Idempotent —
+    no-op when no block is open."""
+    if state.reasoning_block_open and state.reasoning_block_id is not None:
+        block_id = state.reasoning_block_id
+        state.reasoning_block_open = False
+        state.reasoning_block_id = None
+        return [ReasoningEndPart(id=block_id)]
+    return []
+
+
+def _translate_reasoning_delta(envelope: AgentTimelineEventEnvelope, state: TranslatorState) -> list[StreamPart]:
+    """Mirror of :func:`_translate_text_delta` for reasoning streams.
+
+    Wave 9 task #2 followup #2: the runtime now emits
+    ``reasoning.delta`` events carrying the model's actual thinking
+    text (not just status badges). The FE consumes these as
+    AI SDK v5 ``reasoning-start`` / ``reasoning-delta`` / ``reasoning-end``
+    parts so the activity timeline can render Claude/Cursor-style
+    "思考N" blocks at the right chronological position.
+
+    The block stays open across consecutive ``reasoning.delta`` events
+    and closes when any other event type arrives (tool start / text
+    delta / turn end), so each persisted ``ReasoningPart`` chunk maps
+    cleanly to one wire reasoning block.
+    """
+    delta = (envelope.data or {}).get("delta") or ""
+    parts: list[StreamPart] = []
+    if not state.reasoning_block_open:
+        # Use a per-block id derived from turn_id + sequence so
+        # multiple reasoning blocks in one turn don't collide on the
+        # FE side. ``envelope.event_id`` is unique per emit and stable
+        # for the duration of one block's first delta — good enough.
+        block_id = f"reasoning-{envelope.event_id}"
+        state.reasoning_block_open = True
+        state.reasoning_block_id = block_id
+        parts.append(ReasoningStartPart(id=block_id))
+    assert state.reasoning_block_id is not None  # invariant: opened above
+    parts.append(ReasoningDeltaPart(id=state.reasoning_block_id, delta=str(delta)))
     return parts
 
 
@@ -395,10 +455,27 @@ def translate_envelope(
         if effective_state is not state:
             state.text_block_open = effective_state.text_block_open
             state.text_block_id = effective_state.text_block_id
+            state.reasoning_block_open = effective_state.reasoning_block_open
+            state.reasoning_block_id = effective_state.reasoning_block_id
+        return parts
+
+    if event_type == "reasoning.delta":
+        parts = _translate_reasoning_delta(envelope, effective_state)
+        if effective_state is not state:
+            state.reasoning_block_open = effective_state.reasoning_block_open
+            state.reasoning_block_id = effective_state.reasoning_block_id
         return parts
 
     if event_type in {"tool.started", "external_action.started"}:
-        return _translate_tool_started(envelope, effective_state)
+        # A tool call interrupts any open reasoning block — close it
+        # so the FE sees one chunk per "thinking N" block, mirroring
+        # the runtime's at-rest chunk-on-tool-call boundary.
+        parts = _close_reasoning_block_if_open(effective_state)
+        parts.extend(_translate_tool_started(envelope, effective_state))
+        if effective_state is not state:
+            state.reasoning_block_open = effective_state.reasoning_block_open
+            state.reasoning_block_id = effective_state.reasoning_block_id
+        return parts
 
     if event_type in {"tool.finished", "external_action.finished"}:
         return _translate_tool_finished(envelope)
@@ -411,14 +488,32 @@ def translate_envelope(
         return parts
 
     if event_type == "turn.completed":
-        return [FinishStepPart(), FinishPart()]
+        # Close any open reasoning block on turn end so the FE never
+        # sees a dangling reasoning-start without a matching
+        # reasoning-end (mirrors how text blocks close at turn end).
+        parts = _close_reasoning_block_if_open(effective_state)
+        if effective_state is not state:
+            state.reasoning_block_open = effective_state.reasoning_block_open
+            state.reasoning_block_id = effective_state.reasoning_block_id
+        parts.extend([FinishStepPart(), FinishPart()])
+        return parts
 
     if event_type == "turn.failed":
         message = (envelope.data or {}).get("error") or envelope.label or "turn failed"
-        return [ErrorPart(error_text=str(message)), FinishPart()]
+        parts = _close_reasoning_block_if_open(effective_state)
+        if effective_state is not state:
+            state.reasoning_block_open = effective_state.reasoning_block_open
+            state.reasoning_block_id = effective_state.reasoning_block_id
+        parts.extend([ErrorPart(error_text=str(message)), FinishPart()])
+        return parts
 
     if event_type == "turn.cancelled":
-        return [AbortPart(), FinishPart()]
+        parts = _close_reasoning_block_if_open(effective_state)
+        if effective_state is not state:
+            state.reasoning_block_open = effective_state.reasoning_block_open
+            state.reasoning_block_id = effective_state.reasoning_block_id
+        parts.extend([AbortPart(), FinishPart()])
+        return parts
 
     return []
 

--- a/tests/unit_test/agent_runtime/test_runtime_persistence.py
+++ b/tests/unit_test/agent_runtime/test_runtime_persistence.py
@@ -2,10 +2,17 @@ from aperag.domains.agent_runtime.runtime import (
     _TOOL_SUMMARY_MAX_LEN,
     _compose_assistant_parts,
     _extract_tool_summary,
+    _PersistedReasoning,
     _PersistedToolCall,
 )
 from aperag.domains.agent_runtime.schemas import ReferenceBundleItem
-from aperag.domains.agent_runtime.uimessage import DataCitationPart, SourceUrlPart, TextPart, ToolPart
+from aperag.domains.agent_runtime.uimessage import (
+    DataCitationPart,
+    ReasoningPart,
+    SourceUrlPart,
+    TextPart,
+    ToolPart,
+)
 
 
 def test_compose_assistant_parts_persists_tool_lifecycle_for_reload():
@@ -135,3 +142,131 @@ def test_extract_tool_summary_non_dict_returns_none():
     assert _extract_tool_summary(None) is None
     assert _extract_tool_summary("just a string") is None
     assert _extract_tool_summary(["a", "b"]) is None
+
+
+# ---------------------------------------------------------------------
+# Reasoning timeline (Wave 9 task #2 followup #2 — Claude-style chunks)
+# ---------------------------------------------------------------------
+
+
+def test_compose_assistant_parts_interleaves_reasoning_and_tool_in_timeline():
+    """Architect ratify msg=2639aeea: chronological "思考1 → 工具a →
+    思考2 → 工具b → final answer" pattern. The runtime feeds the
+    timeline pre-ordered; ``_compose_assistant_parts`` must preserve
+    that order so the FE renders Claude/Cursor-style interleaving."""
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="Final answer.",
+        references=[],
+        timeline=[
+            _PersistedReasoning(text="I need to look up the price first."),
+            _PersistedToolCall(
+                tool_call_id="call-1",
+                tool_name="web.search",
+                state="output-available",
+                summary="搜索:price",
+            ),
+            _PersistedReasoning(text="Got it. Let me also fetch the page."),
+            _PersistedToolCall(
+                tool_call_id="call-2",
+                tool_name="web.read",
+                state="output-available",
+                summary="阅读:example.com",
+            ),
+            _PersistedReasoning(text="Now I have enough to answer."),
+        ],
+    )
+    types = [p.type for p in parts]
+    assert types == [
+        "reasoning",
+        "tool-web_search",
+        "reasoning",
+        "tool-web_read",
+        "reasoning",
+        "text",
+    ], "timeline order must be preserved verbatim before TextPart"
+    assert isinstance(parts[0], ReasoningPart)
+    assert parts[0].text == "I need to look up the price first."
+    assert isinstance(parts[5], TextPart)
+    assert parts[5].text == "Final answer."
+
+
+def test_compose_assistant_parts_drops_empty_reasoning_chunks():
+    """Empty-after-strip reasoning entries (whitespace-only) are
+    dropped so the FE never renders an empty thinking block. The
+    runtime's ``_flush_reasoning_chunk`` already strips before
+    pushing — this test pins the composer's defence-in-depth so
+    direct unit-test callers (and any future code path that bypasses
+    the flush helper) still get the same behaviour."""
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="",
+        references=[],
+        timeline=[
+            _PersistedReasoning(text="   \n  "),
+            _PersistedReasoning(text=""),
+            _PersistedToolCall(
+                tool_call_id="call-1",
+                tool_name="web.search",
+                state="output-available",
+            ),
+        ],
+    )
+    types = [p.type for p in parts]
+    assert types == ["tool-web_search"], "empty reasoning chunks must be dropped"
+
+
+def test_compose_assistant_parts_legacy_tool_calls_path_still_works():
+    """Backward compat: callers that haven't migrated to ``timeline``
+    can still pass ``tool_calls`` and get the original tool-first
+    ordering. PR #1798 + PR #1803 paths must not break."""
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="Answer",
+        references=[],
+        tool_calls=[
+            _PersistedToolCall(
+                tool_call_id="call-1",
+                tool_name="web.search",
+                state="output-available",
+                summary="搜索:x",
+            ),
+        ],
+    )
+    types = [p.type for p in parts]
+    assert types == ["tool-web_search", "text"]
+    assert isinstance(parts[0], ToolPart)
+    assert parts[0].summary == "搜索:x"
+
+
+def test_compose_assistant_parts_timeline_takes_precedence_over_tool_calls():
+    """When both ``timeline`` and ``tool_calls`` are supplied (e.g. a
+    transitional caller), ``timeline`` wins and ``tool_calls`` is
+    silently ignored — keeps the new ordered shape canonical without
+    forcing every legacy caller to delete their old kwarg in one PR."""
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="",
+        references=[],
+        timeline=[
+            _PersistedToolCall(
+                tool_call_id="from-timeline",
+                tool_name="web.search",
+                state="output-available",
+            ),
+        ],
+        tool_calls=[
+            _PersistedToolCall(
+                tool_call_id="ignored-legacy",
+                tool_name="web.read",
+                state="output-available",
+            ),
+        ],
+    )
+    assert len(parts) == 1
+    assert isinstance(parts[0], ToolPart)
+    assert parts[0].tool_call_id == "from-timeline"

--- a/tests/unit_test/agent_runtime/test_runtime_persistence.py
+++ b/tests/unit_test/agent_runtime/test_runtime_persistence.py
@@ -270,3 +270,62 @@ def test_compose_assistant_parts_timeline_takes_precedence_over_tool_calls():
     assert len(parts) == 1
     assert isinstance(parts[0], ToolPart)
     assert parts[0].tool_call_id == "from-timeline"
+
+
+# ---------------------------------------------------------------------
+# ThinkingPartDelta overflow handling (huangheng PR #1804 BLOCKER fix)
+# ---------------------------------------------------------------------
+
+
+def test_reasoning_buffer_pre_flush_avoids_part_overflow():
+    """huangheng PR #1804 BLOCKER (msg=e609d5c9): the pre-flight
+    overflow check must run BEFORE appending so no single
+    ``ReasoningPart`` exceeds ``MAX_REASONING_PART_CHARS``.
+
+    Replays the runtime's exact buffer-management logic against a
+    stream of 30 × 200-char deltas (typical for long reasoning
+    streams from large models) and asserts:
+      1. No produced ReasoningPart exceeds the per-part cap.
+      2. Joined text equals the input concatenation (no data loss
+         across flush boundaries).
+      3. Multiple parts are produced (proves chunking actually fires
+         instead of silently dropping data).
+    """
+    from aperag.domains.agent_runtime.runtime import _PersistedReasoning
+    from aperag.domains.agent_runtime.uimessage import MAX_REASONING_PART_CHARS
+
+    deltas = ["x" * 200] * 30  # 6000 chars total > 4096 cap
+    timeline: list = []
+    buffer: list[str] = []
+
+    def _flush():
+        text = "".join(buffer).strip()
+        buffer.clear()
+        if text:
+            timeline.append(_PersistedReasoning(text=text))
+
+    # Mirror the runtime's pre-flight check exactly.
+    for delta in deltas:
+        if sum(len(s) for s in buffer) + len(delta) > MAX_REASONING_PART_CHARS:
+            _flush()
+        buffer.append(delta)
+    _flush()  # trailing flush at turn end
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-overflow",
+        answer_text="",
+        references=[],
+        timeline=timeline,
+    )
+
+    reasoning_parts = [p for p in parts if isinstance(p, ReasoningPart)]
+    assert len(reasoning_parts) >= 2, "buffer cap must produce multiple parts on overflow"
+    for rp in reasoning_parts:
+        assert len(rp.text) <= MAX_REASONING_PART_CHARS, (
+            f"ReasoningPart text length {len(rp.text)} exceeds cap {MAX_REASONING_PART_CHARS} — "
+            "Pydantic validator would reject this part and crash the turn write"
+        )
+    rejoined = "".join(rp.text for rp in reasoning_parts)
+    assert rejoined == "".join(deltas), (
+        "joined text must equal input concatenation (no data lost across flush boundaries)"
+    )

--- a/tests/unit_test/test_agent_runtime_wire_parts.py
+++ b/tests/unit_test/test_agent_runtime_wire_parts.py
@@ -60,6 +60,9 @@ from aperag.domains.agent_runtime.wire.parts import (
     ErrorPart,
     FinishPart,
     FinishStepPart,
+    ReasoningDeltaPart,
+    ReasoningEndPart,
+    ReasoningStartPart,
     SourceUrlPart,
     StartPart,
     StartStepPart,
@@ -158,6 +161,108 @@ def test_translate_text_delta_lifecycle():
     assert isinstance(answer_artifact[0], TextEndPart)
     assert answer_artifact[0].id == "turn-1"
     assert state.text_block_open is False
+
+
+def test_translate_reasoning_delta_lifecycle():
+    """Wave 9 task #2 followup #2 + dongdong gap msg=4c5f4f0e: live SSE
+    stream must surface reasoning text so the FE renders incrementally.
+
+    The first ``reasoning.delta`` opens a reasoning block; subsequent
+    deltas reuse the open block's id; a non-reasoning event (text
+    delta, tool start, turn end) closes the block."""
+    state = TranslatorState()
+
+    first = translate_envelope(
+        _envelope(
+            "reasoning.delta",
+            sequence=2,
+            event_id="evt-r1",
+            data={"delta": "I need"},
+        ),
+        state,
+    )
+    assert len(first) == 2
+    assert isinstance(first[0], ReasoningStartPart)
+    assert first[0].id == "reasoning-evt-r1"
+    assert isinstance(first[1], ReasoningDeltaPart)
+    assert first[1].id == "reasoning-evt-r1"
+    assert first[1].delta == "I need"
+
+    second = translate_envelope(
+        _envelope(
+            "reasoning.delta",
+            sequence=3,
+            event_id="evt-r2",
+            data={"delta": " to look it up."},
+        ),
+        state,
+    )
+    # Reuses the open block's id (NOT the new envelope's event_id).
+    assert len(second) == 1
+    assert isinstance(second[0], ReasoningDeltaPart)
+    assert second[0].id == "reasoning-evt-r1"
+    assert second[0].delta == " to look it up."
+
+
+def test_translate_text_delta_closes_open_reasoning_block():
+    """Reasoning → text transition closes the reasoning block before
+    opening the text block. Without this the FE sees a dangling
+    reasoning-start without a matching reasoning-end."""
+    state = TranslatorState()
+    translate_envelope(
+        _envelope("reasoning.delta", sequence=2, event_id="evt-r1", data={"delta": "thinking"}),
+        state,
+    )
+    parts = translate_envelope(
+        _envelope("text.delta", sequence=3, data={"delta": "answer"}),
+        state,
+    )
+    types = [type(p).__name__ for p in parts]
+    assert types == ["ReasoningEndPart", "TextStartPart", "TextDeltaPart"]
+    assert parts[0].id == "reasoning-evt-r1"
+
+
+def test_translate_tool_started_closes_open_reasoning_block():
+    """Tool call interrupts reasoning — close the reasoning block so
+    each "思考N" block ends cleanly before the upcoming tool action
+    card. Mirror of the runtime's at-rest chunk-on-tool-call boundary
+    (huangheng PR #1804 BLOCKER fix made the BE side work; this is the
+    wire-side equivalent)."""
+    state = TranslatorState()
+    translate_envelope(
+        _envelope("reasoning.delta", sequence=2, event_id="evt-r1", data={"delta": "thinking"}),
+        state,
+    )
+    parts = translate_envelope(
+        _envelope(
+            "tool.started",
+            sequence=3,
+            event_id="evt-t1",
+            label="web.search",
+            data={"tool_name": "web.search", "tool_call_id": "call-1"},
+        ),
+        state,
+    )
+    # First part must be the reasoning-end before the tool-input-* parts.
+    assert isinstance(parts[0], ReasoningEndPart)
+    assert parts[0].id == "reasoning-evt-r1"
+
+
+def test_translate_turn_completed_closes_open_reasoning_block():
+    """Trailing reasoning that didn't end with a tool call (or a text
+    delta) still gets a clean close at turn end."""
+    state = TranslatorState()
+    translate_envelope(
+        _envelope("reasoning.delta", sequence=2, event_id="evt-r1", data={"delta": "final thinking"}),
+        state,
+    )
+    parts = translate_envelope(
+        _envelope("turn.completed", sequence=3, status="completed"),
+        state,
+    )
+    types = [type(p).__name__ for p in parts]
+    assert types == ["ReasoningEndPart", "FinishStepPart", "FinishPart"]
+    assert parts[0].id == "reasoning-evt-r1"
 
 
 def test_translate_tool_started_finished():


### PR DESCRIPTION
## Summary

Wave 9 task #2 followup #2. Implements Claude/Cursor/Codex-style chronological timeline rendering for the agent activity panel: `思考1 → 工具a/b → 思考2 → 工具c → 最终回答` instead of the prior "single growing thinking block at the bottom" pattern.

Per architect ratify msg=2639aeea + earayu2 user-priority (msg=4f76070f thread). The Wave 8 D8.6 chunk-3 transient-reasoning design is intentionally amended — user explicitly asked for Claude-style chronological interleave.

## Schema (uimessage.py)

- New `ReasoningPart(text)` first-class type — distinct from `TextPart` so the FE / serialisation layer can tell "how the agent got there" from "the final answer body" by `type` alone (architect rationale: avoid polymorphic `role` meta on TextPart).
- `transient=False` (default) → reasoning survives reload.
- `MAX_REASONING_PART_CHARS = 4096` per-part length cap. The runtime opens a new ReasoningPart when the buffer fills.
- Added to `UIMessagePart` Union.

## Runtime (runtime.py)

- New `_PersistedReasoning(text)` dataclass.
- `persisted_timeline: list[Any]` — single chronologically-ordered list of `_PersistedToolCall` + `_PersistedReasoning` entries. Canonical source of truth for `_compose_assistant_parts` order.
- `reasoning_buffer: list[str]` accumulator.
- `_flush_reasoning_chunk()` helper — pushes the current buffer onto the timeline as a `_PersistedReasoning` entry. Called on:
  - **Tool-call interrupt** — closes the current chunk before the upcoming tool action card so each "思考N" block sits in its proper chronological slot.
  - **Size-cap reach** — auto-flush when buffer hits `MAX_REASONING_PART_CHARS`.
  - **Turn end** — captures any trailing close-out reasoning that didn't end with a tool call.
- `ThinkingPartDelta` handler now captures `content_delta` into the buffer (previously dropped). Also emits a new `reasoning.delta` SSE event so the FE can stream the live chunk text — mirrors `text.delta` convention.
- Empty deltas keep emitting the existing `agent.state.changed` status event for backward compat with FE thinking badges.

`_compose_assistant_parts` accepts a new `timeline` kwarg that takes precedence over the legacy `tool_calls` kwarg. Order: `timeline` entries first (chronologically interleaved `ReasoningPart` + `ToolPart`), then `TextPart` (answer), then references. Backward-compat: callers passing only `tool_calls` keep the original tool-first ordering — PR #1798 / PR #1803 tests still pass without modification.

## Test plan

12/12 pass (4 new):

- `test_compose_assistant_parts_interleaves_reasoning_and_tool_in_timeline` — pins the canonical "思考1 → 工具a → 思考2 → 工具b → 思考3 → answer" shape.
- `test_compose_assistant_parts_drops_empty_reasoning_chunks` — defence-in-depth against whitespace-only reasoning entries (the runtime's flush helper already strips, but the composer also drops to keep direct unit-test callers safe).
- `test_compose_assistant_parts_legacy_tool_calls_path_still_works` — PR #1798 / PR #1803 callers don't break.
- `test_compose_assistant_parts_timeline_takes_precedence_over_tool_calls` — transitional safety when both kwargs are supplied.

138/138 broader agent_runtime suite passes.

`ruff check` + `ruff format --check` clean.

## Frontend coordination

FE counterpart (separate PR by @dongdong, follow-up to #1801) reads `ReasoningPart` and renders it as a "思考N" block in the activity timeline at its chronological position relative to `ToolPart` entries. Live-stream consumption can wire the new `reasoning.delta` SSE event for incremental rendering of the current chunk.

## References

- Architect ratify: DM msg=2639aeea (first-class ReasoningPart, size-cap chunks, transient=False amend rationale)
- earayu2 ask: msg=de55fd60 + msg=4f76070f (Claude/Cursor/Codex style chronological interleave)
- Builds on: PR #1798 (tool persistence) + PR #1803 (tool summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)