### PR TITLE
feat(agent-runtime): resolve document/collection titles for tool call metadata

### DIFF
--- a/aperag/domains/agent_runtime/runtime.py
+++ b/aperag/domains/agent_runtime/runtime.py
@@ -24,7 +24,7 @@ import os
 # helper 到 agent_runtime 自己 module").
 import uuid as _uuid
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
 
 from pydantic_ai import Agent, AgentRunResultEvent
@@ -174,6 +174,15 @@ class _PersistedToolCall:
     # post-refresh, when the raw ``input`` is intentionally NOT
     # persisted (D9 §A7). Bounded to ``_TOOL_SUMMARY_MAX_LEN`` chars.
     summary: Optional[str] = None
+    # Resolved human-readable titles for any opaque IDs in the tool
+    # input — populated by ``_resolve_tool_titles`` from the DB
+    # (Document.name, Collection.title) so the FE shows
+    # "已阅读文档：03-非洲猪瘟常态化防控技术指南.md" instead of the raw
+    # ``doc12a626b4...`` ID. Keys mirror the FE renderer's
+    # ``extractStringField`` lookup list (``document_title`` /
+    # ``collection_title``) so dongdong's ``agent-turn-renderer.tsx``
+    # picks them up via ``part.metadata`` automatically.
+    titles: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -280,6 +289,65 @@ def _extract_tool_summary(args: Any, language: Optional[str] = None) -> Optional
     return None
 
 
+async def _resolve_tool_titles(args: Any) -> dict[str, str]:
+    """Look up the human-readable titles for any opaque IDs in tool args.
+
+    earayu2 directive (msg=077c88fd 都展示名称而不是 id): the FE
+    activity narration should never expose ``doc12a626b4...`` /
+    ``colf922365f...`` raw IDs to users. The MCP read primitives
+    (``read_document``, ``get_document_metadata``,
+    ``get_collection_metadata``, ...) take only IDs, so without a
+    BE-side lookup the FE has nothing readable to display.
+
+    Returns a dict shaped to match the FE renderer's
+    ``extractStringField(part.metadata, [...])`` lookup keys
+    (``document_title`` / ``collection_title``) so dongdong's
+    PR #1826 ``agent-turn-renderer.tsx`` picks the values up
+    transparently — no FE change needed for new tools that follow
+    the same args shape.
+
+    Returns ``{}`` for anything that doesn't match the recognised
+    args shape OR when the row is gone (deleted document, etc.) —
+    the FE then falls back to its generic per-kind copy
+    ("已查看文档信息" / "已查看知识库信息" etc.).
+
+    Best-effort: never raises (a stray DB error must not break a
+    tool call's user-facing summary). One DB roundtrip per opaque
+    ID found, opening a short-lived async session.
+    """
+
+    if not isinstance(args, dict):
+        return {}
+    document_id = args.get("document_id")
+    collection_id = args.get("collection_id")
+    if not document_id and not collection_id:
+        return {}
+
+    from sqlalchemy import select
+
+    from aperag.config import get_async_session
+    from aperag.domains.knowledge_base.db.models import Collection, Document
+
+    titles: dict[str, str] = {}
+    try:
+        async for session in get_async_session():
+            if isinstance(document_id, str) and document_id.strip():
+                stmt = select(Document.name).where(Document.id == document_id)
+                name = (await session.execute(stmt)).scalars().first()
+                if name:
+                    titles["document_title"] = name
+            if isinstance(collection_id, str) and collection_id.strip():
+                stmt = select(Collection.title).where(Collection.id == collection_id)
+                title = (await session.execute(stmt)).scalars().first()
+                if title:
+                    titles["collection_title"] = title
+            break
+    except Exception:
+        # Title resolution is decorative — never fail the turn over it.
+        return titles
+    return titles
+
+
 def _tool_part_type(tool_name: str) -> str:
     safe = sanitize_tool_name(tool_name or "tool") or "tool"
     return f"tool-{safe}"
