### PR TITLE
feat(agent-chat): render reasoning timeline

### DIFF
--- a/web/src/components/chat/agent-turn-renderer.tsx
+++ b/web/src/components/chat/agent-turn-renderer.tsx
@@ -52,6 +52,7 @@ import {
   type AgentCitationPart,
   type AgentElicitationPart,
   type AgentMessagePart,
+  type AgentReasoningPart,
   type AgentSourceDocumentPart,
   type AgentSourceUrlPart,
   type AgentStreamStatus,
@@ -148,6 +149,7 @@ const STATUS_BADGE_TONE: Record<
 
 function partitionParts(parts: AgentMessagePart[]) {
   const text: AgentTextPart[] = [];
+  const reasoning: AgentReasoningPart[] = [];
   const tool: AgentToolPart[] = [];
   const sourceUrl: AgentSourceUrlPart[] = [];
   const sourceDoc: AgentSourceDocumentPart[] = [];
@@ -156,6 +158,7 @@ function partitionParts(parts: AgentMessagePart[]) {
   const elicitation: AgentElicitationPart[] = [];
   for (const part of parts) {
     if (part.type === 'text') text.push(part);
+    else if (part.type === 'reasoning') reasoning.push(part);
     else if (part.type === 'source-url') sourceUrl.push(part);
     else if (part.type === 'source-document') sourceDoc.push(part);
     else if (part.type === 'data-citation') citation.push(part);
@@ -163,7 +166,16 @@ function partitionParts(parts: AgentMessagePart[]) {
     else if (part.type === 'data-elicitation') elicitation.push(part);
     else if (part.type.startsWith('tool-')) tool.push(part as AgentToolPart);
   }
-  return { text, tool, sourceUrl, sourceDoc, citation, consent, elicitation };
+  return {
+    text,
+    reasoning,
+    tool,
+    sourceUrl,
+    sourceDoc,
+    citation,
+    consent,
+    elicitation,
+  };
 }
 
 function joinTextParts(parts: AgentTextPart[]): string {
@@ -382,6 +394,51 @@ function toolBehaviorDetail(
 function isVisibleToolActivity(part: AgentToolPart): boolean {
   const kind = toolBehaviorKind(part);
   return !(kind === 'generic' && part.state === 'output-available');
+}
+
+// ---------------------------------------------------------------------------
+
+function ReasoningActivityItem({
+  part,
+  ordinal,
+}: {
+  part: AgentReasoningPart;
+  ordinal: number;
+}) {
+  const pageChat = useTranslations('page_chat');
+  const text = part.text.trim();
+  if (!text) return null;
+  const streaming = part.state === 'streaming';
+
+  return (
+    <div className="flex gap-2.5">
+      <div className="flex pt-[3px]">
+        <Sparkles
+          className={cn(
+            'size-3.5 flex-none',
+            streaming ? 'text-primary animate-pulse' : 'text-muted-foreground/70',
+          )}
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 text-[13px] leading-snug">
+          <span className="text-foreground/80 font-medium">
+            {pageChat('activity_stream.reasoning.title', {
+              index: String(ordinal),
+            })}
+          </span>
+          {streaming && (
+            <span className="text-muted-foreground ml-2 text-[12px]">
+              {pageChat('activity_stream.reasoning.streaming')}
+            </span>
+          )}
+        </div>
+        <div className="text-muted-foreground border-border/60 bg-background/70 rounded-md border px-3 py-2 text-[12.5px] leading-relaxed whitespace-pre-wrap">
+          {text}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -629,6 +686,13 @@ export function AgentTurnRenderer({
     Boolean(errorText || turn.error_code || turn.error_message);
   const copyText = answerText || errorText || turn.error_message || '';
   const traceMetaParts: string[] = [];
+  if (grouped.reasoning.length > 0) {
+    traceMetaParts.push(
+      pageChat('activity_stream.meta.thoughts', {
+        count: grouped.reasoning.length,
+      }),
+    );
+  }
   if (visibleToolParts.length > 0) {
     traceMetaParts.push(
       pageChat('activity_stream.meta.steps', {
@@ -644,7 +708,8 @@ export function AgentTurnRenderer({
   const traceMeta = traceMetaParts.join(' · ');
 
   const hasActivity =
-    visibleToolParts.length +
+    grouped.reasoning.length +
+      visibleToolParts.length +
       grouped.consent.length +
       grouped.elicitation.length >
     0;
@@ -708,6 +773,19 @@ export function AgentTurnRenderer({
               {parts.map((part, index) => {
                 if (part.type === 'text') {
                   return null;
+                }
+                if (part.type === 'reasoning') {
+                  const ordinal =
+                    parts
+                      .slice(0, index + 1)
+                      .filter((item) => item.type === 'reasoning').length || 1;
+                  return (
+                    <ReasoningActivityItem
+                      key={`reasoning-${part.id ?? index}`}
+                      part={part}
+                      ordinal={ordinal}
+                    />
+                  );
                 }
                 if (part.type.startsWith('tool-')) {
                   return (

--- a/web/src/features/agent-runtime/index.ts
+++ b/web/src/features/agent-runtime/index.ts
@@ -6,6 +6,7 @@ export type {
   AgentCitationPart,
   AgentElicitationPart,
   AgentMessagePart,
+  AgentReasoningPart,
   AgentSourceDocumentPart,
   AgentSourceUrlPart,
   AgentStreamStatus,

--- a/web/src/features/agent-runtime/reducer.ts
+++ b/web/src/features/agent-runtime/reducer.ts
@@ -34,6 +34,7 @@
 import type {
   ActivityData,
   AgentMessagePart,
+  AgentReasoningPart,
   AgentStreamStatus,
   AgentTextPart,
   AgentToolPart,
@@ -72,12 +73,21 @@ export function applyPart(
       // more parts; status stays streaming.
       return advanceStatus(state, state.status, eventId);
     case 'finish':
-      return advanceStatus(state, 'completed', eventId);
+      return advanceStatus(
+        { ...state, parts: closeReasoning(state.parts, null) },
+        'completed',
+        eventId,
+      );
     case 'abort':
-      return advanceStatus(state, 'aborted', eventId);
+      return advanceStatus(
+        { ...state, parts: closeReasoning(state.parts, null) },
+        'aborted',
+        eventId,
+      );
     case 'error':
       return {
         ...state,
+        parts: closeReasoning(state.parts, null),
         status: 'failed',
         errorText: part.errorText,
         lastSequence: maxSeq(state.lastSequence, eventId),
@@ -107,10 +117,47 @@ export function applyPart(
         lastSequence: maxSeq(state.lastSequence, eventId),
       };
 
+    case 'reasoning':
+      return {
+        ...state,
+        status: state.status === 'idle' ? 'streaming' : state.status,
+        parts: upsertReasoning(
+          state.parts,
+          part.id ?? reasoningIdFromEvent(eventId, state.parts.length),
+          part.text,
+          'done',
+        ),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'reasoning-start':
+      return {
+        ...state,
+        status: state.status === 'idle' ? 'streaming' : state.status,
+        parts: upsertReasoning(state.parts, part.id, '', 'streaming'),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'reasoning-delta':
+      return {
+        ...state,
+        status: state.status === 'idle' ? 'streaming' : state.status,
+        parts: appendReasoningDelta(
+          state.parts,
+          part.id ?? reasoningIdFromEvent(eventId, state.parts.length),
+          part.delta,
+        ),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+    case 'reasoning-end':
+      return {
+        ...state,
+        parts: closeReasoning(state.parts, part.id ?? null),
+        lastSequence: maxSeq(state.lastSequence, eventId),
+      };
+
     case 'tool-input-start':
       return {
         ...state,
-        parts: upsertTool(state.parts, part.toolCallId, {
+        parts: upsertTool(closeReasoning(state.parts, null), part.toolCallId, {
           toolName: part.toolName,
           metadata: part.metadata,
           state: 'input-streaming',
@@ -124,7 +171,7 @@ export function applyPart(
       // streaming…" affordances.
       return {
         ...state,
-        parts: upsertTool(state.parts, part.toolCallId, {
+        parts: upsertTool(closeReasoning(state.parts, null), part.toolCallId, {
           state: 'input-streaming',
         }),
         lastSequence: maxSeq(state.lastSequence, eventId),
@@ -132,7 +179,7 @@ export function applyPart(
     case 'tool-input-available':
       return {
         ...state,
-        parts: upsertTool(state.parts, part.toolCallId, {
+        parts: upsertTool(closeReasoning(state.parts, null), part.toolCallId, {
           toolName: part.toolName,
           input: part.input,
           summary: nullToUndefined(part.summary),
@@ -292,6 +339,65 @@ function closeText(parts: AgentMessagePart[], id: string): AgentMessagePart[] {
   return replaceAt(parts, index, { ...existing, state: 'done' });
 }
 
+// -- reasoning helpers ------------------------------------------------------
+
+function isReasoningPart(
+  part: AgentMessagePart,
+): part is AgentReasoningPart {
+  return part.type === 'reasoning';
+}
+
+function reasoningIdFromEvent(
+  eventId: number | null,
+  partCount: number,
+): string {
+  return `reasoning-${eventId ?? partCount}`;
+}
+
+function upsertReasoning(
+  parts: AgentMessagePart[],
+  id: string,
+  text: string,
+  state: AgentReasoningPart['state'],
+): AgentMessagePart[] {
+  const index = parts.findIndex((p) => isReasoningPart(p) && p.id === id);
+  if (index >= 0) {
+    const existing = parts[index] as AgentReasoningPart;
+    return replaceAt(parts, index, { ...existing, text, state });
+  }
+  return [...parts, { type: 'reasoning', id, text, state }];
+}
+
+function appendReasoningDelta(
+  parts: AgentMessagePart[],
+  id: string,
+  delta: string,
+): AgentMessagePart[] {
+  if (!delta) return parts;
+  const last = parts.at(-1);
+  if (last && isReasoningPart(last) && last.state === 'streaming') {
+    return replaceAt(parts, parts.length - 1, {
+      ...last,
+      text: last.text + delta,
+      state: 'streaming',
+    });
+  }
+  return [...parts, { type: 'reasoning', id, text: delta, state: 'streaming' }];
+}
+
+function closeReasoning(
+  parts: AgentMessagePart[],
+  id: string | null,
+): AgentMessagePart[] {
+  const index =
+    id == null
+      ? parts.findLastIndex((p) => isReasoningPart(p) && p.state === 'streaming')
+      : parts.findIndex((p) => isReasoningPart(p) && p.id === id);
+  if (index < 0) return parts;
+  const existing = parts[index] as AgentReasoningPart;
+  return replaceAt(parts, index, { ...existing, state: 'done' });
+}
+
 // -- tool helpers ---------------------------------------------------------
 
 type ToolPatch = Partial<
@@ -325,6 +431,7 @@ function upsertTool(
       input: patch.input,
       output: patch.output,
       errorText: patch.errorText,
+      summary: patch.summary,
       state: patch.state ?? 'input-streaming',
     };
     return [...parts, created];

--- a/web/src/features/agent-runtime/types.ts
+++ b/web/src/features/agent-runtime/types.ts
@@ -122,6 +122,10 @@ export type StreamPart =
   | { type: 'text-start'; id: string }
   | { type: 'text-delta'; id: string; delta: string }
   | { type: 'text-end'; id: string }
+  | { type: 'reasoning'; id?: string | null; text: string }
+  | { type: 'reasoning-start'; id: string }
+  | { type: 'reasoning-delta'; id?: string | null; delta: string }
+  | { type: 'reasoning-end'; id?: string | null }
   | {
       type: 'tool-input-start';
       toolCallId: string;
@@ -168,6 +172,18 @@ export type AgentTextPart = {
   id: string;
   text: string;
   state: 'streaming' | 'done';
+};
+
+export type AgentReasoningPart = {
+  type: 'reasoning';
+  /**
+   * Reloaded at-rest reasoning parts do not need an id. Live
+   * `reasoning-delta` frames synthesize one so deltas append to the
+   * current thinking block until a tool call closes it.
+   */
+  id?: string;
+  text: string;
+  state?: 'streaming' | 'done';
 };
 
 /**
@@ -234,6 +250,7 @@ export type AgentElicitationPart = {
 
 export type AgentMessagePart =
   | AgentTextPart
+  | AgentReasoningPart
   | AgentToolPart
   | AgentSourceUrlPart
   | AgentSourceDocumentPart

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -370,7 +370,8 @@
       "repeated": "Repeated {count} times while this step stayed active.",
       "meta": {
         "steps": "{count, plural, one {# step} other {# steps}}",
-        "sources": "{count, plural, one {# source} other {# sources}}"
+        "sources": "{count, plural, one {# source} other {# sources}}",
+        "thoughts": "{count, plural, one {# thought} other {# thoughts}}"
       },
       "status": {
         "queued": "Queued",
@@ -490,6 +491,10 @@
         "status": "Status",
         "error_code": "Error code",
         "error_message": "Error message"
+      },
+      "reasoning": {
+        "title": "Thought {index}",
+        "streaming": "thinking…"
       }
     },
     "answer_section": {

--- a/web/src/i18n/en-US/page_chat.json
+++ b/web/src/i18n/en-US/page_chat.json
@@ -2,22 +2,15 @@
   "metadata": {
     "title": "Chats"
   },
-
   "hello_world": "Hi, I'm ApeRAG.",
   "rag_description": "ApeRAG is a production-ready RAG platform that combines graph, vector, and full-text search for hybrid retrieval, knowledge management, and enterprise AI applications.",
-
   "mention_a_collection": "Type @ to mention a collection...",
-
   "display_empty_title": "New chat",
-
   "no_collection_was_found": "No collection was found",
-
   "web_search": "Web search",
   "web_search_is_enabled": "Web search is enabled",
   "web_search_is_disabled": "Web search is disabled",
-
   "references": "References",
-
   "activity_stream": {
     "label": "Agent trace",
     "empty": "Thinking…",
@@ -26,7 +19,8 @@
     "repeated": "Repeated {count} times while this step stayed active.",
     "meta": {
       "steps": "{count, plural, one {# step} other {# steps}}",
-      "sources": "{count, plural, one {# source} other {# sources}}"
+      "sources": "{count, plural, one {# source} other {# sources}}",
+      "thoughts": "{count, plural, one {# thought} other {# thoughts}}"
     },
     "status": {
       "queued": "Queued",
@@ -146,9 +140,12 @@
       "status": "Status",
       "error_code": "Error code",
       "error_message": "Error message"
+    },
+    "reasoning": {
+      "title": "Thought {index}",
+      "streaming": "thinking…"
     }
   },
-
   "answer_section": {
     "failure_details": "Failure details",
     "run_failed": "Run failed",
@@ -162,12 +159,9 @@
     "completed_empty": "This run completed but produced no text content.",
     "pending_empty": "The answer will appear here once the activity stream finishes."
   },
-
   "feedback": {
     "title": "Tell Us What You Think",
-
     "choose_a_category": "Please choose a category for your feedback below.",
-
     "Harmful": {
       "title": "Harmful",
       "description": "Promotes dangerous, violent, or discriminatory acts."
@@ -188,7 +182,6 @@
       "title": "Other",
       "description": "Any issue not covered by the categories above."
     },
-
     "share_your_feedback": "Share your feedback",
     "share_your_feedback_placeholder": "Please provide your feedback so we can continue to enhance your experience."
   }

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -370,7 +370,8 @@
       "repeated": "该步骤保持激活期间重复了 {count} 次。",
       "meta": {
         "steps": "{count} 步",
-        "sources": "{count} 处引用"
+        "sources": "{count} 处引用",
+        "thoughts": "{count} 段思考"
       },
       "status": {
         "queued": "排队中",
@@ -490,6 +491,10 @@
         "status": "状态",
         "error_code": "错误码",
         "error_message": "错误信息"
+      },
+      "reasoning": {
+        "title": "思考 {index}",
+        "streaming": "正在展开…"
       }
     },
     "answer_section": {

--- a/web/src/i18n/zh-CN/page_chat.json
+++ b/web/src/i18n/zh-CN/page_chat.json
@@ -2,22 +2,15 @@
   "metadata": {
     "title": "会话"
   },
-
   "hello_world": "Hi, I'm ApeRAG.",
   "rag_description": "ApeRAG是一个结合图检索、向量搜索和全文搜索技术，提供混合检索、知识管理和企业AI应用解决方案。",
-
   "mention_a_collection": "输入@关联相关知识库...",
-
   "display_empty_title": "新会话",
-
   "no_collection_was_found": "未找到相关知识库",
-
   "web_search": "网络检索",
   "web_search_is_enabled": "网络检索已启用",
   "web_search_is_disabled": "网络检索已禁用",
-
   "references": "参考文献",
-
   "activity_stream": {
     "label": "推理过程",
     "empty": "正在思考…",
@@ -26,7 +19,8 @@
     "repeated": "该步骤保持激活期间重复了 {count} 次。",
     "meta": {
       "steps": "{count} 步",
-      "sources": "{count} 处引用"
+      "sources": "{count} 处引用",
+      "thoughts": "{count} 段思考"
     },
     "status": {
       "queued": "排队中",
@@ -146,9 +140,12 @@
       "status": "状态",
       "error_code": "错误码",
       "error_message": "错误信息"
+    },
+    "reasoning": {
+      "title": "思考 {index}",
+      "streaming": "正在展开…"
     }
   },
-
   "answer_section": {
     "failure_details": "失败详情",
     "run_failed": "运行失败",
@@ -162,12 +159,9 @@
     "completed_empty": "本次运行已完成，但未返回文本内容。",
     "pending_empty": "活动流结束后，回答会显示在这里。"
   },
-
   "feedback": {
     "title": "反馈意见",
-
     "choose_a_category": "请选择反馈类别",
-
     "Harmful": {
       "title": "有害内容",
       "description": "宣扬危险、暴力或歧视性行为"
@@ -188,7 +182,6 @@
       "title": "其他问题",
       "description": "上述类别未涵盖的其他问题"
     },
-
     "share_your_feedback": "分享您的反馈",
     "share_your_feedback_placeholder": "请提供反馈意见，帮助我们持续改进体验"
   }


### PR DESCRIPTION
## Summary

Adds the FE side of the Claude/Cursor-style reasoning timeline for Agent Chat.

- Adds `AgentReasoningPart` and `reasoning` / `reasoning-delta` / `reasoning-end` stream part handling.
- Collapses live reasoning deltas into the current reasoning block, then closes that block when a tool call arrives so the order becomes: thought -> tool -> thought -> tool -> final answer.
- Renders persisted `ReasoningPart` as `思考 N` / `Thought N` blocks in the existing activity stream.
- Keeps final answer text out of the activity timeline; answer still renders in the answer section.

## Relationship to #1804

This is the FE counterpart for PR #1804.

- Reload / at-rest path: once #1804 persists `ReasoningPart`, this PR renders those parts in chronological order.
- Live path: this PR is ready to consume `reasoning-delta` / `reasoning-end` stream parts. #1804 still needs to translate its internal `reasoning.delta` runtime event through `wire/translator.py`; otherwise live reasoning will only appear after reload.

## Validation

- `cd web && yarn i18n:check`
- `cd web && yarn lint --quiet`
- `cd web && yarn type-check --pretty false`
- `git diff --check`
