### PR TITLE
Optimize graph backend read paths

### DIFF
--- a/aperag/indexing/graph_storage/nebula.py
+++ b/aperag/indexing/graph_storage/nebula.py
@@ -389,7 +389,9 @@ class NebulaLineageGraphStore:
                 f"compacted_description string NULL, "
                 f"gmt_created datetime, gmt_updated datetime)",
                 f"CREATE TAG INDEX IF NOT EXISTS `idx_{_ENTITY_TAG}_name` ON `{_ENTITY_TAG}`(name(256))",
+                f"CREATE TAG INDEX IF NOT EXISTS `idx_{_ENTITY_TAG}_entity_type` ON `{_ENTITY_TAG}`(entity_type(128))",
                 f"CREATE TAG INDEX IF NOT EXISTS `idx_{_RELATION_TAG}_source` ON `{_RELATION_TAG}`(source(256))",
+                f"CREATE TAG INDEX IF NOT EXISTS `idx_{_RELATION_TAG}_target` ON `{_RELATION_TAG}`(target(256))",
             ]
             # Wave 7 W7-1 backfill: ALTER TAG ADD for tags created on a
             # pre-Wave-7 schema. Nebula has no ``IF NOT EXISTS`` for ALTER
@@ -520,6 +522,54 @@ class NebulaLineageGraphStore:
             if "not exist" in str(exc).lower() or "no vertex" in str(exc).lower():
                 return []
             raise
+        out = []
+        for i in range(result.row_size()):
+            row = result.row_values(i)
+            if row and row[0].is_string():
+                out.append(row[0].as_string())
+        return out
+
+    def _lookup_relation_vids_by_endpoint(self, *, property_name: str, names: set[str]) -> list[str]:
+        if property_name not in {"source", "target"}:
+            raise ValueError(f"unsupported relation endpoint property {property_name!r}")
+        if not names:
+            return []
+        names_literal = ", ".join(f'"{_escape_str(name)}"' for name in sorted(names))
+        stmt = (
+            f"LOOKUP ON `{_RELATION_TAG}` "
+            f"WHERE `{_RELATION_TAG}`.`{property_name}` IN [{names_literal}] "
+            f"YIELD id(vertex) AS vid | LIMIT 100000"
+        )
+        try:
+            result = self._execute_with_schema_retry(self._space, stmt)
+        except RuntimeError:
+            logger.exception(
+                "Nebula indexed relation lookup failed; falling back to relation VID scan property=%s space=%s",
+                property_name,
+                self._space,
+            )
+            return self._list_all_relation_vids()
+        out = []
+        for i in range(result.row_size()):
+            row = result.row_values(i)
+            if row and row[0].is_string():
+                out.append(row[0].as_string())
+        return out
+
+    def _lookup_entity_vids_by_type(self, *, entity_type: str) -> list[str]:
+        stmt = (
+            f"LOOKUP ON `{_ENTITY_TAG}` "
+            f'WHERE `{_ENTITY_TAG}`.`entity_type` == "{_escape_str(entity_type)}" '
+            f"YIELD id(vertex) AS vid | LIMIT 100000"
+        )
+        try:
+            result = self._execute_with_schema_retry(self._space, stmt)
+        except RuntimeError:
+            logger.exception(
+                "Nebula indexed entity type lookup failed; falling back to entity VID scan space=%s",
+                self._space,
+            )
+            return self._list_all_entity_vids()
         out = []
         for i in range(result.row_size()):
             row = result.row_values(i)
@@ -1071,7 +1121,9 @@ class NebulaLineageGraphStore:
                 next_frontier: set[str] = set()
                 if not current:
                     break
-                for vid in self._list_all_relation_vids():
+                candidate_vids = set(self._lookup_relation_vids_by_endpoint(property_name="source", names=current))
+                candidate_vids.update(self._lookup_relation_vids_by_endpoint(property_name="target", names=current))
+                for vid in candidate_vids:
                     row = self._read_relation_lineage_by_vid(vid)
                     if row is None:
                         continue
@@ -1140,16 +1192,17 @@ class NebulaLineageGraphStore:
         await self.ensure_schema()
 
         def _scan() -> list[EntityWithLineage]:
