### PR TITLE
chore(envs): document NO_PROXY=localhost,127.0.0.1 in env.template

### DIFF
--- a/envs/env.template
+++ b/envs/env.template
@@ -1,3 +1,23 @@
+# IMPORTANT (proxy hygiene): if your shell exports ``HTTP_PROXY`` /
+# ``HTTPS_PROXY`` (e.g. for outbound LLM / web access), you MUST also
+# export ``NO_PROXY`` (and lowercase ``no_proxy``) so localhost-bound
+# requests bypass the proxy. The ``httpx``-based clients ApeRAG uses
+# for Qdrant / Postgres / Redis / Elasticsearch / Object Store all
+# default to ``trust_env=True``; without ``NO_PROXY`` they route
+# ``http://127.0.0.1:6333`` through the proxy and the local proxy
+# (polipo / privoxy / etc.) typically RST's localhost-to-localhost
+# requests, surfacing as ``qdrant_client.http.exceptions.
+# ResponseHandlingException: Server disconnected without sending a
+# response`` and a vector index FAILED row. Recommended setting:
+#
+#   NO_PROXY=localhost,127.0.0.1,::1
+#   no_proxy=localhost,127.0.0.1,::1
+#
+# Uncomment + adjust the next two lines if your machine has shell
+# proxy variables in scope when ``set -a && source .env`` runs.
+# NO_PROXY=localhost,127.0.0.1,::1
+# no_proxy=localhost,127.0.0.1,::1
+
 # MetaDB
 POSTGRES_HOST=127.0.0.1
 POSTGRES_PORT=5432


### PR DESCRIPTION
## Summary

When the host shell exports `HTTP_PROXY` / `HTTPS_PROXY` and `set -a && source .env` brings those into the uvicorn process, every `httpx`-based localhost client ApeRAG uses (Qdrant / Postgres / Redis / Elasticsearch / ObjectStore S3) inherits `trust_env=True` and routes `http://127.0.0.1:*` through the local proxy. Polipo / privoxy RST localhost-to-localhost requests → vector index rows go FAILED with `qdrant_client.http.exceptions.ResponseHandlingException: Server disconnected without sending a response.`.

Caught triaging a real-user vector index FAILED on the local-deploy stack 2026-04-28.

## Change

Add a 20-line header-comment block at the top of `envs/env.template` that explains the failure mode + recommended `NO_PROXY=localhost,127.0.0.1,::1` setting, plus two commented-out lines the operator can uncomment.

`.env.example` is a symlink to `envs/env.template` so the change propagates.

## Test plan

- [x] No code changes — config-only doc PR.
- [x] `bash -c 'set -a && source envs/env.template && set +a && env | grep -i proxy'` shows commented lines do not export anything by default (preserves current behavior; opt-in only).
- [ ] CI green (lint + e2e — should pass unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)