### PR TITLE
fix(collection): Wave 10 Tier 1 use collection's own LLM (no summary-bot model)

### DIFF
--- a/aperag/domains/knowledge_base/service/collection_regen_service.py
+++ b/aperag/domains/knowledge_base/service/collection_regen_service.py
@@ -273,6 +273,34 @@ async def _invoke_summary_agent(collection: Collection) -> str | None:
     from aperag.domains.conversation.service.chat_service import chat_service_global
     from aperag.domains.knowledge_base.schemas import Collection as CollectionSchema
 
+    # Per @earayu2 directive (msg=107cbfa3): "用 collection 的大语言模型，
+    # 没配就不支持". The summary bot is a hidden runtime owner — it does
+    # not carry its own ``completion`` config. Resolve the model_id from
+    # ``collection.config.completion`` and hand it to the agent runtime
+    # via ``CreateTurnRequest.completion``. If the collection has no
+    # completion model configured, Tier 1 returns ``None`` so the caller
+    # falls through to Tier 2 (which itself reads the same collection
+    # LLM via ``build_collection_llm_callable`` — both tiers share the
+    # invariant "model state is bound to ``collection.config``").
+    from aperag.schema.common import ModelSpec
+    from aperag.schema.utils import parseCollectionConfig
+
+    try:
+        parsed_config = parseCollectionConfig(collection.config)
+    except ValueError:
+        logger.exception(
+            "_invoke_summary_agent: failed to parse collection.config for %s",
+            collection.id,
+        )
+        return None
+    collection_completion = parsed_config.completion if parsed_config else None
+    if collection_completion is None or not collection_completion.model_id:
+        logger.info(
+            "_invoke_summary_agent: collection %s has no completion model — Tier 1 skipped, Tier 2 will run",
+            collection.id,
+        )
+        return None
+
     bot = await get_or_create_summary_bot_for_user(collection.user)
     if bot is None:  # pragma: no cover — get_or_create raises on transient failure
         return None
