### PR TITLE
fix(evaluation): drop unused ai_generate_model i18n keys (i18n:check fix-forward)

### DIFF
--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -647,8 +647,6 @@
     "ai_generate_language_ja-JP": "日本語",
     "ai_generate_language_ko-KR": "한국어",
     "ai_generate_advanced": "高级选项",
-    "ai_generate_model_label": "大模型",
-    "ai_generate_model_placeholder": "留空使用知识库默认模型",
     "ai_generate_prompt_label": "Prompt 模板",
     "ai_generate_submit": "生成预览",
     "ai_generate_back": "返回",

--- a/web/src/i18n/zh-CN/page_collection_evaluations.json
+++ b/web/src/i18n/zh-CN/page_collection_evaluations.json
@@ -54,8 +54,6 @@
   "ai_generate_language_ja-JP": "日本語",
   "ai_generate_language_ko-KR": "한국어",
   "ai_generate_advanced": "高级选项",
-  "ai_generate_model_label": "大模型",
-  "ai_generate_model_placeholder": "留空使用知识库默认模型",
   "ai_generate_prompt_label": "Prompt 模板",
   "ai_generate_submit": "生成预览",
   "ai_generate_back": "返回",


### PR DESCRIPTION
## Summary

Fix-forward for the i18n:check failure that landed when #1839 merged (https://github.com/apecloud/ApeRAG/actions/runs/25081773306).

#1839 dropped the per-call model selector from the AI auto-generate dialog (architect ratify msg=da8f7a23 — the BE always uses `collection.config.completion`), but the corresponding zh-CN keys (`ai_generate_model_label`, `ai_generate_model_placeholder`) were left in the dictionary without en-US counterparts. The i18n parity gate failed:

```
i18n check failed:
- zh-CN/page_collection_evaluations.json has extra ai_generate_model_label
- zh-CN/page_collection_evaluations.json has extra ai_generate_model_placeholder
```

Removing the unused zh-CN keys restores parity rather than re-introducing dead UI labels on the en-US side.

## Validation

- `yarn i18n:check` passes locally (`i18n check passed for 2 locales`)
- 2 files / -4 lines

## Required for merge

Same-account constraint applies. @符炫炜 ratify after CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)