### PR TITLE
Cache graph hybrid layout projection

### DIFF
--- a/aperag/domains/knowledge_graph/db/models.py
+++ b/aperag/domains/knowledge_graph/db/models.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     Index,
+    Integer,
     Numeric,
     String,
     Text,
@@ -159,10 +160,33 @@ class LineageEntityAlias(Base):
     gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
 
 
+class GraphHybridLayoutCache(Base):
+    """Cached 2-D projection for the graph-hybrid overview.
+
+    The cache key is derived from the collection/backend/max_entities and
+    the selected entities' lineage/description signature. It avoids
+    repeating vector fetch + PCA work when the graph data has not changed.
+    """
+
+    __tablename__ = "graph_hybrid_layout_cache"
+    __table_args__ = (Index("idx_graph_hybrid_layout_cache_collection_updated", "collection_id", "gmt_updated"),)
+
+    collection_id = Column(String(64), primary_key=True, nullable=False)
+    cache_key = Column(String(64), primary_key=True, nullable=False)
+    backend_type = Column(String(32), nullable=False)
+    max_entities = Column(Integer, nullable=False)
+    entity_count = Column(Integer, nullable=False)
+    points_json = Column(JSON, nullable=False)
+    cluster_labels = Column(JSON, nullable=False)
+    gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    gmt_updated = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+
+
 __all__ = [
     "GraphCurationRun",
     "GraphCurationRunStatus",
     "GraphCurationSuggestion",
     "GraphCurationSuggestionStatus",
+    "GraphHybridLayoutCache",
     "LineageEntityAlias",
 ]

--- a/aperag/domains/knowledge_graph/schemas.py
+++ b/aperag/domains/knowledge_graph/schemas.py
@@ -480,6 +480,10 @@ class GraphEmbeddingMapResponse(BaseModel):
         ...,
         description="cluster index -> entity_type label (1:1 mapping)",
     )
+    layout_from_cache: bool = Field(
+        False,
+        description="Whether the 2-D projection was served from the layout cache",
+    )
 
 
 class GraphHybridNode(GraphNode):
@@ -503,6 +507,10 @@ class GraphHybridResponse(BaseModel):
     is_truncated: bool = Field(
         ...,
         description="Whether the node set hit the max_entities limit",
+    )
+    layout_from_cache: bool = Field(
+        False,
+        description="Whether the 2-D projection was served from the layout cache",
     )
 
 

--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -38,7 +38,10 @@ crossing the boundary.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
+from dataclasses import asdict, is_dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List
 
@@ -411,7 +414,8 @@ class GraphService:
             backend_type=backend_type,
             collection=db_collection,
         )
-        points, cluster_labels, _entities = await self._get_embedding_projection(
+        points, cluster_labels, _entities, layout_from_cache = await self._get_embedding_projection(
+            backend_type=backend_type,
             db_collection=db_collection,
             collection_id=collection_id,
             store=store,
@@ -421,6 +425,7 @@ class GraphService:
             points=points,
             relations=[],
             cluster_labels=cluster_labels,
+            layout_from_cache=layout_from_cache,
         )
 
     async def get_hybrid_graph(
@@ -454,14 +459,21 @@ class GraphService:
         )
 
         max_entities = max(1, min(int(max_entities), 5000))
-        points, cluster_labels, entities = await self._get_embedding_projection(
+        points, cluster_labels, entities, layout_from_cache = await self._get_embedding_projection(
+            backend_type=backend_type,
             db_collection=db_collection,
             collection_id=collection_id,
             store=store,
             max_entities=max_entities,
         )
         if not points:
-            return GraphHybridResponse(nodes=[], edges=[], cluster_labels={}, is_truncated=False)
+            return GraphHybridResponse(
+                nodes=[],
+                edges=[],
+                cluster_labels={},
+                is_truncated=False,
+                layout_from_cache=layout_from_cache,
+            )
 
         point_names = [point.name for point in points]
         allowed = set(point_names)
@@ -515,16 +527,18 @@ class GraphService:
             edges=edge_items,
             cluster_labels=cluster_labels,
             is_truncated=len(entities) >= max_entities,
+            layout_from_cache=layout_from_cache,
         )
 
     async def _get_embedding_projection(
         self,
         *,
+        backend_type: str,
         db_collection: CollectionRow,
         collection_id: str,
         store: Any,
         max_entities: int,
-    ) -> tuple[list[Any], dict[str, str], list[Any]]:
+    ) -> tuple[list[Any], dict[str, str], list[Any], bool]:
         import math
         import uuid as _uuid
 
@@ -533,6 +547,24 @@ class GraphService:
         from aperag.domains.knowledge_graph.schemas import (
             GraphEmbeddingPoint,
         )
