### PR TITLE
feat(graph-extractor): warn on clean JSON with zero entities + relations

### DIFF
--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -315,6 +315,55 @@ async def _extract_one_chunk(
     return _parse_extraction_response(raw=raw, chunk_id=chunk_id)
 
 
+# Cap on raw-response prefix written to the empty-result warn log —
+# enough to recognise a model's error / empty payload pattern at a
+# glance without bloating the log file. Bounded exactly the way Wave
+# 7 task #11 narrative logs are bounded.
+_EMPTY_RESULT_LOG_RAW_PREFIX_CHARS: int = 500
+
+
+def _log_empty_extraction_if_applicable(
+    *,
+    raw: str,
+    chunk_id: str,
+    entities_count: int,
+    relations_count: int,
+) -> None:
+    """Emit a single ``warning`` line when the LLM produced valid JSON
+    that parsed cleanly but contained zero entities AND zero relations.
+
+    Why this exists: Bryce 2026-04-29 incident (msg=358bb68f) — a
+    user switched a collection's completion model to one whose
+    instruction-following degraded against ApeRAG's extraction prompt
+    (DeepSeek V4 Flash via OpenRouter returned ``{"entities":[],
+    "relations":[]}`` for every chunk). The graph index status went
+    ACTIVE per Wave 3 §F.1 semantics (no error → success), but the
+    knowledge graph was silently empty for every doc indexed after
+    the model swap. Diagnosing took several hours of grep + cross-
+    reference because nothing in the logs flagged "extractor ran but
+    produced nothing for THIS many chunks".
+
+    Per-chunk warn level (not error) so it does not page on-call;
+    each line carries the raw response prefix so an ops scan
+    immediately reveals the model-prompt incompatibility pattern. If
+    the same pattern recurs (every chunk in a doc empties out),
+    grep ``graph extractor: empty extraction result`` returns N
+    matches and the model swap timeline lines up with the failure
+    window.
+    """
+    if entities_count > 0 or relations_count > 0:
+        return
+    raw_prefix = raw[:_EMPTY_RESULT_LOG_RAW_PREFIX_CHARS]
+    logger.warning(
+        "graph extractor: empty extraction result for chunk_id=%s "
+        "(LLM response parsed cleanly but produced 0 entities + 0 relations); "
+        "raw response prefix (%d chars max): %r",
+        chunk_id,
+        _EMPTY_RESULT_LOG_RAW_PREFIX_CHARS,
+        raw_prefix,
+    )
+
+
 def _parse_extraction_response(
     *,
     raw: str,
@@ -375,6 +424,12 @@ def _parse_extraction_response(
                 exc,
             )
 
+    _log_empty_extraction_if_applicable(
+        raw=raw,
+        chunk_id=chunk_id,
+        entities_count=len(entities),
+        relations_count=len(relations),
+    )
     return entities, relations
 
 

--- a/tests/integration/test_graph_extractor.py
+++ b/tests/integration/test_graph_extractor.py
@@ -95,6 +95,55 @@ def test_parse_extraction_response_handles_fenced_json():
     assert entities[0].name == "Acme"
 
 
+def test_parse_extraction_response_warns_on_clean_json_with_zero_entities_and_relations(caplog):
+    """Bryce 2026-04-29 incident (msg=358bb68f) — DeepSeek V4 Flash
+    via OpenRouter returned ``{"entities":[],"relations":[]}`` for
+    every chunk, silently producing an empty knowledge graph for
+    every doc indexed after the model swap (status flipped to ACTIVE
+    because nothing raised). The runtime now emits a single
+    ``warning`` per empty extraction so ops can grep
+    ``empty extraction result`` + cross-reference the model timeline
+    when a "graph index ran but produced nothing" pattern recurs.
+    """
+    raw = '{"entities": [], "relations": []}'
+    with caplog.at_level("WARNING", logger="aperag.indexing.graph_extractor"):
+        entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-empty")
+    assert entities == []
+    assert relations == []
+    matching = [r for r in caplog.records if "empty extraction result" in r.getMessage()]
+    assert len(matching) == 1, (
+        "expected exactly one warn line for the model-prompt-incompatibility scenario; "
+        f"got {[r.getMessage() for r in caplog.records]}"
+    )
+    msg = matching[0].getMessage()
+    assert "c-empty" in msg, "warn line must include the chunk_id for cross-reference"
+    assert repr(raw) in msg, "warn line must include the raw response prefix for ops grep"
+
+
+def test_parse_extraction_response_does_not_warn_when_entities_were_extracted(caplog):
+    """The empty-result warn must NOT fire on the success path —
+    otherwise every successful chunk doubles the log volume.
+    """
+    raw = '{"entities": [{"name": "Linus", "type": "person", "description": "x"}], "relations": []}'
+    with caplog.at_level("WARNING", logger="aperag.indexing.graph_extractor"):
+        entities, _ = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    assert len(entities) == 1
+    matching = [r for r in caplog.records if "empty extraction result" in r.getMessage()]
+    assert matching == [], "must not warn when extraction produced entities"
+
+
+def test_parse_extraction_response_does_not_warn_on_relations_only(caplog):
+    """Boundary: relations alone (no entities) is still a successful
+    extraction — warn must not fire.
+    """
+    raw = '{"entities": [], "relations": [{"source": "A", "target": "B", "type": "rel", "description": "x"}]}'
+    with caplog.at_level("WARNING", logger="aperag.indexing.graph_extractor"):
+        _entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    assert len(relations) == 1
+    matching = [r for r in caplog.records if "empty extraction result" in r.getMessage()]
+    assert matching == [], "must not warn when extraction produced relations (even with 0 entities)"
+
+
 def test_parse_extraction_response_returns_empty_on_malformed_json():
     raw = "not valid json — model rambled"
     entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")


### PR DESCRIPTION
## Summary

Diagnostic logging for the model-prompt incompatibility scenario Bryce root-caused at 2026-04-29 03:28 (#summary msg=358bb68f) — DeepSeek V4 Flash via OpenRouter returned `{"entities":[],"relations":[]}` for every chunk under ApeRAG's extraction prompt, silently producing an empty knowledge graph for every doc indexed after a collection's completion model was swapped. `graph_index` status flipped to `ACTIVE` because the parse path raised no error; the only signal was "graph has data only for the one doc indexed BEFORE the model swap".

## Fix

`graph_extractor._parse_extraction_response` now emits a single `warning` line when the LLM produces valid JSON that parses cleanly but contains zero entities AND zero relations:

```
graph extractor: empty extraction result for chunk_id=c-12 
  (LLM response parsed cleanly but produced 0 entities + 0 relations); 
  raw response prefix (500 chars max): '{"entities": [], "relations": []}'
```

Ops can grep `empty extraction result` next time a "graph index ran but produced nothing" pattern recurs and immediately cross-reference the model swap timeline.

## Why warn (not error)

The extractor caller already treats empty-result chunks as benign-skipped; promoting to error would page on-call for what is fundamentally an operator-side model-config issue. Warn level is appropriate: ops scan, no auto-page.

## Why prefix bounded to 500 chars

Matches Wave 7 task #11 narrative log budget — enough to recognise a model's empty-pattern at a glance without bloating log files when an entire 2,000-chunk doc empties out (worst case: 2,000 × 500 chars = 1 MB warn output, still manageable).

## Tests

3 new tests:
- `test_parse_extraction_response_warns_on_clean_json_with_zero_entities_and_relations` — main contract
- `test_parse_extraction_response_does_not_warn_when_entities_were_extracted` — success path stays quiet
- `test_parse_extraction_response_does_not_warn_on_relations_only` — boundary (relations-only is also success)

29/29 tests pass + ruff check/format clean.

## Test plan

- [x] Local 29 tests pass
- [x] Ruff check + format clean
- [ ] CI lint-and-unit + e2e-http-smoke green
- [ ] Post-merge: ops should see the warn line on any future model-incompatibility scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)