@@ -294,6 +322,10 @@ async def _invoke_summary_agent(collection: Collection) -> str | None:
     turn_request = CreateTurnRequest(
         query=query,
         collections=[CollectionSchema(id=collection.id, title=title)],
+        completion=ModelSpec(
+            model_id=collection_completion.model_id,
+            temperature=collection_completion.temperature,
+        ),
     )
 
     chat, bot_orm, turn, _created = await agent_runtime_manager.turn_service.create_or_get_turn(

--- a/tests/unit_test/knowledge_base/test_collection_regen_supplementary.py
+++ b/tests/unit_test/knowledge_base/test_collection_regen_supplementary.py
@@ -31,6 +31,7 @@ from aperag.domains.agent_runtime.uimessage import TextPart
 from aperag.domains.knowledge_base.service import collection_regen_service
 from aperag.domains.knowledge_base.service.collection_regen_service import (
     _extract_answer_text,
+    _invoke_summary_agent,
     _pick_substantive_chunk_text,
     regen_description,
     regen_summary,
@@ -334,3 +335,100 @@ async def test_regen_description_succeeds_with_valid_llm_output(monkeypatch: pyt
 
 async def _async_value(value):
     return value
+
+
+# ---------------------------------------------------------------------
+# _invoke_summary_agent — Tier 1 collection.config.completion contract
+# (per @earayu2 directive msg=107cbfa3: use the collection's LLM, not
+# a default on the summary bot)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invoke_summary_agent_returns_none_when_collection_has_no_completion(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Collection with no ``completion.model_id`` → Tier 1 short-circuits
+    without touching the agent runtime. ``regen_summary`` then falls
+    through to Tier 2."""
+    from types import SimpleNamespace
+
+    collection = SimpleNamespace(
+        id="col_no_llm",
+        user="user-1",
+        title="Collection without LLM",
+        config=(
+            '{"source":"system","enable_vector":true,"enable_fulltext":true,'
+            '"enable_knowledge_graph":false,"enable_summary":false,'
+            '"enable_vision":false,"language":"zh-CN"}'
+        ),
+    )
+
+    # If Tier 1 didn't short-circuit, ``get_or_create_summary_bot_for_user``
+    # would be invoked next — fail loudly so the test pins the early
+    # return contract.
+    async def _should_not_be_called(*_a, **_kw):
+        raise AssertionError("Tier 1 must short-circuit before bot/chat creation")
+
+    monkeypatch.setattr(
+        collection_regen_service,
+        "get_or_create_summary_bot_for_user",
+        _should_not_be_called,
+    )
+
+    assert await _invoke_summary_agent(collection) is None
+
+
+@pytest.mark.asyncio
+async def test_invoke_summary_agent_returns_none_when_completion_model_id_blank(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``completion`` block present but ``model_id`` empty → same
+    short-circuit as the missing-completion case."""
+    from types import SimpleNamespace
+
+    collection = SimpleNamespace(
+        id="col_blank_model",
+        user="user-1",
+        title="Collection with blank model_id",
+        config=('{"source":"system","language":"zh-CN","completion":{"model_id":"","temperature":0.1}}'),
+    )
+
+    async def _should_not_be_called(*_a, **_kw):
+        raise AssertionError("Tier 1 must short-circuit before bot/chat creation")
+
+    monkeypatch.setattr(
+        collection_regen_service,
+        "get_or_create_summary_bot_for_user",
+        _should_not_be_called,
+    )
+
+    assert await _invoke_summary_agent(collection) is None
+
+
+@pytest.mark.asyncio
+async def test_invoke_summary_agent_returns_none_on_unparseable_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A corrupt ``collection.config`` string must not propagate as a
+    crash — it must be logged and degraded to ``None`` so Tier 2 can
+    still run."""
+    from types import SimpleNamespace
+
+    collection = SimpleNamespace(
+        id="col_bad_config",
+        user="user-1",
+        title="Collection with corrupt config",
+        config="{not json",
+    )
+
+    async def _should_not_be_called(*_a, **_kw):
+        raise AssertionError("Tier 1 must short-circuit before bot/chat creation")
+
+    monkeypatch.setattr(
+        collection_regen_service,
+        "get_or_create_summary_bot_for_user",
+        _should_not_be_called,
+    )
+
+    assert await _invoke_summary_agent(collection) is None


### PR DESCRIPTION
## Summary

Follow-up to #1822. Per @earayu2 directive (msg=107cbfa3): summary regen Tier 1 should drive the agent runtime with the **collection's** configured completion model — not a default model on the hidden summary bot.

The summary bot's ``config`` is intentionally empty (``{"agent": {"system_prompt_template": null}}``), so after #1822 unblocked the ``Bot not found`` gate, Tier 1 was raising ``ValidationException("Model specification is required for agent runtime v3")`` inside ``_resolve_request``. Tier 2 (chunks fallback) was silently catching every regen request, but the agent-driven path never ran.

## Fix

In ``_invoke_summary_agent``:

1. Parse ``collection.config`` via ``parseCollectionConfig``.
2. Read ``collection.config.completion`` — if missing/blank ``model_id`` or the JSON fails to parse, return ``None`` so Tier 2 fallback runs.
3. Otherwise build ``ModelSpec(model_id=..., temperature=...)`` and forward it on ``CreateTurnRequest.completion``.

This matches the invariant Tier 2 already follows via ``build_collection_llm_callable`` (same source of truth for the collection's LLM). When a collection has no LLM configured at all, both tiers naturally degrade — Tier 1 returns ``None`` early, Tier 2's ``RuntimeError`` is logged, and ``regen_summary`` returns ``False`` (HTTP 503), telling the operator to configure the LLM first. No new error type, no new bot config slot.

## Files

- ``aperag/domains/knowledge_base/service/collection_regen_service.py`` — ``_invoke_summary_agent`` reads ``collection.config.completion`` and forwards as ``ModelSpec``
- ``tests/unit_test/knowledge_base/test_collection_regen_supplementary.py`` — 3 new tests (missing completion, blank model_id, unparseable config)

## Test plan

- [x] ``uv run pytest tests/unit_test/knowledge_base/test_collection_regen_supplementary.py tests/unit_test/chat`` — 34 passed locally
- [x] ``uv run ruff check`` clean
- [x] ``uv run ruff format --check`` on touched files clean
- [ ] dongdong restart 8012 onto this commit → click "重新生成摘要" on a collection with a configured completion model → confirm BE log shows Tier 1 success rather than Tier 2 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)