### PR TITLE
fix(web): provide intl messages to client provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ db-revision:
 	@uv run alembic -c aperag/alembic.ini revision --autogenerate
 
 db-migrate:
-	@uv run alembic -c aperag/alembic.ini upgrade head
+	@uv run alembic -c aperag/alembic.ini upgrade heads
 
 db-check:
 	@uv run alembic -c aperag/alembic.ini check
@@ -414,4 +414,3 @@ info:
 	@echo "LOCAL_PLATFORM: $(LOCAL_PLATFORM)"
 	@echo "REGISTRY: $(REGISTRY)"
 	@echo "HOST ARCH: $(UNAME_M)"
-

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { getLocale } from '@/services/cookies';
 import 'highlight.js/styles/github-dark.css';
 import './globals.css';
 
-import { getTranslations } from 'next-intl/server';
+import { getMessages, getTranslations } from 'next-intl/server';
 
 const fontSans = Manrope({
   variable: '--font-sans',
@@ -58,6 +58,7 @@ export default async function RootLayout({
 }>) {
   const user = (await getCurrentUser()) ?? undefined;
   const locale = await getLocale();
+  const messages = await getMessages();
 
   return (
     <html lang={locale} suppressHydrationWarning>
@@ -70,7 +71,7 @@ export default async function RootLayout({
           showSpinner={false}
           crawl={false}
         />
-        <NextIntlClientProvider>
+        <NextIntlClientProvider messages={messages}>
           <ThemeProvider
             attribute="class"
             defaultTheme={process.env.NEXT_PUBLIC_DEFAULT_THEME || 'light'}


### PR DESCRIPTION
## Summary\n- pass loaded next-intl messages into the root NextIntlClientProvider\n- fixes client-only dialogs rendering raw i18n keys such as page_collection_evaluations.ai_generate_title\n- update Makefile db-migrate to upgrade all Alembic heads now that main has multiple heads\n\n## Validation\n- make db-migrate\n- web/yarn i18n:check\n- web/yarn lint --quiet\n- web/yarn type-check --pretty false\n- git diff --check