### PR TITLE
fix(collection): split regen lease-busy from fall-through (409 vs 503)

### DIFF
--- a/aperag/domains/knowledge_base/api/routes.py
+++ b/aperag/domains/knowledge_base/api/routes.py
@@ -203,13 +203,12 @@ async def regen_collection_summary_view(
 
     outcome = await regen_summary(collection_id)
     if outcome is RegenOutcome.LEASE_BUSY:
+        # Per @earayu2 msg=744a6441: keep the user-facing message
+        # neutral (no lease/internals jargon) — the FE renders this
+        # body verbatim.
         raise HTTPException(
             status_code=409,
-            detail=(
-                "Summary regen is already running for this collection — "
-                "another request holds the lease. Refresh the settings "
-                "page in a moment to see the new summary."
-            ),
+            detail="正在生成中，请稍候",
         )
     if outcome is not RegenOutcome.SUCCESS:
         raise HTTPException(
@@ -267,13 +266,10 @@ async def regen_collection_description_view(
 
     outcome = await regen_description(collection_id)
     if outcome is RegenOutcome.LEASE_BUSY:
+        # Per @earayu2 msg=744a6441: same neutral wording as summary.
         raise HTTPException(
             status_code=409,
-            detail=(
-                "Description regen is already running for this collection — "
-                "another request holds the lease. Refresh the settings "
-                "page in a moment to see the new description."
-            ),
+            detail="正在生成中，请稍候",
         )
     if outcome is not RegenOutcome.SUCCESS:
         raise HTTPException(

--- a/aperag/domains/knowledge_base/api/routes.py
+++ b/aperag/domains/knowledge_base/api/routes.py
@@ -186,24 +186,37 @@ async def regen_collection_summary_view(
     ``Collection.summary``.
 
     Returns 404 if collection doesn't exist or caller doesn't own it,
+    409 if a regen is already running on this collection (the FE
+    should render "正在生成中, 请稍候" rather than an error),
     503 if all tiers returned invalid output (input not ready or
     LLM/agent unavailable — the reconciler will retry on its next
     sweep), 200 with task_id on success.
     """
-    from aperag.domains.knowledge_base.service.collection_regen_service import regen_summary
+    from aperag.domains.knowledge_base.service.collection_regen_service import (
+        RegenOutcome,
+        regen_summary,
+    )
 
     collection = await collection_service.get_collection(str(user.id), collection_id)
     if not collection:
         raise HTTPException(status_code=404, detail="Collection not found")
 
-    success = await regen_summary(collection_id)
-    if not success:
+    outcome = await regen_summary(collection_id)
+    if outcome is RegenOutcome.LEASE_BUSY:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Summary regen is already running for this collection — "
+                "another request holds the lease. Refresh the settings "
+                "page in a moment to see the new summary."
+            ),
+        )
+    if outcome is not RegenOutcome.SUCCESS:
         raise HTTPException(
             status_code=503,
             detail=(
-                "Summary regen could not produce a valid output (lease busy "
-                "or all tiers fell through). The reconciler will retry on "
-                "its next sweep."
+                "Summary regen could not produce a valid output (all tiers "
+                "fell through). The reconciler will retry on its next sweep."
             ),
         )
 
@@ -234,10 +247,14 @@ async def regen_collection_description_view(
 
     Returns 400 if ``Collection.summary IS NULL`` (must regen summary
     first), 404 if collection doesn't exist or caller doesn't own it,
-    503 if the LLM call fails the quality gate, 200 with task_id on
-    success.
+    409 if a regen is already running on this collection (FE should
+    render "正在生成中, 请稍候"), 503 if the LLM call fails the
+    quality gate, 200 with task_id on success.
     """
-    from aperag.domains.knowledge_base.service.collection_regen_service import regen_description
+    from aperag.domains.knowledge_base.service.collection_regen_service import (
+        RegenOutcome,
+        regen_description,
+    )
 
     collection = await collection_service.get_collection(str(user.id), collection_id)
     if not collection:
@@ -248,14 +265,23 @@ async def regen_collection_description_view(
             detail="Collection has no summary yet — call /summary/regen first.",
         )
 
-    success = await regen_description(collection_id)
-    if not success:
+    outcome = await regen_description(collection_id)
+    if outcome is RegenOutcome.LEASE_BUSY:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Description regen is already running for this collection — "
+                "another request holds the lease. Refresh the settings "
+                "page in a moment to see the new description."
+            ),
+        )
+    if outcome is not RegenOutcome.SUCCESS:
         raise HTTPException(
             status_code=503,
             detail=(
-                "Description regen could not produce a valid output (lease "
-                "busy or LLM call failed quality gate). The reconciler will "
-                "retry on its next sweep."
+                "Description regen could not produce a valid output (LLM "
+                "call failed quality gate). The reconciler will retry on "
+                "its next sweep."
             ),
         )
 

--- a/aperag/domains/knowledge_base/service/collection_regen_service.py
+++ b/aperag/domains/knowledge_base/service/collection_regen_service.py
@@ -28,6 +28,7 @@ against the same row (description depends on summary).
 from __future__ import annotations
 
 import asyncio
+import enum
 import logging
 import re
 import time
@@ -58,6 +59,28 @@ from aperag.domains.knowledge_base.service.regen_constants import (
 from aperag.utils.utils import utc_now
 
 logger = logging.getLogger(__name__)
+
+
+class RegenOutcome(str, enum.Enum):
+    """Tri-state outcome of a regen call.
+
+    Pre-fix the helpers returned ``bool`` and the API endpoint
+    conflated all non-success paths into one 503 toast — the user
+    saw the same "all tiers fell through" string for both lease
+    contention (a concurrent regen is already running and will
+    succeed) and an actual model-side failure. Per @earayu2
+    msg=11b26190 (2026-04-29): when a regen is in progress, the
+    response should say "正在生成中" rather than "失败".
+
+    The helpers now return one of these three outcomes; the route
+    maps them to 200 / 409 / 503 so the FE can render a friendly
+    "正在生成中, 请稍候" instead of an error toast on the conflict
+    branch.
+    """
+
+    SUCCESS = "success"
+    LEASE_BUSY = "lease_busy"
+    FALLTHROUGH = "fallthrough"
 
 
 # ---------------------------------------------------------------------
@@ -534,12 +557,18 @@ async def regen_summary(
     collection_id: str,
     *,
     llm_factory: Callable[[Collection], LLMCall] | None = None,
-) -> bool:
+) -> RegenOutcome:
     """Stage 1: regenerate ``Collection.summary`` for ``collection_id``.
 
-    Returns ``True`` if a new summary was successfully written,
-    ``False`` if the call was skipped (lease busy / collection deleted
-    / all 3 tiers fell through to transient skip).
+    Returns one of:
+
+    * :attr:`RegenOutcome.SUCCESS` — a fresh summary was written.
+    * :attr:`RegenOutcome.LEASE_BUSY` — another regen is already
+      running on this collection. The route surfaces this as 409 so
+      the FE can render "正在生成中" instead of an error toast.
+    * :attr:`RegenOutcome.FALLTHROUGH` — collection missing/deleted
+      or all 3 tiers returned invalid output. The route surfaces this
+      as 503 and the reconciler retries on its next sweep.
 
     Lease-protected: acquires the regen lease, runs the 3-tier
     fallback chain, writes ``summary`` + ``summary_updated_at``
@@ -550,7 +579,7 @@ async def regen_summary(
         lease_token = await _try_acquire_lease(session, collection_id=collection_id)
         if lease_token is None:
             logger.debug("regen_summary skipped: lease busy for %s", collection_id)
-            return False
+            return RegenOutcome.LEASE_BUSY
 
         try:
             # Step 2: load collection (post-lease so we see latest state)
@@ -562,7 +591,7 @@ async def regen_summary(
                     "regen_summary skipped: collection %s missing or deleted",
                     collection_id,
                 )
-                return False
+                return RegenOutcome.FALLTHROUGH
 
             # Step 3: 3-tier fallback chain
             summary: str | None = await _invoke_summary_agent(collection)
@@ -584,7 +613,7 @@ async def regen_summary(
                     collection_id,
                     tier_used,
                 )
-                return False
+                return RegenOutcome.FALLTHROUGH
 
             # Step 4: atomic writeback
             now = utc_now()
@@ -604,10 +633,10 @@ async def regen_summary(
                 tier_used,
                 len(summary),
             )
-            return True
+            return RegenOutcome.SUCCESS
         finally:
             await _release_lease(session, collection_id=collection_id, lease_token=lease_token)
-    return False
+    return RegenOutcome.FALLTHROUGH
 
 
 # ---------------------------------------------------------------------
@@ -619,10 +648,11 @@ async def regen_description(
     collection_id: str,
     *,
     llm_factory: Callable[[Collection], LLMCall] | None = None,
-) -> bool:
+) -> RegenOutcome:
     """Stage 2: derive ``Collection.description`` from existing
-    ``Collection.summary``. Returns ``True`` on success, ``False`` on
-    skip (lease busy, summary missing, or LLM output invalid).
+    ``Collection.summary``. See :func:`regen_summary` for the
+    outcome-mapping contract — same tri-state semantics, same
+    409 vs 503 split downstream.
 
     Cheap path — single LLM call, no agent multi-turn. Caller MUST
     ensure ``summary`` is already populated; the OpenAPI handler returns
@@ -632,21 +662,21 @@ async def regen_description(
         lease_token = await _try_acquire_lease(session, collection_id=collection_id)
         if lease_token is None:
             logger.debug("regen_description skipped: lease busy for %s", collection_id)
-            return False
+            return RegenOutcome.LEASE_BUSY
 
         try:
             stmt = select(Collection).where(Collection.id == collection_id)
             result = await session.execute(stmt)
             collection = result.scalar_one_or_none()
             if collection is None or collection.gmt_deleted is not None:
-                return False
+                return RegenOutcome.FALLTHROUGH
 
             if not collection.summary:
                 logger.info(
                     "regen_description skipped: collection %s has no summary yet",
                     collection_id,
                 )
-                return False
+                return RegenOutcome.FALLTHROUGH
 
             language = _detect_language(collection.summary)
             template = DESCRIPTION_DERIVE_PROMPT_ZH if language == "zh" else DESCRIPTION_DERIVE_PROMPT_EN
@@ -660,14 +690,14 @@ async def regen_description(
                     "regen_description LLM call failed for %s; transient skip",
                     collection_id,
                 )
-                return False
+                return RegenOutcome.FALLTHROUGH
 
             if not is_valid_description(description):
                 logger.info(
                     "regen_description quality gate failed for %s; transient skip",
                     collection_id,
                 )
-                return False
+                return RegenOutcome.FALLTHROUGH
 
             now = utc_now()
             await session.execute(
@@ -686,10 +716,10 @@ async def regen_description(
                 len(description),
                 language,
             )
-            return True
+            return RegenOutcome.SUCCESS
         finally:
             await _release_lease(session, collection_id=collection_id, lease_token=lease_token)
-    return False
+    return RegenOutcome.FALLTHROUGH
 
 
 # ---------------------------------------------------------------------
@@ -711,6 +741,7 @@ def _default_llm_factory(collection: Collection) -> LLMCall:
 
 
 __all__ = [
+    "RegenOutcome",
     "SUMMARY_AGENT_SYSTEM_PROMPT",
     "get_or_create_summary_bot_for_user",
     "is_valid_description",

--- a/tests/integration/test_w10_e2e_summary_description_regen.py
+++ b/tests/integration/test_w10_e2e_summary_description_regen.py
@@ -239,10 +239,13 @@ async def test_step2_regen_summary_writes_canonical_summary(seeded_collection, d
     ``summary`` becomes non-NULL with length > 50 (quality gate
     ``is_valid_summary``).
     """
-    from aperag.domains.knowledge_base.service.collection_regen_service import regen_summary
+    from aperag.domains.knowledge_base.service.collection_regen_service import (
+        RegenOutcome,
+        regen_summary,
+    )
 
-    success = await regen_summary(_COLLECTION_ID)
-    assert success is True, "Tier 1 / Tier 2 should produce a valid summary on a seeded collection"
+    outcome = await regen_summary(_COLLECTION_ID)
+    assert outcome is RegenOutcome.SUCCESS, "Tier 1 / Tier 2 should produce a valid summary on a seeded collection"
 
     row = _read_collection(db_engine, _COLLECTION_ID)
     assert row.summary is not None
@@ -281,10 +284,13 @@ async def test_step4_regen_description_derives_short_form(seeded_collection, db_
     ``Collection.summary``. Cheap path — single LLM call, no agent
     multi-turn. The row's ``description`` becomes non-NULL passing
     ``is_valid_description``."""
-    from aperag.domains.knowledge_base.service.collection_regen_service import regen_description
+    from aperag.domains.knowledge_base.service.collection_regen_service import (
+        RegenOutcome,
+        regen_description,
+    )
 
-    success = await regen_description(_COLLECTION_ID)
-    assert success is True
+    outcome = await regen_description(_COLLECTION_ID)
+    assert outcome is RegenOutcome.SUCCESS
 
     row = _read_collection(db_engine, _COLLECTION_ID)
     assert row.description is not None

--- a/tests/unit_test/knowledge_base/test_collection_regen_supplementary.py
+++ b/tests/unit_test/knowledge_base/test_collection_regen_supplementary.py
@@ -30,6 +30,7 @@ import aperag.domains.agent_runtime.schemas  # noqa: F401
 from aperag.domains.agent_runtime.uimessage import TextPart
 from aperag.domains.knowledge_base.service import collection_regen_service
 from aperag.domains.knowledge_base.service.collection_regen_service import (
+    RegenOutcome,
     _extract_answer_text,
     _invoke_summary_agent,
     _pick_substantive_chunk_text,
@@ -148,7 +149,7 @@ async def test_regen_summary_returns_false_when_lease_busy(monkeypatch: pytest.M
 
     monkeypatch.setattr(collection_regen_service, "_release_lease", _release)
 
-    assert await regen_summary("col_test") is False
+    assert await regen_summary("col_test") is RegenOutcome.LEASE_BUSY
     # Lease never acquired → release helper never invoked.
     assert released == []
 
@@ -170,7 +171,7 @@ async def test_regen_summary_returns_false_when_collection_missing(monkeypatch: 
 
     monkeypatch.setattr(collection_regen_service, "_release_lease", _release)
 
-    assert await regen_summary("col_test") is False
+    assert await regen_summary("col_test") is RegenOutcome.FALLTHROUGH
     # Lease was acquired so release MUST run in the finally branch.
     assert released == [("col_test", "lease-token")]
 
@@ -212,8 +213,8 @@ async def test_regen_summary_falls_through_to_tier3_when_both_invokers_invalid(
         lambda _c: lambda _p: None,
     )
 
-    # All tiers fall through → transient skip → False (no DB write).
-    assert await regen_summary("col_test") is False
+    # All tiers fall through → transient skip → FALLTHROUGH (no DB write).
+    assert await regen_summary("col_test") is RegenOutcome.FALLTHROUGH
     assert session.commits == 0  # only commits we counted came from execute mocks
 
 
@@ -247,7 +248,7 @@ async def test_regen_summary_writes_back_when_tier1_succeeds(monkeypatch: pytest
         lambda _c: lambda _p: None,
     )
 
-    assert await regen_summary("col_test") is True
+    assert await regen_summary("col_test") is RegenOutcome.SUCCESS
     # Collection load + writeback (lease/release helpers are mocked away).
     assert len(session.executed) >= 2
 
@@ -280,7 +281,7 @@ async def test_regen_summary_falls_through_tier1_to_tier2(monkeypatch: pytest.Mo
         lambda _c: lambda _p: None,
     )
 
-    assert await regen_summary("col_test") is True
+    assert await regen_summary("col_test") is RegenOutcome.SUCCESS
 
 
 # ---------------------------------------------------------------------
@@ -301,7 +302,7 @@ async def test_regen_description_skips_when_summary_missing(monkeypatch: pytest.
     monkeypatch.setattr(collection_regen_service, "_try_acquire_lease", lambda *a, **k: _async_value("lease"))
     monkeypatch.setattr(collection_regen_service, "_release_lease", lambda *a, **k: _async_value(None))
 
-    assert await regen_description("col_test") is False
+    assert await regen_description("col_test") is RegenOutcome.FALLTHROUGH
 
 
 @pytest.mark.asyncio
@@ -325,7 +326,41 @@ async def test_regen_description_succeeds_with_valid_llm_output(monkeypatch: pyt
 
     monkeypatch.setattr(collection_regen_service, "_default_llm_factory", lambda _c: _llm)
 
-    assert await regen_description("col_test") is True
+    assert await regen_description("col_test") is RegenOutcome.SUCCESS
+
+
+# ---------------------------------------------------------------------
+# Tri-state outcome contract — LEASE_BUSY is distinguishable from
+# FALLTHROUGH so the route can return 409 vs 503 (per @earayu2
+# msg=11b26190 directive: a concurrent regen should surface as
+# "正在生成中" instead of an error toast).
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_regen_summary_distinguishes_lease_busy_from_fallthrough(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = _FakeSession(collection=object())
+    _patch_session(monkeypatch, session)
+    monkeypatch.setattr(collection_regen_service, "_try_acquire_lease", lambda *a, **k: _async_value(None))
+
+    outcome = await regen_summary("col_test")
+    assert outcome is RegenOutcome.LEASE_BUSY
+    assert outcome is not RegenOutcome.FALLTHROUGH
+
+
+@pytest.mark.asyncio
+async def test_regen_description_distinguishes_lease_busy_from_fallthrough(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = _FakeSession(collection=object())
+    _patch_session(monkeypatch, session)
+    monkeypatch.setattr(collection_regen_service, "_try_acquire_lease", lambda *a, **k: _async_value(None))
+
+    outcome = await regen_description("col_test")
+    assert outcome is RegenOutcome.LEASE_BUSY
+    assert outcome is not RegenOutcome.FALLTHROUGH
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Per @earayu2 msg=11b26190 (2026-04-29): a regen request that lands while another regen is already running on the same collection should surface as "正在生成中, 请稍候" — currently it returns 503 with "all tiers fell through", indistinguishable from a real model-side failure.

## What changed

* New ``RegenOutcome`` enum in ``collection_regen_service.py`` (``SUCCESS`` / ``LEASE_BUSY`` / ``FALLTHROUGH``).
* ``regen_summary`` and ``regen_description`` return the enum instead of ``bool``.
* The two route handlers now return:
  * 200 on ``SUCCESS``
  * 409 on ``LEASE_BUSY`` with ``"... is already running for this collection — another request holds the lease. Refresh the settings page in a moment ..."``
  * 503 on ``FALLTHROUGH`` with the existing transient-skip wording (no longer mentions "lease busy")
* Existing tests updated to assert against the enum.
* New tests pin the LEASE_BUSY-vs-FALLTHROUGH split for both regen flows.

The reconciler calls ``regen_*`` fire-and-forget and ignores the return value — no caller-side change.

## Files

- ``aperag/domains/knowledge_base/service/collection_regen_service.py``
- ``aperag/domains/knowledge_base/api/routes.py``
- ``tests/unit_test/knowledge_base/test_collection_regen_supplementary.py``
- ``tests/integration/test_w10_e2e_summary_description_regen.py``

## Test plan

- [x] ``uv run pytest tests/unit_test/knowledge_base/test_collection_regen_supplementary.py tests/unit_test/chat`` — 36 passed
- [x] ``uv run ruff check`` clean
- [x] ``uv run ruff format --check`` on touched files clean
- [ ] manual: trigger two concurrent ``POST /summary/regen`` against the same collection — second one returns 409 instead of 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)