### PR TITLE
feat(evaluation): AI auto-generate QA pairs preview endpoint

### DIFF
--- a/aperag/domains/evaluation/api/routes.py
+++ b/aperag/domains/evaluation/api/routes.py
@@ -21,6 +21,8 @@ from aperag.domains.evaluation.schemas import (
     CancelRunResponse,
     EvaluationDatasetCreate,
     EvaluationDatasetEnvelope,
+    EvaluationDatasetGeneratePreviewRequest,
+    EvaluationDatasetGeneratePreviewResponse,
     EvaluationDatasetItemEnvelope,
     EvaluationDatasetItemListResponse,
     EvaluationDatasetItemsAppendRequest,
@@ -154,6 +156,53 @@ async def append_evaluation_dataset_items_view(
 ) -> EvaluationDatasetItemsAppendResponse:
     created = await evaluation_dataset_service.append_items(str(user.id), dataset_id, list(body.items))
     return EvaluationDatasetItemsAppendResponse(items=created)
+
+
+@router.post(
+    "/evaluation-datasets/{dataset_id}/items/generate-preview",
+    response_model=EvaluationDatasetGeneratePreviewResponse,
+)
+async def generate_evaluation_dataset_items_preview_view(
+    dataset_id: str,
+    body: EvaluationDatasetGeneratePreviewRequest,
+    user: AuthenticatedUser = Depends(required_user),
+) -> EvaluationDatasetGeneratePreviewResponse:
+    """AI auto-generate QA pairs for the dataset (preview-only).
+
+    Walks the collection's serving chunks, fires one LLM call per
+    substantive chunk, and returns the produced ``{question,
+    expected_answer, reference_context}`` items without writing to the
+    dataset. The caller (FE) lets the user select / edit and POSTs the
+    chosen rows to the existing ``/items`` append endpoint.
+
+    Architect lock ``msg=05c3ec83`` + ``msg=a9fb7efd``; ``count``
+    defaults to 10 and is capped at 100; ``language`` falls back to
+    ``Collection.config.language``.
+    """
+    user_id = str(user.id)
+    # Ensure the caller owns the dataset before we burn LLM credits.
+    await evaluation_dataset_service._require_dataset(user_id, dataset_id)
+
+    from aperag.db.ops import async_db_ops
+    from aperag.domains.evaluation.dataset_generator import generate_preview_items
+    from aperag.exceptions import ResourceNotFoundException
+
+    collection = await async_db_ops.query_collection(user_id, body.collection_id)
+    if collection is None:
+        raise ResourceNotFoundException("Collection", body.collection_id)
+
+    items, resolved_language = await generate_preview_items(
+        collection=collection,
+        count=body.count,
+        language=body.language,
+        prompt_template=body.prompt_template,
+    )
+    return EvaluationDatasetGeneratePreviewResponse(
+        items=items,
+        requested_count=body.count,
+        delivered_count=len(items),
+        language=resolved_language,
+    )
 
 
 @router.put(

--- a/aperag/domains/evaluation/dataset_generator.py
+++ b/aperag/domains/evaluation/dataset_generator.py
@@ -1,0 +1,378 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""AI auto-generate QA pairs for an evaluation dataset (preview path).
+
+Architect lock: ``#evaluation msg=05c3ec83`` + ``msg=a9fb7efd``.
+
+The flow is **preview-only** — no DB write here. The caller (typically
+the FE) takes the returned ``GeneratedDatasetItem`` list, lets the user
+review/edit/select, then POSTs the chosen rows to the existing
+``/items`` append endpoint. That keeps low-quality LLM output out of the
+dataset by default and matches the simple-stable "user controls
+quality" guardrail.
+
+Per-chunk shape (Weston msg=87124ce5 + msg=def9094f):
+
+* Walk the collection's serving chunks.jsonl artifacts and pick
+  ``count`` substantive chunks (>= 200 chars), favouring diversity
+  by round-robin across documents.
+* For each chunk fire one LLM call (parallelised under a small
+  semaphore) asking for a single ``{question, expected_answer}`` JSON
+  object in the resolved language.
+* Each delivered item carries ``reference_context = chunk.text``
+  truncated to :data:`_REFERENCE_CONTEXT_MAX_CHARS` (8 000) so the
+  provenance is deterministic — Phase 3 LLM-as-judge can lift it
+  straight off the dataset row instead of needing a backfill pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any
+
+from sqlalchemy import and_, select
+
+from aperag.config import get_async_session
+from aperag.domains.evaluation.schemas import GeneratedDatasetItem
+from aperag.domains.knowledge_base.db.models import Collection, Document
+
+logger = logging.getLogger(__name__)
+
+
+# Cap on the per-row provenance blob. Weston msg=87124ce5 — keep
+# ``reference_context`` bounded so a 50 000-char chunk does not bloat
+# every dataset row to the point that the eval surface is unusable.
+_REFERENCE_CONTEXT_MAX_CHARS: int = 8000
+
+# Generated questions can be over-eager LLMs. We over-sample chunks by
+# this multiplier so we have material left after dedup / parse failures
+# kick out duds, and still hit the requested ``count``.
+_CHUNK_OVERSAMPLE: int = 2
+
+# Bound concurrent LLM calls per request — mirror the graph-extractor
+# semaphore (#1809) so a count=100 request does not stampede the model
+# provider.
+_LLM_CONCURRENCY: int = 4
+
+# Per-chunk LLM timeout — keep below typical FE wait threshold so the
+# operator gets feedback rather than a blank spinner.
+_PER_CHUNK_LLM_TIMEOUT_SECONDS: float = 60.0
+
+# Substantive-chunk threshold — chunks shorter than this are a poor
+# basis for a QA pair (boilerplate / boilerplate-only headers). Mirror
+# the Wave 10 chunks-fallback heuristic so two paths stay consistent.
+_SUBSTANTIVE_CHUNK_MIN_CHARS: int = 200
+
+
+_SUPPORTED_LANGUAGES: tuple[str, ...] = ("zh-CN", "en-US", "ja-JP", "ko-KR")
+_DEFAULT_LANGUAGE: str = "zh-CN"
+
+
+def _resolve_language(*, request_language: str | None, collection: Collection) -> str:
+    if request_language and request_language in _SUPPORTED_LANGUAGES:
+        return request_language
+    # Fall back to the collection's configured language (Wave 10 §K.13
+    # collection.config.language) before resorting to the product
+    # default. earayu2 msg=e3498dc0: "默认跟随知识库语言".
+    try:
+        from aperag.schema.utils import parseCollectionConfig
+
+        parsed = parseCollectionConfig(collection.config)
+        if parsed and parsed.language and parsed.language in _SUPPORTED_LANGUAGES:
+            return str(parsed.language)
+    except Exception:  # noqa: BLE001 — config malformed → fall through
+        logger.exception(
+            "dataset_generator: parseCollectionConfig failed for %s — using default language",
+            collection.id,
+        )
+    return _DEFAULT_LANGUAGE
+
+
+_PROMPT_TEMPLATES: dict[str, str] = {
+    "zh-CN": (
+        "你是一名信息抽取助手，专门为知识库自动生成问答对，用于后续模型评测。\n"
+        "请阅读下面的【内容】，输出**一对**严格 JSON：\n"
+        '{{"question": "<问题文本>", "expected_answer": "<准确答案>"}}\n\n'
+        "约束：\n"
+        "1. 输出语言：中文。专有名词、法规名称、机构名等可以保留原文。\n"
+        "2. 问题应能直接根据【内容】回答，不要凭空推断。\n"
+        "3. 答案应当精炼（1-3 句），并完全可以从【内容】里得到支撑。\n"
+        "4. 不要输出 JSON 以外的任何文字，不要使用 Markdown 代码块包裹。\n\n"
+        "【内容】\n{chunk_text}\n\n"
+        "JSON："
+    ),
+    "en-US": (
+        "You are an information-extraction assistant. Generate exactly **one** "
+        "QA pair from the CONTENT below for downstream evaluation.\n"
+        "Output strict JSON with this shape (no Markdown fences, no extra text):\n"
+        '{{"question": "<question text>", "expected_answer": "<concise answer>"}}\n\n'
+        "Rules:\n"
+        "1. Output language: English. Proper nouns may stay in their source script.\n"
+        "2. The question must be directly answerable from CONTENT.\n"
+        "3. The answer must be 1-3 sentences and fully supported by CONTENT.\n\n"
+        "CONTENT:\n{chunk_text}\n\n"
+        "JSON:"
+    ),
+    "ja-JP": (
+        "あなたは情報抽出アシスタントです。下記の【コンテンツ】から評価用 QA ペアを"
+        "**1 組**生成してください。\n"
+        "次の形式で **JSON のみ** を出力してください（コードブロック禁止）：\n"
+        '{{"question": "<質問>", "expected_answer": "<簡潔な回答>"}}\n\n'
+        "制約：\n"
+        "1. 出力言語：日本語。固有名詞は原語のままで構いません。\n"
+        "2. 質問は【コンテンツ】から直接回答できる内容に限定してください。\n"
+        "3. 回答は 1〜3 文の簡潔な文章で、完全に【コンテンツ】に裏付けられること。\n\n"
+        "【コンテンツ】\n{chunk_text}\n\n"
+        "JSON："
+    ),
+    "ko-KR": (
+        "당신은 정보 추출 도우미입니다. 아래 【콘텐츠】를 바탕으로 평가용 QA 쌍을 "
+        "**한 개**만 생성하세요.\n"
+        "다음 형식의 **JSON만** 출력하세요(코드 블록 금지):\n"
+        '{{"question": "<질문>", "expected_answer": "<간결한 답변>"}}\n\n'
+        "규칙:\n"
+        "1. 출력 언어: 한국어. 고유 명사는 원어를 유지해도 됩니다.\n"
+        "2. 질문은 【콘텐츠】에서 바로 답할 수 있어야 합니다.\n"
+        "3. 답변은 1-3 문장으로 간결하게, 【콘텐츠】에 근거해 작성하세요.\n\n"
+        "【콘텐츠】\n{chunk_text}\n\n"
+        "JSON:"
+    ),
+}
+
+
+def _format_prompt(*, language: str, chunk_text: str, override: str | None) -> str:
+    if override:
+        # Caller-provided template — accept ``{chunk_text}`` and (optionally)
+        # ``{language}`` placeholders. Fail closed on unsupported placeholders
+        # so a typo does not produce a silently-empty prompt.
+        try:
+            return override.format(chunk_text=chunk_text, language=language)
+        except (KeyError, IndexError):
+            logger.warning(
+                "dataset_generator: prompt_template override has unknown placeholders; "
+                "using default template for language=%s",
+                language,
+            )
+    template = _PROMPT_TEMPLATES.get(language) or _PROMPT_TEMPLATES[_DEFAULT_LANGUAGE]
+    return template.format(chunk_text=chunk_text)
+
+
+_FENCE_RE = re.compile(r"^\s*```(?:json|JSON)?\s*\n?(.*?)\n?```\s*$", re.DOTALL)
+
+
+def _strip_code_fence(raw: str) -> str:
+    match = _FENCE_RE.match(raw)
+    return match.group(1).strip() if match else raw.strip()
+
+
+def _parse_qa_pair(raw: str) -> tuple[str | None, str | None]:
+    """Coerce the LLM's response into ``(question, expected_answer)`` or
+    ``(None, None)`` if the payload is unusable."""
+    payload = _strip_code_fence(raw)
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        return (None, None)
+    if not isinstance(parsed, dict):
+        return (None, None)
+    question = parsed.get("question") or parsed.get("Question")
+    answer = parsed.get("expected_answer") or parsed.get("answer") or parsed.get("Answer")
+    if not isinstance(question, str) or not isinstance(answer, str):
+        return (None, None)
+    question = question.strip()
+    answer = answer.strip()
+    if not question or not answer:
+        return (None, None)
+    return (question, answer)
+
+
+async def _select_chunks(
+    *,
+    collection: Collection,
+    desired_count: int,
+) -> list[dict[str, Any]]:
+    """Walk the collection's serving vector chunks.jsonl artifacts and
+    pull ``desired_count`` substantive chunks, favouring diversity by
+    round-robin across documents."""
+    from aperag.indexing.models import DocumentIndex, IndexStatus, Modality
+    from aperag.indexing.parser import read_chunks
+    from aperag.objectstore.base import get_object_store
+
+    async for session in get_async_session():
+        doc_stmt = (
+            select(Document.id)
+            .where(
+                and_(
+                    Document.collection_id == collection.id,
+                    Document.gmt_deleted.is_(None),
+                )
+            )
+            .order_by(Document.id)
+        )
+        doc_ids = [row[0] for row in (await session.execute(doc_stmt)).all()]
+        if not doc_ids:
+            return []
+
+        index_stmt = select(DocumentIndex.document_id, DocumentIndex.source_path).where(
+            and_(
+                DocumentIndex.document_id.in_(doc_ids),
+                DocumentIndex.modality == Modality.VECTOR.value,
+                DocumentIndex.status == IndexStatus.ACTIVE.value,
+                DocumentIndex.is_serving.is_(True),
+            )
+        )
+        path_by_doc = {doc_id: src for doc_id, src in (await session.execute(index_stmt)).all()}
+        if not path_by_doc:
+            return []
+
+        store = get_object_store()
+        chunks_per_doc: list[list[dict[str, Any]]] = []
+        for doc_id in doc_ids:
+            chunks_path = path_by_doc.get(doc_id)
+            if not chunks_path:
+                continue
+            try:
+                raw_chunks = await asyncio.to_thread(read_chunks, store, chunks_path)
+            except Exception:  # noqa: BLE001 — one bad doc must not fail the request
+                logger.exception(
+                    "dataset_generator: read_chunks failed for %s (doc %s)",
+                    chunks_path,
+                    doc_id,
+                )
+                continue
+            substantive = [
+                c
+                for c in raw_chunks
+                if isinstance(c, dict)
+                and isinstance(c.get("text"), str)
+                and len(c["text"]) >= _SUBSTANTIVE_CHUNK_MIN_CHARS
+            ]
+            if substantive:
+                chunks_per_doc.append(substantive)
+
+        if not chunks_per_doc:
+            return []
+
+        # Round-robin pick across documents so a small dataset still
+        # samples every doc rather than draining one document end to end.
+        picked: list[dict[str, Any]] = []
+        cursors = [0] * len(chunks_per_doc)
+        while len(picked) < desired_count:
+            advanced = False
+            for doc_idx, doc_chunks in enumerate(chunks_per_doc):
+                cur = cursors[doc_idx]
+                if cur >= len(doc_chunks):
+                    continue
+                picked.append(doc_chunks[cur])
+                cursors[doc_idx] = cur + 1
+                advanced = True
+                if len(picked) >= desired_count:
+                    break
+            if not advanced:
+                break
+
+        return picked
+    return []
+
+
+async def _generate_one(
+    *,
+    llm,
+    chunk: dict[str, Any],
+    language: str,
+    prompt_override: str | None,
+    semaphore: asyncio.Semaphore,
+) -> GeneratedDatasetItem | None:
+    chunk_text = str(chunk.get("text") or "")
+    if not chunk_text:
+        return None
+    prompt = _format_prompt(language=language, chunk_text=chunk_text, override=prompt_override)
+    async with semaphore:
+        try:
+            raw = await asyncio.wait_for(llm(prompt), timeout=_PER_CHUNK_LLM_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logger.info("dataset_generator: LLM timeout for chunk; skipping")
+            return None
+        except Exception:  # noqa: BLE001 — per-chunk failure isolation
+            logger.exception("dataset_generator: LLM call failed for chunk; skipping")
+            return None
+    question, expected_answer = _parse_qa_pair(raw)
+    if not question or not expected_answer:
+        return None
+    reference_context = chunk_text[:_REFERENCE_CONTEXT_MAX_CHARS]
+    return GeneratedDatasetItem(
+        question=question,
+        expected_answer=expected_answer,
+        reference_context=reference_context,
+    )
+
+
+async def generate_preview_items(
+    *,
+    collection: Collection,
+    count: int,
+    language: str | None,
+    prompt_template: str | None,
+    llm_factory=None,
+) -> tuple[list[GeneratedDatasetItem], str]:
+    """Produce ``count`` (or fewer) ``GeneratedDatasetItem`` objects from
+    a collection's chunks. ``llm_factory`` defaults to the collection's
+    configured completion model — tests pin a deterministic stub. Returns
+    the items plus the resolved language so the caller can echo it on
+    the response envelope."""
+    resolved_language = _resolve_language(request_language=language, collection=collection)
+
+    selected = await _select_chunks(collection=collection, desired_count=count * _CHUNK_OVERSAMPLE)
+    if not selected:
+        return ([], resolved_language)
+
+    if llm_factory is None:
+        from aperag.indexing.llm import build_collection_llm_callable
+
+        llm_factory = build_collection_llm_callable
+    llm = llm_factory(collection)
+
+    semaphore = asyncio.Semaphore(_LLM_CONCURRENCY)
+    tasks = [
+        _generate_one(
+            llm=llm,
+            chunk=chunk,
+            language=resolved_language,
+            prompt_override=prompt_template,
+            semaphore=semaphore,
+        )
+        for chunk in selected
+    ]
+    results = await asyncio.gather(*tasks)
+
+    items: list[GeneratedDatasetItem] = []
+    seen_questions: set[str] = set()
+    for item in results:
+        if item is None:
+            continue
+        # Trivial dedup — case-insensitive question text. A future LLM-
+        # judge embedding-similarity dedup is a Phase 3 follow-up; the
+        # naive form keeps the simple-stable guardrail intact for MVP.
+        key = item.question.casefold()
+        if key in seen_questions:
+            continue
+        seen_questions.add(key)
+        items.append(item)
+        if len(items) >= count:
+            break
+
+    return (items, resolved_language)
+
+
+__all__ = [
+    "generate_preview_items",
+]

--- a/aperag/domains/evaluation/schemas.py
+++ b/aperag/domains/evaluation/schemas.py
@@ -138,6 +138,65 @@ class EvaluationDatasetItemsAppendResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# AI auto-generate QA pairs (preview-then-confirm flow). Per architect lock
+# msg=05c3ec83 / earayu2 msg=6e354b8e:
+#
+#   * BE walks the collection's chunks.jsonl, picks ``count`` substantive
+#     chunks, calls the configured LLM once per chunk, parses each
+#     ``{question, expected_answer}`` pair.
+#   * BE returns each preview item with ``reference_context`` populated
+#     from the source chunk (FE keeps it hidden in the main list and
+#     surfaces it under a per-row "source" disclosure; bulk-create
+#     transparently persists all three fields).
+#   * No DB write here — the caller picks/edits and POSTs to the existing
+#     ``/items`` append endpoint.
+# ---------------------------------------------------------------------------
+
+
+_GENERATE_PREVIEW_DEFAULT_COUNT = 10
+_GENERATE_PREVIEW_MAX_COUNT = 100
+
+
+class EvaluationDatasetGeneratePreviewRequest(BaseModel):
+    collection_id: str = Field(..., min_length=1)
+    count: int = Field(
+        default=_GENERATE_PREVIEW_DEFAULT_COUNT,
+        ge=1,
+        le=_GENERATE_PREVIEW_MAX_COUNT,
+        description="Number of QA pairs to generate (default 10, max 100).",
+    )
+    language: Optional[str] = Field(
+        None,
+        description=(
+            "ISO locale (zh-CN / en-US / ja-JP / ko-KR). When omitted the "
+            "BE falls back to ``Collection.config.language``."
+        ),
+    )
+    prompt_template: Optional[str] = Field(
+        None,
+        description=(
+            "Override the default per-chunk QA generation prompt. The "
+            "default ships an explicit instruction to emit JSON with "
+            "``question`` and ``expected_answer`` fields in the resolved "
+            "language."
+        ),
+    )
+
+
+class GeneratedDatasetItem(BaseModel):
+    question: str
+    expected_answer: str
+    reference_context: Optional[str] = None
+
+
+class EvaluationDatasetGeneratePreviewResponse(BaseModel):
+    items: list[GeneratedDatasetItem] = Field(default_factory=list)
+    requested_count: int = 0
+    delivered_count: int = 0
+    language: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
 # EvaluationRun lifecycle
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_test/test_evaluation_dataset_generator.py
+++ b/tests/unit_test/test_evaluation_dataset_generator.py
@@ -175,7 +175,7 @@ async def test_generate_preview_items_returns_empty_when_no_chunks(monkeypatch):
         count=5,
         language="zh-CN",
         prompt_template=None,
-        llm_factory=lambda _c: (lambda _p: None),
+        llm_factory=lambda _c: lambda _p: None,
     )
     assert items == []
     assert language == "zh-CN"

--- a/tests/unit_test/test_evaluation_dataset_generator.py
+++ b/tests/unit_test/test_evaluation_dataset_generator.py
@@ -1,0 +1,290 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the AI auto-generate QA pairs path
+(``aperag/domains/evaluation/dataset_generator.py``).
+
+Per architect lock ``#evaluation msg=05c3ec83`` / ``msg=a9fb7efd``: the
+preview endpoint must surface ``{question, expected_answer,
+reference_context}`` items, dedup by question, cap reference_context at
+8 000 chars, and resolve language from request → collection.config →
+default. The tests pin those contracts without a live LLM.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.domains.evaluation import dataset_generator
+from aperag.domains.evaluation.dataset_generator import (
+    _REFERENCE_CONTEXT_MAX_CHARS,
+    _format_prompt,
+    _parse_qa_pair,
+    _resolve_language,
+    generate_preview_items,
+)
+
+# ---------------------------------------------------------------------
+# _parse_qa_pair — shape coercion
+# ---------------------------------------------------------------------
+
+
+def test_parse_qa_pair_accepts_plain_json():
+    raw = json.dumps({"question": "What is RAG?", "expected_answer": "Retrieval-Augmented Generation"})
+    q, a = _parse_qa_pair(raw)
+    assert q == "What is RAG?"
+    assert a == "Retrieval-Augmented Generation"
+
+
+def test_parse_qa_pair_accepts_fenced_json():
+    raw = '```json\n{"question": "Q?", "expected_answer": "A"}\n```'
+    q, a = _parse_qa_pair(raw)
+    assert q == "Q?"
+    assert a == "A"
+
+
+def test_parse_qa_pair_accepts_legacy_keys():
+    """Some models emit ``answer`` instead of ``expected_answer``."""
+    raw = json.dumps({"question": "Q?", "answer": "A"})
+    q, a = _parse_qa_pair(raw)
+    assert q == "Q?"
+    assert a == "A"
+
+
+def test_parse_qa_pair_rejects_invalid_json():
+    q, a = _parse_qa_pair("not even json — model rambled")
+    assert q is None
+    assert a is None
+
+
+def test_parse_qa_pair_rejects_empty_fields():
+    raw = json.dumps({"question": "  ", "expected_answer": ""})
+    q, a = _parse_qa_pair(raw)
+    assert q is None
+    assert a is None
+
+
+def test_parse_qa_pair_rejects_non_object_payload():
+    raw = json.dumps([{"question": "Q?", "expected_answer": "A"}])  # array, not object
+    q, a = _parse_qa_pair(raw)
+    assert q is None
+    assert a is None
+
+
+# ---------------------------------------------------------------------
+# _resolve_language — request → collection.config → default
+# ---------------------------------------------------------------------
+
+
+def _collection_with_language(language: str | None) -> SimpleNamespace:
+    if language is None:
+        config = "{}"
+    else:
+        config = json.dumps({"language": language})
+    return SimpleNamespace(id="col_test", user="u", config=config)
+
+
+def test_resolve_language_uses_request_when_supported():
+    coll = _collection_with_language("zh-CN")
+    assert _resolve_language(request_language="ja-JP", collection=coll) == "ja-JP"
+
+
+def test_resolve_language_ignores_unsupported_request_value():
+    coll = _collection_with_language("zh-CN")
+    assert _resolve_language(request_language="klingon-KL", collection=coll) == "zh-CN"
+
+
+def test_resolve_language_falls_back_to_collection_config():
+    coll = _collection_with_language("ja-JP")
+    assert _resolve_language(request_language=None, collection=coll) == "ja-JP"
+
+
+def test_resolve_language_falls_back_to_default_when_collection_has_none():
+    coll = _collection_with_language(None)
+    assert _resolve_language(request_language=None, collection=coll) == "zh-CN"
+
+
+def test_resolve_language_handles_unparseable_collection_config():
+    coll = SimpleNamespace(id="col_test", user="u", config="{not json")
+    # Falls through to default rather than raising.
+    assert _resolve_language(request_language=None, collection=coll) == "zh-CN"
+
+
+# ---------------------------------------------------------------------
+# _format_prompt — language template + override
+# ---------------------------------------------------------------------
+
+
+def test_format_prompt_uses_zh_template_by_default():
+    prompt = _format_prompt(language="zh-CN", chunk_text="蜜蜂养殖", override=None)
+    assert "蜜蜂养殖" in prompt
+    assert "中文" in prompt
+
+
+def test_format_prompt_uses_en_template():
+    prompt = _format_prompt(language="en-US", chunk_text="Apiary basics", override=None)
+    assert "Apiary basics" in prompt
+    assert "English" in prompt
+
+
+def test_format_prompt_falls_back_to_default_for_unknown_language():
+    prompt = _format_prompt(language="fr-FR", chunk_text="abeilles", override=None)
+    # Default is zh-CN per dataset_generator._DEFAULT_LANGUAGE.
+    assert "abeilles" in prompt
+
+
+def test_format_prompt_override_substitutes_chunk_text():
+    override = "TEMPLATE [{language}] ::: {chunk_text}"
+    prompt = _format_prompt(language="en-US", chunk_text="X", override=override)
+    assert prompt == "TEMPLATE [en-US] ::: X"
+
+
+def test_format_prompt_override_with_unknown_placeholder_falls_back():
+    """A typo in the override (``{question}`` instead of ``{chunk_text}``)
+    must not produce a silently-empty prompt — fall back to the
+    language default so the LLM still has the chunk in context."""
+    override = "Bad template: {question}"
+    prompt = _format_prompt(language="en-US", chunk_text="ChunkA", override=override)
+    assert "ChunkA" in prompt
+
+
+# ---------------------------------------------------------------------
+# generate_preview_items — orchestration
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_preview_items_returns_empty_when_no_chunks(monkeypatch):
+    coll = _collection_with_language("zh-CN")
+
+    async def _no_chunks(*, collection, desired_count):
+        return []
+
+    monkeypatch.setattr(dataset_generator, "_select_chunks", _no_chunks)
+
+    items, language = await generate_preview_items(
+        collection=coll,
+        count=5,
+        language="zh-CN",
+        prompt_template=None,
+        llm_factory=lambda _c: (lambda _p: None),
+    )
+    assert items == []
+    assert language == "zh-CN"
+
+
+@pytest.mark.asyncio
+async def test_generate_preview_items_dedupes_and_caps_reference_context(monkeypatch):
+    coll = _collection_with_language("en-US")
+
+    long_chunk = "a" * (_REFERENCE_CONTEXT_MAX_CHARS + 5_000)
+    chunks = [
+        {"text": long_chunk + "1", "id": "c1"},
+        {"text": "second chunk text " + "b" * 250, "id": "c2"},
+        {"text": "third chunk text " + "c" * 250, "id": "c3"},
+    ]
+
+    async def _select(*, collection, desired_count):
+        return chunks[:desired_count]
+
+    monkeypatch.setattr(dataset_generator, "_select_chunks", _select)
+
+    # Two duplicate questions to verify dedup; one varied.
+    responses = iter(
+        [
+            json.dumps({"question": "Same Q?", "expected_answer": "A1"}),
+            json.dumps({"question": "Same Q?", "expected_answer": "A2"}),
+            json.dumps({"question": "Different Q?", "expected_answer": "A3"}),
+        ]
+    )
+
+    async def _llm(_prompt: str) -> str:
+        return next(responses)
+
+    items, language = await generate_preview_items(
+        collection=coll,
+        count=5,
+        language=None,  # falls back to collection.config.language
+        prompt_template=None,
+        llm_factory=lambda _c: _llm,
+    )
+    assert language == "en-US"
+    assert len(items) == 2
+    assert {item.question for item in items} == {"Same Q?", "Different Q?"}
+    # Reference context capped at the boundary so a 13K-char chunk
+    # cannot bloat the row.
+    for item in items:
+        assert item.reference_context is not None
+        assert len(item.reference_context) <= _REFERENCE_CONTEXT_MAX_CHARS
+
+
+@pytest.mark.asyncio
+async def test_generate_preview_items_skips_failed_llm_responses(monkeypatch):
+    coll = _collection_with_language("zh-CN")
+
+    chunks = [
+        {"text": "chunk one " + "a" * 250, "id": "c1"},
+        {"text": "chunk two " + "b" * 250, "id": "c2"},
+        {"text": "chunk three " + "c" * 250, "id": "c3"},
+    ]
+
+    async def _select(*, collection, desired_count):
+        return chunks
+
+    monkeypatch.setattr(dataset_generator, "_select_chunks", _select)
+
+    responses = iter(
+        [
+            "model rambled, not JSON",
+            json.dumps({"question": "Valid Q?", "expected_answer": "Valid A"}),
+            json.dumps({"question": "", "expected_answer": "no question"}),
+        ]
+    )
+
+    async def _llm(_prompt: str) -> str:
+        return next(responses)
+
+    items, _ = await generate_preview_items(
+        collection=coll,
+        count=5,
+        language="zh-CN",
+        prompt_template=None,
+        llm_factory=lambda _c: _llm,
+    )
+    assert len(items) == 1
+    assert items[0].question == "Valid Q?"
+
+
+@pytest.mark.asyncio
+async def test_generate_preview_items_truncates_to_count(monkeypatch):
+    coll = _collection_with_language("zh-CN")
+
+    chunks = [{"text": f"chunk {i} " + "x" * 250, "id": f"c{i}"} for i in range(10)]
+
+    async def _select(*, collection, desired_count):
+        return chunks[:desired_count]
+
+    monkeypatch.setattr(dataset_generator, "_select_chunks", _select)
+
+    counter = iter(range(100))
+
+    async def _llm(_prompt: str) -> str:
+        i = next(counter)
+        return json.dumps({"question": f"Q{i}", "expected_answer": f"A{i}"})
+
+    items, _ = await generate_preview_items(
+        collection=coll,
+        count=3,
+        language="zh-CN",
+        prompt_template=None,
+        llm_factory=lambda _c: _llm,
+    )
+    assert len(items) == 3


### PR DESCRIPTION
## Summary

Per architect lock ``#evaluation msg=05c3ec83`` + ``msg=a9fb7efd`` and @earayu2 ``msg=dfaec7fa`` ("开工"): adds a preview-only endpoint that turns a collection's chunks into ``{question, expected_answer, reference_context}`` QA pairs so the FE can let the operator review / edit / select before bulk-saving to a dataset (existing append endpoint).

## What changed

**New endpoint**

```
POST /api/v2/evaluation-datasets/{dataset_id}/items/generate-preview
Body: {
  collection_id: str,
  count: int = 10 (max 100),
  language?: "zh-CN" | "en-US" | "ja-JP" | "ko-KR",
  prompt_template?: str
}
→ 200 {
  items: [{question, expected_answer, reference_context}, ...],
  requested_count, delivered_count, language
}
```

**Generator** (``aperag/domains/evaluation/dataset_generator.py``)

* Walks the collection's serving chunks.jsonl artifacts and round-robins across documents to favour diversity.
* Filters to substantive chunks (≥ 200 chars).
* Fires **one LLM call per chunk** (per Weston ``msg=87124ce5`` — deterministic provenance vs single-batch confusion), parallelised under a 4-way semaphore.
* ``reference_context`` is the source chunk text **capped at 8 000 chars** so a 50 K-char chunk cannot bloat every dataset row.
* Language resolution: request → ``collection.config.language`` → ``zh-CN`` default (per @earayu2 ``msg=e3498dc0``).
* Built-in prompt templates for the four supported locales explicitly instruct the model to emit JSON in the resolved language.
* Per-row dedup by case-folded question text; results truncated to ``count``.

## Files

- ``aperag/domains/evaluation/schemas.py`` — request / response / item schemas with default/max bounds
- ``aperag/domains/evaluation/dataset_generator.py`` — chunk walk + per-chunk LLM call + parse + dedup
- ``aperag/domains/evaluation/api/routes.py`` — wires the endpoint right after the existing ``POST /items``
- ``tests/unit_test/test_evaluation_dataset_generator.py`` — 20 new tests

## Test plan

- [x] ``uv run pytest tests/unit_test/test_evaluation_dataset_generator.py tests/unit_test/test_evaluation_v2_openapi_contract.py`` — 27 passed locally
- [x] ``uv run ruff check ./aperag tests`` — clean
- [x] ``uv run ruff format --check`` on touched files — clean
- [ ] dongdong/cuiwenbo FE PR #22 lands → manual: trigger from the dataset page, verify language=zh-CN by default for a Chinese collection, ``count=10`` returns ≤ 10 items each with ``reference_context`` ≤ 8 000 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)