### PR TITLE
feat(agent-chat): auto-collapse reasoning when answer starts

### DIFF
--- a/web/src/components/chat/agent-turn-renderer.tsx
+++ b/web/src/components/chat/agent-turn-renderer.tsx
@@ -78,7 +78,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useFormatter, useTranslations } from 'next-intl';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { MessageCollapseContent } from './message-collapse-content';
 import { MessageFeedback } from './message-feedback';
 
@@ -646,6 +646,8 @@ export function AgentTurnRenderer({
 
   const grouped = useMemo(() => partitionParts(parts), [parts]);
   const answerText = useMemo(() => joinTextParts(grouped.text), [grouped.text]);
+  const [activityOpen, setActivityOpen] = useState(true);
+  const autoCollapsedRef = useRef(false);
   const visibleToolParts = useMemo(
     () => grouped.tool.filter(isVisibleToolActivity),
     [grouped.tool],
@@ -714,6 +716,12 @@ export function AgentTurnRenderer({
       grouped.elicitation.length >
     0;
 
+  useEffect(() => {
+    if (autoCollapsedRef.current || !answerText.trim()) return;
+    autoCollapsedRef.current = true;
+    setActivityOpen(false);
+  }, [answerText]);
+
   return (
     <div className="flex w-full flex-row gap-3.5">
       <div>
@@ -739,7 +747,8 @@ export function AgentTurnRenderer({
         )}
 
         <Collapsible
-          defaultOpen
+          open={activityOpen}
+          onOpenChange={setActivityOpen}
           className="group/activity-stream bg-muted border-border/70 overflow-hidden rounded-xl border"
         >
           <CollapsibleTrigger asChild>

--- a/web/src/components/chat/message-part-ai.tsx
+++ b/web/src/components/chat/message-part-ai.tsx
@@ -3,6 +3,7 @@ import { Markdown } from '@/components/markdown';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import _ from 'lodash';
 import { AlertCircleIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { useCallback } from 'react';
 import { MessageCollapseContent } from './message-collapse-content';
 
@@ -13,6 +14,7 @@ export const MessagePartAi = ({
   part: ChatMessage;
   loading: boolean;
 }) => {
+  const pageChat = useTranslations('page_chat');
   const parseToolCall = useCallback(
     (content: string): { title: string; body: string } => {
       const lines = content.split('\n');
@@ -37,7 +39,10 @@ export const MessagePartAi = ({
       );
     case 'thinking':
       return (
-        <MessageCollapseContent title="Thinking" animate={loading}>
+        <MessageCollapseContent
+          title={pageChat('activity_stream.transient.thinking')}
+          animate={loading}
+        >
           <Markdown>{part.data ?? ''}</Markdown>
         </MessageCollapseContent>
       );


### PR DESCRIPTION
## Summary

- make the Agent activity stream controlled instead of always `defaultOpen`
- automatically collapse the reasoning/tool timeline once answer text starts streaming
- only auto-collapse once per rendered turn so users can manually reopen it without fighting the UI

## Validation

- `cd web && yarn lint --quiet`