-            # Nebula has no JSON / property-equality index we can rely
-            # on across versions, so we enumerate all entity VIDs via
-            # LOOKUP, fetch + filter in Python, then apply
-            # ``ORDER BY name SKIP offset LIMIT limit`` semantics on the
-            # in-Python result set. Matches the
-            # ``query_entities_by_keyword`` approach (acceptable per
-            # simple-stable directive — operators don't manage a
-            # per-collection text-index infra).
+            # If ``label`` is provided, try the entity_type tag index
+            # first; otherwise enumerate all entity VIDs. Fetch + sort
+            # in Python to preserve the cross-backend
+            # ``ORDER BY name SKIP offset LIMIT limit`` contract.
             rows: list[EntityWithLineage] = []
-            for vid in self._list_all_entity_vids():
+            candidate_vids = (
+                self._lookup_entity_vids_by_type(entity_type=label)
+                if label is not None
+                else self._list_all_entity_vids()
+            )
+            for vid in candidate_vids:
                 row = self._read_entity_lineage_by_vid(vid)
                 if row is None:
                     continue

--- a/aperag/indexing/graph_storage/neo4j.py
+++ b/aperag/indexing/graph_storage/neo4j.py
@@ -134,6 +134,9 @@ _RELATION_LABEL = "aperag_LineageRelation"
 
 _ENTITY_CONSTRAINT_NAME = "aperag_lineage_entity_collection_name_unique"
 _RELATION_CONSTRAINT_NAME = "aperag_lineage_relation_collection_triple_unique"
+_ENTITY_TYPE_NAME_INDEX_NAME = "aperag_lineage_entity_collection_type_name_idx"
+_RELATION_SOURCE_INDEX_NAME = "aperag_lineage_relation_collection_source_idx"
+_RELATION_TARGET_INDEX_NAME = "aperag_lineage_relation_collection_target_idx"
 
 
 # ---------------------------------------------------------------------
@@ -209,6 +212,18 @@ class Neo4jLineageGraphStore:
                 f"CREATE CONSTRAINT {_RELATION_CONSTRAINT_NAME} IF NOT EXISTS "
                 f"FOR (r:{_RELATION_LABEL}) "
                 f"REQUIRE (r.collection_id, r.source, r.target, r.relation_type) IS UNIQUE"
+            )
+            await session.run(
+                f"CREATE INDEX {_ENTITY_TYPE_NAME_INDEX_NAME} IF NOT EXISTS "
+                f"FOR (n:{_ENTITY_LABEL}) ON (n.collection_id, n.entity_type, n.name)"
+            )
+            await session.run(
+                f"CREATE INDEX {_RELATION_SOURCE_INDEX_NAME} IF NOT EXISTS "
+                f"FOR (r:{_RELATION_LABEL}) ON (r.collection_id, r.source)"
+            )
+            await session.run(
+                f"CREATE INDEX {_RELATION_TARGET_INDEX_NAME} IF NOT EXISTS "
+                f"FOR (r:{_RELATION_LABEL}) ON (r.collection_id, r.target)"
             )
 
     # -- find-by-document scans (pre-rebuild phase) -------------------
@@ -739,34 +754,51 @@ class Neo4jLineageGraphStore:
         async def _fetch_relations_touching(session, names: list[str]) -> set[str]:
             if not names:
                 return set()