+
+        max_entities = max(1, min(int(max_entities), 5000))
+        entities = await store.list_entities(limit=max_entities, offset=0)
+        if not entities:
+            return [], {}, [], False
+
+        cache_key = self._embedding_projection_cache_key(
+            collection_id=collection_id,
+            backend_type=backend_type,
+            max_entities=max_entities,
+            collection_config=getattr(db_collection, "config", None),
+            entities=entities,
+        )
+        cached = await self._load_embedding_projection_cache(collection_id=collection_id, cache_key=cache_key)
+        if cached is not None:
+            points, cluster_labels = cached
+            return points, cluster_labels, entities, True
+
         from aperag.indexing.worker_factory import _build_collection_qdrant_connector
 
         adaptor, _embedder, _vector_size = await asyncio.to_thread(
@@ -540,11 +572,6 @@ class GraphService:
             db_collection,
         )
         connector = adaptor.connector
-
-        max_entities = max(1, min(int(max_entities), 5000))
-        entities = await store.list_entities(limit=max_entities, offset=0)
-        if not entities:
-            return [], {}, []
 
         ids: list[str] = []
         id_to_entity: dict[str, Any] = {}
@@ -564,7 +591,7 @@ class GraphService:
 
         retrieved = await asyncio.to_thread(connector.retrieve, ids, with_vectors=True)
         if not retrieved:
-            return [], {}, []
+            return [], {}, entities, False
 
         vectors: list[list[float]] = []
         kept_entities: list[Any] = []
@@ -580,14 +607,14 @@ class GraphService:
             vectors.append(vector)
             kept_entities.append(entity)
         if not vectors:
-            return [], {}, []
+            return [], {}, entities, False
 
         matrix = np.asarray(vectors, dtype=np.float32)
         centered = matrix - matrix.mean(axis=0, keepdims=True)
         try:
             _u, _s, vh = np.linalg.svd(centered, full_matrices=False)
         except np.linalg.LinAlgError:
-            return [], {}, []
+            return [], {}, entities, False
 
         components = vh[:2]
         coords = centered @ components.T
@@ -635,7 +662,128 @@ class GraphService:
             )
             point_entities.append(entity)
 
-        return points, cluster_labels, point_entities
+        await self._save_embedding_projection_cache(
+            collection_id=collection_id,
+            cache_key=cache_key,
+            backend_type=backend_type,
+            max_entities=max_entities,
+            points=points,
+            cluster_labels=cluster_labels,
+        )
+
+        return points, cluster_labels, point_entities, False
+
+    def _embedding_projection_cache_key(
+        self,
+        *,
+        collection_id: str,
+        backend_type: str,
+        max_entities: int,
+        collection_config: Any,
+        entities: list[Any],
+    ) -> str:
+        payload = {
+            "version": 1,
+            "collection_id": collection_id,
+            "backend_type": backend_type,
+            "max_entities": max_entities,
+            "collection_config": _stable_jsonish(collection_config),
+            "entities": [
+                {
+                    "name": getattr(entity, "name", None),
+                    "entity_type": getattr(entity, "entity_type", None),
+                    "source_lineage": _stable_jsonish(getattr(entity, "source_lineage", None)),
+                    "description_parts": _stable_jsonish(getattr(entity, "description_parts", None)),
+                    "compacted_description": getattr(entity, "compacted_description", None),
+                }
+                for entity in entities
+            ],
+        }
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    async def _load_embedding_projection_cache(
+        self,
+        *,
+        collection_id: str,
+        cache_key: str,
+    ) -> tuple[list[Any], dict[str, str]] | None:
+        from pydantic import ValidationError
+
+        from aperag.config import get_async_session
+        from aperag.domains.knowledge_graph.db.models import GraphHybridLayoutCache
+        from aperag.domains.knowledge_graph.schemas import GraphEmbeddingPoint
+
+        try:
+            async for session in get_async_session():
+                row = await session.get(GraphHybridLayoutCache, (collection_id, cache_key))
+                if row is None:
+                    return None
+                try:
+                    points = [GraphEmbeddingPoint.model_validate(item) for item in row.points_json or []]
+                    cluster_labels = {str(k): str(v) for k, v in (row.cluster_labels or {}).items()}
+                except (TypeError, ValidationError, ValueError):
+                    logger.warning(
+                        "Ignoring invalid graph hybrid layout cache row",
+                        extra={"collection_id": collection_id, "cache_key": cache_key},
+                        exc_info=True,
+                    )
+                    return None
+                return points, cluster_labels
+        except Exception:
+            logger.warning(
+                "Failed to read graph hybrid layout cache",
+                extra={"collection_id": collection_id, "cache_key": cache_key},
+                exc_info=True,
+            )
+        return None
+
+    async def _save_embedding_projection_cache(
+        self,
+        *,
+        collection_id: str,
+        cache_key: str,
+        backend_type: str,
+        max_entities: int,
+        points: list[Any],
+        cluster_labels: dict[str, str],
+    ) -> None:
+        from sqlalchemy import delete
+
+        from aperag.config import get_async_session
+        from aperag.domains.knowledge_graph.db.models import GraphHybridLayoutCache
+
+        try:
+            async for session in get_async_session():
+                await session.merge(
+                    GraphHybridLayoutCache(
+                        collection_id=collection_id,
+                        cache_key=cache_key,
+                        backend_type=backend_type,
+                        max_entities=max_entities,
+                        entity_count=len(points),
+                        points_json=[
+                            point.model_dump(mode="json") if hasattr(point, "model_dump") else dict(point)
+                            for point in points
+                        ],
+                        cluster_labels=dict(cluster_labels),
+                    )
+                )
+                await session.execute(
+                    delete(GraphHybridLayoutCache).where(
+                        GraphHybridLayoutCache.collection_id == collection_id,
+                        GraphHybridLayoutCache.max_entities == max_entities,
+                        GraphHybridLayoutCache.cache_key != cache_key,
+                    )
+                )
+                await session.commit()
+                return
+        except Exception:
+            logger.warning(
+                "Failed to write graph hybrid layout cache",
+                extra={"collection_id": collection_id, "cache_key": cache_key},
+                exc_info=True,
+            )
 
     # --------------------------------------------------------- internal helpers
     def _optimize_graph_for_visualization(self, nodes, edges, max_nodes):
