### PR TITLE
fix(mcp): aggregate per-modality DocumentIndex rows for indexing_status

### DIFF
--- a/aperag/mcp/tools/get_document_metadata.py
+++ b/aperag/mcp/tools/get_document_metadata.py
@@ -36,14 +36,13 @@ from aperag.domains.knowledge_base.db.models import (
 from aperag.exceptions import DocumentNotFoundException
 from aperag.indexing.models import (
     DocumentIndex,
-    IndexStatus,
 )
 from aperag.mcp.tools._d9_base import (
     authorization_gate,
     resolve_authenticated_user,
     tenancy_gate,
 )
-from aperag.mcp.tools.list_documents import _DOCUMENT_STATUS_TO_INDEXING
+from aperag.mcp.tools.list_documents import _DOCUMENT_STATUS_TO_INDEXING, _aggregate_index_status
 from aperag.mcp.tools.schemas import DocumentMetadata
 
 
@@ -87,16 +86,16 @@ async def get_document_metadata(
         # ``chunks.jsonl`` artifact when an MCP client actually
         # consumes the field.
         chunk_count = 0
-        idx_stmt = select(DocumentIndex.id).where(
-            DocumentIndex.document_id == document_id,
-            DocumentIndex.status == IndexStatus.ACTIVE.value,
-            DocumentIndex.is_serving.is_(True),
-        )
-        # Run the query so the Wave 3 §F.1 partial-unique invariant
-        # is exercised through this caller path; the result is used
-        # only as a "the document has at least one serving modality"
-        # signal, not for the dropped index_data.
-        _ = (await session.execute(idx_stmt)).scalars().first()
+        # Fetch ALL DocumentIndex rows for this doc so we can compute
+        # the aggregate document-level status truthfully.
+        # ``Document.status`` is a stale ``PENDING`` after confirm
+        # (no writer in the index pipeline) so reading it directly
+        # would always say "pending" even when every modality is
+        # ACTIVE+is_serving. Mirrors the FE aggregation
+        # (document_service.py:105 ``_index_statuses_to_document_status``).
+        idx_stmt = select(DocumentIndex).where(DocumentIndex.document_id == document_id)
+        all_indexes = list((await session.execute(idx_stmt)).scalars().all())
+        overall_status = _aggregate_index_status(all_indexes, fallback=document.status)
         break
 
     media_type, _ = mimetypes.guess_type(document.name or "")
@@ -107,7 +106,7 @@ async def get_document_metadata(
         media_type=media_type or "application/octet-stream",
         size_bytes=int(document.size or 0),
         indexed_chunks_count=chunk_count,
-        indexing_status=_DOCUMENT_STATUS_TO_INDEXING.get(document.status, "pending"),
+        indexing_status=_DOCUMENT_STATUS_TO_INDEXING.get(overall_status, "pending"),
         failure_reason=None,
         created_at=document.gmt_created,
         updated_at=document.gmt_updated,

--- a/aperag/mcp/tools/list_documents.py
+++ b/aperag/mcp/tools/list_documents.py
@@ -63,6 +63,41 @@ _DOCUMENT_STATUS_TO_INDEXING = {
 }
 
 
+def _aggregate_index_status(
+    indexes: list[DocumentIndex],
+    *,
+    fallback: DocumentStatus,
+) -> DocumentStatus:
+    """Aggregate per-modality :class:`DocumentIndex` rows into one
+    document-level status — async-session-friendly twin of
+    :meth:`Document.get_overall_index_status`.
+
+    The ORM helper executes a SELECT inline (sync API), so it cannot
+    be called against the async session used by the MCP tool layer.
+    This function operates on rows the caller has already fetched, so
+    the aggregation logic stays exactly the same as the FE-side
+    ``_index_statuses_to_document_status`` (document_service.py:105) —
+    both surfaces (FE list + MCP list) now report the same thing.
+
+    Why this matters: ``Document.status`` is set to ``PENDING`` at
+    confirm time and never updated by the indexing pipeline (no
+    writer in reconciler / index workers). Reading the raw column
+    surfaces stale "pending" forever. The truth lives in the
+    per-modality ``DocumentIndex`` rows.
+    """
+
+    if not indexes:
+        return fallback
+    statuses = [idx.status for idx in indexes]
+    if any(s == IndexStatus.FAILED.value for s in statuses):
+        return DocumentStatus.FAILED
+    if any(s in (IndexStatus.PENDING.value, IndexStatus.RUNNING.value) for s in statuses):
+        return DocumentStatus.RUNNING
+    if all(idx.status == IndexStatus.ACTIVE.value and idx.is_serving for idx in indexes):
+        return DocumentStatus.COMPLETE
+    return fallback
+
+
 def _media_type_for(name: Optional[str]) -> str:
     if not name:
         return "application/octet-stream"
@@ -162,18 +197,30 @@ async def list_documents(
         # ``chunks.jsonl`` artifact when an MCP client actually
         # consumes the field.
         chunk_counts: dict[str, int] = {}
+        overall_statuses: dict[str, DocumentStatus] = {}
         if documents:
             doc_ids = [d.id for d in documents]
-            # Run a serving-row query so the §F.1 partial-unique
-            # invariant is exercised through this caller path even
-            # though we no longer compose chunk_count from it.
-            idx_stmt = select(DocumentIndex.document_id).where(
-                DocumentIndex.document_id.in_(doc_ids),
-                DocumentIndex.status == IndexStatus.ACTIVE.value,
-                DocumentIndex.is_serving.is_(True),
-            )
-            for doc_id in (await session.execute(idx_stmt)).scalars().all():
-                chunk_counts.setdefault(doc_id, 0)
+            # Fetch ALL DocumentIndex rows for these docs (any status)
+            # so we can aggregate the document-level status truthfully —
+            # ``Document.status`` is a stale ``PENDING`` for everything
+            # past confirm-time (no writer in the index pipeline).
+            all_idx_stmt = select(DocumentIndex).where(DocumentIndex.document_id.in_(doc_ids))
+            indexes_by_doc: dict[str, list[DocumentIndex]] = {}
+            for idx in (await session.execute(all_idx_stmt)).scalars().all():
+                indexes_by_doc.setdefault(idx.document_id, []).append(idx)
+            for d in documents:
+                overall_statuses[d.id] = _aggregate_index_status(
+                    indexes_by_doc.get(d.id, []),
+                    fallback=d.status,
+                )
+                # Preserve the ACTIVE+is_serving signal that the §F.1
+                # partial-unique invariant relies on (caller-path
+                # exercise — chunk_count placeholder until T3.x plumbs
+                # a real chunk count through ``chunks.jsonl``).
+                if any(
+                    idx.status == IndexStatus.ACTIVE.value and idx.is_serving for idx in indexes_by_doc.get(d.id, [])
+                ):
+                    chunk_counts.setdefault(d.id, 0)
         break
 
     items = [
@@ -184,7 +231,7 @@ async def list_documents(
             media_type=_media_type_for(d.name),
             size_bytes=int(d.size or 0),
             indexed_chunks_count=int(chunk_counts.get(d.id, 0)),
-            indexing_status=_DOCUMENT_STATUS_TO_INDEXING.get(d.status, "pending"),
+            indexing_status=_DOCUMENT_STATUS_TO_INDEXING.get(overall_statuses.get(d.id, d.status), "pending"),
             failure_reason=None,
             created_at=d.gmt_created,
             updated_at=d.gmt_updated,

--- a/tests/unit_test/mcp/test_list_documents_status_aggregation.py
+++ b/tests/unit_test/mcp/test_list_documents_status_aggregation.py
@@ -1,0 +1,127 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pin the MCP-side index-status aggregation contract.
+
+Why this test exists: ``Document.status`` is set to ``PENDING`` at
+``confirm_documents`` time and never updated by the indexing
+pipeline (no writer in reconciler / index workers — verified by
+grep). Reading the raw column directly causes
+``list_documents`` / ``get_document_metadata`` to forever report
+``"pending"`` even when every modality is ``ACTIVE+is_serving``.
+
+The FE goes through ``_index_statuses_to_document_status``
+(document_service.py:105) which aggregates the per-modality
+``DocumentIndex`` rows. The MCP tool now does the same via
+``_aggregate_index_status`` so both surfaces (FE list + MCP list +
+agent activity narration) report the same truth.
+
+earayu2 bug report (msg=dec8bcff): UI shows complete, agent says
+"all 8 docs are pending". huangheng grep evidence (msg=ed0db20c).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aperag.domains.knowledge_base.db.models import DocumentStatus
+from aperag.indexing.models import IndexStatus
+from aperag.mcp.tools.list_documents import _aggregate_index_status
+
+
+@dataclass
+class _FakeIndex:
+    """Stand-in for ``DocumentIndex`` ORM rows — only the two fields
+    the aggregator reads, no DB session required."""
+
+    status: str
+    is_serving: bool = False
+
+
+def test_aggregate_returns_complete_when_all_modalities_active_and_serving():
+    """The canonical "knowledge base looks healthy" case — every
+    modality has its serving row in ACTIVE state. The pre-fix code
+    would have returned the stale ``Document.status`` (PENDING)
+    instead, which is what made the agent say "待索引" for fully
+    indexed docs."""
+
+    indexes = [
+        _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True),
+        _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True),
+        _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True),
+    ]
+    assert _aggregate_index_status(indexes, fallback=DocumentStatus.PENDING) is DocumentStatus.COMPLETE
+
+
+def test_aggregate_returns_running_when_any_modality_pending_or_running():
+    indexes_pending = [
+        _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True),
+        _FakeIndex(status=IndexStatus.PENDING.value),
+    ]
+    assert _aggregate_index_status(indexes_pending, fallback=DocumentStatus.COMPLETE) is DocumentStatus.RUNNING
+
+    indexes_running = [
+        _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True),
+        _FakeIndex(status=IndexStatus.RUNNING.value),
+    ]
+    assert _aggregate_index_status(indexes_running, fallback=DocumentStatus.COMPLETE) is DocumentStatus.RUNNING
+
+
+def test_aggregate_returns_failed_when_any_modality_failed():
+    """FAILED dominates all other statuses — surface the failure even
+    if other modalities are healthy, so the user sees something is
+    wrong rather than a silent partial-index state."""
+
+    indexes = [
+        _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True),
+        _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True),
+        _FakeIndex(status=IndexStatus.FAILED.value),
+    ]
+    assert _aggregate_index_status(indexes, fallback=DocumentStatus.COMPLETE) is DocumentStatus.FAILED
+
+
+def test_aggregate_active_but_not_serving_returns_fallback():
+    """The "cutover transit" edge case from
+    ``Document.get_overall_index_status`` — modality is ACTIVE but
+    not yet flipped to ``is_serving=True``. We don't claim COMPLETE
+    yet; we hand back to the caller's fallback (which is
+    ``Document.status`` from the row, typically PENDING)."""
+
+    indexes = [
+        _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=False),
+    ]
+    assert _aggregate_index_status(indexes, fallback=DocumentStatus.PENDING) is DocumentStatus.PENDING
+
+
+def test_aggregate_no_indexes_returns_fallback():
+    """An empty list means no modality was ever scheduled for this
+    document — return the caller's fallback (typically the raw
+    ``Document.status``, which is the most informative thing we have
+    in that scenario)."""
+
+    assert _aggregate_index_status([], fallback=DocumentStatus.UPLOADED) is DocumentStatus.UPLOADED
+    assert _aggregate_index_status([], fallback=DocumentStatus.PENDING) is DocumentStatus.PENDING
+
+
+def test_failed_takes_precedence_over_running():
+    """Pin the priority order: FAILED beats RUNNING beats COMPLETE.
+    Without this ordering, a document with one FAILED modality and
+    one PENDING modality would appear as RUNNING and the user
+    wouldn't know to retry the failed one."""
+
+    indexes = [
+        _FakeIndex(status=IndexStatus.RUNNING.value),
+        _FakeIndex(status=IndexStatus.FAILED.value),
+    ]
+    assert _aggregate_index_status(indexes, fallback=DocumentStatus.PENDING) is DocumentStatus.FAILED


