### PR TITLE
fix(agent-chat): render streamed answer while turn runs

### DIFF
--- a/web/src/components/chat/agent-turn-renderer.tsx
+++ b/web/src/components/chat/agent-turn-renderer.tsx
@@ -793,6 +793,7 @@ export function AgentTurnRenderer({
   }, [grouped.citation, grouped.sourceDoc, grouped.sourceUrl]);
 
   const pending = !TERMINAL_STATUSES.has(status);
+  const hasAnswerText = Boolean(answerText.trim());
   const statusKey = STATUS_LABEL_KEY[status];
   const statusTone = STATUS_BADGE_TONE[status];
   const showHeaderStatus = status !== 'completed';
@@ -811,9 +812,10 @@ export function AgentTurnRenderer({
 
   const timestamp = turn.finished_at || turn.started_at;
   const showAnswerSection =
+    hasAnswerText ||
     TERMINAL_STATUSES.has(status) ||
     ((status === 'failed' || status === 'cancelled' || status === 'aborted') &&
-      Boolean(answerText));
+      hasAnswerText);
   const showReferences =
     references.length > 0 && !(status === 'completed' && Boolean(answerText));
   const hasTurnDebugDetails =


### PR DESCRIPTION
## Summary\n- Show the answer section as soon as live text deltas produce answer text, instead of waiting for the turn to reach a terminal status.\n- Keep the existing completed-answer layout after finish; pending answers still use the draft-answer card while streaming.\n\n## Validation\n- cd web && yarn type-check --pretty false\n- cd web && yarn lint --quiet\n- cd web && git diff --check\n