### PR TITLE
fix(graph): chunked gather in main pass — bound coroutine fan-out

### DIFF
--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -98,6 +98,21 @@ _DEFAULT_EXTRACTOR_LLM_CONCURRENCY = 4
 # picked per huangheng spec msg=80b01696.
 _BOOTSTRAP_CHUNK_COUNT = 20
 
+# Maximum number of chunks dispatched per ``asyncio.gather`` batch
+# in the main pass. Pre-fix the main pass called
+# ``asyncio.gather(*[N coroutines])`` over the entire post-bootstrap
+# remainder, so a 2 395-chunk document scheduled 2 375 simultaneous
+# task objects on the event loop. Even with a Semaphore(4) limiting
+# concurrent execution, the event loop still tracked the 2 375 task
+# references and pumped them through the scheduler — at scale this
+# wedged the BE process during a real user upload (Harry Potter txt,
+# observed 2026-04-28). Bounded gather batches cap the coroutine
+# fan-out per round so memory + scheduler pressure stays flat
+# regardless of document size. 50 was picked per architect ratify
+# msg=cec8b206 — produces ~48 batches for the 2 395-chunk doc and
+# overlaps cleanly with the 4-way semaphore.
+_MAIN_PASS_BATCH_SIZE = 50
+
 
 def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
     """Construct a :class:`GraphExtractor` closure bound to
@@ -148,12 +163,17 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
            types feedback loop where the prompt's allowed-types list
            grows as the document is read.
         2. **Main pass** — run the remaining chunks through
-           ``asyncio.gather`` bounded by an
-           :class:`asyncio.Semaphore` of width
-           :data:`_DEFAULT_EXTRACTOR_LLM_CONCURRENCY`. The active type
-           list is frozen at the bootstrap end-state — by 20 chunks it
-           has typically saturated for the document, and even if a
-           later chunk introduces a brand-new type we accept the small
+           ``asyncio.gather`` in fixed-size batches of
+           :data:`_MAIN_PASS_BATCH_SIZE`, bounded inside each batch
+           by an :class:`asyncio.Semaphore` of width
+           :data:`_DEFAULT_EXTRACTOR_LLM_CONCURRENCY`. The batched
+           form bounds coroutine fan-out per round so a 2 000+ chunk
+           document does not schedule thousands of simultaneous task
+           references onto the event loop (which previously wedged
+           the BE process at ~2 395 chunks). The active type list is
+           frozen at the bootstrap end-state — by 20 chunks it has
+           typically saturated for the document, and even if a later
+           chunk introduces a brand-new type we accept the small
            recall hit in exchange for ~5x wall-clock speedup.
 
         Per-chunk failures are isolated in both passes (log + skip);
@@ -202,7 +222,7 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
                 [entity.entity_type for entity in ents],
             )
 
-        # ---- Pass 2: parallel gather over remaining chunks ----
+        # ---- Pass 2: parallel gather over remaining chunks (chunked) ----
         remaining = chunks[_BOOTSTRAP_CHUNK_COUNT:]
         if not remaining:
             return entities, relations
@@ -241,10 +261,17 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
                     )
                     return ([], [])
 
-        results = await asyncio.gather(*(_bounded_extract(chunk) for chunk in remaining))
-        for ents, rels in results:
-            entities.extend(ents)
-            relations.extend(rels)
+        # Process the remainder in fixed-size gather batches so the
+        # event loop never holds more than ``_MAIN_PASS_BATCH_SIZE``
+        # task references at once. The Semaphore still caps actual
+        # concurrent LLM calls within each batch; the outer batching
+        # is only there to bound coroutine fan-out.
+        for batch_start in range(0, len(remaining), _MAIN_PASS_BATCH_SIZE):
+            batch = remaining[batch_start : batch_start + _MAIN_PASS_BATCH_SIZE]
+            batch_results = await asyncio.gather(*(_bounded_extract(chunk) for chunk in batch))
+            for ents, rels in batch_results:
+                entities.extend(ents)
+                relations.extend(rels)
 
         return entities, relations
 

--- a/tests/integration/test_graph_extractor.py
+++ b/tests/integration/test_graph_extractor.py
@@ -450,6 +450,61 @@ def test_extractor_main_pass_runs_remaining_chunks_in_parallel(monkeypatch: pyte
     asyncio.run(_run())
 
 
+def test_extractor_main_pass_uses_chunked_gather_batches(monkeypatch: pytest.MonkeyPatch):
+    """Pin the bounded coroutine fan-out invariant: the main pass
+    dispatches at most ``_MAIN_PASS_BATCH_SIZE`` coroutines per
+    ``asyncio.gather`` round, regardless of document size. Pre-fix
+    the extractor scheduled all post-bootstrap chunks at once, which
+    wedged the BE process around 2 395 chunks (Harry Potter txt,
+    observed 2026-04-28).
+
+    We instrument ``asyncio.gather`` so we can assert each invocation
+    receives no more than the configured batch size, and that the
+    sum of all dispatched coroutines equals the post-bootstrap
+    remainder.
+    """
+
+    in_flight = {"calls": 0}
+
+    async def _stub_llm(_prompt: str) -> str:
+        in_flight["calls"] += 1
+        return _entity_response("e")
+
+    _stub_integration(monkeypatch, _stub_llm)
+
+    real_gather = asyncio.gather
+    gather_batch_sizes: list[int] = []
+
+    def _instrumented_gather(*coros, **kwargs):
+        gather_batch_sizes.append(len(coros))
+        return real_gather(*coros, **kwargs)
+
+    monkeypatch.setattr(asyncio, "gather", _instrumented_gather)
+
+    async def _run() -> None:
+        extractor = ge.build_collection_graph_extractor(_make_collection())
+        # Pick a count well above the batch size so we get multiple
+        # gather rounds (bootstrap 20 + 130 main = 150 total → 3 main
+        # batches of 50 with the default ``_MAIN_PASS_BATCH_SIZE``).
+        total_chunks = ge._BOOTSTRAP_CHUNK_COUNT + (3 * ge._MAIN_PASS_BATCH_SIZE - 20)
+        chunks = [{"chunk_id": f"c-{i}", "text": f"chunk text {i}"} for i in range(total_chunks)]
+        await extractor(chunks)
+
+    asyncio.run(_run())
+
+    # Every gather invocation must be ≤ the batch size.
+    assert gather_batch_sizes, "main pass must invoke asyncio.gather at least once"
+    for size in gather_batch_sizes:
+        assert 0 < size <= ge._MAIN_PASS_BATCH_SIZE, (
+            f"main pass gather batch size {size} exceeds cap {ge._MAIN_PASS_BATCH_SIZE}"
+        )
+
+    # The sum of all gather coroutines must equal the post-bootstrap
+    # remainder — proves no chunk is dropped or double-dispatched.
+    expected_main_coros = (3 * ge._MAIN_PASS_BATCH_SIZE) - 20  # remainder after bootstrap
+    assert sum(gather_batch_sizes) == expected_main_coros
+
+
 def test_extractor_main_pass_isolates_chunk_failures(monkeypatch: pytest.MonkeyPatch):
     """Per-chunk failures in the parallel pass must not poison sibling
     chunks' entities. Same isolation contract as the original serial