-            cypher = (
+            relation_query = (
                 f"MATCH (r:{_RELATION_LABEL} {{collection_id: $collection_id}}) "
-                f"WHERE r.source IN $names OR r.target IN $names "
+                f"WHERE {{endpoint_predicate}} "
                 f"RETURN r.source AS source, r.target AS target, r.relation_type AS relation_type, "
                 f"       r.evidence_lineage AS evidence_lineage, "
                 f"       r.description_parts AS description_parts, "
                 f"       r.compacted_description AS compacted_description"
             )
-            result = await session.run(cypher, collection_id=self._collection_id, names=names)
             next_frontier: set[str] = set()
-            async for rec in result:
-                key = (rec["source"], rec["target"], rec["relation_type"])
-                if key not in seen_relations:
-                    seen_relations[key] = RelationWithLineage(
-                        source=rec["source"],
-                        target=rec["target"],
-                        relation_type=rec["relation_type"],
-                        evidence_lineage=tuple(
-                            LineageMember.from_dict(json.loads(s)) for s in (rec["evidence_lineage"] or [])
-                        ),
-                        description_parts=tuple(
-                            DescriptionPart.from_dict(json.loads(s)) for s in (rec["description_parts"] or [])
-                        ),
-                        compacted_description=rec["compacted_description"],
-                    )
-                for endpoint in (rec["source"], rec["target"]):
-                    if endpoint not in seen_entities and endpoint not in next_frontier:
-                        next_frontier.add(endpoint)
+
+            async def _consume(result) -> None:
+                async for rec in result:
+                    key = (rec["source"], rec["target"], rec["relation_type"])
+                    if key not in seen_relations:
+                        seen_relations[key] = RelationWithLineage(
+                            source=rec["source"],
+                            target=rec["target"],
+                            relation_type=rec["relation_type"],
+                            evidence_lineage=tuple(
+                                LineageMember.from_dict(json.loads(s)) for s in (rec["evidence_lineage"] or [])
+                            ),
+                            description_parts=tuple(
+                                DescriptionPart.from_dict(json.loads(s)) for s in (rec["description_parts"] or [])
+                            ),
+                            compacted_description=rec["compacted_description"],
+                        )
+                    for endpoint in (rec["source"], rec["target"]):
+                        if endpoint not in seen_entities and endpoint not in next_frontier:
+                            next_frontier.add(endpoint)
+
+            # Split source and target lookups so Neo4j can use the
+            # matching composite index instead of evaluating an OR over
+            # the full per-collection relation label set.
+            source_result = await session.run(
+                relation_query.format(endpoint_predicate="r.source IN $names"),
+                collection_id=self._collection_id,
+                names=names,
+            )
+            await _consume(source_result)
+            target_result = await session.run(
+                relation_query.format(endpoint_predicate="r.target IN $names"),
+                collection_id=self._collection_id,
+                names=names,
+            )
+            await _consume(target_result)
             return next_frontier
 
         async with self._session() as session:

--- a/aperag/indexing/graph_storage/postgres.py
+++ b/aperag/indexing/graph_storage/postgres.py
@@ -113,6 +113,12 @@ class _LineageEntityRow(_LineageGraphBase):
             "source_lineage",
             postgresql_using="gin",
         ),
+        Index(
+            "idx_lineage_entity_collection_type_name",
+            "collection_id",
+            "entity_type",
+            "name",
+        ),
     )
 
     collection_id = Column(String(64), primary_key=True)
@@ -158,6 +164,16 @@ class _LineageRelationRow(_LineageGraphBase):
             "idx_lineage_relation_evidence_lineage_gin",
             "evidence_lineage",
             postgresql_using="gin",
+        ),
+        # The composite PK already covers ``collection_id + source``.
+        # This target-leading index keeps neighbour expansion indexed
+        # in both directions once the OR predicate is split below.
+        Index(
+            "idx_lineage_relation_collection_target_source_type",
+            "collection_id",
+            "target",
+            "source",
+            "relation_type",
         ),
     )
 
