### PR TITLE
[codex] Polish landing feedback

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import NextTopLoader from 'nextjs-toploader';
 
 import { AppProvider } from '@/components/providers/app-provider';
 import { ThemeProvider } from '@/components/providers/theme-provider';
+import { getLocale } from '@/services/cookies';
 import 'highlight.js/styles/github-dark.css';
 import './globals.css';
 
@@ -56,9 +57,10 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const user = (await getCurrentUser()) ?? undefined;
+  const locale = await getLocale();
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning>
       <body
         className={`${fontSans.variable} ${fontSerif.variable} ${fontMono.variable} font-sans antialiased`}
       >

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -2,8 +2,7 @@ import { PageContainer, PageContent } from '@/components/page-container';
 import { Button } from '@/components/ui/button';
 import { listMarketplaceCollections } from '@/features/marketplace/server-api';
 import type { SharedCollection } from '@/features/marketplace/types';
-import { ENTITY_PALETTE } from '@/lib/design-tokens';
-import { BookOpen, Eye, Plus } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
 import { CollectionList } from './collection-list';
@@ -20,10 +19,6 @@ export default async function Page() {
   } catch (err) {
     console.log(err);
   }
-
-  const featured = [...collections].sort(
-    (a, b) => (b.subscription_count || 0) - (a.subscription_count || 0),
-  )[0];
 
   return (
     <PageContainer>
@@ -50,121 +45,8 @@ export default async function Page() {
           </div>
         </div>
 
-        {featured && (
-          <div className="bg-foreground text-background border-foreground/10 mb-6 grid overflow-hidden rounded-xl border shadow-sm lg:grid-cols-[1.35fr_0.65fr]">
-            <div className="flex min-h-72 flex-col justify-between gap-8 p-6 md:p-8">
-              <div className="text-primary font-mono text-[11px] tracking-[0.12em] uppercase">
-                {page_marketplace('featured_label')}
-              </div>
-              <div>
-                <h2 className="mt-3 max-w-2xl font-serif text-3xl leading-tight font-normal md:text-[40px]">
-                  {featured.title}
-                </h2>
-                {featured.description && (
-                  <p className="text-background/70 mt-3 max-w-2xl text-sm leading-6">
-                    {featured.description}
-                  </p>
-                )}
-                <div className="text-background/60 mt-5 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-background font-mono text-lg tabular-nums">
-                      {featured.subscription_count || 0}
-                    </span>
-                    <span>{page_marketplace('subscriptions')}</span>
-                  </div>
-                  <div>
-                    {page_marketplace('published_by', {
-                      owner:
-                        featured.owner_username ||
-                        page_marketplace('owner_unknown'),
-                    })}
-                  </div>
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Button asChild>
-                  <Link
-                    href={`/marketplace/collections/${featured.id}/documents`}
-                  >
-                    <Eye className="size-4" />
-                    {page_marketplace('preview')}
-                  </Link>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="border-background/20 bg-background/5 text-background hover:bg-background/10 hover:text-background"
-                  asChild
-                >
-                  <Link href="/workspace/collections">
-                    <Plus className="size-4" />
-                    {page_marketplace('publish_hint_action')}
-                  </Link>
-                </Button>
-              </div>
-            </div>
-            <div className="border-background/10 relative hidden min-h-72 border-l lg:block">
-              <div className="bg-primary/25 absolute top-1/2 left-1/2 size-56 -translate-x-1/2 -translate-y-1/2 rounded-full blur-3xl" />
-              <div className="absolute inset-8">
-                <MarketplaceGraphMotif />
-              </div>
-            </div>
-          </div>
-        )}
-
         <CollectionList collections={collections} />
       </PageContent>
     </PageContainer>
   );
 }