### PR DESCRIPTION
## Summary

Hot-fix follow-up to PR #1805. Architect own-up #24 ([msg=cec8b206]): the main pass's `asyncio.gather(*[N])` over the entire post-bootstrap remainder wedged the BE process at ~2 395 chunks (Harry Potter txt, real user upload 2026-04-28). The `Semaphore(4)` limited concurrent execution but every chunk's coroutine was scheduled on the event loop the moment gather was called — memory + scheduler pressure scaled with chunk count.

## Fix

Wrap the main-pass dispatch in fixed-size batches of `_MAIN_PASS_BATCH_SIZE = 50`. Each batch is its own `asyncio.gather` call; the existing `Semaphore(4)` still caps concurrent LLM calls inside the batch, but the outer loop guarantees the event loop never holds more than 50 task references at once.

## Test plan

- [x] 26/26 `test_graph_extractor.py` tests pass — 1 new regression case patches `asyncio.gather` to assert (a) each invocation ≤ batch size, (b) sum of invocations = post-bootstrap remainder (no chunk dropped or double-dispatched).
- [x] `uvx ruff check` / `format` clean.
- [ ] CI green (lint + e2e-http-smoke + e2e-http-provider).

## Notes

- Wall-clock unchanged at document level — still bounded by `concurrency * per_chunk_seconds * (chunks / concurrency)`.
- Memory + scheduler pressure now flat regardless of document size.
- Bootstrap pass (first 20 chunks serial) unchanged — Wave 11 dynamic-entity-types feedback loop still preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)