### PR TITLE
feat(embedding): inline retry on transient provider errors

### DIFF
--- a/aperag/llm/embed/embedding_service.py
+++ b/aperag/llm/embed/embedding_service.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import random
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Sequence, Tuple
 
@@ -27,10 +29,21 @@ from aperag.llm.llm_error_types import (
     BatchProcessingError,
     EmbeddingError,
     EmptyTextError,
+    is_retryable_error,
     wrap_litellm_error,
 )
 
 logger = logging.getLogger(__name__)
+
+# Inline retry budget for ``_embed_batch_uncached``. Reduces user-
+# visible "FAILED → reconciler 30s flip → re-running" latency cycles
+# when a provider returns transient 429 / 5xx / timeout. The
+# orchestrator-level row retry (5 attempts × 30/60/120/240/480s
+# backoff in ``aperag/indexing/orchestrator.py:_finalize_failed``)
+# remains the outer safety net for genuine outages or persistent rate
+# saturation past this small budget.
+_EMBED_INLINE_MAX_ATTEMPTS: int = 3
+_EMBED_INLINE_BASE_DELAY_SECONDS: float = 1.0
 
 
 class EmbeddingService:
@@ -310,6 +323,19 @@ class EmbeddingService:
         """
         Embed a batch of contents using litellm.
 
+        On a retryable provider error (429 RateLimit / TimeoutError /
+        5xx ServerError per :func:`is_retryable_error`), we retry up
+        to :data:`_EMBED_INLINE_MAX_ATTEMPTS` times with exponential
+        backoff (1s, 2s, 4s base) plus jitter, before propagating to
+        the orchestrator's row-level retry path. Inline retries
+        absorb short-lived rate-limit hiccups without burning a
+        ``DocumentIndex`` row's 5-attempt budget + 30s reconciler
+        cycle, which is the user-visible "vector occasionally fails
+        and re-runs" symptom this addresses.
+
+        Non-retryable errors (auth / quota / config / validation)
+        propagate immediately — no point in retrying.
+
         Args:
             batch: Sequence of contents to embed
 
@@ -320,44 +346,72 @@ class EmbeddingService:
             EmbeddingError: If embedding fails
         """
 
