### PR TITLE
fix(agent-chat): collapse reasoning only when answer starts

### DIFF
--- a/web/src/components/chat/agent-turn-renderer.tsx
+++ b/web/src/components/chat/agent-turn-renderer.tsx
@@ -800,6 +800,12 @@ export function AgentTurnRenderer({
     visibleToolParts.findLast(
       (part) => toolBehaviorPhase(part.state) === 'running',
     ) || visibleToolParts.at(-1);
+  const hasStreamingReasoning = grouped.reasoning.some(
+    (part) => part.state === 'streaming',
+  );
+  const hasRunningTool = visibleToolParts.some(
+    (part) => toolBehaviorPhase(part.state) === 'running',
+  );
   const headerStatusLabel =
     (pending && activityLabel(transientActivity, pageChat)) ||
     (pending && activeToolPart
@@ -850,10 +856,22 @@ export function AgentTurnRenderer({
     0;
 
   useEffect(() => {
-    if (autoCollapsedRef.current || !answerText.trim()) return;
+    autoCollapsedRef.current = false;
+    setActivityOpen(true);
+  }, [turn.turn_id]);
+
+  useEffect(() => {
+    if (
+      autoCollapsedRef.current ||
+      !answerText.trim() ||
+      hasStreamingReasoning ||
+      hasRunningTool
+    ) {
+      return;
+    }
     autoCollapsedRef.current = true;
     setActivityOpen(false);
-  }, [answerText]);
+  }, [answerText, hasRunningTool, hasStreamingReasoning]);
 
   return (
     <div className="flex w-full flex-row gap-3.5">


### PR DESCRIPTION
## Summary\n- Keep the activity stream open while reasoning or tool calls are still actively streaming.\n- Auto-collapse only once the answer text exists and active reasoning/tools have finished, matching the desired flow: thinking stays open, answer starts, then trace collapses.\n- Reset the auto-collapse guard for each new turn so manual reopen still works within a turn.\n\n## Validation\n- cd web && yarn type-check --pretty false\n- cd web && yarn lint --quiet\n- cd web && git diff --check\n