@@ -797,36 +813,46 @@ class PostgresLineageGraphStore:
             already in ``names``) for the next-hop frontier."""
             if not names:
                 return set()
-            result = await conn.execute(
-                select(
-                    _LineageRelationRow.source,
-                    _LineageRelationRow.target,
-                    _LineageRelationRow.relation_type,
-                    _LineageRelationRow.evidence_lineage,
-                    _LineageRelationRow.description_parts,
-                    _LineageRelationRow.compacted_description,
-                ).where(
-                    _LineageRelationRow.collection_id == self._collection_id,
-                    (_LineageRelationRow.source.in_(list(names))) | (_LineageRelationRow.target.in_(list(names))),
-                )
+            relation_stmt = select(
+                _LineageRelationRow.source,
+                _LineageRelationRow.target,
+                _LineageRelationRow.relation_type,
+                _LineageRelationRow.evidence_lineage,
+                _LineageRelationRow.description_parts,
+                _LineageRelationRow.compacted_description,
+            ).where(
+                _LineageRelationRow.collection_id == self._collection_id,
             )
-            next_frontier: set[str] = set()
-            for row in result:
-                key = (row.source, row.target, row.relation_type)
-                if key not in seen_relations:
-                    seen_relations[key] = RelationWithLineage(
-                        source=row.source,
-                        target=row.target,
-                        relation_type=row.relation_type,
-                        evidence_lineage=tuple(LineageMember.from_dict(elem) for elem in (row.evidence_lineage or [])),
-                        description_parts=tuple(
-                            DescriptionPart.from_dict(part) for part in (row.description_parts or [])
-                        ),
-                        compacted_description=row.compacted_description,
-                    )
-                for endpoint in (row.source, row.target):
-                    if endpoint not in seen_entities and endpoint not in next_frontier:
-                        next_frontier.add(endpoint)
+
+            def _consume(result) -> None:
+                for row in result:
+                    key = (row.source, row.target, row.relation_type)
+                    if key not in seen_relations:
+                        seen_relations[key] = RelationWithLineage(
+                            source=row.source,
+                            target=row.target,
+                            relation_type=row.relation_type,
+                            evidence_lineage=tuple(
+                                LineageMember.from_dict(elem) for elem in (row.evidence_lineage or [])
+                            ),
+                            description_parts=tuple(
+                                DescriptionPart.from_dict(part) for part in (row.description_parts or [])
+                            ),
+                            compacted_description=row.compacted_description,
+                        )
+                    for endpoint in (row.source, row.target):
+                        if endpoint not in seen_entities and endpoint not in next_frontier:
+                            next_frontier.add(endpoint)
+
+            # Split the bidirectional lookup so PostgreSQL can use the
+            # source-leading primary key for one branch and the
+            # target-leading index for the other. A single OR predicate
+            # can degrade to a broad per-collection scan on larger
+            # lineage tables.
+            source_result = await conn.execute(relation_stmt.where(_LineageRelationRow.source.in_(list(names))))
+            _consume(source_result)
+            target_result = await conn.execute(relation_stmt.where(_LineageRelationRow.target.in_(list(names))))
+            _consume(target_result)
             return next_frontier
 
         async with self._engine.connect() as conn:

--- a/aperag/indexing/worker_factory.py
+++ b/aperag/indexing/worker_factory.py
@@ -676,21 +676,44 @@ def _resolve_collection_user_id(collection: Any) -> str:
 
 
 _VALID_GRAPH_BACKENDS = ("postgres", "neo4j", "nebula")
+_GRAPH_BACKEND_ALIASES = {
+    "postgres": "postgres",
+    "postgresql": "postgres",
+    "neo4j": "neo4j",
+    "nebula": "nebula",
+}
+
+
+def _default_graph_backend_type() -> str:
+    from aperag.config import settings
+
+    return settings.graph_db_type or "postgresql"
+
+
+def _normalise_graph_backend_type(raw: Any, *, collection: Any) -> str:
+    backend = str(raw).strip().lower()
+    normalised = _GRAPH_BACKEND_ALIASES.get(backend)
+    if normalised is None:
+        raise WorkerFactoryError(
+            f"unknown graph_backend_type {backend!r} on collection "
+            f"{getattr(collection, 'id', '<unknown>')}; expected one of "
+            f"{tuple(_GRAPH_BACKEND_ALIASES)}"
+        )
+    return normalised
 
 
 def _resolve_graph_backend_type(collection: Any) -> str:
     """Read ``collection.config.graph_backend_type`` from the
-    collection's persisted config. Defaults to ``"postgres"`` if the
-    field is absent (older collections created before chunk 4b)."""
+    collection's persisted config. If absent, fall back to deployment
+    level ``GRAPH_DB_TYPE`` (``postgresql`` normalises to the internal
+    ``postgres`` adapter name)."""
     cfg = getattr(collection, "config", None)
     raw: Any = None
