### PR TITLE
fix(agent-chat): hide draft label and guard markdown links

### DIFF
--- a/web/src/components/chat/agent-turn-renderer.tsx
+++ b/web/src/components/chat/agent-turn-renderer.tsx
@@ -80,7 +80,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useFormatter, useTranslations } from 'next-intl';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MessageCollapseContent } from './message-collapse-content';
 import { MessageFeedback } from './message-feedback';
 
@@ -781,6 +781,7 @@ export function AgentTurnRenderer({
   const answerText = useMemo(() => joinTextParts(grouped.text), [grouped.text]);
   const [activityOpen, setActivityOpen] = useState(true);
   const autoCollapsedRef = useRef(false);
+  const userControlledActivityRef = useRef(false);
   const visibleToolParts = useMemo(
     () => grouped.tool.filter(isVisibleToolActivity),
     [grouped.tool],
@@ -859,12 +860,14 @@ export function AgentTurnRenderer({
 
   useEffect(() => {
     autoCollapsedRef.current = false;
+    userControlledActivityRef.current = false;
     setActivityOpen(true);
   }, [turn.turn_id]);
 
   useEffect(() => {
     if (
       autoCollapsedRef.current ||
+      userControlledActivityRef.current ||
       !answerText.trim() ||
       hasStreamingReasoning ||
       hasRunningTool
@@ -874,6 +877,11 @@ export function AgentTurnRenderer({
     autoCollapsedRef.current = true;
     setActivityOpen(false);
   }, [answerText, hasRunningTool, hasStreamingReasoning]);
+
+  const handleActivityOpenChange = useCallback((open: boolean) => {
+    userControlledActivityRef.current = true;
+    setActivityOpen(open);
+  }, []);
 
   return (
     <div className="flex w-full flex-row gap-3.5">
@@ -901,7 +909,7 @@ export function AgentTurnRenderer({
 
         <Collapsible
           open={activityOpen}
-          onOpenChange={setActivityOpen}
+          onOpenChange={handleActivityOpenChange}
           className="group/activity-stream bg-muted border-border/70 overflow-hidden rounded-xl border"
         >
           <CollapsibleTrigger asChild>
@@ -994,7 +1002,7 @@ export function AgentTurnRenderer({
         </Collapsible>
 
         {showAnswerSection &&
-          (status === 'completed' ? (
+          (status === 'completed' || (pending && hasAnswerText) ? (
             <div className="text-[15px] leading-[1.65] tracking-[-0.003em]">
               {answerText ? (
                 <Markdown>{answerText}</Markdown>

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -52,6 +52,30 @@ const parseAssetUrl = (src: string) => {
   };
 };
 
+const EXTERNAL_URL_PATTERN = /^https?:\/\//i;
+const CJK_URL_TERMINATOR_PATTERN = /[）。，；：！？、》】」』（]/u;
+const TRAILING_URL_PUNCTUATION_PATTERN = /[\s)\]}.,;:!?，。；：！？、）】》」』]+$/u;
+
+const normalizeMarkdownHref = (href?: string) => {
+  let url = href?.replace(/\.md(?=($|[#?]))/, '') || '/';
+
+  try {
+    const decoded = decodeURI(url);
+    if (EXTERNAL_URL_PATTERN.test(decoded)) {
+      const terminatorIndex = decoded.search(CJK_URL_TERMINATOR_PATTERN);
+      if (terminatorIndex > 0) {
+        url = decoded.slice(0, terminatorIndex);
+      } else {
+        url = decoded;
+      }
+    }
+  } catch {
+    // Keep the original href if it is not a valid percent-encoded string.
+  }
+
+  return url.trim().replace(TRAILING_URL_PUNCTUATION_PATTERN, '') || '/';
+};
+
 export const buildDocumentAssetUrl = (src: string, context?: AssetContext) => {
   if (!src.startsWith('asset://')) {
     return src;
@@ -78,8 +102,9 @@ export const buildDocumentAssetUrl = (src: string, context?: AssetContext) => {
 };
 
 const securityLink = (props: JSX.IntrinsicElements['a']) => {
-  const target = props.href?.match(/^http/) ? '_blank' : '_self';
-  const url = props.href?.replace(/\.md/, '');
+  const url = normalizeMarkdownHref(props.href);
+  const isExternal = EXTERNAL_URL_PATTERN.test(url);
+  const target = isExternal ? '_blank' : '_self';
 
   const isNavLink = props.className?.includes('toc-link');
   return isNavLink ? (
@@ -91,6 +116,16 @@ const securityLink = (props: JSX.IntrinsicElements['a']) => {
         {props.children}
       </TooltipContent>
     </Tooltip>
+  ) : isExternal ? (
+    <a
+      {...props}
+      href={url}
+      target={target}
+      rel="noopener noreferrer"
+      className="underline"
+    >
+      {props.children}
+    </a>
   ) : (
     <Link {...props} href={url || '/'} target={target} className="underline">
       {props.children}
@@ -99,10 +134,11 @@ const securityLink = (props: JSX.IntrinsicElements['a']) => {
 };
 
 const unSecurityLink = (props: JSX.IntrinsicElements['a']) => {
-  const url = props.href?.replace(/\.md/, '') || '/';
+  const url = normalizeMarkdownHref(props.href);
+  const isExternal = EXTERNAL_URL_PATTERN.test(url);
   const isNavLink = props.className?.includes('toc-link');
   const handleLinkClick: MouseEventHandler<HTMLAnchorElement> = (e) => {
-    if (!url.match(/http/)) {
+    if (!isExternal) {
       e.preventDefault();
       e.stopPropagation();
     }
@@ -121,6 +157,17 @@ const unSecurityLink = (props: JSX.IntrinsicElements['a']) => {
         {props.children}
       </TooltipContent>
     </Tooltip>
+  ) : isExternal ? (
+    <a
+      {...props}
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline"
+      onClick={handleLinkClick}
+    >
+      {props.children}
+    </a>
   ) : (
     <Link
       {...props}


### PR DESCRIPTION
## Summary\n- Render streaming answer text with the same plain answer layout instead of showing the Draft answer card/label.\n- Normalize Markdown hrefs that include trailing Chinese punctuation or prose.\n- Render external Markdown links with plain anchors instead of Next Link so malformed model-generated external URLs cannot crash prefetch.\n\n## Validation\n- cd web && yarn type-check --pretty false\n- cd web && yarn lint --quiet\n- cd web && git diff --check\n