### PR TITLE
fix(collection): unbreak Wave 10 §K.13 summary regen Tier 1

### DIFF
--- a/aperag/domains/agent_runtime/services.py
+++ b/aperag/domains/agent_runtime/services.py
@@ -308,21 +308,31 @@ class TurnService:
         self.redis_store = redis_store or AgentRuntimeRedisStore()
         self.uimessage_store = uimessage_store
 
-    async def get_chat_and_bot(self, user: str, chat_id: str):
+    async def get_chat_and_bot(self, user: str, chat_id: str, *, _allow_system_bot: bool = False):
+        # Wave 10 §K.13 — ``_allow_system_bot=True`` is the trusted
+        # internal seam used by ``collection_regen_service`` Stage 1
+        # Tier 1 to drive the per-user hidden ``BotType.SUMMARY`` bot
+        # through the same agent-runtime pipeline. Bypass the
+        # default-deny ``is_system`` filter and accept SUMMARY in
+        # addition to AGENT. User-facing turn endpoints keep the
+        # original guards.
         chat = await self.db_ops.query_chat_by_id(user, chat_id)
         if not chat:
             raise ChatNotFoundException(chat_id)
 
-        bot = await self.db_ops.query_bot(user, chat.bot_id)
+        bot = await self.db_ops.query_bot(user, chat.bot_id, exclude_system=not _allow_system_bot)
         if not bot:
             raise ResourceNotFoundException("Bot", chat.bot_id)
-        if bot.type != BotType.AGENT:
+        allowed_types = {BotType.AGENT, BotType.SUMMARY} if _allow_system_bot else {BotType.AGENT}
+        if bot.type not in allowed_types:
             raise ValidationException("Only agent bots are supported")
 
         return chat, bot
 
-    async def create_or_get_turn(self, user: str, chat_id: str, request: CreateTurnRequest):
-        chat, bot = await self.get_chat_and_bot(user, chat_id)
+    async def create_or_get_turn(
+        self, user: str, chat_id: str, request: CreateTurnRequest, *, _allow_system_bot: bool = False
+    ):
+        chat, bot = await self.get_chat_and_bot(user, chat_id, _allow_system_bot=_allow_system_bot)
         idempotency_key = request.client_idempotency_key or uuid.uuid4().hex
         existing = await self.db_ops.query_agent_turn_by_idempotency(user, chat_id, idempotency_key)
         if existing:

--- a/aperag/domains/conversation/service/chat_service.py
+++ b/aperag/domains/conversation/service/chat_service.py
@@ -131,11 +131,20 @@ class ChatService:
 
         return history
 
-    async def create_chat(self, user: str, bot_id: str) -> Chat:
-        bot = await self.db_ops.query_bot(user, bot_id)
+    async def create_chat(self, user: str, bot_id: str, *, _allow_system_bot: bool = False) -> Chat:
+        # Wave 10 §K.13 — ``_allow_system_bot=True`` is the trusted
+        # internal seam used by ``collection_regen_service`` Stage 1
+        # Tier 1 to create a chat under the per-user hidden
+        # ``BotType.SUMMARY`` bot. Bypass the default-deny ``is_system``
+        # filter and accept SUMMARY in addition to AGENT — both share
+        # the agent-runtime infrastructure (the SUMMARY toolset is
+        # restricted by ``aperag/domains/agent_runtime`` based on
+        # ``bot.type``). User-facing path keeps the original guards.
+        bot = await self.db_ops.query_bot(user, bot_id, exclude_system=not _allow_system_bot)
         if bot is None:
             raise ResourceNotFoundException("Bot", bot_id)
-        if bot.type != BotType.AGENT:
+        allowed_types = {BotType.AGENT, BotType.SUMMARY} if _allow_system_bot else {BotType.AGENT}
+        if bot.type not in allowed_types:
             raise ValidationException("Only agent bots are supported")
 
         chat = await self.db_ops.create_chat(user=user, bot_id=bot_id)