-    if cfg is None:
-        return "postgres"
-    if hasattr(cfg, "graph_backend_type"):
+    if cfg is not None and hasattr(cfg, "graph_backend_type"):
         raw = cfg.graph_backend_type
-    elif isinstance(cfg, Mapping):
+    elif cfg is not None and isinstance(cfg, Mapping):
         raw = cfg.get("graph_backend_type")
-    elif isinstance(cfg, str):
+    elif cfg is not None and isinstance(cfg, str):
         # ``Collection.config`` may be persisted as a JSON string by
         # SQLAlchemy when the column type is Text; parse defensively.
         import json
@@ -701,13 +724,7 @@ def _resolve_graph_backend_type(collection: Any) -> str:
             parsed = None
         if isinstance(parsed, Mapping):
             raw = parsed.get("graph_backend_type")
-    backend = raw or "postgres"
-    if backend not in _VALID_GRAPH_BACKENDS:
-        raise WorkerFactoryError(
-            f"unknown graph_backend_type {backend!r} on collection "
-            f"{getattr(collection, 'id', '<unknown>')}; expected one of {_VALID_GRAPH_BACKENDS}"
-        )
-    return backend
+    return _normalise_graph_backend_type(raw or _default_graph_backend_type(), collection=collection)
 
 
 def _build_lineage_graph_store_inner(*, backend_type: str, collection: Any) -> Any:

--- a/aperag/migration/versions/20260429072000-a9f4e2c7d6b1_graph_visualization_read_indexes.py
+++ b/aperag/migration/versions/20260429072000-a9f4e2c7d6b1_graph_visualization_read_indexes.py
@@ -1,0 +1,47 @@
+"""add graph visualization read indexes
+
+The hybrid graph UI reads lineage entities by collection/type/name and
+expands relation neighbours in both source and target directions. The
+original PostgreSQL schema had only JSONB lineage indexes plus the
+source-leading relation primary key, so target-side expansion could
+fall back to a broad per-collection scan.
+
+Revision ID: a9f4e2c7d6b1
+Revises: f2c3d4e5b6a8
+Create Date: 2026-04-29 07:20:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a9f4e2c7d6b1"
+down_revision: Union[str, None] = "f2c3d4e5b6a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_lineage_entity_collection_type_name",
+        "aperag_lineage_entity",
+        ["collection_id", "entity_type", "name"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_lineage_relation_collection_target_source_type",
+        "aperag_lineage_relation",
+        ["collection_id", "target", "source", "relation_type"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_lineage_relation_collection_target_source_type",
+        table_name="aperag_lineage_relation",
+    )
+    op.drop_index(
+        "idx_lineage_entity_collection_type_name",
+        table_name="aperag_lineage_entity",
+    )

--- a/tests/integration/test_worker_factory.py
+++ b/tests/integration/test_worker_factory.py
@@ -215,25 +215,36 @@ def _make_collection_stub(*, config_obj: Any = None) -> Any:
     return _Stub()
 
 
-def test_resolve_graph_backend_type_defaults_to_postgres():
+def test_resolve_graph_backend_type_defaults_to_deployment_graph_db_type(monkeypatch: pytest.MonkeyPatch):
     """A collection with no ``config`` or no ``graph_backend_type`` field