@@ -330,7 +398,7 @@ def _compose_assistant_parts(
                         output=entry.output,
                         error_text=entry.error_text,
                         summary=entry.summary,
-                        metadata={"mcpToolName": entry.tool_name},
+                        metadata={"mcpToolName": entry.tool_name, **entry.titles},
                     )
                 )
     else:
@@ -343,7 +411,7 @@ def _compose_assistant_parts(
                     output=call.output,
                     error_text=call.error_text,
                     summary=call.summary,
-                    metadata={"mcpToolName": call.tool_name},
+                    metadata={"mcpToolName": call.tool_name, **call.titles},
                 )
             )
     if answer_text:
@@ -665,14 +733,23 @@ class PydanticAIRuntime(AgentRuntime):
                         # this thinking block before the upcoming tool
                         # action card.
                         _flush_reasoning_chunk()
+                        normalized_args = self._normalize_jsonish(event.part.args)
+                        # Resolve human-readable titles for any opaque
+                        # IDs in the args (document_id / collection_id)
+                        # so the FE activity narration can show real
+                        # names instead of "doc12a626b4..." raw IDs
+                        # (earayu2 directive msg=077c88fd: 都展示名称
+                        # 而不是 id).
+                        resolved_titles = await _resolve_tool_titles(normalized_args)
                         tool_call = _PersistedToolCall(
                             tool_call_id=tool_call_id,
                             tool_name=tool_name,
                             state="input-available",
                             summary=_extract_tool_summary(
-                                self._normalize_jsonish(event.part.args),
+                                normalized_args,
                                 language=resolved_request.agent_message.language,
                             ),
+                            titles=resolved_titles,
                         )
                         persisted_tool_calls.append(tool_call)
                         persisted_tool_index[tool_call_id] = tool_call
@@ -693,7 +770,11 @@ class PydanticAIRuntime(AgentRuntime):
                             data={
                                 "tool_name": tool_name,
                                 "tool_call_id": tool_call_id,
-                                "args": self._normalize_jsonish(event.part.args),
+                                "args": normalized_args,
+                                # Pass titles down on the live stream
+                                # too so FE shows real names during
+                                # streaming, not just after reload.
+                                "titles": resolved_titles,
                             },
                         )
                         if self._is_external_action(tool_name):

