### PR TITLE
fix(evaluation): inject collection LLM as answer model into worker

### DIFF
--- a/aperag/domains/evaluation/worker.py
+++ b/aperag/domains/evaluation/worker.py
@@ -84,6 +84,7 @@ async def dispatch_evaluation_turn(
     user_id: str,
     bot_id: str,
     input_message: str,
+    completion=None,
     timeout_seconds: float = 300.0,
     poll_interval_seconds: float = 0.25,
 ) -> TurnDispatchOutcome:
@@ -97,6 +98,14 @@ async def dispatch_evaluation_turn(
     The implementation MUST stay runtime-API-only: no HTTP side-channel
     back to the bot router, no synchronous shortcut around
     ``agent_runtime_manager`` — per the ``#13 agent-runtime`` contract.
+
+    ``completion`` (a ``ModelSpec``) is the answer-side model the agent
+    runtime v3 needs after PR #1697 / Wave 10. The caller resolves it
+    from the run's ``collection_id`` → ``collection.config.completion``
+    so each evaluation case is answered by the same LLM the collection
+    is configured with — without it the runtime raises ``Model
+    specification is required for agent runtime v3`` and every case in
+    the run fails (regression caught via @earayu2 msg=c44beebc).
     """
 
     # Local imports: keep the module import-safe for tests that do not
@@ -115,7 +124,7 @@ async def dispatch_evaluation_turn(
     chat_view = await chat_service_global.create_chat(user_id, bot_id)
     chat_id = chat_view.id
 
-    turn_request = CreateTurnRequest(query=input_message)
+    turn_request = CreateTurnRequest(query=input_message, completion=completion)
     _chat, _bot, turn, _created = await agent_runtime_manager.turn_service.create_or_get_turn(
         user_id, chat_id, turn_request
     )
@@ -282,6 +291,22 @@ async def execute_evaluation_run(
     user_id = run.user_id
     bot_id = run.bot_id
 
+    # Resolve the answer-side completion model spec once per run from
+    # the collection config — agent runtime v3 (Wave 10) raises
+    # ``Model specification is required`` if neither the bot nor the
+    # request carries a ``completion`` block. The user's bot config
+    # is empty by default and the runtime is not allowed to fall back
+    # to a global model, so the worker pulls
+    # ``collection.config.completion`` and threads it through every
+    # turn dispatch. ``None`` means the collection itself has no LLM
+    # configured; the dispatch will surface the original runtime error
+    # so the operator knows to configure one (mirror PR #1825 ``_invoke
+    # _summary_agent`` fall-through pattern).
+    completion = await _resolve_run_completion(
+        user_id=user_id,
+        collection_id=getattr(run, "collection_id", None),
+    )
+
     for item in items:
         current_run = await ops.get_run_for_worker(run_id)
         if current_run is None:
@@ -301,6 +326,7 @@ async def execute_evaluation_run(
             item=item,
             user_id=user_id,
             bot_id=bot_id,
+            completion=completion,
             summary=summary,
             ops=ops,
             dispatch=dispatch,
@@ -316,12 +342,65 @@ async def execute_evaluation_run(
     return final_status
 
 
+async def _resolve_run_completion(
+    *,
+    user_id: str,
+    collection_id: Optional[str],
+):
+    """Return the answer-side ``ModelSpec`` for the run, copied from the
+    collection's configured completion model.
+
+    Returns ``None`` when the run has no associated collection, or the
+    collection cannot be loaded, or its config carries no completion
+    binding — the caller passes that ``None`` straight through and the
+    runtime surfaces its native ``Model specification is required for
+    agent runtime v3`` error so the operator knows to configure one.
+    Mirrors the ``_invoke_summary_agent`` pattern from PR #1825.
+    """
+    if not collection_id:
+        return None
+
+    from aperag.db.ops import async_db_ops as _db_ops
+    from aperag.schema.common import ModelSpec
+    from aperag.schema.utils import parseCollectionConfig
+
+    collection = await _db_ops.query_collection(user_id, collection_id)
+    if collection is None:
+        logger.info(
+            "evaluation worker: collection %s for run vanished or unauthorized; "
+            "agent runtime will surface its own missing-model error",
+            collection_id,
+        )
+        return None
+    try:
+        parsed = parseCollectionConfig(collection.config)
+    except ValueError:
+        logger.exception(
+            "evaluation worker: failed to parse collection %s config; falling through",
+            collection_id,
+        )
+        return None
+    completion = parsed.completion if parsed else None
+    if completion is None or not completion.model_id:
+        logger.info(
+            "evaluation worker: collection %s has no completion model — agent runtime "
+            "will surface its own missing-model error",
+            collection_id,
+        )
+        return None
+    return ModelSpec(
+        model_id=completion.model_id,
+        temperature=completion.temperature,
+    )
+
+
 async def _process_run_item(
     *,
     run,
     item: EvaluationRunItem,
     user_id: str,
     bot_id: str,
+    completion,
     summary: EvaluationRunSummary,
     ops: AsyncDatabaseOps,
     dispatch: DispatchFn,
@@ -340,6 +419,7 @@ async def _process_run_item(
             user_id=user_id,
             bot_id=bot_id,
             input_message=item.input_message,
+            completion=completion,
         )
     except Exception as exc:  # noqa: BLE001 - translate runtime errors to FAILED attempt
         logger.exception("dispatch_evaluation_turn crashed for run_item %s", item.id)

--- a/tests/unit_test/test_evaluation_v2_worker.py
+++ b/tests/unit_test/test_evaluation_v2_worker.py
@@ -430,6 +430,68 @@ def test_execute_evaluation_run_short_circuits_when_run_already_terminal():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Wave 10-style answer-model injection: the worker must thread
+# ``collection.config.completion`` into every dispatch as
+# ``CreateTurnRequest.completion``, otherwise agent runtime v3 raises
+# ``Model specification is required for agent runtime v3`` and every
+# case in the run fails (regression caught via @earayu2 msg=c44beebc).
+# ---------------------------------------------------------------------------
+
+
+def test_execute_evaluation_run_threads_collection_completion_into_dispatch(monkeypatch):
+    run, items = _make_run_and_items(item_count=2)
+    run.collection_id = "col_eval"
+    ops = _FakeOps(run, items)
+
+    captured_completions: list[object] = []
+
+    async def fake_dispatch(*, user_id, bot_id, input_message, completion=None, **_kwargs):
+        captured_completions.append(completion)
+        return TurnDispatchOutcome(status=EvaluationRunItemAttemptStatus.COMPLETED, answer_text="ok")
+
+    async def fake_resolve(**_kwargs):
+        from aperag.schema.common import ModelSpec
+
+        return ModelSpec(model_id="mdl_collection_default", temperature=0.1)
+
+    monkeypatch.setattr(worker, "_resolve_run_completion", fake_resolve)
+
+    asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert len(captured_completions) == 2, "every item must receive the run-scoped completion"
+    for spec in captured_completions:
+        assert spec is not None
+        assert getattr(spec, "model_id", None) == "mdl_collection_default"
+
+
+def test_execute_evaluation_run_passes_none_completion_when_collection_has_no_llm(monkeypatch):
+    """When the collection has no completion model configured, the
+    worker must still call dispatch with ``completion=None`` so the
+    runtime surfaces its own native error (not silently swallow)."""
+    run, items = _make_run_and_items(item_count=1)
+    run.collection_id = "col_no_llm"
+    ops = _FakeOps(run, items)
+
+    captured_completion = []
+
+    async def fake_dispatch(*, user_id, bot_id, input_message, completion=None, **_kwargs):
+        captured_completion.append(completion)
+        return TurnDispatchOutcome(
+            status=EvaluationRunItemAttemptStatus.FAILED,
+            error_message="Model specification is required for agent runtime v3",
+        )
+
+    async def fake_resolve(**_kwargs):
+        return None
+
+    monkeypatch.setattr(worker, "_resolve_run_completion", fake_resolve)
+
+    asyncio.run(execute_evaluation_run(run.id, db_ops=ops, dispatch_fn=fake_dispatch))
+
+    assert captured_completion == [None]
+
+
 def test_worker_module_source_has_no_benchmark_or_dataset_version_references():
     source = Path(worker.__file__).read_text(encoding="utf-8").lower()
     forbidden = ("benchmark_", "dataset_version_id", "/api/v2/bots", "httpx")


### PR DESCRIPTION
## Summary

Per @earayu2 reproducer ``msg=c44beebc``: every case in an evaluation run failed with ``Model specification is required for agent runtime v3``. **Same root cause** as the Wave 10 §K.13 summary regen path before PR #1825 — agent runtime v3 requires a ``ModelSpec`` on every turn but the evaluation worker created a ``CreateTurnRequest(query=...)`` with no ``completion`` field.

This PR is the **answer-side P0 fix only**. It unblocks the failing runs immediately. The broader scope discussion (``judge_model`` + LLM-as-judge real impl) is a separate follow-up — earayu2/Weston/architect aligned on doing the bigger refactor next, but this fix is a hard prerequisite either way (the runtime needs the answer-side ``completion``).

## Fix

* New helper ``_resolve_run_completion`` (in worker.py) reads ``collection.config.completion`` for the run's ``collection_id`` and builds a ``ModelSpec(model_id=..., temperature=...)``.
* ``execute_evaluation_run`` resolves once per run and threads it through ``_process_run_item`` to ``dispatch_evaluation_turn``.
* ``dispatch_evaluation_turn`` accepts ``completion`` and forwards it on ``CreateTurnRequest.completion``.
* When the collection has no LLM configured (or vanished), the helper returns ``None`` and the runtime surfaces its native missing-model error rather than silently swallowing — matches the Tier 1 fall-through pattern in PR #1825.

## Files

- ``aperag/domains/evaluation/worker.py`` — ``+`` \\~75 LOC, ``_resolve_run_completion`` helper + ``completion`` plumbing through ``execute_evaluation_run`` → ``_process_run_item`` → ``dispatch_evaluation_turn``
- ``tests/unit_test/test_evaluation_v2_worker.py`` — 2 new pins (collection LLM threaded; ``None`` path on unconfigured collection)

## Test plan

- [x] ``uv run pytest tests/unit_test/test_evaluation_v2_worker.py`` — 13 passed (11 existing + 2 new)
- [x] ``uvx ruff check`` (CI ruff 0.15.12) clean
- [x] ``uvx ruff format --check`` clean
- [ ] dongdong restart 8012 onto this commit → run an existing evaluation run on the bees collection → confirm cases stop failing with "Model specification is required"

🤖 Generated with [Claude Code](https://claude.com/claude-code)