-        try:
-            response = litellm.embedding(
-                custom_llm_provider=self.embedding_provider,
-                model=self.model,
-                api_base=self.api_base,
-                api_key=self.api_key,
-                input=list(batch),
-                caching=False,
-                # Pin ``encoding_format="float"`` so LiteLLM does not forward
-                # an OpenAI-default that Alibaba DashScope's
-                # ``compatible-mode/v1/embeddings`` rejects with
-                # ``'encoding_format' only support with [float, base64]``
-                # (observed as ``litellm.BadRequestError`` 400 in task #11
-                # Phase B). ``"float"`` is accepted by every OpenAI-compat
-                # provider we call here and matches the wire shape
-                # ``response["data"][i]["embedding"]`` we already consume.
-                # See task #15.
-                encoding_format="float",
-            )
-
-            if not response or "data" not in response:
-                raise EmbeddingError(
-                    "Invalid response format from embedding API",
-                    {"provider": self.embedding_provider, "model": self.model, "batch_size": len(batch)},
+        last_wrapped: Exception | None = None
+        for attempt in range(1, _EMBED_INLINE_MAX_ATTEMPTS + 1):
+            try:
+                response = litellm.embedding(
+                    custom_llm_provider=self.embedding_provider,
+                    model=self.model,
+                    api_base=self.api_base,
+                    api_key=self.api_key,
+                    input=list(batch),
+                    caching=False,
+                    # Pin ``encoding_format="float"`` so LiteLLM does not forward
+                    # an OpenAI-default that Alibaba DashScope's
+                    # ``compatible-mode/v1/embeddings`` rejects with
+                    # ``'encoding_format' only support with [float, base64]``
+                    # (observed as ``litellm.BadRequestError`` 400 in task #11
+                    # Phase B). ``"float"`` is accepted by every OpenAI-compat
+                    # provider we call here and matches the wire shape
+                    # ``response["data"][i]["embedding"]`` we already consume.
+                    # See task #15.
+                    encoding_format="float",
                 )
 
-            embeddings = [item["embedding"] for item in response["data"]]
+                if not response or "data" not in response:
+                    raise EmbeddingError(
+                        "Invalid response format from embedding API",
+                        {"provider": self.embedding_provider, "model": self.model, "batch_size": len(batch)},
+                    )
 
-            # Validate embedding dimensions
-            if embeddings and len(set(len(emb) for emb in embeddings)) > 1:
-                dimensions = [len(emb) for emb in embeddings]
-                logger.warning(f"Inconsistent embedding dimensions: {set(dimensions)}")
+                embeddings = [item["embedding"] for item in response["data"]]
 
-            return embeddings
-        except Exception as e:
-            logger.error(f"Batch embedding API call failed: {str(e)}")
-            # Convert litellm errors to our custom types
-            raise wrap_litellm_error(e, "embedding", self.embedding_provider, self.model) from e
+                # Validate embedding dimensions
+                if embeddings and len(set(len(emb) for emb in embeddings)) > 1:
+                    dimensions = [len(emb) for emb in embeddings]
+                    logger.warning(f"Inconsistent embedding dimensions: {set(dimensions)}")
+
+                return embeddings
+            except Exception as e:
+                wrapped = wrap_litellm_error(e, "embedding", self.embedding_provider, self.model)
+                last_wrapped = wrapped
+                if attempt < _EMBED_INLINE_MAX_ATTEMPTS and is_retryable_error(wrapped):
+                    delay = _EMBED_INLINE_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+                    delay += random.uniform(0, delay)  # full-jitter on top of exponential base
+                    logger.warning(
+                        "Embedding API retryable error on attempt %s/%s "
+                        "(provider=%s model=%s batch_size=%s err=%s); "
+                        "sleeping %.2fs before retry",
+                        attempt,
+                        _EMBED_INLINE_MAX_ATTEMPTS,
+                        self.embedding_provider,
+                        self.model,
+                        len(batch),
+                        type(wrapped).__name__,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                logger.error(f"Batch embedding API call failed: {str(e)}")
+                raise wrapped from e
+
+        # Exhausted budget on retryable errors — propagate the last
+        # wrapped error so the orchestrator can take its row-level
+        # retry. Unreachable in practice (the loop either returns
+        # embeddings or raises inside the except branch), but kept
+        # for type-checker correctness.
+        assert last_wrapped is not None
+        raise last_wrapped
 
     def _cache_key_for_input(self, text: str) -> dict:
         return {

--- a/tests/unit_test/llm/test_embedding_inline_retry.py
+++ b/tests/unit_test/llm/test_embedding_inline_retry.py
@@ -1,0 +1,174 @@
+# Copyright 2026 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Inline retry regression tests for ``_embed_batch_uncached``.
+
+Pre-fix the embedding service called ``litellm.embedding`` once and
+let any 429 / 5xx / timeout propagate to the orchestrator's row-level
+retry path (5 attempts × 30/60/120/240/480s backoff). On a flaky
+DashScope / OpenRouter rate-limit window this surfaced as the user-
+visible "vector occasionally fails, then auto-retries to running"
+UX (task #8 msg=02508e12).
+
+Fix: short inline retry budget (3 attempts, exponential 1s/2s/4s base
++ jitter) absorbs short-lived hiccups without burning a full row-
+level cycle. Non-retryable errors (auth / quota / config / validation)
+propagate immediately.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from aperag.llm.embed import embedding_service as embedding_module
+from aperag.llm.embed.embedding_service import (
+    _EMBED_INLINE_BASE_DELAY_SECONDS,
+    _EMBED_INLINE_MAX_ATTEMPTS,
+    EmbeddingService,
+)
+from aperag.llm.llm_error_types import (
+    AuthenticationError,
+    RateLimitError,
+)
+
+
+def _fake_litellm_response(batch_size: int, dim: int = 4):
+    return {"data": [{"embedding": [0.0] * dim} for _ in range(batch_size)]}
+
+
+def _build_service() -> EmbeddingService:
+    return EmbeddingService(
+        embedding_provider="alibabacloud",
+        embedding_model="text-embedding-v3",
+        embedding_service_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        embedding_service_api_key="sk-test-not-used",
+        embedding_max_chunks_in_batch=8,
+        caching=False,
+    )
+
+
+class _FakeRateLimit(Exception):
+    """Stand-in for the litellm-side rate-limit error.
+
+    ``wrap_litellm_error`` keys off the exception class name + message
+    keywords. Naming this ``RateLimitError`` is enough for the wrap
+    helper to map it to :class:`aperag.llm.llm_error_types.RateLimitError`,
+    which is what :func:`is_retryable_error` recognises as retryable.
+    """
+
+    def __init__(self, message: str = "rate limit exceeded") -> None:
+        super().__init__(message)
+
+
+# Match the class name the wrap helper detects.
+_FakeRateLimit.__name__ = "RateLimitError"
+
+
+class _FakeAuthError(Exception):
+    """Non-retryable: auth failure (401-style). Must propagate
+    immediately without retry — retrying would just burn quota and
+    the orchestrator's row-level slots."""
+
+    def __init__(self, message: str = "invalid api key") -> None:
+        super().__init__(message)
+
+
+_FakeAuthError.__name__ = "AuthenticationError"
+
+
+def test_embed_batch_uncached_retries_on_rate_limit_then_succeeds(monkeypatch):
+    """First call hits 429; second call returns valid embeddings.
+    The service must absorb the 429 inline and return the batch
+    embeddings on the retry without bubbling to the caller."""
+    service = _build_service()
+    # Don't actually sleep in the test.
+    monkeypatch.setattr(embedding_module.time, "sleep", lambda _delay: None)
+
+    call_count = {"n": 0}
+
+    def fake_embedding(**_kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise _FakeRateLimit()
+        return _fake_litellm_response(batch_size=1)
+
+    with patch.object(embedding_module.litellm, "embedding", side_effect=fake_embedding):
+        result = service._embed_batch_uncached(["hello"])
+
+    assert len(result) == 1
+    assert call_count["n"] == 2, "must have retried exactly once after the 429"
+
+
+def test_embed_batch_uncached_exhausts_budget_and_propagates_rate_limit(monkeypatch):
+    """All attempts hit 429 → after the configured budget the
+    wrapped :class:`RateLimitError` propagates so the orchestrator
+    can still take its row-level retry."""
+    service = _build_service()
+    monkeypatch.setattr(embedding_module.time, "sleep", lambda _delay: None)
+
+    call_count = {"n": 0}
+
+    def fake_embedding(**_kwargs):
+        call_count["n"] += 1
+        raise _FakeRateLimit()
+
+    with patch.object(embedding_module.litellm, "embedding", side_effect=fake_embedding):
+        with pytest.raises(RateLimitError):
+            service._embed_batch_uncached(["hello"])
+
+    assert call_count["n"] == _EMBED_INLINE_MAX_ATTEMPTS, (
+        f"expected exactly {_EMBED_INLINE_MAX_ATTEMPTS} attempts before propagating"
+    )
+
+
+def test_embed_batch_uncached_does_not_retry_non_retryable_errors(monkeypatch):
+    """Auth / quota / config / validation errors are wasted retries —
+    they propagate immediately without consuming the inline budget."""
+    service = _build_service()
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(embedding_module.time, "sleep", lambda delay: sleep_calls.append(delay))
+
+    call_count = {"n": 0}
+
+    def fake_embedding(**_kwargs):
+        call_count["n"] += 1
+        raise _FakeAuthError()
+
+    with patch.object(embedding_module.litellm, "embedding", side_effect=fake_embedding):
+        with pytest.raises(AuthenticationError):
+            service._embed_batch_uncached(["hello"])
+
+    assert call_count["n"] == 1, "non-retryable error must NOT trigger inline retry"
+    assert sleep_calls == [], "no backoff sleep should fire for non-retryable error"
+
+
+def test_embed_batch_uncached_uses_exponential_base_delay(monkeypatch):
+    """Backoff schedule is exponential off ``_EMBED_INLINE_BASE_DELAY_SECONDS``
+    with full-jitter on top. The minimum sleep on attempt N must be
+    ``base * 2^(N-1)`` (jitter only adds, never subtracts)."""
+    service = _build_service()
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(embedding_module.time, "sleep", lambda delay: sleep_calls.append(delay))
+
+    def fake_embedding(**_kwargs):
+        raise _FakeRateLimit()
+
+    with patch.object(embedding_module.litellm, "embedding", side_effect=fake_embedding):
+        with pytest.raises(RateLimitError):
+            service._embed_batch_uncached(["hello"])
+
+    # 3 attempts → 2 sleeps (no sleep after the last failure).
+    assert len(sleep_calls) == _EMBED_INLINE_MAX_ATTEMPTS - 1
+    # Exponential base: attempt 1 retry sleeps at least base, attempt 2 retry
+    # sleeps at least 2*base. Jitter only adds (uniform(0, delay)), so the
+    # minimum is the base; the maximum is 2x the base.
+    base = _EMBED_INLINE_BASE_DELAY_SECONDS
+    assert base <= sleep_calls[0] <= 2 * base
+    assert 2 * base <= sleep_calls[1] <= 4 * base


### PR DESCRIPTION
## Summary

Embedding service called `litellm.embedding` once and let any 429 / 5xx / timeout propagate to the orchestrator's row-level retry (5 attempts × 30/60/120/240/480s backoff in `_finalize_failed` + 30s reconciler cycle). On a flaky DashScope / OpenRouter rate-limit window this surfaced as the user-visible "vector occasionally fails, then auto-retries to running and succeeds" UX reported in task #8 msg=02508e12.

This adds a short **inline retry budget** (3 attempts max, 1s/2s/4s base exponential + full-jitter) inside `_embed_batch_uncached`. Short-lived hiccups are now absorbed without burning a `DocumentIndex` row's outer retry budget.

## Two-layer defense composes

```
inline retry (3×, ~1-7s)              ──absorbs transient hiccups──>
  row-level retry (5×, 30s–8min)      ──absorbs longer outages──>
    operator intervention (manual)
```

## Scope

- `aperag/llm/embed/embedding_service.py` — wraps the litellm call body in a 3-attempt loop. Reuses the existing `is_retryable_error` classifier from `aperag/llm/llm_error_types.py:381` so retry policy stays in sync with orchestrator's decision.
- Non-retryable errors (auth / quota / config / validation) propagate immediately — retrying them just burns provider quota.

## Constants

```python
_EMBED_INLINE_MAX_ATTEMPTS: int = 3
_EMBED_INLINE_BASE_DELAY_SECONDS: float = 1.0
```

## Tests (4 new)

- `test_embed_batch_uncached_retries_on_rate_limit_then_succeeds` — first 429 absorbed, 2nd call returns embeddings ✅
- `test_embed_batch_uncached_exhausts_budget_and_propagates_rate_limit` — all 3 attempts hit 429 → `RateLimitError` propagates ✅
- `test_embed_batch_uncached_does_not_retry_non_retryable_errors` — `AuthenticationError` immediate raise, no inline sleep ✅
- `test_embed_batch_uncached_uses_exponential_base_delay` — verifies sleep[0] ∈ [1s, 2s], sleep[1] ∈ [2s, 4s] ✅

All 4 pass locally + 1 pre-existing test (`test_embed_batch_pins_encoding_format_to_float`) still green (no regression).

## Test plan

- [x] Local 4 tests pass + ruff clean
- [ ] CI lint-and-unit + e2e-http-smoke green
- [ ] Post-merge: deploy + observe rate-limit recovery in production indexing log (fewer FAILED → RUNNING flips)

## Related

- Pairs with PR #1805 (Bryce — graph extractor concurrency) per earayu2 ratify msg=f30570c7 + simplified scope msg=2b5952e1 / PM msg=21dbb656
- Closes task #8 P2 (embedding inline retry)
- task #8 P0 (graph extractor concurrency) covered by PR #1805

🤖 Generated with [Claude Code](https://claude.com/claude-code)