### PR TITLE
fix(collections): restore create collection action

### DIFF
--- a/web/src/app/workspace/collections/page.tsx
+++ b/web/src/app/workspace/collections/page.tsx
@@ -3,12 +3,15 @@ import {
   PageContent,
   PageHeader,
 } from '@/components/page-container';
+import { Button } from '@/components/ui/button';
 
 import { listCollections } from '@/features/collection/server-api';
 import type { CollectionView } from '@/features/collection/types';
 import { toJson } from '@/lib/utils';
+import { Plus } from 'lucide-react';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import Link from 'next/link';
 import { CollectionList } from './collection-list';
 
 export const dynamic = 'force-dynamic';
@@ -23,6 +26,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page() {
   const page_collections = await getTranslations('page_collections');
+  const page_collection_new = await getTranslations('page_collection_new');
 
   let collections: CollectionView[] = [];
   try {
@@ -42,7 +46,7 @@ export default async function Page() {
         breadcrumbs={[{ title: page_collections('metadata.title') }]}
       />
       <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
-        <div className="mb-9">
+        <div className="mb-9 flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0">
             <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
               {page_collections('workspace_label')}
@@ -54,6 +58,12 @@ export default async function Page() {
               {page_collections('metadata.description')}
             </p>
           </div>
+          <Button asChild className="w-fit shrink-0">
+            <Link href="/workspace/collections/new">
+              <Plus className="size-4" />
+              {page_collection_new('metadata.title')}
+            </Link>
+          </Button>
         </div>
         <CollectionList collections={toJson(collections)} />
       </PageContent>


### PR DESCRIPTION
## Summary
- add a persistent "Add collection" action to the collections page header
- reuse the existing /workspace/collections/new route and localized page_collection_new title

## Validation
- yarn lint --quiet
