### PR TITLE
feat(agent-runtime): wire user language end-to-end (default Chinese)

### DIFF
--- a/aperag/domains/agent_runtime/runtime.py
+++ b/aperag/domains/agent_runtime/runtime.py
@@ -225,13 +225,41 @@ def _compact_url_label(value: str) -> str:
         return value
 
 
-def _extract_tool_summary(args: Any) -> Optional[str]:
+# Per-language label pair for the tool-call activity subtitle:
+# ``(search_verb, read_verb)``. New ``CreateTurnRequest.language``
+# values must add an entry here. Unknown / missing language falls back
+# to ``_DEFAULT_TOOL_SUMMARY_LABELS`` (Chinese) — earayu2 directive
+# msg=4d8373a4: 默认中文。
+_TOOL_SUMMARY_LABELS: dict[str, tuple[str, str]] = {
+    "zh-CN": ("搜索", "阅读"),
+    "zh-TW": ("搜尋", "閱讀"),
+    "en-US": ("Search", "Read"),
+    "ja-JP": ("検索", "閲覧"),
+    "ko-KR": ("검색", "읽기"),
+    "fr-FR": ("Recherche", "Lecture"),
+    "de-DE": ("Suche", "Lesen"),
+    "es-ES": ("Buscar", "Leer"),
+    "it-IT": ("Cerca", "Leggi"),
+    "pt-BR": ("Buscar", "Ler"),
+    "ru-RU": ("Поиск", "Чтение"),
+}
+_DEFAULT_TOOL_SUMMARY_LABELS: tuple[str, str] = _TOOL_SUMMARY_LABELS["zh-CN"]
+
+
+def _tool_summary_labels(language: Optional[str]) -> tuple[str, str]:
+    if not language:
+        return _DEFAULT_TOOL_SUMMARY_LABELS
+    return _TOOL_SUMMARY_LABELS.get(language, _DEFAULT_TOOL_SUMMARY_LABELS)
+
+
+def _extract_tool_summary(args: Any, language: Optional[str] = None) -> Optional[str]:
     """Project the raw tool input into a small user-facing summary.
 
-    Recognises common tool-input shapes and returns ``"搜索：…"`` /
-    ``"阅读：…"`` style copy. Returns ``None`` when the args don't fit
-    a recognised shape — the FE falls back to its generic per-tool
-    label in that case.
+    Recognises common tool-input shapes and returns a localized
+    ``"<verb>:<value>"`` string (e.g. ``"搜索:张飞牛肉"`` /
+    ``"Search:beekeeping"``) honouring the user's selected language.
+    Returns ``None`` when the args don't fit a recognised shape — the
+    FE falls back to its generic per-tool label in that case.
 
     Bounded to ``_TOOL_SUMMARY_MAX_LEN`` chars so persisted rows stay
     small. Raw args are NEVER persisted in full (D9 §A7) — this
@@ -240,14 +268,15 @@ def _extract_tool_summary(args: Any) -> Optional[str]:
     """
     if not isinstance(args, dict):
         return None
+    search_verb, read_verb = _tool_summary_labels(language)
     for key in ("query", "q", "keyword", "keywords"):
         value = args.get(key)
         if isinstance(value, str) and value.strip():
-            return _truncate_summary(f"搜索:{value.strip()}")
+            return _truncate_summary(f"{search_verb}:{value.strip()}")
     for key in ("url", "uri", "link"):
         value = args.get(key)
         if isinstance(value, str) and value.strip():
-            return _truncate_summary(f"阅读:{_compact_url_label(value.strip())}")
+            return _truncate_summary(f"{read_verb}:{_compact_url_label(value.strip())}")
     return None
 
 
@@ -640,7 +669,10 @@ class PydanticAIRuntime(AgentRuntime):
                             tool_call_id=tool_call_id,
                             tool_name=tool_name,
                             state="input-available",
