### PR TITLE
fix(mcp): report real indexed chunk counts

### DIFF
--- a/aperag/mcp/tools/get_document_metadata.py
+++ b/aperag/mcp/tools/get_document_metadata.py
@@ -42,7 +42,11 @@ from aperag.mcp.tools._d9_base import (
     resolve_authenticated_user,
     tenancy_gate,
 )
-from aperag.mcp.tools.list_documents import _DOCUMENT_STATUS_TO_INDEXING, _aggregate_index_status
+from aperag.mcp.tools.list_documents import (
+    _DOCUMENT_STATUS_TO_INDEXING,
+    _aggregate_index_status,
+    _count_chunks_from_indexes,
+)
 from aperag.mcp.tools.schemas import DocumentMetadata
 
 
@@ -76,16 +80,6 @@ async def get_document_metadata(
         if not document:
             raise DocumentNotFoundException(document_id)
 
-        # Wave 3 hard-cut: legacy ``DocumentIndex.index_data`` JSON
-        # blob is gone (the new §F.1 schema decomposes that
-        # information across per-modality rows + the ``derived/`` /
-        # backend stores). Chunk count is no longer a per-document
-        # scalar; surface 0 here to keep the
-        # :class:`DocumentMetadata` shape stable. Future T3.x can
-        # plumb a real chunk count through the parser /
-        # ``chunks.jsonl`` artifact when an MCP client actually
-        # consumes the field.
-        chunk_count = 0
         # Fetch ALL DocumentIndex rows for this doc so we can compute
         # the aggregate document-level status truthfully.
         # ``Document.status`` is a stale ``PENDING`` after confirm
@@ -96,6 +90,7 @@ async def get_document_metadata(
         idx_stmt = select(DocumentIndex).where(DocumentIndex.document_id == document_id)
         all_indexes = list((await session.execute(idx_stmt)).scalars().all())
         overall_status = _aggregate_index_status(all_indexes, fallback=document.status)
+        chunk_count = await _count_chunks_from_indexes(all_indexes)
         break
 
     media_type, _ = mimetypes.guess_type(document.name or "")

--- a/aperag/mcp/tools/list_documents.py
+++ b/aperag/mcp/tools/list_documents.py
@@ -43,12 +43,14 @@ from aperag.domains.knowledge_base.db.models import (
 from aperag.indexing.models import (
     DocumentIndex,
     IndexStatus,
+    Modality,
 )
 from aperag.mcp.tools._d9_base import (
     authorization_gate,
     resolve_authenticated_user,
     tenancy_gate,
 )
+from aperag.mcp.tools._parsed_doc import _read_object_store_text
 from aperag.mcp.tools.schemas import DocumentList, DocumentMetadata
 from aperag.service.pagination import decode_offset_cursor, encode_offset_cursor
 
@@ -103,6 +105,34 @@ def _media_type_for(name: Optional[str]) -> str:
         return "application/octet-stream"
     mt, _ = mimetypes.guess_type(name)
     return mt or "application/octet-stream"
+
+
+def _serving_chunks_path(indexes: list[DocumentIndex]) -> str | None:
+    """Return the canonical chunks artifact path for the serving vector index.
+
+    Vector/fulltext/graph sync all consume the parser-produced
+    ``chunks.jsonl`` artifact. For the vector modality, the serving
+    ``DocumentIndex.source_path`` is that chunks path; older transitional
+    rows may also carry it as ``derived_artifact_path``. MCP metadata must
+    surface the real chunk count from this artifact instead of the previous
+    placeholder ``0`` — otherwise agents incorrectly infer that a complete
+    document has no searchable content.
+    """
+
+    for idx in indexes:
+        if idx.modality == Modality.VECTOR.value and idx.status == IndexStatus.ACTIVE.value and idx.is_serving:
+            return idx.source_path or idx.derived_artifact_path
+    return None
+
+
+async def _count_chunks_from_indexes(indexes: list[DocumentIndex]) -> int:
+    chunks_path = _serving_chunks_path(indexes)
+    if not chunks_path:
+        return 0
+    body = await _read_object_store_text(chunks_path)
+    if not body:
+        return 0
+    return sum(1 for line in body.splitlines() if line.strip())
 
 
 _SORT_COLS = {
@@ -188,14 +218,6 @@ async def list_documents(
             page_stmt = select(Document).where(and_(*base_filters)).order_by(sort_clause).offset(offset).limit(limit)
             documents = list((await session.execute(page_stmt)).scalars().all())
 
-        # Wave 3 hard-cut: legacy ``DocumentIndex.index_data`` JSON
-        # blob is gone (the new §F.1 schema decomposes that
-        # information across per-modality rows + the ``derived/`` /
-        # backend stores). Chunk count is no longer a per-document
-        # scalar; surface 0 here to keep the page response shape
-        # stable. Future T3.x can plumb a real chunk count through
-        # ``chunks.jsonl`` artifact when an MCP client actually
-        # consumes the field.
         chunk_counts: dict[str, int] = {}
         overall_statuses: dict[str, DocumentStatus] = {}
         if documents:
@@ -213,14 +235,7 @@ async def list_documents(
                     indexes_by_doc.get(d.id, []),
                     fallback=d.status,
                 )
-                # Preserve the ACTIVE+is_serving signal that the §F.1
-                # partial-unique invariant relies on (caller-path
-                # exercise — chunk_count placeholder until T3.x plumbs
-                # a real chunk count through ``chunks.jsonl``).
-                if any(
-                    idx.status == IndexStatus.ACTIVE.value and idx.is_serving for idx in indexes_by_doc.get(d.id, [])
-                ):
-                    chunk_counts.setdefault(d.id, 0)
+                chunk_counts[d.id] = await _count_chunks_from_indexes(indexes_by_doc.get(d.id, []))
         break
 
     items = [

--- a/tests/unit_test/mcp/test_list_documents_status_aggregation.py
+++ b/tests/unit_test/mcp/test_list_documents_status_aggregation.py
@@ -33,11 +33,16 @@ earayu2 bug report (msg=dec8bcff): UI shows complete, agent says
 
 from __future__ import annotations
 
+import importlib
 from dataclasses import dataclass
 
+import pytest
+
 from aperag.domains.knowledge_base.db.models import DocumentStatus
-from aperag.indexing.models import IndexStatus
-from aperag.mcp.tools.list_documents import _aggregate_index_status
+from aperag.indexing.models import IndexStatus, Modality
+from aperag.mcp.tools.list_documents import _aggregate_index_status, _count_chunks_from_indexes
+
+list_documents_module = importlib.import_module("aperag.mcp.tools.list_documents")
 
 
 @dataclass
@@ -47,6 +52,9 @@ class _FakeIndex:
 
     status: str
     is_serving: bool = False
+    modality: str = Modality.VECTOR.value
+    source_path: str | None = None
+    derived_artifact_path: str | None = None
 
 
 def test_aggregate_returns_complete_when_all_modalities_active_and_serving():
@@ -125,3 +133,45 @@ def test_failed_takes_precedence_over_running():
         _FakeIndex(status=IndexStatus.FAILED.value),
     ]
     assert _aggregate_index_status(indexes, fallback=DocumentStatus.PENDING) is DocumentStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_chunk_count_reads_serving_vector_chunks_jsonl(monkeypatch):
+    """A complete document must not report ``indexed_chunks_count=0`` when
+    its serving vector index points at a real chunks artifact. Agents use
+    this field to decide whether content is available, so a placeholder 0
+    is user-visible misinformation."""
+
+    reads: list[str] = []
+
+    async def _fake_read(path: str) -> str:
+        reads.append(path)
+        return '{"chunk_id":"c1","text":"one"}\n\n{"chunk_id":"c2","text":"two"}\n'
+
+    monkeypatch.setattr(list_documents_module, "_read_object_store_text", _fake_read)
+
+    count = await _count_chunks_from_indexes(
+        [
+            _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True, source_path="derived/parse_1/chunks.jsonl"),
+        ]
+    )
+
+    assert count == 2
+    assert reads == ["derived/parse_1/chunks.jsonl"]
+
+
+@pytest.mark.asyncio
+async def test_chunk_count_ignores_non_serving_or_non_vector_indexes(monkeypatch):
+    async def _fake_read(path: str) -> str:  # pragma: no cover - should not be called
+        raise AssertionError("non-serving/non-vector indexes must not be read")
+
+    monkeypatch.setattr(list_documents_module, "_read_object_store_text", _fake_read)
+
+    count = await _count_chunks_from_indexes(
+        [
+            _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=True, modality=Modality.FULLTEXT.value),
+            _FakeIndex(status=IndexStatus.ACTIVE.value, is_serving=False, source_path="chunks.jsonl"),
+        ]
+    )
+
+    assert count == 0


### PR DESCRIPTION
## Summary
- replace the MCP `indexed_chunks_count=0` placeholder with a real count from the serving vector index `chunks.jsonl`
- apply the same count to `list_documents` and `get_document_metadata`
- add unit coverage for counting serving vector chunks and ignoring non-serving/non-vector rows

## Validation
- `uv run pytest tests/unit_test/mcp/test_list_documents_status_aggregation.py tests/unit_test/test_d10c_read_primitives_surface.py -q`

## Context
Follow-up to #1819/#1820 for earayu2 AgentChat report: status is now `complete`, but Agent still sees `indexed_chunks_count: 0` and treats complete documents as suspicious/empty.