-
-const MarketplaceGraphMotif = () => {
-  const nodes = [
-    [50, 50, 16, ENTITY_PALETTE.event],
-    [22, 22, 8, ENTITY_PALETTE.person],
-    [78, 28, 9, ENTITY_PALETTE.org],
-    [84, 76, 10, ENTITY_PALETTE.concept],
-    [27, 78, 8, ENTITY_PALETTE.product],
-    [52, 88, 7, ENTITY_PALETTE.doc],
-  ] as const;
-
-  return (
-    <div className="relative h-full w-full">
-      <svg
-        aria-hidden="true"
-        className="text-background/20 absolute inset-0 h-full w-full"
-        viewBox="0 0 100 100"
-      >
-        {nodes.slice(1).map(([x, y], index) => (
-          <line
-            key={`${x}-${y}-${index}`}
-            x1="50"
-            y1="50"
-            x2={x}
-            y2={y}
-            stroke="currentColor"
-            strokeWidth="0.45"
-          />
-        ))}
-      </svg>
-      {nodes.map(([x, y, size, color], index) => (
-        <div
-          key={`${x}-${y}`}
-          className="border-background/20 absolute rounded-full border shadow-sm"
-          style={{
-            left: `${x}%`,
-            top: `${y}%`,
-            width: size,
-            height: size,
-            backgroundColor: color,
-            transform: 'translate(-50%, -50%)',
-          }}
-          aria-hidden="true"
-        >
-          {index === 0 && (
-            <div className="border-primary/60 absolute inset-[-10px] rounded-full border border-dashed" />
-          )}
-        </div>
-      ))}
-    </div>
-  );
-};

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { AppLogo } from '@/components/app-topbar';
+import { AppLocaleDropdownMenu, AppLogo } from '@/components/app-topbar';
 import { Button } from '@/components/ui/button';
 import {
   ArrowRight,
@@ -19,7 +19,6 @@ const navLinks = [
   { href: '#agent', key: 'nav.agent' },
   { href: '#graph', key: 'nav.graph' },
   { href: '#deployment', key: 'nav.deployment' },
-  { href: '/docs', key: 'nav.docs' },
 ] as const;
 
 const capabilityKeys = ['hybrid', 'graph', 'agent', 'deployment'] as const;
@@ -51,10 +50,7 @@ export default async function Home() {
           }}
         />
         <div className="flex flex-col justify-center">
-          <div className="bg-card text-muted-foreground mb-7 inline-flex w-fit items-center gap-2 rounded-full border px-2 py-1 pr-3 text-xs shadow-xs">
-            <span className="bg-primary text-primary-foreground rounded-full px-2 py-0.5 font-mono text-[10px] tracking-[0.16em] uppercase">
-              {t('hero.badge')}
-            </span>
+          <div className="bg-card text-muted-foreground mb-7 inline-flex w-fit items-center rounded-full border px-3 py-1 text-xs shadow-xs">
             <span>{t('hero.badge_text')}</span>
           </div>
           <h1 className="max-w-3xl font-serif text-5xl leading-[1.02] font-normal tracking-[-0.045em] text-balance md:text-6xl lg:text-7xl">
