### PR TITLE
feat(agent-chat): show friendly MCP tool activity

### DIFF
--- a/web/src/components/chat/agent-turn-renderer.tsx
+++ b/web/src/components/chat/agent-turn-renderer.tsx
@@ -72,7 +72,9 @@ import {
   Globe2,
   HandCoins,
   HelpCircle,
+  Library,
   LoaderCircle,
+  Network,
   Search,
   Sparkles,
   XCircle,
@@ -229,8 +231,16 @@ function sourceDocToReference(part: AgentSourceDocumentPart): Reference {
 type ToolBehaviorKind =
   | 'web_search'
   | 'web_read'
+  | 'collection_list'
+  | 'collection_metadata'
+  | 'document_list'
+  | 'document_metadata'
   | 'knowledge_search'
+  | 'graph_lookup'
   | 'document_read'
+  | 'document_outline'
+  | 'document_section'
+  | 'document_chunk'
   | 'generic';
 
 type ToolBehaviorPhase = 'running' | 'done' | 'error';
@@ -248,6 +258,16 @@ function toolDisplayName(part: AgentToolPart): string {
   );
 }
 
+function matchesToolName(name: string, ...tools: string[]): boolean {
+  return tools.some(
+    (tool) =>
+      name === tool ||
+      name.endsWith(`_${tool}`) ||
+      name.endsWith(`-${tool}`) ||
+      name.includes(tool),
+  );
+}
+
 function toolBehaviorKind(part: AgentToolPart): ToolBehaviorKind {
   const name = toolDisplayName(part).toLowerCase();
   if (name.includes('web_search') || name.includes('search_web')) {
@@ -261,13 +281,40 @@ function toolBehaviorKind(part: AgentToolPart): ToolBehaviorKind {
   ) {
     return 'web_read';
   }
-  if (
-    name.includes('read_document') ||
-    name.includes('document_read') ||
-    name.includes('read_section') ||
-    name.includes('read_chunk')
-  ) {
+  if (matchesToolName(name, 'read_document_chunk', 'read_chunk')) {
+    return 'document_chunk';
+  }
+  if (matchesToolName(name, 'read_document_section', 'read_section')) {
+    return 'document_section';
+  }
+  if (matchesToolName(name, 'read_document_outline', 'read_outline')) {
+    return 'document_outline';
+  }
+  if (matchesToolName(name, 'read_document', 'document_read')) {
     return 'document_read';
+  }
+  if (matchesToolName(name, 'get_document_metadata')) {
+    return 'document_metadata';
+  }
+  if (matchesToolName(name, 'list_documents')) {
+    return 'document_list';
+  }
+  if (matchesToolName(name, 'get_collection_metadata')) {
+    return 'collection_metadata';
+  }
+  if (matchesToolName(name, 'list_collections')) {
+    return 'collection_list';
+  }
+  if (
+    matchesToolName(
+      name,
+      'graph_search',
+      'query_graph_entities',
+      'expand_graph_subgraph',
+      'get_entity_detail',
+    )
+  ) {
+    return 'graph_lookup';
   }
   if (
     name.includes('knowledge') ||
@@ -296,10 +343,20 @@ function toolBehaviorIcon(kind: ToolBehaviorKind, phase: ToolBehaviorPhase) {
     case 'web_search':
     case 'knowledge_search':
       return Search;
+    case 'graph_lookup':
+      return Network;
     case 'web_read':
       return Globe2;
     case 'document_read':
+    case 'document_outline':
+    case 'document_section':
+    case 'document_chunk':
+    case 'document_metadata':
+    case 'document_list':
       return BookOpen;
+    case 'collection_list':
+    case 'collection_metadata':
+      return Library;
     default:
       return Sparkles;
   }
@@ -326,6 +383,12 @@ function extractStringField(
     const candidate = record[key];
     if (typeof candidate === 'string' && candidate.trim()) {
       return candidate.trim();
+    }
+    if (Array.isArray(candidate)) {
+      const first = candidate.find(
+        (item): item is string => typeof item === 'string' && !!item.trim(),
+      );
+      if (first) return first.trim();
     }
   }
   if (depth <= 0) return undefined;
@@ -360,6 +423,76 @@ function toolBehaviorDetail(
     extractStringField(part.metadata, ['query', 'q', 'keyword', 'keywords']) ||
     extractStringField(part.input, ['query', 'q', 'keyword', 'keywords']) ||
     extractStringField(part.output, ['query', 'q', 'keyword', 'keywords']);
+  const document =
+    extractStringField(part.metadata, [
+      'document_title',
+      'document_name',
+      'filename',
+      'file_name',
+      'title',
+      'name',
+    ]) ||
+    extractStringField(part.input, [
+      'document_title',
+      'document_name',
+      'filename',
+      'file_name',
+      'title',
+      'name',
+    ]) ||
+    extractStringField(part.output, [
+      'document_title',
+      'document_name',
+      'filename',
+      'file_name',
+      'title',
+      'name',
+    ]);
+  const collection =
+    extractStringField(part.metadata, ['collection_title', 'collection_name']) ||
+    extractStringField(part.input, ['collection_title', 'collection_name']) ||
+    extractStringField(part.output, ['collection_title', 'collection_name']);
+  const section =
+    extractStringField(part.metadata, ['section_path', 'heading_anchor']) ||
+    extractStringField(part.input, ['section_path', 'heading_anchor']) ||
+    extractStringField(part.output, ['section_path', 'heading_anchor']);
+  const chunk =
+    extractStringField(part.metadata, ['chunk_id']) ||
+    extractStringField(part.input, ['chunk_id']) ||
+    extractStringField(part.output, ['chunk_id']);
+  const entity =
+    extractStringField(part.metadata, ['entity_name', 'entity_names']) ||
+    extractStringField(part.input, ['entity_name', 'entity_names']) ||
+    extractStringField(part.output, ['entity_name', 'entity_names']);
+
+  if (kind === 'document_section' && section) {
+    return pageChat('activity_stream.tool.detail.document_section_ref', {
+      section,
+    });
+  }
+  if (
+    (kind === 'document_read' ||
+      kind === 'document_outline' ||
+      kind === 'document_metadata') &&
+    document
+  ) {
+    return pageChat('activity_stream.tool.detail.document', { document });
+  }
+  if (
+    (kind === 'collection_list' ||
+      kind === 'collection_metadata' ||
+      kind === 'document_list') &&
+    collection
+  ) {
+    return pageChat('activity_stream.tool.detail.collection', { collection });
+  }
+  if (kind === 'graph_lookup' && entity) {
+    return pageChat('activity_stream.tool.detail.graph_entity', { entity });
+  }
+  if (kind === 'graph_lookup' && query) {
+    return pageChat('activity_stream.tool.detail.graph_query', { query });
+  }
+
   if (query) {
     return pageChat('activity_stream.tool.detail.search_query', { query });
   }

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -404,15 +404,55 @@
             "done": "Read the web page",
             "error": "Web page read did not complete"
           },
+          "collection_list": {
+            "running": "Checking available knowledge bases",
+            "done": "Checked available knowledge bases",
+            "error": "Knowledge base check did not complete"
+          },
+          "collection_metadata": {
+            "running": "Checking knowledge base details",
+            "done": "Checked knowledge base details",
+            "error": "Knowledge base details were not available"
+          },
+          "document_list": {
+            "running": "Checking documents in the knowledge base",
+            "done": "Checked documents in the knowledge base",
+            "error": "Document list was not available"
+          },
+          "document_metadata": {
+            "running": "Checking document details",
+            "done": "Checked document details",
+            "error": "Document details were not available"
+          },
           "knowledge_search": {
             "running": "Searching the knowledge base",
             "done": "Found relevant knowledge",
             "error": "Knowledge search did not complete"
           },
+          "graph_lookup": {
+            "running": "Reading the knowledge graph",
+            "done": "Read the knowledge graph",
+            "error": "Knowledge graph lookup did not complete"
+          },
           "document_read": {
             "running": "Reading source material",
             "done": "Read the source material",
             "error": "Source reading did not complete"
+          },
+          "document_outline": {
+            "running": "Checking the document outline",
+            "done": "Checked the document outline",
+            "error": "Document outline was not available"
+          },
+          "document_section": {
+            "running": "Reading a document section",
+            "done": "Read a document section",
+            "error": "Document section was not available"
+          },
+          "document_chunk": {
+            "running": "Reading a document passage",
+            "done": "Read a document passage",
+            "error": "Document passage was not available"
           },
           "generic": {
             "running": "Working through one step",
@@ -424,10 +464,24 @@
           "search_query": "Search: {query}",
           "source_title": "Source: {title}",
           "web_url": "Reading: {url}",
+          "collection": "Knowledge base: {collection}",
+          "document": "Document: {document}",
+          "document_section_ref": "Section: {section}",
+          "document_chunk_ref": "Passage: {chunk}",
+          "graph_query": "Graph query: {query}",
+          "graph_entity": "Entity: {entity}",
           "web_search": "Looking for useful information on the web",
           "web_read": "Opening and reading a relevant page",
           "knowledge_search": "Filtering relevant content from the knowledge base",
+          "collection_list": "Checking which knowledge bases are available",
+          "collection_metadata": "Checking knowledge base settings and metadata",
+          "document_list": "Checking which documents are available",
+          "document_metadata": "Checking document status and metadata",
+          "graph_lookup": "Inspecting entities and relations in the knowledge graph",
           "document_read": "Extracting key points from existing documents",
+          "document_outline": "Reading the document structure",
+          "document_section": "Reading a specific section",
+          "document_chunk": "Reading a specific passage",
           "generic": "Organizing intermediate information",
           "done": "Used the result in the answer",
           "error": "This step failed; continuing with available information"

--- a/web/src/i18n/en-US/page_chat.json
+++ b/web/src/i18n/en-US/page_chat.json
@@ -53,15 +53,55 @@
           "done": "Read the web page",
           "error": "Web page read did not complete"
         },
+        "collection_list": {
+          "running": "Checking available knowledge bases",
+          "done": "Checked available knowledge bases",
+          "error": "Knowledge base check did not complete"
+        },
+        "collection_metadata": {
+          "running": "Checking knowledge base details",
+          "done": "Checked knowledge base details",
+          "error": "Knowledge base details were not available"
+        },
+        "document_list": {
+          "running": "Checking documents in the knowledge base",
+          "done": "Checked documents in the knowledge base",
+          "error": "Document list was not available"
+        },
+        "document_metadata": {
+          "running": "Checking document details",
+          "done": "Checked document details",
+          "error": "Document details were not available"
+        },
         "knowledge_search": {
           "running": "Searching the knowledge base",
           "done": "Found relevant knowledge",
           "error": "Knowledge search did not complete"
         },
+        "graph_lookup": {
+          "running": "Reading the knowledge graph",
+          "done": "Read the knowledge graph",
+          "error": "Knowledge graph lookup did not complete"
+        },
         "document_read": {
           "running": "Reading source material",
           "done": "Read the source material",
           "error": "Source reading did not complete"
+        },
+        "document_outline": {
+          "running": "Checking the document outline",
+          "done": "Checked the document outline",
+          "error": "Document outline was not available"
+        },
+        "document_section": {
+          "running": "Reading a document section",
+          "done": "Read a document section",
+          "error": "Document section was not available"
+        },
+        "document_chunk": {
+          "running": "Reading a document passage",
+          "done": "Read a document passage",
+          "error": "Document passage was not available"
         },
         "generic": {
           "running": "Working through one step",
@@ -73,10 +113,24 @@
         "search_query": "Search: {query}",
         "source_title": "Source: {title}",
         "web_url": "Reading: {url}",
+        "collection": "Knowledge base: {collection}",
+        "document": "Document: {document}",
+        "document_section_ref": "Section: {section}",
+        "document_chunk_ref": "Passage: {chunk}",
+        "graph_query": "Graph query: {query}",
+        "graph_entity": "Entity: {entity}",
         "web_search": "Looking for useful information on the web",
         "web_read": "Opening and reading a relevant page",
         "knowledge_search": "Filtering relevant content from the knowledge base",
+        "collection_list": "Checking which knowledge bases are available",
+        "collection_metadata": "Checking knowledge base settings and metadata",
+        "document_list": "Checking which documents are available",
+        "document_metadata": "Checking document status and metadata",
+        "graph_lookup": "Inspecting entities and relations in the knowledge graph",
         "document_read": "Extracting key points from existing documents",
+        "document_outline": "Reading the document structure",
+        "document_section": "Reading a specific section",
+        "document_chunk": "Reading a specific passage",
         "generic": "Organizing intermediate information",
         "done": "Used the result in the answer",
         "error": "This step failed; continuing with available information"

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -404,15 +404,55 @@
             "done": "已阅读网页内容",
             "error": "网页阅读没有成功"
           },
+          "collection_list": {
+            "running": "正在查看可用知识库",
+            "done": "已查看可用知识库",
+            "error": "知识库列表没有成功获取"
+          },
+          "collection_metadata": {
+            "running": "正在查看知识库信息",
+            "done": "已查看知识库信息",
+            "error": "知识库信息没有成功获取"
+          },
+          "document_list": {
+            "running": "正在查看知识库文档",
+            "done": "已查看知识库文档",
+            "error": "文档列表没有成功获取"
+          },
+          "document_metadata": {
+            "running": "正在查看文档信息",
+            "done": "已查看文档信息",
+            "error": "文档信息没有成功获取"
+          },
           "knowledge_search": {
             "running": "正在检索知识库",
             "done": "已找到相关知识",
             "error": "知识库检索没有成功"
           },
+          "graph_lookup": {
+            "running": "正在查看知识图谱",
+            "done": "已查看知识图谱",
+            "error": "知识图谱没有成功读取"
+          },
           "document_read": {
             "running": "正在阅读资料",
             "done": "已阅读资料",
             "error": "资料阅读没有成功"
+          },
+          "document_outline": {
+            "running": "正在查看文档大纲",
+            "done": "已查看文档大纲",
+            "error": "文档大纲没有成功获取"
+          },
+          "document_section": {
+            "running": "正在阅读文档章节",
+            "done": "已阅读文档章节",
+            "error": "文档章节没有成功读取"
+          },
+          "document_chunk": {
+            "running": "正在阅读文档片段",
+            "done": "已阅读文档片段",
+            "error": "文档片段没有成功读取"
           },
           "generic": {
             "running": "正在处理信息",
@@ -424,10 +464,24 @@
           "search_query": "搜索：{query}",
           "source_title": "来源：{title}",
           "web_url": "阅读：{url}",
+          "collection": "知识库：{collection}",
+          "document": "文档：{document}",
+          "document_section_ref": "章节：{section}",
+          "document_chunk_ref": "片段：{chunk}",
+          "graph_query": "图谱查询：{query}",
+          "graph_entity": "实体：{entity}",
           "web_search": "正在从网页中寻找可用信息",
           "web_read": "正在打开并阅读相关页面",
           "knowledge_search": "正在从知识库中筛选相关内容",
+          "collection_list": "正在确认可用知识库",
+          "collection_metadata": "正在查看知识库配置和元信息",
+          "document_list": "正在确认知识库里有哪些文档",
+          "document_metadata": "正在查看文档状态和元信息",
+          "graph_lookup": "正在查看知识图谱中的实体和关系",
           "document_read": "正在从已有文档中提取要点",
+          "document_outline": "正在查看文档结构",
+          "document_section": "正在阅读指定章节",
+          "document_chunk": "正在阅读指定片段",
           "generic": "正在整理中间信息",
           "done": "已把结果用于回答",
           "error": "这一步失败，已继续处理可用信息"

--- a/web/src/i18n/zh-CN/page_chat.json
+++ b/web/src/i18n/zh-CN/page_chat.json
@@ -53,15 +53,55 @@
           "done": "已阅读网页内容",
           "error": "网页阅读没有成功"
         },
+        "collection_list": {
+          "running": "正在查看可用知识库",
+          "done": "已查看可用知识库",
+          "error": "知识库列表没有成功获取"
+        },
+        "collection_metadata": {
+          "running": "正在查看知识库信息",
+          "done": "已查看知识库信息",
+          "error": "知识库信息没有成功获取"
+        },
+        "document_list": {
+          "running": "正在查看知识库文档",
+          "done": "已查看知识库文档",
+          "error": "文档列表没有成功获取"
+        },
+        "document_metadata": {
+          "running": "正在查看文档信息",
+          "done": "已查看文档信息",
+          "error": "文档信息没有成功获取"
+        },
         "knowledge_search": {
           "running": "正在检索知识库",
           "done": "已找到相关知识",
           "error": "知识库检索没有成功"
         },
+        "graph_lookup": {
+          "running": "正在查看知识图谱",
+          "done": "已查看知识图谱",
+          "error": "知识图谱没有成功读取"
+        },
         "document_read": {
           "running": "正在阅读资料",
           "done": "已阅读资料",
           "error": "资料阅读没有成功"
+        },
+        "document_outline": {
+          "running": "正在查看文档大纲",
+          "done": "已查看文档大纲",
+          "error": "文档大纲没有成功获取"
+        },
+        "document_section": {
+          "running": "正在阅读文档章节",
+          "done": "已阅读文档章节",
+          "error": "文档章节没有成功读取"
+        },
+        "document_chunk": {
+          "running": "正在阅读文档片段",
+          "done": "已阅读文档片段",
+          "error": "文档片段没有成功读取"
         },
         "generic": {
           "running": "正在处理信息",
@@ -73,10 +113,24 @@
         "search_query": "搜索：{query}",
         "source_title": "来源：{title}",
         "web_url": "阅读：{url}",
+        "collection": "知识库：{collection}",
+        "document": "文档：{document}",
+        "document_section_ref": "章节：{section}",
+        "document_chunk_ref": "片段：{chunk}",
+        "graph_query": "图谱查询：{query}",
+        "graph_entity": "实体：{entity}",
         "web_search": "正在从网页中寻找可用信息",
         "web_read": "正在打开并阅读相关页面",
         "knowledge_search": "正在从知识库中筛选相关内容",
+        "collection_list": "正在确认可用知识库",
+        "collection_metadata": "正在查看知识库配置和元信息",
+        "document_list": "正在确认知识库里有哪些文档",
+        "document_metadata": "正在查看文档状态和元信息",
+        "graph_lookup": "正在查看知识图谱中的实体和关系",
         "document_read": "正在从已有文档中提取要点",
+        "document_outline": "正在查看文档结构",
+        "document_section": "正在阅读指定章节",
+        "document_chunk": "正在阅读指定片段",
         "generic": "正在整理中间信息",
         "done": "已把结果用于回答",
         "error": "这一步失败，已继续处理可用信息"


### PR DESCRIPTION
## Summary\n- Map MCP tool calls to user-facing activity copy such as knowledge graph lookup, document list/detail reads, document outline/section/chunk reads, and collection metadata checks.\n- Surface useful context from tool input/metadata/output (document, collection, section, chunk, graph query/entity) instead of generic completed-step copy.\n- Add zh-CN/en-US i18n keys and regenerate merged locale bundles.\n\n## Validation\n- cd web && yarn i18n:sync\n- cd web && yarn type-check --pretty false\n- cd web && yarn lint --quiet\n- cd web && git diff --check\n