-                            summary=_extract_tool_summary(self._normalize_jsonish(event.part.args)),
+                            summary=_extract_tool_summary(
+                                self._normalize_jsonish(event.part.args),
+                                language=resolved_request.agent_message.language,
+                            ),
                         )
                         persisted_tool_calls.append(tool_call)
                         persisted_tool_index[tool_call_id] = tool_call

--- a/aperag/domains/agent_runtime/schemas.py
+++ b/aperag/domains/agent_runtime/schemas.py
@@ -162,7 +162,7 @@ class CreateTurnRequest(BaseModel):
             "pt-BR",
             "ru-RU",
         ]
-    ] = "en-US"
+    ] = "zh-CN"
     files: list[File] = Field(default_factory=list)
     client_idempotency_key: Optional[str] = None
 
@@ -222,7 +222,7 @@ class AgentMessage(BaseModel):
             "pt-BR",
             "ru-RU",
         ]
-    ] = Field("en-US", description="Language preference for the response", examples=["en-US"])
+    ] = Field("zh-CN", description="Language preference for the response", examples=["zh-CN"])
     files: Optional[list[File]] = None
 
 

--- a/aperag/domains/conversation/api/openai_routes.py
+++ b/aperag/domains/conversation/api/openai_routes.py
@@ -70,7 +70,7 @@ async def openai_chat_completions_view(
     request: Request,
     bot_id: str | None = Query(default=None, description="Agent bot id that backs this OpenAI-compatible call"),
     chat_id: str | None = Query(default=None, description="Existing chat id. Omit to create an ephemeral chat"),
-    language: str = Query(default="en-US", description="Response language passed through to Agent Runtime"),
+    language: str = Query(default="zh-CN", description="Response language passed through to Agent Runtime"),
     user: AuthenticatedUser = Depends(required_user),
 ):
     """OpenAI-compatible chat completions endpoint backed by Agent Runtime V3."""

--- a/aperag/domains/conversation/service/chat_completion_service.py
+++ b/aperag/domains/conversation/service/chat_completion_service.py
@@ -197,7 +197,7 @@ class ChatCompletionService:
             payload = OpenAIChatCompletionRequest.model_validate(body_data or {})
             bot_id = str(query_params.get("bot_id") or "").strip()
             chat_id = str(query_params.get("chat_id") or "").strip() or None
-            language = str(query_params.get("language") or "en-US").strip() or "en-US"
+            language = str(query_params.get("language") or "zh-CN").strip() or "zh-CN"
             if language not in _SUPPORTED_LANGUAGES:
                 raise ValidationException(f"Unsupported language '{language}'")
             if not bot_id:

--- a/aperag/service/prompt_template_service.py
+++ b/aperag/service/prompt_template_service.py
@@ -32,7 +32,7 @@ You are ApeRAG's research assistant. Use ApeRAG MCP tools to verify information 
 
 ## Stable Rules
 
-- Respond in the user's language.
+- Respond in the language the user explicitly requests for this turn (the per-turn query prompt names the exact language). The default is Simplified Chinese (zh-CN) — never silently switch to English or another language.
 - Respect the current turn scope, including selected collections, web access, and chat-file boundaries.
 - Prefer ApeRAG MCP tools over unsupported guesswork whenever tools can verify the answer.
 - Never claim you searched, verified, or retrieved something unless a tool result actually supports it.