--- a/aperag/domains/agent_runtime/wire/translator.py
+++ b/aperag/domains/agent_runtime/wire/translator.py
@@ -297,6 +297,13 @@ def _translate_tool_started(envelope: AgentTimelineEventEnvelope, state: Transla
     raw_tool_name = data.get("tool_name") or envelope.label or "tool"
     tool_call_id = str(data.get("tool_call_id") or envelope.event_id)
     safe_name, metadata = _resolve_tool_name(str(raw_tool_name), state.safe_tool_name_resolver)
+    # Forward resolved titles (document_title / collection_title) on
+    # the wire so the FE renderer surfaces real names DURING streaming
+    # too — not only after refresh from the at-rest ToolPart.metadata.
+    # Mirrors the at-rest composition in ``_compose_assistant_parts``.
+    resolved_titles = data.get("titles")
+    if isinstance(resolved_titles, dict) and resolved_titles:
+        metadata = {**metadata, **resolved_titles}
     tool_input = _extract_tool_input(envelope)
     return [
         ToolInputStartPart(

--- a/tests/unit_test/agent_runtime/test_tool_call_titles.py
+++ b/tests/unit_test/agent_runtime/test_tool_call_titles.py
@@ -1,0 +1,116 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pin the tool-call title-resolution contract.
+
+earayu2 directive (msg=077c88fd 都展示名称而不是 id): MCP read
+primitives like ``read_document(document_id, ...)`` and
+``get_collection_metadata(collection_id)`` only carry opaque IDs in
+their input. Without a BE-side title lookup the FE activity narration
+ends up showing ``"已查看文档：doc12a626b4..."`` to users, which
+defeats the whole "user-friendly tool labels" feature.
+
+The runtime now resolves titles into ``ToolPart.metadata`` keyed by
+``document_title`` / ``collection_title`` — exact match for the FE
+renderer's ``extractStringField(part.metadata, [...])`` lookup
+list in ``agent-turn-renderer.tsx`` (PR #1826), so dongdong's FE
+picks them up automatically with zero extra mapping.
+"""
+
+from __future__ import annotations
+
+from aperag.domains.agent_runtime.runtime import (
+    _compose_assistant_parts,
+    _PersistedToolCall,
+)
+from aperag.domains.agent_runtime.uimessage import ToolPart
+
+
+def test_persisted_tool_call_titles_flow_into_toolpart_metadata():
+    """The renderer reads ``part.metadata.document_title`` /
+    ``collection_title``; verify the at-rest composer merges
+    ``_PersistedToolCall.titles`` into the metadata dict alongside
+    ``mcpToolName``."""
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="",
+        references=[],
+        tool_calls=[
+            _PersistedToolCall(
+                tool_call_id="call-1",
+                tool_name="read_document",
+                state="output-available",
+                titles={
+                    "document_title": "03-非洲猪瘟常态化防控技术指南.md",
+                    "collection_title": "技术文档库",
+                },
+            )
+        ],
+    )
+    assert len(parts) == 1
+    assert isinstance(parts[0], ToolPart)
+    assert parts[0].metadata == {
+        "mcpToolName": "read_document",
+        "document_title": "03-非洲猪瘟常态化防控技术指南.md",
+        "collection_title": "技术文档库",
+    }
+
+
+def test_persisted_tool_call_with_no_titles_keeps_metadata_minimal():
+    """When the tool args don't have any opaque IDs (e.g., ``web_search``
+    with just a query) the resolver returns ``{}`` — metadata stays
+    on the original ``mcpToolName``-only shape so we don't bloat
+    ``agent_message.parts`` with empty title fields."""
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="",
+        references=[],
+        tool_calls=[
+            _PersistedToolCall(
+                tool_call_id="call-1",
+                tool_name="web_search",
+                state="output-available",
+                summary="搜索:中国蜜蜂产业",
+            )
+        ],
+    )
+    assert parts[0].metadata == {"mcpToolName": "web_search"}, "no titles resolved → metadata should stay minimal"
+
+
+def test_persisted_tool_call_titles_applied_on_timeline_path_too():
+    """The chronological timeline path (Wave 9 reasoning interleave)
+    also needs to propagate titles — both ``timeline=`` and legacy
+    ``tool_calls=`` callers must agree."""
+
+    parts = _compose_assistant_parts(
+        turn_id="turn-1",
+        answer_text="",
+        references=[],
+        timeline=[
+            _PersistedToolCall(
+                tool_call_id="call-1",
+                tool_name="get_document_metadata",
+                state="output-available",
+                titles={"document_title": "中国蜜蜂产业概况"},
+            ),
+        ],
+    )
+    tool_parts = [p for p in parts if isinstance(p, ToolPart)]
+    assert len(tool_parts) == 1
+    assert tool_parts[0].metadata == {
+        "mcpToolName": "get_document_metadata",
+        "document_title": "中国蜜蜂产业概况",
+    }

--- a/tests/unit_test/test_agent_runtime_wire_parts.py
+++ b/tests/unit_test/test_agent_runtime_wire_parts.py
@@ -315,6 +315,44 @@ def test_translate_tool_started_finished():
     assert not hasattr(finished[0], "error_text")
 
 
+def test_translate_tool_started_forwards_resolved_titles_in_metadata():
+    """The runtime resolves ``document_title`` / ``collection_title``
+    from opaque IDs in the tool args (earayu2 directive: 都展示名称
+    而不是 id) and emits them on ``tool.started.data.titles``. The
+    translator must merge those into ``ToolInputStartPart.metadata``
+    so the FE renderer (PR #1826 ``agent-turn-renderer.tsx``) shows
+    real names DURING streaming, not just after refresh."""
+
+    state = TranslatorState()
+    parts = translate_envelope(
+        _envelope(
+            "tool.started",
+            sequence=2,
+            event_id="event-tool-titles",
+            label="read_document",
+            status="started",
+            actor="tool",
+            data={
+                "tool_name": "read_document",
+                "args": {
+                    "collection_id": "colf922365f64d169fd",
+                    "document_id": "doc12a626b4821d6c4e",
+                },
+                "titles": {
+                    "document_title": "03-非洲猪瘟常态化防控技术指南.md",
+                    "collection_title": "技术文档库",
+                },
+            },
+        ),
+        state,
+    )
+    assert isinstance(parts[0], ToolInputStartPart)
+    assert parts[0].metadata == {
+        "document_title": "03-非洲猪瘟常态化防控技术指南.md",
+        "collection_title": "技术文档库",
+    }
+
+
 def test_translate_tool_lifecycle_uses_runtime_tool_call_id():
     state = TranslatorState()
     started = translate_envelope(


### PR DESCRIPTION
## Summary

Companion to dongdong's PR #1826 — fulfills earayu2's directive (msg=077c88fd 都展示名称而不是 id) on the BE side.

dongdong's PR #1826 made the FE renderer hide raw IDs (no more "已查看文档：doc12a626b4...") and prefer real names when present. But the names weren't actually flowing through — MCP read primitives like `read_document(document_id)` and `get_collection_metadata(collection_id)` only carry opaque IDs in their input. So users saw generic "已查看文档信息" instead of the real document name.

## Changes

1. **`_resolve_tool_titles(args)`** — async helper that:
   - Reads `args.document_id` → `Document.name`
   - Reads `args.collection_id` → `Collection.title`
   - Returns dict keyed `document_title` / `collection_title` (exact match for the FE renderer's `extractStringField(part.metadata, [...])` lookup list)
   - Best-effort: stray DB error → `{}` rather than failing the turn

2. **`_PersistedToolCall.titles`** — new `dict[str, str]` field that survives reload via `agent_message.parts`.

3. **FunctionToolCallEvent handler** awaits the resolver on every tool call, stores result on the persisted record, and includes `titles` on `tool.started.data` for live SSE consumers.

4. **`_compose_assistant_parts`** merges titles into `ToolPart.metadata` alongside `mcpToolName` for both the timeline and legacy `tool_calls` paths.

5. **Wire translator** (`_translate_tool_started`) forwards titles from the envelope into `ToolInputStartPart.metadata` so the FE shows real names DURING streaming, not just after refresh.

## Why this layout

dongdong's `agent-turn-renderer.tsx` already does:
```ts
const document = extractStringField(part.metadata, ['document_title', 'document_name', 'filename', 'file_name', 'title', 'name']);
const collection = extractStringField(part.metadata, ['collection_title', 'collection_name']);
```

By writing exactly those keys into `metadata`, the FE picks them up automatically — zero FE change needed for new tools that follow the same args shape.

## Test plan

- [x] 3 new unit tests pin the contract (`test_tool_call_titles.py`):
  - titles flow into `ToolPart.metadata`
  - empty titles keep metadata minimal (no bloat)
  - timeline path also propagates titles
- [x] 1 new wire translator test pins live-stream forwarding (`test_translate_tool_started_forwards_resolved_titles_in_metadata`)
- [x] `uv run ruff check` clean
- [ ] Manual on @dongdong's local 3002 stack after merge: same chat URL, new turn that calls `read_document` / `get_document_metadata` — should show "已阅读文档：03-非洲猪瘟常态化防控技术指南.md" (real name) instead of "已查看文档信息" (generic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)