### PR TITLE
fix(documents): restore .txt / .md preview after PR #1815 regression

### DIFF
--- a/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { Markdown } from '@/components/markdown';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import type { DocumentPreview } from '@/features/document/types';
@@ -47,6 +48,13 @@ const IMAGE_EXTENSIONS = new Set([
   'tif',
   'tiff',
 ]);
+
+// See workspace mirror for the rationale — .txt / .md / .markdown
+// uploads have their original content surfaced via
+// ``DocumentPreview.markdown_content`` and should still display in
+// the preview pane after PR #1815 hid the parsed-text tab (which was
+// only meant to suppress poor PDF parses).
+const TEXT_PREVIEW_EXTENSIONS = new Set(['txt', 'md', 'markdown']);
 
 const getExtension = (filename?: string | null) =>
   filename?.split('.').pop()?.toLowerCase() ?? '';
@@ -100,6 +108,8 @@ export const DocumentDetail = ({
       : undefined;
   const isPdf = extension === 'pdf';
   const isImage = IMAGE_EXTENSIONS.has(extension);
+  const isTextPreview = TEXT_PREVIEW_EXTENSIONS.has(extension);
+  const markdownContent = documentPreview.markdown_content?.trim();
   const pdfPreviewUrl = isPdf
     ? originalObjectUrl || convertedPdfUrl
     : undefined;
@@ -181,6 +191,12 @@ export const DocumentDetail = ({
               className="border-border/70 bg-background max-h-[75vh] max-w-full rounded-lg border object-contain shadow-sm"
             />
           </div>
+        ) : isTextPreview && markdownContent ? (
+          <Card className="border-border/70 rounded-xl">
+            <CardContent className="p-5 md:p-6">
+              <Markdown>{markdownContent}</Markdown>
+            </CardContent>
+          </Card>
         ) : (
           <Card className="border-border/70 rounded-xl">
             <CardContent className="text-muted-foreground flex min-h-72 flex-col items-center justify-center gap-4 p-8 text-center text-sm">

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { getDocumentStatusColor } from '@/app/workspace/collections/tools';
 import { FormatDate } from '@/components/format-date';
+import { Markdown } from '@/components/markdown';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -22,6 +23,15 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
+
+// Plain-text / markdown extensions whose ``markdown_content`` field on
+// the BE-side ``DocumentPreview`` IS the original file content (the
+// indexing pipeline copies the upload through verbatim — there's no
+// "parse" step to hide). Keep this surface so .txt / .md / .markdown
+// uploads still display in the original-preview pane after PR #1815
+// removed the parsed-text tab (parsed-text was only suppressed for
+// PDFs, where the parsed render quality was poor).
+const TEXT_PREVIEW_EXTENSIONS = new Set(['txt', 'md', 'markdown']);
 
 const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -113,6 +123,8 @@ export const DocumentDetail = ({
 
   const isPdf = extension === 'pdf';
   const isImage = IMAGE_EXTENSIONS.has(extension);
+  const isTextPreview = TEXT_PREVIEW_EXTENSIONS.has(extension);
+  const markdownContent = documentPreview.markdown_content?.trim();
   const pdfPreviewUrl = isPdf
     ? originalObjectUrl || convertedPdfUrl
     : undefined;
@@ -221,6 +233,12 @@ export const DocumentDetail = ({
               className="border-border/70 bg-background max-h-[75vh] max-w-full rounded-lg border object-contain shadow-sm"
             />
           </div>
+        ) : isTextPreview && markdownContent ? (
+          <Card className="border-border/70 py-0 shadow-sm">
+            <CardContent className="p-5">
+              <Markdown>{markdownContent}</Markdown>
+            </CardContent>
+          </Card>
         ) : (
           <Card className="border-border/70 py-0 shadow-sm">
             <CardContent className="text-muted-foreground flex min-h-72 flex-col items-center justify-center gap-4 p-8 text-center text-sm">


### PR DESCRIPTION
## Summary

Regression fix for [PR #1815](https://github.com/apecloud/ApeRAG/pull/1815). That PR removed the parsed-text tab to hide PDF parsed-markdown (per earayu2 msg=153f4b85). It incorrectly also dropped the render path for `.txt` / `.md` / `.markdown` uploads — for those extensions the BE-side `DocumentPreview.markdown_content` IS the original file content (no parse step to hide).

User report: a 117KB `parsed.txt` showed just "该格式暂不支持在线原文预览" + download CTA (earayu2 msg=36aa3c44 / task #10).

## Fix

Add `TEXT_PREVIEW_EXTENSIONS` set (`txt` / `md` / `markdown`) and route those uploads back through the `<Markdown>` render path. PDF preview path stays unchanged — the parsed-text tab stays hidden for PDFs (earayu2's original intent intact). Image preview + download-CTA fallback paths likewise unchanged.

Both `document-detail.tsx` mirrors (workspace + marketplace) updated in lockstep.

## Test plan

- [x] `yarn type-check --pretty false` — clean (only pre-existing cosmograph errors)
- [x] `yarn lint --quiet` — clean
- [ ] CI green
- [ ] Post-merge: visual verify on a `.txt` upload — content displays via Markdown component

🤖 Generated with [Claude Code](https://claude.com/claude-code)