### PR TITLE
feat(evaluation): hide eval-spawned chats from user chat list

### DIFF
--- a/aperag/domains/conversation/db/models.py
+++ b/aperag/domains/conversation/db/models.py
@@ -103,6 +103,14 @@ class ChatPeerType(str, Enum):
     WEIXIN_OFFICIAL = "weixin_official"
     WEB = "web"
     DINGTALK = "dingtalk"
+    # Internal-source flag for evaluation-run dispatched chats. The
+    # worker creates one ``Chat`` per case so the agent runtime has a
+    # real conversation to drive, but the user did not start it — so
+    # the row must not surface in the bot's chat list (per @earayu2
+    # msg=92d6fb21 + Weston msg=387ce23d). The chat-list query filters
+    # ``EVALUATION`` out by default; ``include_internal=True`` lets
+    # internal call sites (run detail trace links) still find the row.
+    EVALUATION = "evaluation"
 
 
 class TurnFeedbackType(str, Enum):

--- a/aperag/domains/conversation/schemas.py
+++ b/aperag/domains/conversation/schemas.py
@@ -119,7 +119,9 @@ class Chat(BaseModel):
     title: Optional[str] = None
     bot_id: Optional[str] = None
     peer_id: Optional[str] = None
-    peer_type: Optional[Literal["system", "feishu", "weixin", "weixin_official", "web", "dingtalk"]] = None
+    peer_type: Optional[Literal["system", "feishu", "weixin", "weixin_official", "web", "dingtalk", "evaluation"]] = (
+        None
+    )
     status: Optional[Literal["active", "archived"]] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
@@ -177,7 +179,9 @@ class ChatDetails(BaseModel):
     title: Optional[str] = None
     bot_id: Optional[str] = None
     peer_id: Optional[str] = None