-    falls back to the default ``postgres`` backend (the §D.3.5 reference
-    adapter; new collections that opt into knowledge graph automatically
-    use the application's own PostgreSQL without extra infra).
+    falls back to the deployment-level ``GRAPH_DB_TYPE`` setting. This
+    keeps UI-created collections (which send ``null`` unless explicitly
+    configured) aligned with Neo4j / Nebula deployments.
     """
 
+    from aperag.config import settings
     from aperag.indexing.worker_factory import _resolve_graph_backend_type
 
-    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=None)) == "postgres"
+    monkeypatch.setattr(settings, "graph_db_type", "neo4j")
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=None)) == "neo4j"
 
     class _ConfigNoBackend:
         graph_backend_type = None
 
-    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=_ConfigNoBackend())) == "postgres"
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=_ConfigNoBackend())) == "neo4j"
+
+    monkeypatch.setattr(settings, "graph_db_type", "nebula")
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=None)) == "nebula"
+
+    monkeypatch.setattr(settings, "graph_db_type", "postgresql")
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=None)) == "postgres"
 
 
-@pytest.mark.parametrize("backend", ["postgres", "neo4j", "nebula"])
-def test_resolve_graph_backend_type_reads_from_pydantic_attr(backend: str):
+@pytest.mark.parametrize(
+    ("backend", "expected"),
+    [("postgres", "postgres"), ("postgresql", "postgres"), ("neo4j", "neo4j"), ("nebula", "nebula")],
+)
+def test_resolve_graph_backend_type_reads_from_pydantic_attr(backend: str, expected: str):
     """A pydantic-shaped ``CollectionConfig`` exposes
     ``graph_backend_type`` as an attribute; the resolver reads it
     straight off."""
@@ -243,7 +254,7 @@ def test_resolve_graph_backend_type_reads_from_pydantic_attr(backend: str):
     class _Config:
         graph_backend_type = backend
 
-    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=_Config())) == backend
+    assert _resolve_graph_backend_type(_make_collection_stub(config_obj=_Config())) == expected
 
 
 def test_resolve_graph_backend_type_reads_from_dict_config():
@@ -280,6 +291,20 @@ def test_resolve_graph_backend_type_rejects_unknown():
         _resolve_graph_backend_type(_make_collection_stub(config_obj=_Config()))
     assert "duckdb" in str(exc.value)
     assert "postgres" in str(exc.value)
+
+
+def test_resolve_graph_backend_type_rejects_unknown_deployment_default(monkeypatch: pytest.MonkeyPatch):
+    """Deployment-level ``GRAPH_DB_TYPE`` typos are surfaced when the
+    collection does not override the backend."""
+
+    from aperag.config import settings
+    from aperag.indexing.worker_factory import _resolve_graph_backend_type
+
+    monkeypatch.setattr(settings, "graph_db_type", "duckdb")
+    with pytest.raises(WorkerFactoryError) as exc:
+        _resolve_graph_backend_type(_make_collection_stub(config_obj=None))
+    assert "duckdb" in str(exc.value)
+    assert "postgresql" in str(exc.value)
 
 
 def test_resolve_entity_lock_returns_inmemory_for_postgres_and_neo4j():


### PR DESCRIPTION
## Summary
- make collection graph backend resolution fall back to deployment-level GRAPH_DB_TYPE when collection config is unset, normalizing postgresql to the internal postgres adapter
- add PostgreSQL lineage read indexes and split source/target neighbor expansion so both branches can use indexes
- add Neo4j read indexes and split source/target expansion into index-friendly queries
- add Nebula entity_type/target tag indexes with indexed lookup attempts that fall back to the existing full VID scan if a Nebula version/query shape rejects them

## Verification
- python3 -m py_compile aperag/indexing/worker_factory.py aperag/indexing/graph_storage/postgres.py aperag/indexing/graph_storage/neo4j.py aperag/indexing/graph_storage/nebula.py aperag/migration/versions/20260429072000-a9f4e2c7d6b1_graph_visualization_read_indexes.py
- uv run --with pytest-asyncio pytest tests/integration/test_worker_factory.py -q
- uv run ruff check aperag/indexing/worker_factory.py aperag/indexing/graph_storage/postgres.py aperag/indexing/graph_storage/neo4j.py aperag/indexing/graph_storage/nebula.py tests/integration/test_worker_factory.py aperag/migration/versions/20260429072000-a9f4e2c7d6b1_graph_visualization_read_indexes.py
- uv run ruff format --check aperag/indexing/worker_factory.py aperag/indexing/graph_storage/postgres.py aperag/indexing/graph_storage/neo4j.py aperag/indexing/graph_storage/nebula.py tests/integration/test_worker_factory.py aperag/migration/versions/20260429072000-a9f4e2c7d6b1_graph_visualization_read_indexes.py
- uv run --directory aperag alembic heads
- uv run --with pytest-asyncio pytest tests/integration/compat/test_lineage_graph_compat.py::test_expand_neighbors_n_hops_returns_seed_and_relations -q (skipped locally: no compat backend configured)
- git diff --check