--- a/aperag/domains/knowledge_base/service/collection_regen_service.py
+++ b/aperag/domains/knowledge_base/service/collection_regen_service.py
@@ -278,7 +278,12 @@ async def _invoke_summary_agent(collection: Collection) -> str | None:
         return None
 
     user_id = collection.user
-    chat_view = await chat_service_global.create_chat(user_id, bot.id)
+    # Wave 10 §K.13 — opt into the trusted internal seam on both
+    # ``chat_service`` and ``TurnService``. Without this, the public
+    # APIs reject the SUMMARY bot under the default-deny ``is_system``
+    # filter (PR #1786) + the AGENT-only type guard, surfacing as
+    # ``Bot not found: bot…`` toasts on the FE Regen button.
+    chat_view = await chat_service_global.create_chat(user_id, bot.id, _allow_system_bot=True)
     chat_id = chat_view.id
 
     title = collection.title or collection.id
@@ -292,7 +297,7 @@ async def _invoke_summary_agent(collection: Collection) -> str | None:
     )
 
     chat, bot_orm, turn, _created = await agent_runtime_manager.turn_service.create_or_get_turn(
-        user_id, chat_id, turn_request
+        user_id, chat_id, turn_request, _allow_system_bot=True
     )
 
     lease_owner = await agent_runtime_manager.claim_turn(turn.id)

--- a/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
+++ b/tests/unit_test/agent_runtime/test_agent_runtime_v3.py
@@ -102,7 +102,9 @@ class _FakeCreateTurnDbOps:
     async def query_chat_by_id(self, _user, _chat_id):
         return SimpleNamespace(id="chat-1", bot_id="bot-1")
 
-    async def query_bot(self, _user, _bot_id):
+    async def query_bot(self, _user, _bot_id, *, exclude_system: bool = True):
+        # ``exclude_system`` ignored — the legacy AGENT bot used in this
+        # fixture is non-system and would pass either filter.
         return SimpleNamespace(id="bot-1", type="agent")
 
     async def query_agent_turn_by_idempotency(self, _user, _chat_id, _idempotency_key):

