### PR TITLE
fix(mcp): resolve parsed_markdown via DocumentIndex.derived_artifact_path (with legacy fallback)

### DIFF
--- a/aperag/mcp/tools/_parsed_doc.py
+++ b/aperag/mcp/tools/_parsed_doc.py
@@ -109,20 +109,55 @@ def resolve_parse_version(document, collection) -> str:
     )
 
 
-async def read_parsed_markdown(document) -> str:
-    """Return the parsed markdown for ``document`` from the object store.
+async def _resolve_serving_markdown_path(document_id: str) -> Optional[str]:
+    """Look up the canonical post-Wave 3 markdown path for a document.
 
-    Returns an empty string when the parsed.md blob is missing — that
-    matches the behavior of ``DocumentService.get_document_preview``
-    (warns + continues with empty content rather than 500ing).
+    The new parser writes the per-parse-version markdown blob at
+    ``{base}/derived/parse_<v>/markdown.md`` and stores the
+    ``derived_artifact_path`` on the per-modality
+    :class:`DocumentIndex` row. The serving VECTOR row is the
+    canonical handle the FE
+    (``DocumentService.get_document_preview``) uses via
+    ``_markdown_path_from_derived_artifact``; we mirror that exactly
+    so MCP and FE return the same content.
+
+    Returns ``None`` when no serving VECTOR index row exists yet —
+    the caller then falls back to the legacy ``{base}/parsed.md``
+    blob (still written by the old writer for backward compat) so
+    documents that haven't migrated to the new derived/ layout still
+    resolve.
     """
+
+    import os
+
+    from sqlalchemy import select
+
+    from aperag.config import get_async_session
+    from aperag.indexing.models import DocumentIndex, Modality
+
+    async for session in get_async_session():
+        stmt = select(DocumentIndex.derived_artifact_path).where(
+            DocumentIndex.document_id == document_id,
+            DocumentIndex.modality == Modality.VECTOR.value,
+            DocumentIndex.is_serving.is_(True),
+        )
+        derived_path = (await session.execute(stmt)).scalars().first()
+        break
+
+    if not derived_path:
+        return None
+    return f"{os.path.dirname(derived_path)}/markdown.md"
+
+
+async def _read_object_store_text(path: str) -> str:
+    """Stream a UTF-8 text blob from the object store. Returns ``""``
+    on miss / read error so callers can fall back gracefully."""
 
     from aperag.objectstore.base import get_async_object_store
 
     async_obj_store = get_async_object_store()
-    markdown_path = f"{document.object_store_base_path()}/parsed.md"
     try:
-        result = await async_obj_store.get(markdown_path)
+        result = await async_obj_store.get(path)
     except Exception:
         return ""
     if not result:
@@ -135,6 +170,39 @@ async def read_parsed_markdown(document) -> str:
         return content.decode("utf-8")
     except UnicodeDecodeError:
         return content.decode("utf-8", errors="replace")
+
+
+async def read_parsed_markdown(document) -> str:
+    """Return the parsed markdown for ``document`` from the object store.
+
+    Resolution order (must match the FE preview path):
+
+    1. Canonical Wave 3+ location:
+       ``dirname(DocumentIndex.derived_artifact_path)/markdown.md``
+       (per-parse-version, written by the new parser, surfaced by
+       ``DocumentService.get_document_preview`` →
+       ``_markdown_path_from_derived_artifact``).
+    2. Legacy fallback: ``{document.object_store_base_path()}/parsed.md``
+       — still produced by the old writer (``document_parser.py:181``
+       dual-writes it), so older docs and the parser's compat path
+       still resolve.
+
+    Returns ``""`` only when both paths are unavailable. Without the
+    derived path lookup, MCP would always fall through to the legacy
+    blob — which doesn't exist for newer collections that bypassed
+    the legacy writer (earayu2 bug msg=dec8bcff: agent saw
+    ``parsed_markdown is empty for all documents`` even though the
+    docs were fully indexed).
+    """
+
+    derived_path = await _resolve_serving_markdown_path(document.id)
+    if derived_path:
+        content = await _read_object_store_text(derived_path)
+        if content:
+            return content
+
+    legacy_path = f"{document.object_store_base_path()}/parsed.md"
+    return await _read_object_store_text(legacy_path)
 
 
 # --- outline derivation ------------------------------------------------------

--- a/tests/unit_test/mcp/test_read_parsed_markdown_derived_path.py
+++ b/tests/unit_test/mcp/test_read_parsed_markdown_derived_path.py
@@ -1,0 +1,165 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pin the MCP markdown-resolution contract.
+
+``read_parsed_markdown`` must read from the canonical Wave 3+
+location (``dirname(DocumentIndex.derived_artifact_path)/markdown.md``)
+*first* and only fall back to the legacy ``{base}/parsed.md`` blob
+when the derived row isn't available.
+
+Without this layered resolution, MCP returns empty markdown for any
+document whose parser bypassed the legacy dual-writer — earayu2 bug
+msg=dec8bcff: "parsed_markdown is empty for all documents" even
+though the docs were fully indexed and visible in the FE preview.
+
+The FE goes through ``DocumentService.get_document_preview`` →
+``_markdown_path_from_derived_artifact`` (document_service.py:120,
+1232). The MCP layer now mirrors that exactly so both surfaces
+return the same content for the same document.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from aperag.mcp.tools import _parsed_doc
+
+
+@dataclass
+class _FakeDocument:
+    """Mirrors :meth:`Document.object_store_base_path` exactly so the
+    fallback path string matches what production would produce.
+    Production uses ``user-{user}/{collection_id}/{id}``."""
+
+    id: str
+    user: str = "1"
+    collection_id: str = "col-1"
+
+    def object_store_base_path(self) -> str:
+        return f"user-{self.user}/{self.collection_id}/{self.id}"
+
+
+@pytest.mark.asyncio
+async def test_read_parsed_markdown_prefers_derived_artifact_path(monkeypatch):
+    """When a serving VECTOR DocumentIndex row exists, the markdown
+    must be read from ``dirname(derived_artifact_path)/markdown.md``
+    — the per-parse-version location the new parser writes to (and
+    the only location post-Wave 3 collections have content at)."""
+
+    derived_path = "user-1/col-1/doc-1/derived/parse_abc123/manifest.json"
+    expected_md_path = "user-1/col-1/doc-1/derived/parse_abc123/markdown.md"
+
+    async def _fake_resolve(document_id):
+        assert document_id == "doc-1"
+        return f"{expected_md_path}"
+
+    reads: list[str] = []
+
+    async def _fake_read(path):
+        reads.append(path)
+        if path == expected_md_path:
+            return "# Hello from derived path"
+        return ""
+
+    monkeypatch.setattr(_parsed_doc, "_resolve_serving_markdown_path", _fake_resolve)
+    monkeypatch.setattr(_parsed_doc, "_read_object_store_text", _fake_read)
+
+    out = await _parsed_doc.read_parsed_markdown(_FakeDocument(id="doc-1"))
+    assert out == "# Hello from derived path"
+    assert reads == [expected_md_path], (
+        "must hit the derived path first, never falling through to legacy when content is found"
+    )
+    assert "/parsed.md" not in derived_path  # sanity: derived path is NOT the legacy path
+
+
+@pytest.mark.asyncio
+async def test_read_parsed_markdown_falls_back_to_legacy_when_no_serving_index(monkeypatch):
+    """Documents created before the derived/ layout, or whose
+    serving-VECTOR row hasn't materialized yet, still resolve via
+    the legacy ``{base}/parsed.md`` writer (document_parser.py:181
+    dual-writes it). Removing the fallback would regress old
+    collections."""
+
+    async def _fake_resolve(document_id):
+        return None  # no serving VECTOR index yet
+
+    reads: list[str] = []
+
+    async def _fake_read(path):
+        reads.append(path)
+        if path == "user-1/col-1/doc-1/parsed.md":
+            return "# Legacy content"
+        return ""
+
+    monkeypatch.setattr(_parsed_doc, "_resolve_serving_markdown_path", _fake_resolve)
+    monkeypatch.setattr(_parsed_doc, "_read_object_store_text", _fake_read)
+
+    out = await _parsed_doc.read_parsed_markdown(_FakeDocument(id="doc-1"))
+    assert out == "# Legacy content"
+    assert reads == ["user-1/col-1/doc-1/parsed.md"], (
+        "with no derived path resolved, must read straight from the legacy location"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_parsed_markdown_falls_back_to_legacy_when_derived_blob_missing(monkeypatch):
+    """A serving row exists but the derived blob itself is
+    missing/unreadable (e.g. object-store transient failure or a
+    half-migrated state). The legacy path is the safety net."""
+
+    derived_md_path = "user-1/col-1/doc-1/derived/parse_abc123/markdown.md"
+    legacy_path = "user-1/col-1/doc-1/parsed.md"
+
+    async def _fake_resolve(document_id):
+        return derived_md_path
+
+    reads: list[str] = []
+
+    async def _fake_read(path):
+        reads.append(path)
+        if path == legacy_path:
+            return "# Legacy content (derived blob 404'd)"
+        return ""  # derived path read fails
+
+    monkeypatch.setattr(_parsed_doc, "_resolve_serving_markdown_path", _fake_resolve)
+    monkeypatch.setattr(_parsed_doc, "_read_object_store_text", _fake_read)
+
+    out = await _parsed_doc.read_parsed_markdown(_FakeDocument(id="doc-1"))
+    assert out == "# Legacy content (derived blob 404'd)"
+    assert reads == [derived_md_path, legacy_path], (
+        "derived must be tried first, then legacy as fallback when derived returns empty"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_parsed_markdown_returns_empty_when_both_paths_miss(monkeypatch):
+    """Neither path has content — return ``""`` so callers (and the
+    LLM-facing API surface) get a deterministic empty string instead
+    of crashing or surfacing a stack trace. Matches the pre-fix
+    contract."""
+
+    async def _fake_resolve(document_id):
+        return "user-1/col-1/doc-1/derived/parse_abc/markdown.md"
+
+    async def _fake_read(path):
+        return ""  # everything is empty
+
+    monkeypatch.setattr(_parsed_doc, "_resolve_serving_markdown_path", _fake_resolve)
+    monkeypatch.setattr(_parsed_doc, "_read_object_store_text", _fake_read)
+
+    out = await _parsed_doc.read_parsed_markdown(_FakeDocument(id="doc-1"))
+    assert out == ""


### PR DESCRIPTION
## Summary

Companion to PR #1819 — fixes the second half of the bug earayu2 reported (msg=dec8bcff): even after status aggregation lands, the agent narration says ``parsed_markdown is empty for all documents`` because `read_parsed_markdown` reads the wrong object-store path.

dongdong root-caused (msg=7cce7d9d): the new parser writes the per-parse-version markdown to ``{base}/derived/parse_<v>/markdown.md`` and stores the location in `DocumentIndex.derived_artifact_path`. The legacy `{base}/parsed.md` blob is dual-written today but newer collections / regenerated docs may bypass it.

## Fix

`read_parsed_markdown` now mirrors the FE preview path exactly (``DocumentService.get_document_preview`` → ``_markdown_path_from_derived_artifact``, document_service.py:120,1232):

1. Resolve `dirname(DocumentIndex.derived_artifact_path)/markdown.md` for the serving VECTOR row → read.
2. Fall back to the legacy `{base}/parsed.md` when no serving row exists OR the derived blob returns empty.
3. Return `""` only when both miss — preserves the existing "warn + continue, never 500" contract.

Signature unchanged; the 3 callers (`read_document` / `read_document_section` / `read_document_outline`) need no edit.

Two private helpers extracted for testability:
- `_resolve_serving_markdown_path(document_id)` — derived path lookup
- `_read_object_store_text(path)` — UTF-8 streaming read with ``""`` on miss

## Test plan

- [x] 4 new unit tests (`test_read_parsed_markdown_derived_path.py`):
  - prefers derived path when serving VECTOR row exists
  - falls back to legacy when no serving VECTOR row
  - falls back to legacy when derived blob returns empty
  - returns ``""`` when both paths miss
- [x] `uv run ruff check` clean
- [ ] Manual on @dongdong's local 3002 stack after merge with #1819: same chat, new turn — agent should narrate real document content (not "parsed_markdown is empty")

## Sequencing

Merge order recommendation: `#1819 → this PR`. They fix independent halves of the same agent-chat narration bug; together they restore end-to-end behavior. dongdong (msg=b96f1f99) plans to redeploy after both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)