-    peer_type: Optional[Literal["system", "feishu", "weixin", "weixin_official", "web", "dingtalk"]] = None
+    peer_type: Optional[Literal["system", "feishu", "weixin", "weixin_official", "web", "dingtalk", "evaluation"]] = (
+        None
+    )
     history: Optional[list[AgentTurnSnapshot]] = Field(
         None,
         description=(

--- a/aperag/domains/conversation/service/chat_service.py
+++ b/aperag/domains/conversation/service/chat_service.py
@@ -131,7 +131,14 @@ class ChatService:
 
         return history
 
-    async def create_chat(self, user: str, bot_id: str, *, _allow_system_bot: bool = False) -> Chat:
+    async def create_chat(
+        self,
+        user: str,
+        bot_id: str,
+        *,
+        peer_type=None,
+        _allow_system_bot: bool = False,
+    ) -> Chat:
         # Wave 10 §K.13 — ``_allow_system_bot=True`` is the trusted
         # internal seam used by ``collection_regen_service`` Stage 1
         # Tier 1 to create a chat under the per-user hidden
@@ -147,7 +154,11 @@ class ChatService:
         if bot.type not in allowed_types:
             raise ValidationException("Only agent bots are supported")
 
-        chat = await self.db_ops.create_chat(user=user, bot_id=bot_id)
+        # ``peer_type`` defaults to ``SYSTEM`` (set in the repo layer)
+        # for normal user-driven chats. Internal call sites — e.g. the
+        # evaluation worker — pass ``ChatPeerType.EVALUATION`` so the
+        # row is filtered out of the bot's chat list by default.
+        chat = await self.db_ops.create_chat(user=user, bot_id=bot_id, peer_type=peer_type)
         return self.build_chat_response(chat)
 
     async def list_chats(
@@ -156,8 +167,18 @@ class ChatService:
         bot_id: str,
         page: int = 1,
         page_size: int = 50,
+        *,
+        include_internal: bool = False,
     ):
-        """List chats with pagination, sorting and search capabilities."""
+        """List chats with pagination, sorting and search capabilities.
+
+        ``include_internal`` defaults to ``False`` so chats created by
+        internal flows (e.g. the evaluation worker, which spawns one
+        ``Chat`` per case via ``ChatPeerType.EVALUATION``) stay out of
+        the bot's user-facing chat list. Run-detail trace links and
+        other internal call sites pass ``include_internal=True`` to see
+        the full set.
+        """
 
         sort_mapping = {
             "created": ChatRow.gmt_created,
@@ -168,13 +189,16 @@ class ChatService:
         async def _execute_paginated_query(session):
             from sqlalchemy import and_, desc, select
 
-            query = select(ChatRow).where(
-                and_(
-                    ChatRow.user == user,
-                    ChatRow.bot_id == bot_id,
-                    ChatRow.status != ChatStatus.DELETED,
-                )
-            )
+            from aperag.domains.conversation.db.models import ChatPeerType
+
+            conds = [
+                ChatRow.user == user,
+                ChatRow.bot_id == bot_id,
+                ChatRow.status != ChatStatus.DELETED,
+            ]
+            if not include_internal:
+                conds.append(ChatRow.peer_type != ChatPeerType.EVALUATION)
+            query = select(ChatRow).where(and_(*conds))
 
             from aperag.utils.pagination import ListParams, PaginationHelper, PaginationParams, SortParams
 

--- a/aperag/domains/evaluation/worker.py
+++ b/aperag/domains/evaluation/worker.py
@@ -118,10 +118,16 @@ async def dispatch_evaluation_turn(
     from aperag.domains.agent_runtime.db.models import AgentTurnStatus
     from aperag.domains.agent_runtime.runtime import agent_runtime_manager
     from aperag.domains.agent_runtime.schemas import CreateTurnRequest
+    from aperag.domains.conversation.db.models import ChatPeerType
     from aperag.domains.conversation.service.chat_service import chat_service_global
 
     start = time.monotonic()
-    chat_view = await chat_service_global.create_chat(user_id, bot_id)
+    # ``peer_type=EVALUATION`` flags this chat as internally-spawned
+    # so it does not surface in the bot's user-facing chat list (per
+    # @earayu2 msg=92d6fb21 + Weston msg=387ce23d). Run-detail trace
+    # links can still resolve the row by passing
+    # ``include_internal=True`` on the chat-list query.
+    chat_view = await chat_service_global.create_chat(user_id, bot_id, peer_type=ChatPeerType.EVALUATION)
     chat_id = chat_view.id
 
     turn_request = CreateTurnRequest(query=input_message, completion=completion)

--- a/tests/unit_test/chat/test_chat_service_evaluation_peer_type.py
+++ b/tests/unit_test/chat/test_chat_service_evaluation_peer_type.py
@@ -1,0 +1,82 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Internal-source ``ChatPeerType.EVALUATION`` filter (per @earayu2
+msg=41b411cd + Weston msg=387ce23d).
+
+Evaluation runs spawn one ``Chat`` per case so the agent runtime has
+a real conversation to drive, but the user did not start it — so the
+row must not surface in the bot's chat list. The new
+``ChatPeerType.EVALUATION`` enum value flags those rows; the
+``list_chats`` query filters them out by default and accepts
+``include_internal=True`` for internal trace lookups.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.domains.conversation.db.models import BotType, ChatPeerType
+from aperag.domains.conversation.service.chat_service import ChatService
+
+
+def test_chat_peer_type_has_evaluation_value():
+    assert ChatPeerType.EVALUATION.value == "evaluation"
+
+
+class _FakeBotDbOps:
+    def __init__(self):
+        self.created_chat_calls = []
+        self._bot = SimpleNamespace(
+            id="bot-1",
+            user="user-1",
+            type=BotType.AGENT,
+            status="ACTIVE",
+            is_system=False,
+        )
+
+    async def query_bot(self, _user, _bot_id, *, exclude_system: bool = True):
+        return self._bot
+
+    async def create_chat(self, *, user, bot_id, peer_type=None, **_kwargs):
+        from datetime import datetime, timezone
+
+        self.created_chat_calls.append({"user": user, "bot_id": bot_id, "peer_type": peer_type})
+        return SimpleNamespace(
+            id="chat-1",
+            title="t",
+            bot_id=bot_id,
+            peer_type=peer_type,
+            peer_id=None,
+            gmt_created=datetime.now(timezone.utc),
+            gmt_updated=datetime.now(timezone.utc),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_chat_default_peer_type_is_none():
+    """Default user-driven path leaves ``peer_type`` unset; the repo
+    layer fills in ``ChatPeerType.SYSTEM``."""
+    db_ops = _FakeBotDbOps()
+    svc = ChatService()
+    svc.db_ops = db_ops
+    await svc.create_chat("user-1", "bot-1")
+    assert db_ops.created_chat_calls == [{"user": "user-1", "bot_id": "bot-1", "peer_type": None}]
+
+
+@pytest.mark.asyncio
+async def test_create_chat_threads_evaluation_peer_type_through():
+    """Internal call sites (eval worker) explicitly pass EVALUATION so
+    ``list_chats`` can hide the row from the bot's chat list."""
+    db_ops = _FakeBotDbOps()
+    svc = ChatService()
+    svc.db_ops = db_ops
+    await svc.create_chat("user-1", "bot-1", peer_type=ChatPeerType.EVALUATION)
+    assert db_ops.created_chat_calls == [{"user": "user-1", "bot_id": "bot-1", "peer_type": ChatPeerType.EVALUATION}]


### PR DESCRIPTION
## Summary

Per @earayu2 ``msg=92d6fb21`` + ``msg=41b411cd`` + Weston ``msg=387ce23d``: the evaluation worker creates one ``Chat`` per case so the agent runtime has a real conversation to drive, but those chats surface in the bot's chat list and pollute the user's workspace ("我多了一堆会话" — they didn't start them).

User-driven chats and eval-spawned chats both default to ``ChatPeerType.SYSTEM``, so we cannot filter on the existing column. Per architect lock, add a new enum value rather than a boolean column — keeps the "渠道来源" semantics of ``peer_type`` and avoids a schema migration.

## What changed

* ``ChatPeerType`` gains ``EVALUATION = "evaluation"``.
* ``Chat`` Pydantic schema's ``peer_type`` Literal includes the new value.
* ``ChatService.create_chat`` accepts a ``peer_type`` keyword and threads it to the repo. Default ``None`` keeps user-driven chats on the existing ``SYSTEM`` path.
* ``ChatService.list_chats`` filters out ``ChatPeerType.EVALUATION`` by default; ``include_internal=True`` is the opt-in for run-detail trace links and other internal call sites.
* ``dispatch_evaluation_turn`` (eval worker) passes ``peer_type=ChatPeerType.EVALUATION`` so every case-spawned chat is hidden.

No alembic migration — ``peer_type`` is a string column whose width already accommodates ``"evaluation"``.

## Files

- ``aperag/domains/conversation/db/models.py`` — enum value
- ``aperag/domains/conversation/schemas.py`` — Pydantic Literal
- ``aperag/domains/conversation/service/chat_service.py`` — ``create_chat`` keyword + ``list_chats`` filter
- ``aperag/domains/evaluation/worker.py`` — eval worker passes ``ChatPeerType.EVALUATION``
- ``tests/unit_test/chat/test_chat_service_evaluation_peer_type.py`` — 3 new pins

## Test plan

- [x] ``uv run pytest tests/unit_test/chat tests/unit_test/test_evaluation_v2_worker.py`` — 35 passed
- [x] ``uvx ruff check`` clean (CI ruff 0.15.12)
- [x] ``uvx ruff format --check`` clean
- [ ] dongdong restart 8012 onto this commit → run a fresh evaluation → confirm the user's bot chat list does not gain new "Untitled" rows during the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)