--- a/tests/unit_test/chat/test_chat_service_summary_bot.py
+++ b/tests/unit_test/chat/test_chat_service_summary_bot.py
@@ -1,0 +1,169 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Wave 10 §K.13 regression — ``chat_service.create_chat`` and
+``TurnService.get_chat_and_bot`` must allow the per-user hidden
+``BotType.SUMMARY`` bot through the trusted internal seam used by
+``collection_regen_service`` Stage 1 Tier 1.
+
+Without this flag, the regen flow surfaced as ``Bot not found: bot…``
+404 toasts on the FE Regen button (see issue triaged via
+msg=6e36e981 / msg=3d6024a2): the default-deny ``exclude_system`` filter
+introduced by PR #1786 hid the summary bot from ``query_bot``, and the
+pre-existing AGENT-only type guard rejected SUMMARY even before that
+landed.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.domains.agent_runtime.schemas import CreateTurnRequest
+from aperag.domains.agent_runtime.services import TurnService
+from aperag.domains.conversation.db.models import BotType
+from aperag.domains.conversation.service.chat_service import ChatService
+from aperag.exceptions import ResourceNotFoundException, ValidationException
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+class _FakeBotDbOps:
+    """Mimics ``query_bot``'s ``exclude_system`` semantics: when the flag
+    is True the system bot is hidden (returns None); when False the
+    system bot is returned. ``create_chat`` is a pass-through that
+    captures inputs."""
+
+    def __init__(self, *, bot_type: BotType, is_system: bool):
+        self._bot = SimpleNamespace(
+            id="botsummary123",
+            user="user-1",
+            type=bot_type,
+            status="ACTIVE",
+            is_system=is_system,
+        )
+        self._chat = SimpleNamespace(
+            id="chat-summary-1",
+            title="Test Chat",
+            bot_id="botsummary123",
+            peer_type=None,
+            peer_id=None,
+            gmt_created=_now(),
+            gmt_updated=_now(),
+        )
+        self.create_chat_calls = []
+
+    async def query_bot(self, user, bot_id, *, exclude_system: bool = True):
+        if exclude_system and self._bot.is_system:
+            return None
+        if user != "user-1" or bot_id != self._bot.id:
+            return None
+        return self._bot
+
+    async def create_chat(self, *, user, bot_id, **kwargs):
+        self.create_chat_calls.append((user, bot_id))
+        return self._chat
+
+
+@pytest.mark.asyncio
+async def test_create_chat_default_rejects_summary_bot_with_404():
+    """Default-deny path — user-facing API must keep returning 404."""
+    db_ops = _FakeBotDbOps(bot_type=BotType.SUMMARY, is_system=True)
+    service = ChatService()
+    service.db_ops = db_ops
+
+    with pytest.raises(ResourceNotFoundException):
+        await service.create_chat("user-1", "botsummary123")
+    assert db_ops.create_chat_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_chat_allow_system_accepts_summary_bot():
+    """Trusted internal path — regen Stage 1 Tier 1 must succeed."""
+    db_ops = _FakeBotDbOps(bot_type=BotType.SUMMARY, is_system=True)
+    service = ChatService()
+    service.db_ops = db_ops
+
+    chat = await service.create_chat("user-1", "botsummary123", _allow_system_bot=True)
+    assert chat.id == "chat-summary-1"
+    assert chat.bot_id == "botsummary123"
+    assert db_ops.create_chat_calls == [("user-1", "botsummary123")]
+
+
+@pytest.mark.asyncio
+async def test_create_chat_allow_system_still_rejects_unknown_type():
+    """Even with the trusted flag, only AGENT and SUMMARY pass — a stray
+    KNOWLEDGE/COMMON system bot must still be rejected so the seam is
+    not a generic escape hatch."""
+    db_ops = _FakeBotDbOps(bot_type=BotType.KNOWLEDGE, is_system=True)
+    service = ChatService()
+    service.db_ops = db_ops
+
+    with pytest.raises(ValidationException):
+        await service.create_chat("user-1", "botsummary123", _allow_system_bot=True)
+
+
+class _FakeTurnDbOps(_FakeBotDbOps):
+    async def query_chat_by_id(self, user, chat_id):
+        if user == "user-1" and chat_id == self._chat.id:
+            return self._chat
+        return None
+
+
+@pytest.mark.asyncio
+async def test_get_chat_and_bot_default_rejects_summary_bot_with_404():
+    db_ops = _FakeTurnDbOps(bot_type=BotType.SUMMARY, is_system=True)
+    service = TurnService()
+    service.db_ops = db_ops
+
+    with pytest.raises(ResourceNotFoundException):
+        await service.get_chat_and_bot("user-1", "chat-summary-1")
+
+
+@pytest.mark.asyncio
+async def test_get_chat_and_bot_allow_system_accepts_summary_bot():
+    db_ops = _FakeTurnDbOps(bot_type=BotType.SUMMARY, is_system=True)
+    service = TurnService()
+    service.db_ops = db_ops
+
+    chat, bot = await service.get_chat_and_bot("user-1", "chat-summary-1", _allow_system_bot=True)
+    assert chat.id == "chat-summary-1"
+    assert bot.type == BotType.SUMMARY
+
+
+@pytest.mark.asyncio
+async def test_create_or_get_turn_threads_allow_system_flag_through():
+    """``_invoke_summary_agent`` calls ``create_or_get_turn`` with the
+    flag — make sure the wrapper actually forwards it to
+    ``get_chat_and_bot`` rather than silently dropping the kwarg."""
+    db_ops = _FakeTurnDbOps(bot_type=BotType.SUMMARY, is_system=True)
+    service = TurnService()
+    service.db_ops = db_ops
+
+    captured = {}
+    original = service.get_chat_and_bot
+
+    async def _spy(user, chat_id, *, _allow_system_bot=False):
+        captured["flag"] = _allow_system_bot
+        return await original(user, chat_id, _allow_system_bot=_allow_system_bot)
+
+    service.get_chat_and_bot = _spy  # type: ignore[assignment]
+
+    # We don't care about the rest of the turn-creation path failing
+    # against the fake db — the only assertion that matters is that the
+    # flag was propagated. ``query_agent_turn_by_idempotency`` will be
+    # missing on the fake; catch any AttributeError from there.
+    request = CreateTurnRequest(query="hello", collections=[])
+    try:
+        await service.create_or_get_turn("user-1", "chat-summary-1", request, _allow_system_bot=True)
+    except AttributeError:
+        pass
+
+    assert captured["flag"] is True


