### PR TITLE
tune graph hybrid label density

### DIFF
--- a/web/src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx
@@ -68,7 +68,7 @@ const pickClusterColor = (cluster: number) => {
   return HYBRID_CLUSTER_PALETTE[((cluster % len) + len) % len];
 };
 
-const IMPORTANT_LABEL_SIZE = 16;
+const IMPORTANT_LABEL_SIZE = 13;
 const INITIAL_FIT_PADDING = 0;
 const INITIAL_FIT_ZOOM_BOOST = 1.22;
 const LABEL_RADIUS = 5;


### PR DESCRIPTION
## Summary
- lower graph-hybrid progressive label threshold from 16 to 13 so a few more important entity names appear by default
- keep the zoom-aware gating behavior from #1823 unchanged

## Tests
- yarn type-check
- yarn lint (passes with pre-existing unrelated warnings)