### PR TITLE
fix(marketplace): remove featured collection panel

### DIFF
--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -2,8 +2,7 @@ import { PageContainer, PageContent } from '@/components/page-container';
 import { Button } from '@/components/ui/button';
 import { listMarketplaceCollections } from '@/features/marketplace/server-api';
 import type { SharedCollection } from '@/features/marketplace/types';
-import { ENTITY_PALETTE } from '@/lib/design-tokens';
-import { BookOpen, Eye, Plus } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
 import { CollectionList } from './collection-list';
@@ -20,10 +19,6 @@ export default async function Page() {
   } catch (err) {
     console.log(err);
   }
-
-  const featured = [...collections].sort(
-    (a, b) => (b.subscription_count || 0) - (a.subscription_count || 0),
-  )[0];
 
   return (
     <PageContainer>
@@ -50,121 +45,8 @@ export default async function Page() {
           </div>
         </div>
 
-        {featured && (
-          <div className="bg-foreground text-background border-foreground/10 mb-6 grid overflow-hidden rounded-xl border shadow-sm lg:grid-cols-[1.35fr_0.65fr]">
-            <div className="flex min-h-72 flex-col justify-between gap-8 p-6 md:p-8">
-              <div className="text-primary font-mono text-[11px] tracking-[0.12em] uppercase">
-                {page_marketplace('featured_label')}
-              </div>
-              <div>
-                <h2 className="mt-3 max-w-2xl font-serif text-3xl leading-tight font-normal md:text-[40px]">
-                  {featured.title}
-                </h2>
-                {featured.description && (
-                  <p className="text-background/70 mt-3 max-w-2xl text-sm leading-6">
-                    {featured.description}
-                  </p>
-                )}
-                <div className="text-background/60 mt-5 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-background font-mono text-lg tabular-nums">
-                      {featured.subscription_count || 0}
-                    </span>
-                    <span>{page_marketplace('subscriptions')}</span>
-                  </div>
-                  <div>
-                    {page_marketplace('published_by', {
-                      owner:
-                        featured.owner_username ||
-                        page_marketplace('owner_unknown'),
-                    })}
-                  </div>
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Button asChild>
-                  <Link
-                    href={`/marketplace/collections/${featured.id}/documents`}
-                  >
-                    <Eye className="size-4" />
-                    {page_marketplace('preview')}
-                  </Link>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="border-background/20 bg-background/5 text-background hover:bg-background/10 hover:text-background"
-                  asChild
-                >
-                  <Link href="/workspace/collections">
-                    <Plus className="size-4" />
-                    {page_marketplace('publish_hint_action')}
-                  </Link>
-                </Button>
-              </div>
-            </div>
-            <div className="border-background/10 relative hidden min-h-72 border-l lg:block">
-              <div className="bg-primary/25 absolute top-1/2 left-1/2 size-56 -translate-x-1/2 -translate-y-1/2 rounded-full blur-3xl" />
-              <div className="absolute inset-8">
-                <MarketplaceGraphMotif />
-              </div>
-            </div>
-          </div>
-        )}
-
         <CollectionList collections={collections} />
       </PageContent>
     </PageContainer>
   );
 }
-
-const MarketplaceGraphMotif = () => {
-  const nodes = [
-    [50, 50, 16, ENTITY_PALETTE.event],
-    [22, 22, 8, ENTITY_PALETTE.person],
-    [78, 28, 9, ENTITY_PALETTE.org],
-    [84, 76, 10, ENTITY_PALETTE.concept],
-    [27, 78, 8, ENTITY_PALETTE.product],
-    [52, 88, 7, ENTITY_PALETTE.doc],
-  ] as const;
-
-  return (
-    <div className="relative h-full w-full">
-      <svg
-        aria-hidden="true"
-        className="text-background/20 absolute inset-0 h-full w-full"
-        viewBox="0 0 100 100"
-      >
-        {nodes.slice(1).map(([x, y], index) => (
-          <line
-            key={`${x}-${y}-${index}`}
-            x1="50"
-            y1="50"
-            x2={x}
-            y2={y}
-            stroke="currentColor"
-            strokeWidth="0.45"
-          />
-        ))}
-      </svg>
-      {nodes.map(([x, y, size, color], index) => (
-        <div
-          key={`${x}-${y}`}
-          className="border-background/20 absolute rounded-full border shadow-sm"
-          style={{
-            left: `${x}%`,
-            top: `${y}%`,
-            width: size,
-            height: size,
-            backgroundColor: color,
-            transform: 'translate(-50%, -50%)',
-          }}
-          aria-hidden="true"
-        >
-          {index === 0 && (
-            <div className="border-primary/60 absolute inset-[-10px] rounded-full border border-dashed" />
-          )}
-        </div>
-      ))}
-    </div>
-  );
-};

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -1094,7 +1094,6 @@
       "description": "Browse published collections from the workspace, preview their documents, and subscribe the useful ones into your own collection list."
     },
     "workspace_label": "Workspace",
-    "featured_label": "Featured collection",
     "published_collection": "Published collection",
     "published_by": "Published by {owner}",
     "owner_unknown": "Unknown owner",

--- a/web/src/i18n/en-US/page_marketplace.json
+++ b/web/src/i18n/en-US/page_marketplace.json
@@ -4,7 +4,6 @@
     "description": "Browse published collections from the workspace, preview their documents, and subscribe the useful ones into your own collection list."
   },
   "workspace_label": "Workspace",
-  "featured_label": "Featured collection",
   "published_collection": "Published collection",
   "published_by": "Published by {owner}",
   "owner_unknown": "Unknown owner",

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -1094,7 +1094,6 @@
       "description": "浏览工作区中已发布的知识库，预览文档内容，并把有用的知识库订阅到自己的列表。"
     },
     "workspace_label": "工作区",
-    "featured_label": "精选知识库",
     "published_collection": "已发布知识库",
     "published_by": "由 {owner} 发布",
     "owner_unknown": "未知发布者",

--- a/web/src/i18n/zh-CN/page_marketplace.json
+++ b/web/src/i18n/zh-CN/page_marketplace.json
@@ -4,7 +4,6 @@
     "description": "浏览工作区中已发布的知识库，预览文档内容，并把有用的知识库订阅到自己的列表。"
   },
   "workspace_label": "工作区",
-  "featured_label": "精选知识库",
   "published_collection": "已发布知识库",
   "published_by": "由 {owner} 发布",
   "owner_unknown": "未知发布者",


### PR DESCRIPTION
## Summary
- remove the featured collection panel from the marketplace landing page
- drop the unused featured collection i18n label from zh-CN/en-US catalogs

## Validation
- yarn i18n:sync
- yarn lint --quiet
- yarn type-check --pretty false
- git diff --check
- curl http://localhost:3002/marketplace returns 200 and no longer contains the featured label