### PR DESCRIPTION
## Summary

Fix the ``Bot not found: bot…`` 404 toast on the FE collection settings "重新生成摘要 / 重新生成描述" buttons (reproduced via msg=6e36e981 / msg=3d6024a2 — bot ID confirmed as the user's hidden Summary Generation Bot in DB).

**Root cause** (two compounding gates against the SUMMARY bot, neither one updated by Wave 10):

1. PR #1786 made ``query_bot`` default to ``exclude_system=True``, hiding the per-user hidden ``BotType.SUMMARY`` bot from any caller that did not opt in.
2. ``chat_service.create_chat`` (line 138-139 pre-fix) and ``TurnService.get_chat_and_bot`` (line 319 pre-fix) additionally enforced ``bot.type == BotType.AGENT``, so even with ``exclude_system=False`` the SUMMARY bot would have been rejected with ``ValidationException``.

``collection_regen_service._invoke_summary_agent`` routes through both, so Stage 1 Tier 1 has been raising on every call since Wave 10 launch — Tier 2 fallback **never runs** because the exception propagates up out of ``regen_summary``, and the regen endpoint returns 404 to the FE.

**Fix**: introduce a ``_allow_system_bot=False`` keyword on both methods. When ``True``, ``query_bot`` is called with ``exclude_system=False`` and the type check accepts ``{AGENT, SUMMARY}``. Default ``False`` keeps user-facing endpoints (``POST /api/v2/bots/{bot_id}/chats``, etc.) on the original strict path. ``_invoke_summary_agent`` opts in at both call sites.

The SUMMARY bot is correct to share the agent-runtime pipeline — its toolset is restricted by ``aperag/domains/agent_runtime`` based on ``bot.type``, not by an entirely separate runtime.

## Files

- ``aperag/domains/conversation/service/chat_service.py`` — ``create_chat(_allow_system_bot=False)``
- ``aperag/domains/agent_runtime/services.py`` — ``get_chat_and_bot(_allow_system_bot=False)`` + ``create_or_get_turn(_allow_system_bot=False)`` thread-through
- ``aperag/domains/knowledge_base/service/collection_regen_service.py`` — ``_invoke_summary_agent`` opts in on both call sites
- ``tests/unit_test/chat/test_chat_service_summary_bot.py`` — 6 new tests (default-deny vs trusted-internal × ``create_chat`` / ``get_chat_and_bot`` / ``create_or_get_turn``)
- ``tests/unit_test/agent_runtime/test_agent_runtime_v3.py`` — fake ``query_bot`` accepts ``exclude_system`` kwarg

## Test plan

- [x] ``uv run pytest tests/unit_test/chat tests/unit_test/agent_runtime/test_agent_runtime_v3.py tests/unit_test/knowledge_base/test_collection_regen* tests/unit_test/conversation`` — 61 passed locally
- [x] ``uv run ruff check ./aperag tests/unit_test/`` — clean
- [x] ``uv run ruff format --check`` on touched files — clean
- [ ] manual: click "重新生成摘要" on the dispatched collection in the deploy and confirm the toast no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)