@@ -70,7 +70,32 @@ DEFAULT_AGENT_QUERY_PROMPT = """{% set collection_list = [] %}
 {% endif %}
 {% set web_status = "enabled" if web_search_enabled else "disabled" %}
 {% set chat_context = "Files are available in this chat." if has_chat_files else "No chat files are available." %}
-{% set response_language = language or "the user's language" %}
+{# Map BCP-47 language code → explicit native-language directive so the
+   model can't fall back to its training-default language. Default is
+   Chinese per earayu2 directive (msg=4d8373a4: 默认中文). #}
+{% if language == "en-US" %}
+{% set language_directive = "Please answer in English." %}
+{% elif language == "zh-TW" %}
+{% set language_directive = "請使用繁體中文回答。" %}
+{% elif language == "ja-JP" %}
+{% set language_directive = "日本語で回答してください。" %}
+{% elif language == "ko-KR" %}
+{% set language_directive = "한국어로 답변해 주세요." %}
+{% elif language == "fr-FR" %}
+{% set language_directive = "Veuillez répondre en français." %}
+{% elif language == "de-DE" %}
+{% set language_directive = "Bitte antworten Sie auf Deutsch." %}
+{% elif language == "es-ES" %}
+{% set language_directive = "Por favor, responda en español." %}
+{% elif language == "it-IT" %}
+{% set language_directive = "Si prega di rispondere in italiano." %}
+{% elif language == "pt-BR" %}
+{% set language_directive = "Por favor, responda em português." %}
+{% elif language == "ru-RU" %}
+{% set language_directive = "Пожалуйста, ответьте на русском языке." %}
+{% else %}
+{% set language_directive = "请使用简体中文回答。" %}
+{% endif %}
 
 **User request**: {{ query }}
 
@@ -82,7 +107,7 @@ DEFAULT_AGENT_QUERY_PROMPT = """{% set collection_list = [] %}
 - Chat files: {{ chat_context }}
 
 **Current task requirements**:
-- Answer in {{ response_language }}
+- {{ language_directive }} This is a hard requirement — do not switch languages mid-response.
 - Use only the tools allowed by the scope above
 - If evidence is insufficient, say what is missing
 - If a tool fails, explain the failed step briefly

--- a/tests/unit_test/agent_runtime/test_runtime_persistence.py
+++ b/tests/unit_test/agent_runtime/test_runtime_persistence.py
@@ -108,6 +108,8 @@ def test_compose_assistant_parts_persists_tool_summary():
 
 
 def test_extract_tool_summary_search_query():
+    """Default (no language) must produce Chinese labels — earayu2
+    msg=4d8373a4 directive: 默认中文."""
     assert _extract_tool_summary({"query": "张飞牛肉"}) == "搜索:张飞牛肉"
     assert _extract_tool_summary({"q": "beekeeping"}) == "搜索:beekeeping"
     assert _extract_tool_summary({"keyword": "wave 9"}) == "搜索:wave 9"
@@ -142,6 +144,45 @@ def test_extract_tool_summary_non_dict_returns_none():
     assert _extract_tool_summary(None) is None
     assert _extract_tool_summary("just a string") is None
     assert _extract_tool_summary(["a", "b"]) is None
+
+
+# ---------------------------------------------------------------------
+# Language-aware tool summary (earayu2 msg=4d8373a4 全链路打通)
+# ---------------------------------------------------------------------
+
+
+def test_extract_tool_summary_english_locale_uses_english_labels():
+    """User selects English → tool subtitles must read 'Search:' /
+    'Read:' instead of '搜索:' / '阅读:'. Without this the FE picks
+    up ``ToolPart.summary`` (always Chinese before the fix) and bypasses
+    its own i18n fallback chain."""
+    assert _extract_tool_summary({"query": "beekeeping"}, language="en-US") == "Search:beekeeping"
+    assert _extract_tool_summary({"url": "https://example.com/foo"}, language="en-US") == "Read:example.com/foo"
+
+
+def test_extract_tool_summary_chinese_locale_keeps_native_labels():
+    assert _extract_tool_summary({"query": "张飞牛肉"}, language="zh-CN") == "搜索:张飞牛肉"
+    assert _extract_tool_summary({"query": "蜜蜂"}, language="zh-TW") == "搜尋:蜜蜂"
+
+
+def test_extract_tool_summary_localised_for_known_locales():
+    """Spot-check non-English-non-Chinese locales also localise so the
+    FE i18n contract holds end-to-end."""
+    assert _extract_tool_summary({"query": "ハチミツ"}, language="ja-JP") == "検索:ハチミツ"
+    assert _extract_tool_summary({"query": "꿀벌"}, language="ko-KR") == "검색:꿀벌"
+    assert _extract_tool_summary({"query": "abeille"}, language="fr-FR") == "Recherche:abeille"
+
+
+def test_extract_tool_summary_unknown_locale_falls_back_to_default_chinese():
+    """Unrecognised / future BCP-47 codes must fall back to the
+    documented default (Chinese), not to English. Pins earayu2's
+    "默认中文" requirement (msg=4d8373a4)."""
+    # ``language=None`` is the FE-omitted-the-field path.
+    assert _extract_tool_summary({"query": "x"}, language=None) == "搜索:x"
+    # Unknown explicit code → still default Chinese.
+    assert _extract_tool_summary({"query": "x"}, language="xx-YY") == "搜索:x"
+    # Empty string is treated as "no preference" → default Chinese.
+    assert _extract_tool_summary({"query": "x"}, language="") == "搜索:x"
 
 
 # ---------------------------------------------------------------------