@@ -84,8 +80,8 @@ export default async function Home() {
               <Link href="/marketplace">{t('hero.secondary_cta')}</Link>
             </Button>
           </div>
-          <div className="text-muted-foreground mt-9 grid gap-3 text-sm sm:grid-cols-3">
-            {(['private', 'models', 'license'] as const).map((key) => (
+          <div className="text-muted-foreground mt-9 grid gap-3 text-sm sm:grid-cols-2">
+            {(['private', 'models'] as const).map((key) => (
               <div key={key} className="flex items-center gap-2">
                 <span className="bg-accent-soft text-accent-ink grid size-5 place-items-center rounded-full">
                   <Check className="size-3" />
@@ -243,11 +239,9 @@ function LandingNav({ t }: { t: LandingTranslations }) {
           ))}
         </nav>
         <div className="ml-auto flex items-center gap-2">
+          <AppLocaleDropdownMenu />
           <Button asChild variant="ghost" size="sm" className="rounded-full">
             <Link href="/auth/signin">{t('nav.signin')}</Link>
-          </Button>
-          <Button asChild size="sm" className="rounded-full">
-            <Link href="/workspace/collections">{t('nav.start')}</Link>
           </Button>
         </div>
       </div>
@@ -287,42 +281,50 @@ function HeroAgentTrace({ t }: { t: LandingTranslations }) {
           </div>
           <p className="mt-2 text-sm leading-6">{t('hero_trace.prompt')}</p>
         </div>
-        <div className="bg-secondary/55 border-t px-6 py-5">
-          <div className="mb-4 flex items-center gap-2">
-            <Sparkles className="text-primary size-4" />
-            <span className="text-muted-foreground font-mono text-[11px] tracking-[0.16em] uppercase">
-              {t('hero_trace.title')}
-            </span>
-            <span className="text-muted-foreground ml-auto font-mono text-[11px]">
-              {t('hero_trace.meta')}
-            </span>
-          </div>
-          <div className="space-y-4">
-            {traceSteps.map((key, index) => (
-              <div key={key} className="grid grid-cols-[1.5rem_1fr] gap-3">
-                <div className="bg-card text-primary mt-1 grid size-6 place-items-center rounded-full shadow-xs">
-                  {index === 0 ? (
-                    <Sparkles className="size-3.5" />
-                  ) : index === 1 ? (
-                    <Network className="size-3.5" />
-                  ) : index === 2 ? (
-                    <BookOpenText className="size-3.5" />
-                  ) : index === 3 ? (
-                    <GitBranch className="size-3.5" />
-                  ) : (
-                    <Check className="size-3.5" />
-                  )}
-                </div>
-                <div>
-                  <div className="text-muted-foreground font-mono text-[10px] tracking-[0.14em] uppercase">
-                    {t(`hero_trace.steps.${key}.label`)}
+        <div className="border-t p-4">
+          <div className="bg-muted border-border/70 overflow-hidden rounded-xl border">
+            <div className="text-muted-foreground flex items-center gap-2 px-3.5 py-2.5">
+              <Sparkles className="text-primary size-3" />
+              <span className="font-mono text-[10.5px] tracking-[0.08em] uppercase">
+                {t('hero_trace.title')}
+              </span>
+              <span className="text-muted-foreground/80 ml-2 truncate text-[11px]">
+                {t('hero_trace.meta')}
+              </span>
+            </div>
+            <div className="border-border/70 border-t px-4 py-3.5">
+              <div className="relative flex flex-col gap-3.5">
+                <div className="bg-border absolute top-3 bottom-3 left-[11px] w-px" />
+                {traceSteps.map((key, index) => (
+                  <div
+                    key={key}
+                    className="relative grid grid-cols-[1.5rem_1fr] gap-3"
+                  >
+                    <div className="bg-card text-primary z-10 grid size-6 place-items-center rounded-full shadow-xs">
+                      {index === 0 ? (
+                        <Sparkles className="size-3.5" />
+                      ) : index === 1 ? (
+                        <Network className="size-3.5" />
+                      ) : index === 2 ? (
+                        <BookOpenText className="size-3.5" />
+                      ) : index === 3 ? (
+                        <GitBranch className="size-3.5" />
+                      ) : (
+                        <Check className="size-3.5" />
+                      )}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-muted-foreground font-mono text-[10px] tracking-[0.14em] uppercase">
+                        {t(`hero_trace.steps.${key}.label`)}
+                      </div>
+                      <p className="text-foreground/85 mt-1 text-sm leading-6">
+                        {t(`hero_trace.steps.${key}.text`)}
+                      </p>
+                    </div>
                   </div>
-                  <p className="text-foreground/85 mt-1 text-sm leading-6">
-                    {t(`hero_trace.steps.${key}.text`)}
-                  </p>
-                </div>
+                ))}
               </div>
-            ))}
+            </div>
           </div>
         </div>
       </div>
@@ -484,7 +486,7 @@ function GraphVisual({ t }: { t: LandingTranslations }) {
           {t('graph.legend')}
         </div>
         <div className="text-muted-foreground mt-3 grid grid-cols-2 gap-x-5 gap-y-2 text-xs">
-          {['Person', 'Org', 'Product', 'Event'].map((item, index) => (
+          {['person', 'org', 'product', 'event'].map((item, index) => (
             <div key={item} className="flex items-center gap-2">
               <span
                 className={`size-2 rounded-full ${
@@ -497,7 +499,7 @@ function GraphVisual({ t }: { t: LandingTranslations }) {
                         : 'bg-chart-5'
                 }`}
               />
-              {item}
+              {t(`graph.legend_items.${item}`)}
             </div>
           ))}
         </div>

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -968,7 +968,6 @@
       "start": "Open workspace"
     },
     "hero": {
-      "badge": "v2",
       "badge_text": "GraphRAG x Agent runtime · private deployment",
       "title": "Turn enterprise knowledge into",
       "title_accent": "traceable answers.",
@@ -977,13 +976,12 @@
       "secondary_cta": "Browse marketplace",
       "points": {
         "private": "Private deployment",
-        "models": "Works with mainstream models",
-        "license": "Apache 2.0"
+        "models": "Works with mainstream models"
       }
     },
     "hero_trace": {
       "status": "running",
-      "user": "Operator",
+      "user": "User",
       "prompt": "SMT-03 on line 3 reported E-047 this morning. Help me narrow down the likely cause.",
       "title": "Agent trace",
       "meta": "sources tracked",
@@ -1052,6 +1050,12 @@
       "title": "Dense relationships, rendered with restraint.",
       "description": "The graph view keeps entity types, neighbors, search, and merge suggestions available while using a quieter warm palette for daily work.",
       "legend": "Entity types",
+      "legend_items": {
+        "person": "Person",
+        "org": "Org",
+        "product": "Product",
+        "event": "Event"
+      },
       "nodes": {
         "center": "SMT",
         "org": "ORG",

--- a/web/src/i18n/en-US/page_landing.json
+++ b/web/src/i18n/en-US/page_landing.json
@@ -8,7 +8,6 @@
     "start": "Open workspace"
   },
   "hero": {
-    "badge": "v2",
     "badge_text": "GraphRAG x Agent runtime · private deployment",
     "title": "Turn enterprise knowledge into",
     "title_accent": "traceable answers.",
@@ -17,13 +16,12 @@
     "secondary_cta": "Browse marketplace",
     "points": {
       "private": "Private deployment",
-      "models": "Works with mainstream models",
-      "license": "Apache 2.0"
+      "models": "Works with mainstream models"
     }
   },
   "hero_trace": {
     "status": "running",
-    "user": "Operator",
+    "user": "User",
     "prompt": "SMT-03 on line 3 reported E-047 this morning. Help me narrow down the likely cause.",
     "title": "Agent trace",
     "meta": "sources tracked",
@@ -92,6 +90,12 @@
     "title": "Dense relationships, rendered with restraint.",
     "description": "The graph view keeps entity types, neighbors, search, and merge suggestions available while using a quieter warm palette for daily work.",
     "legend": "Entity types",
+    "legend_items": {
+      "person": "Person",
+      "org": "Org",
+      "product": "Product",
+      "event": "Event"
+    },
     "nodes": {
       "center": "SMT",
       "org": "ORG",

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -968,7 +968,6 @@
       "start": "进入工作区"
     },
     "hero": {
-      "badge": "v2",
       "badge_text": "GraphRAG × Agent 运行时 · 私有化部署",
       "title": "让企业知识变成",
       "title_accent": "可追溯的答案。",
@@ -977,13 +976,12 @@
       "secondary_cta": "浏览市场",
       "points": {
         "private": "私有化部署",
-        "models": "兼容主流模型",
-        "license": "Apache 2.0"
+        "models": "兼容主流模型"
       }
     },
     "hero_trace": {
       "status": "运行中",
-      "user": "操作员",
+      "user": "用户",
       "prompt": "3 号线 SMT-03 今早报 E-047，帮我判断最可能的原因。",
       "title": "Agent 轨迹",
       "meta": "来源已记录",
@@ -1052,6 +1050,12 @@
       "title": "复杂关系，也要克制呈现。",
       "description": "图谱页保留实体类型、邻居高亮、搜索和合并建议，同时用更安静的暖色体系服务日常使用。",
       "legend": "实体类型",
+      "legend_items": {
+        "person": "人员",
+        "org": "组织",
+        "product": "产品",
+        "event": "事件"
+      },
       "nodes": {
         "center": "SMT",
         "org": "组织",

--- a/web/src/i18n/zh-CN/page_landing.json
+++ b/web/src/i18n/zh-CN/page_landing.json
@@ -8,7 +8,6 @@
     "start": "进入工作区"
   },
   "hero": {
-    "badge": "v2",
     "badge_text": "GraphRAG × Agent 运行时 · 私有化部署",
     "title": "让企业知识变成",
     "title_accent": "可追溯的答案。",
@@ -17,13 +16,12 @@
     "secondary_cta": "浏览市场",
     "points": {
       "private": "私有化部署",
-      "models": "兼容主流模型",
-      "license": "Apache 2.0"
+      "models": "兼容主流模型"
     }
   },
   "hero_trace": {
     "status": "运行中",
-    "user": "操作员",
+    "user": "用户",
     "prompt": "3 号线 SMT-03 今早报 E-047，帮我判断最可能的原因。",
     "title": "Agent 轨迹",
     "meta": "来源已记录",
@@ -92,6 +90,12 @@
     "title": "复杂关系，也要克制呈现。",
     "description": "图谱页保留实体类型、邻居高亮、搜索和合并建议，同时用更安静的暖色体系服务日常使用。",
     "legend": "实体类型",
+    "legend_items": {
+      "person": "人员",
+      "org": "组织",
+      "product": "产品",
+      "event": "事件"
+    },
     "nodes": {
       "center": "SMT",
       "org": "组织",

--- a/web/src/services/cookies.ts
+++ b/web/src/services/cookies.ts
@@ -9,7 +9,7 @@ const locales = ['en-US', 'zh-CN'] as const;
 export type LocaleEnum = (typeof locales)[number];
 
 const defaultLocale: LocaleEnum = (process.env.NEXT_PUBLIC_DEFAULT_LOCALE ||
-  'en-US') as LocaleEnum;
+  'zh-CN') as LocaleEnum;
 
 /**
  * get locale


### PR DESCRIPTION
## Summary
- remove landing page V2, Docs nav, header workspace CTA, and open-source/license messaging
- add locale switcher with zh-CN as the default locale and localized graph legend labels
- align the landing agent trace styling with the app activity timeline and remove the marketplace featured collection module

## Validation
- node scripts/i18n-watch.mjs
- git diff --check
- targeted string checks for removed labels

Note: full web lint/build was not run because web/node_modules is not installed in this checkout.