### PR DESCRIPTION
## Summary

Fixes the bug earayu2 reported in agent chat (#AgentChat msg=dec8bcff): the UI shows knowledge-base documents as ✅ complete and indexed, but the agent activity narration says **all 8 documents are 待索引 (pending)** and `parsed_markdown is empty`.

## Root cause (huangheng grep evidence msg=ed0db20c)

`Document.status` raw column is set to `PENDING` at `confirm_documents` time (`document_service.py:1552`) and **never updated by the indexing pipeline**. Grep of every `.status =` writer across the codebase confirms only PENDING / DELETED / EXPIRED writers — no COMPLETE / RUNNING / FAILED writer exists.

The truth lives in per-modality `DocumentIndex` rows. The FE goes through `_index_statuses_to_document_status` (`document_service.py:105`) which aggregates them. MCP's `list_documents.py:187` and `get_document_metadata.py:110` were reading the stale raw column directly, so they forever returned `"pending"` even when every modality is `ACTIVE+is_serving`.

## Fix

New `_aggregate_index_status(indexes, fallback)` helper in `list_documents.py` that mirrors the FE aggregation rules (FAILED > RUNNING > COMPLETE > fallback). It operates on already-fetched rows so it's compatible with the async session used by MCP tools — the existing ORM helper `Document.get_overall_index_status` cannot be plugged in directly because it executes a sync `session.execute(stmt)` call and would raise against the async session.

Both MCP tools now fetch ALL DocumentIndex rows for the doc(s) in their query path and pass them through the helper. `Document.status` is kept as the fallback for the empty-indexes case (no modality was ever scheduled).

## What this does NOT cover

- **Stale `parsed_markdown` path** (dongdong msg=7cce7d9d): `read_document` / `read_document_section` / `read_document_outline` still read from the legacy `{base}/parsed.md`; the new artifact lives at `dirname(DocumentIndex.derived_artifact_path)/markdown.md`. That's a separate fix touching `_parsed_doc.read_parsed_markdown` + 3 callers — keeping it out of this PR to keep the diff focused. If the agent's "parsed_markdown empty" narration doesn't自愈 once status is fixed (huangheng's hypothesis: agent short-circuits on status=pending and stops asking for content), I'll open a follow-up PR.

## Test plan

- [x] 6 new unit tests covering all aggregation branches (`test_list_documents_status_aggregation.py`):
  - all-ACTIVE+serving → COMPLETE
  - any PENDING/RUNNING → RUNNING
  - any FAILED → FAILED (precedence)
  - ACTIVE-but-not-serving (cutover transit) → fallback
  - empty index list → fallback
  - FAILED beats RUNNING (priority order)
- [x] `uv run ruff check` clean
- [ ] Manual verify on @dongdong's local 3002 stack after merge: same chat URL, new turn — agent should now narrate "已索引" / "complete" instead of "待索引" for the 8 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)