### PR TITLE
fix(documents): localize index status + handle null status (no broken cell)

### DIFF
--- a/web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
@@ -4,6 +4,7 @@ import type {
 } from '@/features/document/types';
 import { cn } from '@/lib/utils';
 import _ from 'lodash';
+import { useTranslations } from 'next-intl';
 
 const getIndexStatusBg = (status?: DocumentIndexStatusType | null) => {
   const data: Record<DocumentIndexStatusType, string> = {
@@ -22,12 +23,40 @@ export const DocumentIndexStatus = ({
   document: Document;
   accessorKey: string;
 }) => {
-  const status = _.get(document, accessorKey);
+  const page_documents = useTranslations('page_documents');
+  const status = _.get(document, accessorKey) as
+    | DocumentIndexStatusType
+    | null
+    | undefined;
+  // See workspace mirror (../../../workspace/.../document-index-status.tsx)
+  // for the rationale — null/undefined index_status maps to localized
+  // "not started" so freshly-uploaded PENDING documents don't render
+  // an empty cell next to a gray dot. Explicit switch keeps each
+  // i18n key compile-time verifiable by ``next-intl``.
+  let label: string;
+  switch (status) {
+    case 'ACTIVE':
+      label = page_documents('index_status_active');
+      break;
+    case 'RUNNING':
+      label = page_documents('index_status_running');
+      break;
+    case 'PENDING':
+      label = page_documents('index_status_pending');
+      break;
+    case 'FAILED':
+      label = page_documents('index_status_failed');
+      break;
+    default:
+      label = page_documents('index_status_not_started');
+  }
   const color = getIndexStatusBg(status);
   return (
     <div className="flex flex-row items-center gap-2">
       <div className={cn('size-1.5 rounded-4xl', color)}></div>
-      <div className="text-xs">{_.capitalize(status)}</div>
+      <div className={cn('text-xs', !status && 'text-muted-foreground')}>
+        {label}
+      </div>
     </div>
   );
 };

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
@@ -4,6 +4,7 @@ import type {
 } from '@/features/document/types';
 import { cn } from '@/lib/utils';
 import _ from 'lodash';
+import { useTranslations } from 'next-intl';
 
 const getIndexStatusBg = (status?: DocumentIndexStatusType | null) => {
   const data: Record<DocumentIndexStatusType, string> = {
@@ -22,12 +23,46 @@ export const DocumentIndexStatus = ({
   document: Document;
   accessorKey: string;
 }) => {
-  const status = _.get(document, accessorKey);
+  const page_documents = useTranslations('page_documents');
+  const status = _.get(document, accessorKey) as
+    | DocumentIndexStatusType
+    | null
+    | undefined;
+  // Localized label per status; null/undefined (index row not yet
+  // created — typical for freshly-uploaded PENDING documents whose
+  // indexing pipeline hasn't started) maps to ``not_started`` so the
+  // cell never renders an empty string next to a gray dot (the prior
+  // shape was visually indistinguishable from a broken cell —
+  // earayu2 bug report msg=dbe6f513 task #10).
+  // Explicit map (vs ``\`index_status_${status.toLowerCase()}\``) so
+  // ``next-intl``'s typed-key checker can verify each i18n key at
+  // compile time — a dynamic template would widen to the full
+  // namespace union and require placeholder args for keys it never
+  // resolves to.
+  let label: string;
+  switch (status) {
+    case 'ACTIVE':
+      label = page_documents('index_status_active');
+      break;
+    case 'RUNNING':
+      label = page_documents('index_status_running');
+      break;
+    case 'PENDING':
+      label = page_documents('index_status_pending');
+      break;
+    case 'FAILED':
+      label = page_documents('index_status_failed');
+      break;
+    default:
+      label = page_documents('index_status_not_started');
+  }
   const color = getIndexStatusBg(status);
   return (
     <div className="flex flex-row items-center gap-2">
       <div className={cn('size-1.5 rounded-4xl', color)}></div>
-      <div className="text-xs">{_.capitalize(status)}</div>
+      <div className={cn('text-xs', !status && 'text-muted-foreground')}>
+        {label}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Document table's three index columns (vector / fulltext / graph) rendered just a gray dot with no text next to it for PENDING documents — visually indistinguishable from a broken cell.

Earayu2 reported the bug at task #10 msg=dbe6f513 ([screenshot](attachment in #summary)): the freshly-uploaded `tsla-20250331-gen.pdf` row had `进度=PENDING` and the three index columns showed only "•" while COMPLETE rows showed "• Active".

Two related fixes:

### 1. Null-status handling

The `*_index_status` field is null/undefined for documents whose per-modality index rows haven't been created yet (PENDING, indexing pipeline not started). Pre-fix `_.capitalize(undefined)` returned `''` → empty cell next to a gray dot.

Post-fix: null/undefined explicitly maps to the already-existing `index_status_not_started` i18n key → cell reads "Not started" / "未开始" alongside the dot.

### 2. Localized labels

The cell previously showed `_.capitalize(status)` which surfaced the raw enum (`Active`, `Running`, `Pending`, `Failed`) regardless of locale. The same `page_documents` namespace already had translations for these in both en-US and zh-CN — the cell just wasn't using them.

Post-fix: explicit `switch` over status, calling `page_documents('index_status_active')` etc. The cell renders `Ready` / `已就绪` per locale, matching every other status surface in the app.

### Why explicit `switch` over dynamic template

The natural shorthand:
```typescript
page_documents(`index_status_${status.toLowerCase()}`)
```
triggers TS2554 because next-intl's typed-key checker widens the dynamic template to the full `page_documents` namespace union, which includes keys with placeholder args (e.g. `{count, plural, ...}`) — and those keys require ≥2 args.

Explicit `switch` keeps each i18n key compile-time verifiable.

## Scope

- `web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx` — main change
- `web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx` — mirror

The two files are exact siblings of each other; both updated identically so workspace and marketplace document tables stay consistent.

## Test plan

- [x] `yarn type-check --pretty false` — clean (only pre-existing cosmograph errors remain, unrelated)
- [x] `yarn lint --quiet` — clean
- [x] `yarn i18n:check` — clean (no new keys, just consuming existing translations)
- [ ] CI lint-and-unit + e2e-http-smoke green
- [ ] Post-merge: redeploy + visual verify on document table — PENDING row index columns should read "未开始" / "Not started", COMPLETE rows should read "已就绪" / "Ready"

## Pre-existing TS errors (NOT introduced by this PR)

`yarn type-check` on main reports 4 errors in `cosmograph-semantic-map.tsx` + `cosmograph-topology.tsx` (`@cosmograph/react` type declarations missing). These predate this PR. Per PM msg=baf0ed73 they're tracked separately, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)