@@ -834,6 +982,23 @@ def _adapt_lineage_relations(relations: list[Any]) -> List[SimpleNamespace]:
             )
         )
     return out
+
+
+def _stable_jsonish(value: Any) -> Any:
+    """Return a deterministic JSON-serialisable projection for hashing."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if is_dataclass(value):
+        return _stable_jsonish(asdict(value))
+    if hasattr(value, "model_dump"):
+        return _stable_jsonish(value.model_dump(mode="json"))
+    if isinstance(value, dict):
+        return {str(k): _stable_jsonish(v) for k, v in sorted(value.items(), key=lambda item: str(item[0]))}
+    if isinstance(value, (set, frozenset)):
+        return [_stable_jsonish(item) for item in sorted(value, key=repr)]
+    if isinstance(value, (list, tuple)):
+        return [_stable_jsonish(item) for item in value]
+    return repr(value)
 
 
 # ---------------------------------------------------------------------------

--- a/aperag/migration/versions/20260429083000-b7c9d0e1f2a4_graph_hybrid_layout_cache.py
+++ b/aperag/migration/versions/20260429083000-b7c9d0e1f2a4_graph_hybrid_layout_cache.py
@@ -1,0 +1,48 @@
+"""add graph hybrid layout cache
+
+Revision ID: b7c9d0e1f2a4
+Revises: c4d8e9f1a2b3
+Create Date: 2026-04-29 08:30:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b7c9d0e1f2a4"
+down_revision = "c4d8e9f1a2b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "graph_hybrid_layout_cache",
+        sa.Column("collection_id", sa.String(length=64), nullable=False),
+        sa.Column("cache_key", sa.String(length=64), nullable=False),
+        sa.Column("backend_type", sa.String(length=32), nullable=False),
+        sa.Column("max_entities", sa.Integer(), nullable=False),
+        sa.Column("entity_count", sa.Integer(), nullable=False),
+        sa.Column("points_json", sa.JSON(), nullable=False),
+        sa.Column("cluster_labels", sa.JSON(), nullable=False),
+        sa.Column("gmt_created", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("gmt_updated", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("collection_id", "cache_key"),
+    )
+    op.create_index(
+        "idx_graph_hybrid_layout_cache_collection_updated",
+        "graph_hybrid_layout_cache",
+        ["collection_id", "gmt_updated"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_graph_hybrid_layout_cache_collection_updated",
+        table_name="graph_hybrid_layout_cache",
+    )
+    op.drop_table("graph_hybrid_layout_cache")

--- a/tests/unit_test/domains/knowledge_graph/test_service.py
+++ b/tests/unit_test/domains/knowledge_graph/test_service.py
@@ -99,7 +99,8 @@ async def test_get_hybrid_graph_joins_projection_and_lineage_metadata(monkeypatc
     service = GraphService()
     service._get_and_validate_collection = AsyncMock(return_value=SimpleNamespace(id="col1"))
 
-    async def fake_projection(*, db_collection, collection_id, store, max_entities):
+    async def fake_projection(*, backend_type, db_collection, collection_id, store, max_entities):
+        assert backend_type == "postgres"
         assert collection_id == "col1"
         assert max_entities == 1000
         assert isinstance(store, FakeStore)
@@ -124,6 +125,7 @@ async def test_get_hybrid_graph_joins_projection_and_lineage_metadata(monkeypatc
             ],
             {"0": "person", "1": "organization"},
             [_entity("A", "person"), _entity("B", "organization")],
+            False,
         )
 
     service._get_embedding_projection = fake_projection
@@ -140,3 +142,49 @@ async def test_get_hybrid_graph_joins_projection_and_lineage_metadata(monkeypatc
     ]
     assert [(edge.source, edge.target) for edge in graph.edges] == [("A", "B")]
     assert graph.cluster_labels == {"0": "person", "1": "organization"}
+    assert graph.layout_from_cache is False
+
+
+async def test_get_embedding_projection_uses_layout_cache(monkeypatch):
+    from aperag.domains.knowledge_graph.schemas import GraphEmbeddingPoint
+    from aperag.indexing import worker_factory
+
+    class FakeStore:
+        async def list_entities(self, *, limit, offset):
+            assert limit == 1000
+            assert offset == 0
+            return [_entity("A", "person")]
+
+    cached_points = [
+        GraphEmbeddingPoint(
+            name="A",
+            entity_type="person",
+            cluster=0,
+            x=1.0,
+            y=2.0,
+            source_chunk_count=0,
+        )
+    ]
+
+    service = GraphService()
+    service._load_embedding_projection_cache = AsyncMock(return_value=(cached_points, {"0": "person"}))
+    service._save_embedding_projection_cache = AsyncMock()
+    monkeypatch.setattr(
+        worker_factory,
+        "_build_collection_qdrant_connector",
+        lambda collection: (_ for _ in ()).throw(AssertionError("vector connector should not be built on cache hit")),
+    )
+
+    points, cluster_labels, entities, layout_from_cache = await service._get_embedding_projection(
+        backend_type="postgres",
+        db_collection=SimpleNamespace(id="col1"),
+        collection_id="col1",
+        store=FakeStore(),
+        max_entities=1000,
+    )
+
+    assert points == cached_points
+    assert cluster_labels == {"0": "person"}
+    assert [entity.name for entity in entities] == ["A"]
+    assert layout_from_cache is True
+    service._save_embedding_projection_cache.assert_not_called()

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -4227,6 +4227,12 @@ export interface components {
             cluster_labels: {
                 [key: string]: string;
             };
+            /**
+             * Layout From Cache
+             * @description Whether the 2-D projection was served from the layout cache
+             * @default false
+             */
+            layout_from_cache: boolean;
         };
         /**
          * GraphEmbeddingPoint
@@ -4345,6 +4351,12 @@ export interface components {
              * @description Whether the node set hit the max_entities limit
              */
             is_truncated: boolean;
+            /**
+             * Layout From Cache
+             * @description Whether the 2-D projection was served from the layout cache
+             * @default false
+             */
+            layout_from_cache: boolean;
         };
         /**
          * GraphLabelsResponse


### PR DESCRIPTION
## Summary
- add a persistent `graph_hybrid_layout_cache` table for graph-hybrid 2-D projection coordinates
- key the cache by collection/backend/max_entities plus collection config and selected entities' lineage/description signature
- reuse cached projection points before building the vector connector, avoiding repeated vector retrieve + PCA/SVD when graph data is unchanged
- expose `layout_from_cache` on embedding-map and hybrid DTOs for observability/debugging
- add a targeted cache-hit unit test and regenerate typed OpenAPI schema

## Scope note
This PR intentionally implements the layout-coordinate cache first. The broader lazy-detail split should be a follow-up because marketplace currently has search/hybrid endpoints but no entity detail route, and relation detail has no standalone endpoint yet.

## Tests
- `uvx ruff check --no-fix ./aperag ./tests`
- `uvx ruff format --check ./aperag ./tests`
- `uv run --extra test pytest tests/unit_test/domains/knowledge_graph/test_service.py -q`
- `uv run --extra test python scripts/export_openapi.py --check`
- `uv run --extra test alembic -c aperag/alembic.ini heads`
- `uv run --extra test python -m py_compile aperag/migration/versions/20260429083000-b7c9d0e1f2a4_graph_hybrid_layout_cache.py`
- `cd web && yarn type-check`
- `cd web && yarn lint` (passes with existing unrelated warnings)
- `git diff --check`
