### PR TITLE
fix(graph-hybrid): preserve initial canvas height

### DIFF
--- a/web/src/app/marketplace/collections/[collectionId]/graph/page.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/graph/page.tsx
@@ -17,9 +17,9 @@ export default async function Page({
 
   return (
     <PageContainer>
-      <div className="flex min-h-[calc(100vh-48px)] flex-col px-0">
+      <div className="flex h-[calc(100vh-48px)] min-h-[720px] flex-col px-0">
         <CollectionHeader collection={collection} className="w-full" />
-        <PageContent className="flex min-h-[720px] w-full flex-1 flex-col">
+        <PageContent className="flex min-h-0 w-full flex-1 flex-col">
           <CollectionGraphHybrid marketplace />
         </PageContent>
       </div>

--- a/web/src/app/workspace/collections/[collectionId]/graph-hybrid/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-hybrid/page.tsx
@@ -23,9 +23,9 @@ export default async function Page() {
           },
         ]}
       />
-      <div className="flex min-h-[calc(100vh-48px)] flex-col px-0">
+      <div className="flex h-[calc(100vh-48px)] min-h-[720px] flex-col px-0">
         <CollectionHeader className="w-full" />
-        <PageContent className="flex min-h-[720px] w-full flex-1 flex-col">
+        <PageContent className="flex min-h-0 w-full flex-1 flex-col">
           <CollectionGraphHybrid />
         </PageContent>
       </div>


### PR DESCRIPTION
## Summary
- make workspace graph-hybrid page use a definite viewport-height flex container
- apply the same sizing fix to marketplace graph pages
- keep the graph content region as the flex child so refresh/direct-open measurement returns non-zero canvas height

## Verification
- yarn install --frozen-lockfile --offline
- yarn type-check
- yarn lint (passes with existing unrelated warnings)
- git diff --check