### PR TITLE
fix(frontend): restore i18n and type-check gates

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -29,6 +29,7 @@ const traceSteps = [
   'compare',
   'answer',
 ] as const;
+const graphLegendItems = ['person', 'org', 'product', 'event'] as const;
 const agentFeatureKeys = ['runtime', 'mcp', 'audit'] as const;
 const deploymentFeatureKeys = ['private', 'models', 'management'] as const;
 
@@ -486,7 +487,7 @@ function GraphVisual({ t }: { t: LandingTranslations }) {
           {t('graph.legend')}
         </div>
         <div className="text-muted-foreground mt-3 grid grid-cols-2 gap-x-5 gap-y-2 text-xs">
-          {['person', 'org', 'product', 'event'].map((item, index) => (
+          {graphLegendItems.map((item, index) => (
             <div key={item} className="flex items-center gap-2">
               <span
                 className={`size-2 rounded-full ${

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -647,8 +647,6 @@
     "ai_generate_language_ja-JP": "日本語",
     "ai_generate_language_ko-KR": "한국어",
     "ai_generate_advanced": "高级选项",
-    "ai_generate_model_label": "大模型",
-    "ai_generate_model_placeholder": "留空使用知识库默认模型",
     "ai_generate_prompt_label": "Prompt 模板",
     "ai_generate_submit": "生成预览",
     "ai_generate_back": "返回",

--- a/web/src/i18n/zh-CN/page_collection_evaluations.json
+++ b/web/src/i18n/zh-CN/page_collection_evaluations.json
@@ -54,8 +54,6 @@
   "ai_generate_language_ja-JP": "日本語",
   "ai_generate_language_ko-KR": "한국어",
   "ai_generate_advanced": "高级选项",
-  "ai_generate_model_label": "大模型",
-  "ai_generate_model_placeholder": "留空使用知识库默认模型",
   "ai_generate_prompt_label": "Prompt 模板",
   "ai_generate_submit": "生成预览",
   "ai_generate_back": "返回",


### PR DESCRIPTION
## Summary\n- remove stale zh-CN-only AI generate model i18n keys that broke i18n:check after PR #1839\n- type the landing graph legend items as a const tuple so frontend type-check passes on current main\n\n## Tests\n- cd web && yarn i18n:check\n- cd web && yarn type-check\n