### PR TITLE
Optimize graph visualization topology fetch

### DIFF
--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -120,14 +120,15 @@ class GraphService:
         1. ``store.list_entities(label, limit=query_max_nodes)`` —
            label-filtered entity list (primary work; new Protocol
            method shipped in this PR).
-        2. ``GraphSearchService.get_subgraph(names, hops=max_depth)`` —
-           optional edge expansion when ``max_depth > 0``.
+        2. ``store.expand_neighbors_n_hops(names, hops=1)`` — optional
+           edge expansion when ``max_depth > 0``.
 
-        Each layer has clean semantics (W7-5 ``get_subgraph`` is
-        anchor-expansion, NOT label-filter; using it as the primary
-        entry point would force a wrapper that re-list_entities just
-        to compute anchors — drift the architect catches in
-        msg=838d57c3 own-up).
+        The public ``max_depth`` query parameter is kept for API
+        compatibility, but this visualization endpoint only returns
+        relations whose source AND target are both in the seed entity
+        set. Under that filter, 1-hop expansion already discovers every
+        relation the endpoint can return; deeper expansion only walks
+        external neighbours that are discarded afterwards.
         """
         db_collection = await self._get_and_validate_collection(user_id, collection_id)
 
@@ -137,7 +138,6 @@ class GraphService:
 
         # Lazy imports keep the service module free of indexing-layer
         # dependencies at import time (mirror ``get_graph_labels``).
-        from aperag.indexing.graph_search_service import build_graph_search_service_for
         from aperag.indexing.worker_factory import (
             _build_lineage_graph_store,
             _resolve_graph_backend_type,
@@ -155,11 +155,10 @@ class GraphService:
         # neighbours past the ``label`` filter.
         relations: list[Any] = []
         if entities and max_depth > 0:
-            search = build_graph_search_service_for(db_collection)
             seed_names = [entity.name for entity in entities]
-            _, subgraph_relations = await search.get_subgraph(
+            _, subgraph_relations = await store.expand_neighbors_n_hops(
                 entity_names=seed_names,
-                hops=max_depth,
+                hops=1,
             )
             allowed = set(seed_names)
             relations = [rel for rel in subgraph_relations if rel.source in allowed and rel.target in allowed]

--- a/tests/unit_test/domains/knowledge_graph/test_service.py
+++ b/tests/unit_test/domains/knowledge_graph/test_service.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aperag.domains.knowledge_graph.service import GraphService
 
@@ -25,17 +25,19 @@ def _relation(source: str, target: str) -> SimpleNamespace:
     )
 
 
-async def test_get_knowledge_graph_unpacks_graph_search_subgraph_tuple(monkeypatch):
+async def test_get_knowledge_graph_uses_store_one_hop_for_visualization(monkeypatch):
+    subgraph_calls = []
+
     class FakeStore:
         async def list_entities(self, *, label, limit):
             assert label is None
             assert limit == 20
             return [_entity("A", "person"), _entity("B", "organization")]
 
-    class FakeSearch:
-        async def get_subgraph(self, *, entity_names, hops):
+        async def expand_neighbors_n_hops(self, *, entity_names, hops):
             assert entity_names == ["A", "B"]
-            assert hops == 2
+            assert hops == 1
+            subgraph_calls.append((tuple(entity_names), hops))
             return (
                 [_entity("A", "person"), _entity("B", "organization")],
                 [
@@ -44,7 +46,7 @@ async def test_get_knowledge_graph_unpacks_graph_search_subgraph_tuple(monkeypat
                 ],
             )
 
-    from aperag.indexing import graph_search_service, worker_factory
+    from aperag.indexing import worker_factory
 
     monkeypatch.setattr(worker_factory, "_resolve_graph_backend_type", lambda collection: "postgres")
     monkeypatch.setattr(
@@ -52,22 +54,20 @@ async def test_get_knowledge_graph_unpacks_graph_search_subgraph_tuple(monkeypat
         "_build_lineage_graph_store",
         lambda *, backend_type, collection: FakeStore(),
     )
-    monkeypatch.setattr(
-        graph_search_service,
-        "build_graph_search_service_for",
-        lambda collection: FakeSearch(),
-    )
 
     service = GraphService()
     service._get_and_validate_collection = AsyncMock(return_value=SimpleNamespace(id="col1"))
 
-    graph = await service.get_knowledge_graph(
-        user_id="user1",
-        collection_id="col1",
-        label="*",
-        max_depth=2,
-        max_nodes=10,
-    )
+    with patch("aperag.indexing.graph_search_service.build_graph_search_service_for") as build_search:
+        graph = await service.get_knowledge_graph(
+            user_id="user1",
+            collection_id="col1",
+            label="*",
+            max_depth=3,
+            max_nodes=10,
+        )
 
     assert [node.id for node in graph.nodes] == ["A", "B"]
     assert [(edge.source, edge.target) for edge in graph.edges] == [("A", "B")]
+    assert subgraph_calls == [(("A", "B"), 1)]
+    build_search.assert_not_called()


### PR DESCRIPTION
## Summary
- keep the public `/graphs` API compatible while making visualization topology expansion use the graph store directly
- cap the internal visualization edge expansion to 1 hop, because the endpoint filters relations back to seed-internal edges
- avoid constructing `GraphSearchService` for `/graphs`, removing unnecessary vector connector / embedder initialization from topology fetches

## Validation
- `python3 -m py_compile aperag/domains/knowledge_graph/service.py`
- `uv run --with pytest-asyncio pytest tests/unit_test/domains/knowledge_graph/test_service.py -q`
- `ruff check aperag/domains/knowledge_graph/service.py tests/unit_test/domains/knowledge_graph/test_service.py`
- `ruff format --check aperag/domains/knowledge_graph/service.py tests/unit_test/domains/knowledge_graph/test_service.py`
- `git diff --check`