--- a/tests/unit_test/test_prompt_template_service.py
+++ b/tests/unit_test/test_prompt_template_service.py
@@ -83,6 +83,9 @@ def test_build_agent_query_prompt_respects_chat_level_file_override():
 
 
 def test_build_agent_query_prompt_handles_default_scope_and_language_fallback():
+    """When ``language`` is None the prompt must fall back to the
+    documented default — Simplified Chinese — instead of leaving the
+    LLM to guess. Pins earayu2's "默认中文" requirement (msg=4d8373a4)."""
     agent_message = AgentMessage(
         query="Summarize the available sources",
         collections=[],
@@ -101,4 +104,39 @@ def test_build_agent_query_prompt_handles_default_scope_and_language_fallback():
     assert "Collection rule: Discover and select relevant collections automatically." in prompt
     assert "Web search: disabled" in prompt
     assert "Chat files: No chat files are available." in prompt
-    assert "Answer in the user's language" in prompt
+    assert "请使用简体中文回答。" in prompt
+    assert "do not switch languages mid-response" in prompt
+
+
+def test_build_agent_query_prompt_emits_native_language_directive_for_known_locales():
+    """Each supported BCP-47 code injects a *native-language* directive
+    so the model can't fall back to its training-default language. The
+    explicit native-script string is the lever — generic "respond in
+    the user's language" copy does not survive provider hot-paths."""
+    expectations = {
+        "en-US": "Please answer in English.",
+        "zh-CN": "请使用简体中文回答。",
+        "zh-TW": "請使用繁體中文回答。",
+        "ja-JP": "日本語で回答してください。",
+        "ko-KR": "한국어로 답변해 주세요.",
+        "fr-FR": "Veuillez répondre en français.",
+        "de-DE": "Bitte antworten Sie auf Deutsch.",
+        "es-ES": "Por favor, responda en español.",
+        "it-IT": "Si prega di rispondere in italiano.",
+        "pt-BR": "Por favor, responda em português.",
+        "ru-RU": "Пожалуйста, ответьте на русском языке.",
+    }
+    for code, directive in expectations.items():
+        agent_message = AgentMessage(
+            query="dummy",
+            collections=[],
+            web_search_enabled=False,
+            language=code,
+        )
+        prompt = pts.build_agent_query_prompt(
+            chat_id=None,
+            agent_message=agent_message,
+            user="user-1",
+            template=pts.DEFAULT_AGENT_QUERY_PROMPT,
+        )
+        assert directive in prompt, f"language={code} prompt missing expected directive {directive!r}"


### PR DESCRIPTION
## Summary

earayu2 directive (msg=4d8373a4 全链路打通): when the user picks Chinese, every user-facing surface must be Chinese; when they pick English, every surface must be English; when nothing is specified, **default to Simplified Chinese**.

The audit (msg=e1ca330a) found 4 backend break points where language preference was either hardcoded or too vague for the LLM to honour. This PR fixes 3 of them on the BE side; FE break #2 (legacy "Thinking" hardcode) is being amended into PR #1811 by @dongdong.

## Changes

### 1. Tool summary subtitles — was always Chinese (CRITICAL)

`aperag/domains/agent_runtime/runtime.py` — `_extract_tool_summary` previously hardcoded `"搜索:" / "阅读:"` regardless of user language. The FE renderer reads `ToolPart.summary` first (`agent-turn-renderer.tsx:354`), which **bypassed** the FE i18n fallback chain → user picked English but tool subtitles still showed `"搜索:keyword"`.

Now reads from a per-locale label map (zh-CN / zh-TW / en-US / ja-JP / ko-KR / fr-FR / de-DE / es-ES / it-IT / pt-BR / ru-RU). Unknown / missing → Chinese.

### 2. Per-turn query prompt — was too vague

`aperag/service/prompt_template_service.py` — `DEFAULT_AGENT_QUERY_PROMPT` was `"Answer in {language or 'the user's language'}"`. Generic copy doesn't survive provider hot-paths reliably; some models silently fall back to their training-default language.

Now injects a **native-script directive** per locale (`"请使用简体中文回答。"` / `"Please answer in English."` / `"日本語で回答してください。"` etc.) plus an explicit "do not switch languages mid-response" guardrail. Default for None / unknown locale is Chinese.

### 3. System prompt instruction

`APERAG_AGENT_INSTRUCTION` line 35 — replaced `"Respond in the user's language."` with explicit deferral to the per-turn directive plus zh-CN default note. Static text (this template isn't Jinja-rendered today) so the per-turn directive does the heavy lifting.

### 4. Schema defaults flipped to zh-CN

- `aperag/domains/agent_runtime/schemas.py` — `CreateTurnRequest.language` and `AgentMessage.language` defaults
- `aperag/domains/conversation/api/openai_routes.py` — OpenAI-compat `language` query default
- `aperag/domains/conversation/service/chat_completion_service.py` — fallback when query param missing

The FE always sends an explicit locale (next-intl `locale`), so this only matters for direct API callers + OpenAPI contract examples. Two other already-zh-CN defaults (`schema/common.py:222`, `domains/conversation/schemas.py:203`) are left as-is.

## Tests

- 4 new tests on `_extract_tool_summary`: English / Chinese / JP-KR-FR / unknown → Chinese
- 1 new test on the prompt template covering all 11 supported BCP-47 codes (asserts native-script directive present)
- Updated existing `test_build_agent_query_prompt_handles_default_scope_and_language_fallback` to assert the new `"请使用简体中文回答。"` default instead of the old generic phrasing

All 151 tests pass locally (`tests/unit_test/test_prompt_template_service.py` + `tests/unit_test/agent_runtime/`). `uv run ruff check` clean.

## Test plan

- [x] Unit tests cover the language matrix end-to-end
- [ ] Manual on @dongdong's local stack after merge: switch FE locale to en-US, send a search query, confirm tool subtitle shows `"Search: ..."` AND model replies in English. Switch back to zh-CN, confirm `"搜索:..."` AND Chinese reply.

## Out of scope

- **User-level persistent language preference** (DB column on `User` model): this is a design enhancement, not a bug. Today the language lives in next-intl on the FE and is sent per-turn; if user switches device / clears cookie the FE picks the next-intl default. Open a separate task if needed.
- `VisibleAgentState` enum hardcoded English values: not currently consumed by FE (no grep hits), low risk; left as-is to keep this PR focused.
- FE legacy `message-part-ai.tsx` hardcoded `"Thinking"`: amended into @dongdong's PR #1811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)