### PR TITLE
Add graph hybrid data endpoint

### DIFF
--- a/aperag/domains/knowledge_graph/api/routes.py
+++ b/aperag/domains/knowledge_graph/api/routes.py
@@ -34,6 +34,7 @@ from aperag.domains.identity.service.auth_dependencies import required_user
 from aperag.domains.knowledge_graph.schemas import (
     GraphEmbeddingMapResponse,
     GraphEntitiesSearchResponse,
+    GraphHybridResponse,
     GraphLabelsResponse,
     GraphSearchEntity,
     GraphSubgraphExpandRequest,
@@ -395,6 +396,32 @@ async def graph_embedding_map_view(
         raise HTTPException(status_code=400, detail="max_entities must be between 1 and 5000")
     try:
         return await graph_service.get_embedding_map(
+            str(user.id),
+            collection_id,
+            max_entities=max_entities,
+        )
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get(
+    "/collections/{collection_id}/graphs/hybrid",
+    tags=["graph"],
+    response_model=GraphHybridResponse,
+)
+async def graph_hybrid_view(
+    request: Request,
+    collection_id: str,
+    max_entities: int = 1000,
+    user: AuthenticatedUser = Depends(required_user),
+) -> GraphHybridResponse:
+    """Return positioned graph nodes and relation metadata for the hybrid view."""
+    if not (1 <= max_entities <= 5000):
+        raise HTTPException(status_code=400, detail="max_entities must be between 1 and 5000")
+    try:
+        return await graph_service.get_hybrid_graph(
             str(user.id),
             collection_id,
             max_entities=max_entities,

--- a/aperag/domains/knowledge_graph/schemas.py
+++ b/aperag/domains/knowledge_graph/schemas.py
@@ -482,6 +482,30 @@ class GraphEmbeddingMapResponse(BaseModel):
     )
 
 
+class GraphHybridNode(GraphNode):
+    """Node in the graph-hybrid visualization."""
+
+    x: float = Field(..., description="X coordinate in the 2-D projection of the entity vector")
+    y: float = Field(..., description="Y coordinate in the 2-D projection of the entity vector")
+    cluster: int = Field(..., description="entity_type bucket index (sequential, not k-means clustering)")
+    value: int = Field(..., description="Display size weight derived from relation degree", ge=1)
+
+
+class GraphHybridResponse(BaseModel):
+    """Response for ``GET /graphs/hybrid``."""
+
+    nodes: list[GraphHybridNode] = Field(..., description="Positioned entity nodes")
+    edges: list[GraphEdge] = Field(..., description="Relations whose endpoints both have coordinates")
+    cluster_labels: dict[str, str] = Field(
+        ...,
+        description="cluster index -> entity_type label (1:1 mapping)",
+    )
+    is_truncated: bool = Field(
+        ...,
+        description="Whether the node set hit the max_entities limit",
+    )
+
+
 __all__ = [
     "GraphLabelsResponse",
     "GraphNodeProperties",
@@ -506,4 +530,6 @@ __all__ = [
     "GraphEmbeddingPoint",
     "GraphEmbeddingMapRelation",
     "GraphEmbeddingMapResponse",
+    "GraphHybridNode",
+    "GraphHybridResponse",
 ]

--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -37,6 +37,7 @@ crossing the boundary.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
     from aperag.domains.knowledge_graph.schemas import (
         GraphEmbeddingMapResponse,
         GraphEntitiesSearchResponse,
+        GraphHybridResponse,
         GraphRelationView,
         GraphSearchEntity,
         GraphSubgraphExpandResponse,
@@ -391,24 +393,13 @@ class GraphService:
     ) -> "GraphEmbeddingMapResponse":
         """Return a 2-D PCA projection of graph entity vectors.
 
-        The hybrid graph view joins these stable coordinates with the
-        existing topology response. Keeping coordinates and topology
-        separate lets the frontend reuse the normal graph endpoint for
-        edge metadata while this endpoint stays bounded to vector-backed
-        entities only.
+        Kept as the low-level compatibility endpoint for consumers that
+        only need vector-backed coordinates. The graph-hybrid page uses
+        ``get_hybrid_graph`` so it can share one selected entity set
+        across points, node metadata, and relation metadata.
         """
-        import asyncio
-        import math
-        import uuid as _uuid
-
-        import numpy as np
-
-        from aperag.domains.knowledge_graph.schemas import (
-            GraphEmbeddingMapResponse,
-            GraphEmbeddingPoint,
-        )
+        from aperag.domains.knowledge_graph.schemas import GraphEmbeddingMapResponse
         from aperag.indexing.worker_factory import (
-            _build_collection_qdrant_connector,
             _build_lineage_graph_store,
             _resolve_graph_backend_type,
         )
@@ -420,6 +411,130 @@ class GraphService:
             backend_type=backend_type,
             collection=db_collection,
         )
+        points, cluster_labels, _entities = await self._get_embedding_projection(
+            db_collection=db_collection,
+            collection_id=collection_id,
+            store=store,
+            max_entities=max_entities,
+        )
+        return GraphEmbeddingMapResponse(
+            points=points,
+            relations=[],
+            cluster_labels=cluster_labels,
+        )
+
+    async def get_hybrid_graph(
+        self,
+        user_id: str,
+        collection_id: str,
+        *,
+        max_entities: int = 1000,
+    ) -> "GraphHybridResponse":
+        """Return the single DTO consumed by the graph-hybrid page.
+
+        This endpoint keeps the expensive join on the backend: vector
+        projection supplies positioned nodes, the lineage store supplies
+        node/edge metadata, and relation expansion is filtered to edges
+        whose endpoints both have coordinates. The frontend can render
+        from one response instead of racing ``/graphs`` and
+        ``/embedding-map`` then repeating the join in React.
+        """
+        from aperag.domains.knowledge_graph.schemas import GraphHybridNode, GraphHybridResponse
+        from aperag.indexing.worker_factory import (
+            _build_lineage_graph_store,
+            _resolve_graph_backend_type,
+        )
+
+        db_collection = await self._get_and_validate_collection(user_id, collection_id)
+        backend_type = _resolve_graph_backend_type(db_collection)
+        store = await asyncio.to_thread(
+            _build_lineage_graph_store,
+            backend_type=backend_type,
+            collection=db_collection,
+        )
+
+        max_entities = max(1, min(int(max_entities), 5000))
+        points, cluster_labels, entities = await self._get_embedding_projection(
+            db_collection=db_collection,
+            collection_id=collection_id,
+            store=store,
+            max_entities=max_entities,
+        )
+        if not points:
+            return GraphHybridResponse(nodes=[], edges=[], cluster_labels={}, is_truncated=False)
+
+        point_names = [point.name for point in points]
+        allowed = set(point_names)
+        _subgraph_entities, relations = await store.expand_neighbors_n_hops(entity_names=point_names, hops=1)
+        relations = [rel for rel in relations if rel.source in allowed and rel.target in allowed]
+
+        adapted_entities = _adapt_lineage_entities(entities)
+        adapted_relations = _adapt_lineage_relations(relations)
+        node_items = self._to_ui_dict(adapted_entities, [], is_truncated=False)["nodes"]
+        edge_items = self._to_ui_dict([], adapted_relations, is_truncated=False)["edges"]
+        node_item_by_id = {item["id"]: item for item in node_items}
+
+        degree = {name: 0 for name in allowed}
+        for edge in edge_items:
+            source = str(edge["source"])
+            target = str(edge["target"])
+            if source in degree:
+                degree[source] += 1
+            if target in degree:
+                degree[target] += 1
+
+        nodes: list[GraphHybridNode] = []
+        for point in points:
+            base = node_item_by_id.get(
+                point.name,
+                {
+                    "id": point.name,
+                    "labels": [point.entity_type] if point.entity_type else [],
+                    "properties": {
+                        "entity_id": point.name,
+                        "entity_name": point.name,
+                        "entity_type": point.entity_type,
+                        "source_chunk_count": point.source_chunk_count,
+                    },
+                },
+            )
+            nodes.append(
+                GraphHybridNode.model_validate(
+                    {
+                        **base,
+                        "x": point.x,
+                        "y": point.y,
+                        "cluster": point.cluster,
+                        "value": max(8, min(22, 8 + degree.get(point.name, 0))),
+                    }
+                )
+            )
+
+        return GraphHybridResponse(
+            nodes=nodes,
+            edges=edge_items,
+            cluster_labels=cluster_labels,
+            is_truncated=len(entities) >= max_entities,
+        )
+
+    async def _get_embedding_projection(
+        self,
+        *,
+        db_collection: CollectionRow,
+        collection_id: str,
+        store: Any,
+        max_entities: int,
+    ) -> tuple[list[Any], dict[str, str], list[Any]]:
+        import math
+        import uuid as _uuid
+
+        import numpy as np
+
+        from aperag.domains.knowledge_graph.schemas import (
+            GraphEmbeddingPoint,
+        )
+        from aperag.indexing.worker_factory import _build_collection_qdrant_connector
+
         adaptor, _embedder, _vector_size = await asyncio.to_thread(
             _build_collection_qdrant_connector,
             db_collection,
@@ -429,7 +544,7 @@ class GraphService:
         max_entities = max(1, min(int(max_entities), 5000))
         entities = await store.list_entities(limit=max_entities, offset=0)
         if not entities:
-            return GraphEmbeddingMapResponse(points=[], relations=[], cluster_labels={})
+            return [], {}, []
 
         ids: list[str] = []
         id_to_entity: dict[str, Any] = {}
@@ -449,7 +564,7 @@ class GraphService:
 
         retrieved = await asyncio.to_thread(connector.retrieve, ids, with_vectors=True)
         if not retrieved:
-            return GraphEmbeddingMapResponse(points=[], relations=[], cluster_labels={})
+            return [], {}, []
 
         vectors: list[list[float]] = []
         kept_entities: list[Any] = []
@@ -465,14 +580,14 @@ class GraphService:
             vectors.append(vector)
             kept_entities.append(entity)
         if not vectors:
-            return GraphEmbeddingMapResponse(points=[], relations=[], cluster_labels={})
+            return [], {}, []
 
         matrix = np.asarray(vectors, dtype=np.float32)
         centered = matrix - matrix.mean(axis=0, keepdims=True)
         try:
             _u, _s, vh = np.linalg.svd(centered, full_matrices=False)
         except np.linalg.LinAlgError:
-            return GraphEmbeddingMapResponse(points=[], relations=[], cluster_labels={})
+            return [], {}, []
 
         components = vh[:2]
         coords = centered @ components.T
@@ -489,6 +604,7 @@ class GraphService:
         cluster_for_type: dict[str, int] = {}
         cluster_labels: dict[str, str] = {}
         points: list[GraphEmbeddingPoint] = []
+        point_entities: list[Any] = []
         for entity, xy in zip(kept_entities, coords, strict=True):
             entity_type = (entity.entity_type or "unknown") or "unknown"
             cluster_idx = cluster_for_type.get(entity_type)
@@ -517,12 +633,9 @@ class GraphService:
                     source_chunk_count=len(chunk_ids),
                 )
             )
+            point_entities.append(entity)
 
-        return GraphEmbeddingMapResponse(
-            points=points,
-            relations=[],
-            cluster_labels=cluster_labels,
-        )
+        return points, cluster_labels, point_entities
 
     # --------------------------------------------------------- internal helpers
     def _optimize_graph_for_visualization(self, nodes, edges, max_nodes):

--- a/aperag/domains/marketplace/api/routes.py
+++ b/aperag/domains/marketplace/api/routes.py
@@ -40,6 +40,7 @@ from aperag.domains.identity.service.auth_dependencies import optional_user, req
 from aperag.domains.knowledge_graph.schemas import (
     GraphEmbeddingMapResponse,
     GraphEntitiesSearchResponse,
+    GraphHybridResponse,
     KnowledgeGraph,
 )
 from aperag.domains.knowledge_graph.service import graph_service
@@ -325,6 +326,38 @@ async def get_marketplace_collection_graph_embedding_map(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting marketplace collection graph embedding map {collection_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get(
+    "/marketplace/collections/{collection_id}/graph/hybrid",
+    tags=["graph"],
+    response_model=GraphHybridResponse,
+)
+async def get_marketplace_collection_graph_hybrid(
+    request: Request,
+    collection_id: str,
+    max_entities: int = Query(1000, ge=1, le=5000),
+    user: AuthenticatedUser = Depends(optional_user),
+) -> GraphHybridResponse:
+    """Get positioned graph-hybrid data for MarketplaceCollection (read-only)."""
+    try:
+        user_id = str(user.id) if user else ""
+        marketplace_info = await marketplace_collection_service.check_marketplace_access(user_id, collection_id)
+        owner_user_id = marketplace_info["owner_user_id"]
+        return await graph_service.get_hybrid_graph(
+            str(owner_user_id),
+            collection_id,
+            max_entities=max_entities,
+        )
+    except CollectionNotPublishedError:
+        raise HTTPException(status_code=404, detail="Collection not found or not published")
+    except CollectionMarketplaceAccessDeniedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error getting marketplace collection graph hybrid {collection_id}: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/aperag/migration/versions/20260429081500-c4d8e9f1a2b3_merge_graph_indexes_and_evaluation_models.py
+++ b/aperag/migration/versions/20260429081500-c4d8e9f1a2b3_merge_graph_indexes_and_evaluation_models.py
@@ -1,0 +1,23 @@
+"""merge graph index and evaluation model migration heads
+
+Revision ID: c4d8e9f1a2b3
+Revises: a1b2c3d4e5f7, a9f4e2c7d6b1
+Create Date: 2026-04-29 08:15:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+revision = "c4d8e9f1a2b3"
+down_revision = ("a1b2c3d4e5f7", "a9f4e2c7d6b1")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/tests/unit_test/domains/knowledge_graph/test_service.py
+++ b/tests/unit_test/domains/knowledge_graph/test_service.py
@@ -71,3 +71,72 @@ async def test_get_knowledge_graph_uses_store_one_hop_for_visualization(monkeypa
     assert [(edge.source, edge.target) for edge in graph.edges] == [("A", "B")]
     assert subgraph_calls == [(("A", "B"), 1)]
     build_search.assert_not_called()
+
+
+async def test_get_hybrid_graph_joins_projection_and_lineage_metadata(monkeypatch):
+    class FakeStore:
+        async def expand_neighbors_n_hops(self, *, entity_names, hops):
+            assert entity_names == ["A", "B"]
+            assert hops == 1
+            return (
+                [_entity("A", "person"), _entity("B", "organization")],
+                [
+                    _relation("A", "B"),
+                    _relation("A", "outside"),
+                ],
+            )
+
+    from aperag.domains.knowledge_graph.schemas import GraphEmbeddingPoint
+    from aperag.indexing import worker_factory
+
+    monkeypatch.setattr(worker_factory, "_resolve_graph_backend_type", lambda collection: "postgres")
+    monkeypatch.setattr(
+        worker_factory,
+        "_build_lineage_graph_store",
+        lambda *, backend_type, collection: FakeStore(),
+    )
+
+    service = GraphService()
+    service._get_and_validate_collection = AsyncMock(return_value=SimpleNamespace(id="col1"))
+
+    async def fake_projection(*, db_collection, collection_id, store, max_entities):
+        assert collection_id == "col1"
+        assert max_entities == 1000
+        assert isinstance(store, FakeStore)
+        return (
+            [
+                GraphEmbeddingPoint(
+                    name="A",
+                    entity_type="person",
+                    cluster=0,
+                    x=1.0,
+                    y=2.0,
+                    source_chunk_count=0,
+                ),
+                GraphEmbeddingPoint(
+                    name="B",
+                    entity_type="organization",
+                    cluster=1,
+                    x=3.0,
+                    y=4.0,
+                    source_chunk_count=0,
+                ),
+            ],
+            {"0": "person", "1": "organization"},
+            [_entity("A", "person"), _entity("B", "organization")],
+        )
+
+    service._get_embedding_projection = fake_projection
+
+    graph = await service.get_hybrid_graph(
+        user_id="user1",
+        collection_id="col1",
+        max_entities=1000,
+    )
+
+    assert [(node.id, node.x, node.y, node.cluster, node.value) for node in graph.nodes] == [
+        ("A", 1.0, 2.0, 0, 9),
+        ("B", 3.0, 4.0, 1, 9),
+    ]
+    assert [(edge.source, edge.target) for edge in graph.edges] == [("A", "B")]
+    assert graph.cluster_labels == {"0": "person", "1": "organization"}

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -590,6 +590,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/marketplace/collections/{collection_id}/graph/hybrid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Marketplace Collection Graph Hybrid
+         * @description Get positioned graph-hybrid data for MarketplaceCollection (read-only).
+         */
+        get: operations["marketplace_get_marketplace_collection_graph_hybrid"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/marketplace/collections/{collection_id}/graph/entities/search": {
         parameters: {
             query?: never;
@@ -1125,6 +1145,26 @@ export interface paths {
          * @description Return projected entity coordinates for the hybrid graph view.
          */
         get: operations["knowledge_graph_graph_embedding_map_view"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/collections/{collection_id}/graphs/hybrid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Graph Hybrid View
+         * @description Return positioned graph nodes and relation metadata for the hybrid view.
+         */
+        get: operations["knowledge_graph_graph_hybrid_view"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4235,6 +4275,76 @@ export interface components {
              * @description Entities returned by vector recall, ordered by descending similarity score
              */
             entities: components["schemas"]["GraphSearchEntity"][];
+        };
+        /**
+         * GraphHybridNode
+         * @description Node in the graph-hybrid visualization.
+         */
+        GraphHybridNode: {
+            /**
+             * Id
+             * @description Unique identifier for the node (entity name)
+             * @example 墨香居
+             */
+            id: string;
+            /**
+             * Labels
+             * @description Labels associated with the node
+             * @example [
+             *       "墨香居"
+             *     ]
+             */
+            labels: string[];
+            /** @description Public node properties */
+            properties: components["schemas"]["GraphNodeProperties"];
+            /**
+             * X
+             * @description X coordinate in the 2-D projection of the entity vector
+             */
+            x: number;
+            /**
+             * Y
+             * @description Y coordinate in the 2-D projection of the entity vector
+             */
+            y: number;
+            /**
+             * Cluster
+             * @description entity_type bucket index (sequential, not k-means clustering)
+             */
+            cluster: number;
+            /**
+             * Value
+             * @description Display size weight derived from relation degree
+             */
+            value: number;
+        };
+        /**
+         * GraphHybridResponse
+         * @description Response for ``GET /graphs/hybrid``.
+         */
+        GraphHybridResponse: {
+            /**
+             * Nodes
+             * @description Positioned entity nodes
+             */
+            nodes: components["schemas"]["GraphHybridNode"][];
+            /**
+             * Edges
+             * @description Relations whose endpoints both have coordinates
+             */
+            edges: components["schemas"]["GraphEdge"][];
+            /**
+             * Cluster Labels
+             * @description cluster index -> entity_type label (1:1 mapping)
+             */
+            cluster_labels: {
+                [key: string]: string;
+            };
+            /**
+             * Is Truncated
+             * @description Whether the node set hit the max_entities limit
+             */
+            is_truncated: boolean;
         };
         /**
          * GraphLabelsResponse
@@ -7785,6 +7895,40 @@ export interface operations {
             };
         };
     };
+    marketplace_get_marketplace_collection_graph_hybrid: {
+        parameters: {
+            query?: {
+                max_entities?: number;
+                engine?: unknown;
+            };
+            header?: never;
+            path: {
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GraphHybridResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     marketplace_search_marketplace_collection_graph_entities: {
         parameters: {
             query: {
@@ -8727,6 +8871,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GraphEmbeddingMapResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    knowledge_graph_graph_hybrid_view: {
+        parameters: {
+            query?: {
+                max_entities?: number;
+                engine?: unknown;
+            };
+            header?: never;
+            path: {
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GraphHybridResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx
@@ -4,18 +4,15 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
-  getGraphEmbeddingMap,
-  getKnowledgeGraph,
-  getMarketplaceGraphEmbeddingMap,
-  getMarketplaceKnowledgeGraph,
+  getGraphHybrid,
+  getMarketplaceGraphHybrid,
   searchMarketplaceGraphEntities,
   searchGraphEntities,
 } from '@/features/knowledge-graph/client-api';
 import type {
   GraphEdge,
-  GraphNode,
+  GraphHybridNode,
   GraphSearchEntity,
-  KnowledgeGraph,
 } from '@/features/knowledge-graph/types';
 import { ApiClientError } from '@/lib/api/typed/errors';
 import { CANVAS_DARK, COLORS } from '@/lib/design-tokens';
@@ -125,17 +122,13 @@ const endpointId = (endpoint: unknown) => {
   return String(endpoint || '');
 };
 
-// PCA-positioned hybrid node — extends GraphNode with the layout-fixed
-// coordinates that come from the `/embedding-map` endpoint. fx/fy are
+// PCA-positioned hybrid node — extends the backend hybrid DTO with the
+// d3-force pinned coordinates. fx/fy are
 // the d3-force "pinned" coordinates, which short-circuits the
 // simulation so the visual reflects the real PCA projection.
-type HybridNode = GraphNode & {
-  value: number;
-  x: number;
-  y: number;
+type HybridNode = GraphHybridNode & {
   fx: number;
   fy: number;
-  cluster: number;
 };
 
 type GraphCamera = {
@@ -213,73 +206,28 @@ export const CollectionGraphHybrid = ({
     setGraphError(undefined);
 
     try {
-      const [embedding, topology] = await Promise.all([
-        marketplace
-          ? getMarketplaceGraphEmbeddingMap(params.collectionId, 1000)
-          : getGraphEmbeddingMap(params.collectionId, 1000),
-        marketplace
-          ? getMarketplaceKnowledgeGraph(params.collectionId)
-          : (getKnowledgeGraph(params.collectionId) as Promise<
-              KnowledgeGraph | undefined
-            >),
-      ]);
+      const hybrid = marketplace
+        ? await getMarketplaceGraphHybrid(params.collectionId, 1000)
+        : await getGraphHybrid(params.collectionId, 1000);
 
-      if (!embedding || embedding.points.length === 0) {
+      if (!hybrid || hybrid.nodes.length === 0) {
         setGraphData({ nodes: [], links: [] });
         setClusterLabels({});
         return;
       }
 
-      const kgNodesByName = new Map<string, GraphNode>();
-      for (const n of topology?.nodes ?? []) {
-        kgNodesByName.set(String(n.id), n);
-      }
-
-      // Build hybrid nodes — PCA coordinates first, KG metadata joined
-      // by entity name. Nodes that don't have a KG match still render
-      // (we want the full PCA cloud); the detail panel handles missing
-      // descriptions gracefully.
-      const nodes: HybridNode[] = embedding.points.map((p) => {
-        const kg = kgNodesByName.get(p.name);
-        return {
-          ...(kg ?? {
-            id: p.name,
-            labels: [],
-            properties: { entity_type: p.entity_type ?? undefined },
-          }),
-          id: p.name,
-          value: NODE_MIN,
-          x: p.x,
-          y: p.y,
-          fx: p.x,
-          fy: p.y,
-          cluster: p.cluster,
-        };
-      });
-
-      // Filter KG edges to only those joining two PCA-positioned nodes.
-      // Compute degree-based node `value` (mirrors /graph) so the
-      // canvas painter renders bigger circles for hub nodes.
-      const nameToIndex = new Map(nodes.map((n, i) => [n.id, i]));
-      const links: GraphEdge[] = [];
-      for (const edge of topology?.edges ?? []) {
-        const sId = String(edge.source);
-        const tId = String(edge.target);
-        const sIdx = nameToIndex.get(sId);
-        const tIdx = nameToIndex.get(tId);
-        if (sIdx === undefined || tIdx === undefined) continue;
-        links.push(edge);
-        nodes[sIdx].value += 1;
-        nodes[tIdx].value += 1;
-      }
-      for (const n of nodes) {
-        n.value = Math.max(NODE_MIN, Math.min(n.value, NODE_MAX));
-      }
+      const nodes: HybridNode[] = hybrid.nodes.map((node) => ({
+        ...node,
+        value: Math.max(NODE_MIN, Math.min(node.value, NODE_MAX)),
+        fx: node.x,
+        fy: node.y,
+      }));
+      const links: GraphEdge[] = hybrid.edges ?? [];
 
       setGraphData({ nodes, links });
 
       const labels: Record<number, string> = {};
-      for (const [k, v] of Object.entries(embedding.cluster_labels)) {
+      for (const [k, v] of Object.entries(hybrid.cluster_labels)) {
         labels[Number(k)] = v;
       }
       setClusterLabels(labels);

--- a/web/src/features/knowledge-graph/client-api.ts
+++ b/web/src/features/knowledge-graph/client-api.ts
@@ -4,6 +4,7 @@ import { browserApiClient } from '@/lib/api/typed/browser';
 
 import type {
   GraphEmbeddingMapResponse,
+  GraphHybridResponse,
   GraphLabelsResponse,
   GraphSearchEntity,
   KnowledgeGraph,
@@ -120,6 +121,22 @@ export async function getGraphEmbeddingMap(
   return data ?? null;
 }
 
+export async function getGraphHybrid(
+  collectionId: string,
+  maxEntities = 1000,
+): Promise<GraphHybridResponse | null> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/collections/{collection_id}/graphs/hybrid',
+    {
+      params: {
+        path: { collection_id: collectionId },
+        query: { max_entities: maxEntities },
+      },
+    },
+  );
+  return data ?? null;
+}
+
 export async function searchGraphEntities(
   collectionId: string,
   q: string,
@@ -170,6 +187,22 @@ export async function getMarketplaceGraphEmbeddingMap(
 ): Promise<GraphEmbeddingMapResponse | null> {
   const { data } = await browserApiClient.GET(
     '/api/v2/marketplace/collections/{collection_id}/graph/embedding-map',
+    {
+      params: {
+        path: { collection_id: collectionId },
+        query: { max_entities: maxEntities },
+      },
+    },
+  );
+  return data ?? null;
+}
+
+export async function getMarketplaceGraphHybrid(
+  collectionId: string,
+  maxEntities = 1000,
+): Promise<GraphHybridResponse | null> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/marketplace/collections/{collection_id}/graph/hybrid',
     {
       params: {
         path: { collection_id: collectionId },

--- a/web/src/features/knowledge-graph/types.ts
+++ b/web/src/features/knowledge-graph/types.ts
@@ -20,6 +20,12 @@ export type GraphSearchEntity = NonNullable<
 export type GraphEmbeddingMapResponse = NonNullable<
   components['schemas']['GraphEmbeddingMapResponse']
 >;
+export type GraphHybridResponse = NonNullable<
+  components['schemas']['GraphHybridResponse']
+>;
+export type GraphHybridNode = NonNullable<
+  components['schemas']['GraphHybridNode']
+>;
 export type GraphEmbeddingPoint = NonNullable<
   components['schemas']['GraphEmbeddingPoint']
 >;


### PR DESCRIPTION
## Summary
- add `/collections/{collection_id}/graphs/hybrid` and marketplace `/graph/hybrid` endpoints that return positioned nodes, filtered relation metadata, cluster labels, and truncation state in one DTO
- share embedding projection logic between the existing embedding-map endpoint and the new hybrid endpoint
- switch the graph-hybrid frontend from parallel `embedding-map` + `/graphs` calls to a single hybrid API call
- regenerate typed OpenAPI client types and add a targeted service unit test for backend join/filter behavior
- add a no-op Alembic merge migration to reconcile the graph index migration head from #1851 with the evaluation migration head from #1853

## Tests
- `uv run --extra test pytest tests/unit_test/domains/knowledge_graph/test_service.py -q`
- `uvx ruff check --no-fix ./aperag ./tests`
- `uvx ruff format --check ./aperag ./tests`
- `uv run --extra test python scripts/export_openapi.py --check`
- `uv run --extra test alembic -c aperag/alembic.ini heads`
- `uv run --extra test python -m py_compile aperag/migration/versions/20260429081500-c4d8e9f1a2b3_merge_graph_indexes_and_evaluation_models.py`
- `cd web && yarn type-check`
- `cd web && yarn lint` (passes with existing unrelated warnings)
- `git diff --check`
