### PR TITLE
fix(web): hide evaluation feature

### DIFF
--- a/web/src/app/workspace/bots/[botId]/evaluation/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/evaluation/page.tsx
@@ -1,66 +1,9 @@
-import { BotSectionNav } from '@/components/evaluation/bot-section-nav';
-import { EvaluationRunsPanel } from '@/components/evaluation/evaluation-runs-panel';
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-import { getBot } from '@/features/bot/server-api';
-import { listEvaluationRuns } from '@/features/evaluation/server-api';
-import { toJson } from '@/lib/utils';
-import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 
 export default async function Page({
-  params,
+  params: _params,
 }: {
   params: Promise<{ botId: string }>;
 }) {
-  const { botId } = await params;
-  const pageBot = await getTranslations('page_bot');
-  const pageBotEvaluation = await getTranslations('page_bot_evaluation');
-
-  let bot;
-
-  try {
-    const botRes = await getBot(botId);
-    if (!botRes) {
-      notFound();
-    }
-    bot = toJson(botRes);
-  } catch {
-    notFound();
-  }
-
-  const runs = await listEvaluationRuns({ botId });
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: pageBot('metadata.title'),
-          },
-          {
-            title: bot.title || botId,
-            href: `/workspace/bots/${botId}/chats`,
-          },
-          {
-            title: pageBotEvaluation('metadata.title'),
-          },
-        ]}
-      />
-      <PageContent className="pb-0">
-        <BotSectionNav botId={botId} active="evaluation" />
-      </PageContent>
-      <PageContent>
-        <EvaluationRunsPanel
-          bot={bot}
-          runs={runs.items}
-          unavailable={runs.unavailable}
-          error={runs.error}
-        />
-      </PageContent>
-    </PageContainer>
-  );
+  notFound();
 }

--- a/web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx
+++ b/web/src/app/workspace/bots/[botId]/evaluation/runs/[runId]/page.tsx
@@ -1,85 +1,9 @@
-import { BotSectionNav } from '@/components/evaluation/bot-section-nav';
-import { EvaluationRunDetail } from '@/components/evaluation/evaluation-run-detail';
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-import { getBot } from '@/features/bot/server-api';
-import {
-  getEvaluationRunDetail,
-  listEvaluationRunItems,
-} from '@/features/evaluation/server-api';
-import { toJson } from '@/lib/utils';
-import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 
 export default async function Page({
-  params,
+  params: _params,
 }: {
   params: Promise<{ botId: string; runId: string }>;
 }) {
-  const { botId, runId } = await params;
-  const [runDetail, runItems] = await Promise.all([
-    getEvaluationRunDetail(runId),
-    listEvaluationRunItems(runId),
-  ]);
-  const resolvedBotId = runDetail.payload?.run?.bot_id || botId;
-
-  if (
-    runDetail.payload?.run?.bot_id &&
-    runDetail.payload.run.bot_id !== botId
-  ) {
-    notFound();
-  }
-
-  const pageBot = await getTranslations('page_bot');
-  const pageBotEvaluation = await getTranslations('page_bot_evaluation');
-
-  let bot;
-
-  try {
-    const botRes = await getBot(resolvedBotId);
-    if (!botRes) {
-      notFound();
-    }
-    bot = toJson(botRes);
-  } catch {
-    notFound();
-  }
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: pageBot('metadata.title'),
-          },
-          {
-            title: bot.title || resolvedBotId,
-            href: `/workspace/bots/${resolvedBotId}/evaluation`,
-          },
-          {
-            title: pageBotEvaluation('metadata.title'),
-            href: `/workspace/bots/${resolvedBotId}/evaluation`,
-          },
-          {
-            title: runId,
-          },
-        ]}
-      />
-      <PageContent className="pb-0">
-        <BotSectionNav botId={resolvedBotId} active="evaluation" />
-      </PageContent>
-      <PageContent>
-        <EvaluationRunDetail
-          botId={resolvedBotId}
-          detail={runDetail.payload}
-          items={runItems.items}
-          unavailable={runDetail.unavailable || runItems.unavailable}
-          error={runDetail.error || runItems.error}
-        />
-      </PageContent>
-    </PageContainer>
-  );
+  notFound();
 }

--- a/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
@@ -34,7 +34,6 @@ import {
   Download,
   EllipsisVertical,
   Files,
-  FlaskConical,
   FolderSearch,
   Settings,
   Trash,
@@ -57,7 +56,6 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
   const { collection, share, loadShare } = useCollectionContext();
   const pathname = usePathname();
   const page_collections = useTranslations('page_collections');
-  const page_evaluations = useTranslations('page_collection_evaluations');
   const page_documents = useTranslations('page_documents');
   const page_graph = useTranslations('page_graph');
   const page_search = useTranslations('page_search');
@@ -98,12 +96,6 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
           icon: Files,
           label: page_documents('metadata.title'),
         },
-        {
-          href: urls.evaluations,
-          active: Boolean(pathname.match(urls.evaluations)),
-          icon: FlaskConical,
-          label: page_evaluations('metadata.title'),
-        },
         collection.config?.enable_knowledge_graph
           ? {
               href: urls.graph,
@@ -131,12 +123,10 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
       collection.config?.enable_knowledge_graph,
       page_collections,
       page_documents,
-      page_evaluations,
       page_graph,
       page_search,
       pathname,
       urls.documents,
-      urls.evaluations,
       urls.graph,
       urls.search,
       urls.settings,

--- a/web/src/app/workspace/collections/[collectionId]/evaluations/[evaluationId]/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/evaluations/[evaluationId]/page.tsx
@@ -1,60 +1,9 @@
-import { EvaluationRunDetail } from '@/components/evaluation/evaluation-run-detail';
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-import {
-  getEvaluationRunDetail,
-  listEvaluationRunItems,
-} from '@/features/evaluation/server-api';
-import { getTranslations } from 'next-intl/server';
-import { CollectionHeader } from '../../collection-header';
+import { notFound } from 'next/navigation';
 
 export default async function Page({
-  params,
+  params: _params,
 }: Readonly<{
   params: Promise<{ collectionId: string; evaluationId: string }>;
 }>) {
-  const { collectionId, evaluationId } = await params;
-  const [runDetail, runItems] = await Promise.all([
-    getEvaluationRunDetail(evaluationId),
-    listEvaluationRunItems(evaluationId),
-  ]);
-
-  const pageCollections = await getTranslations('page_collections');
-  const pageEvaluations = await getTranslations('page_collection_evaluations');
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: pageCollections('metadata.title'),
-            href: '/workspace/collections',
-          },
-          {
-            title: pageEvaluations('metadata.title'),
-            href: `/workspace/collections/${collectionId}/evaluations`,
-          },
-          {
-            title:
-              runDetail.payload?.run?.name ||
-              runDetail.payload?.run?.id ||
-              evaluationId,
-          },
-        ]}
-      />
-      <CollectionHeader />
-      <PageContent>
-        <EvaluationRunDetail
-          botId={runDetail.payload?.run?.bot_id ?? undefined}
-          detail={runDetail.payload}
-          items={runItems.items}
-          unavailable={runDetail.unavailable || runItems.unavailable}
-          error={runDetail.error || runItems.error}
-        />
-      </PageContent>
-    </PageContainer>
-  );
+  notFound();
 }

--- a/web/src/app/workspace/collections/[collectionId]/evaluations/datasets/[datasetId]/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/evaluations/datasets/[datasetId]/page.tsx
@@ -1,69 +1,9 @@
-import { EvaluationDatasetItemsPanel } from '@/components/evaluation/evaluation-dataset-items-panel';
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-import {
-  getEvaluationDataset,
-  listEvaluationDatasetItems,
-} from '@/features/evaluation/server-api';
-import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
-import { CollectionHeader } from '../../../collection-header';
 
 export default async function Page({
-  params,
+  params: _params,
 }: Readonly<{
   params: Promise<{ collectionId: string; datasetId: string }>;
 }>) {
-  const { collectionId, datasetId } = await params;
-  const [datasetState, itemsState] = await Promise.all([
-    getEvaluationDataset(datasetId),
-    listEvaluationDatasetItems(datasetId),
-  ]);
-
-  if (
-    !datasetState.payload &&
-    !datasetState.unavailable &&
-    !datasetState.error
-  ) {
-    notFound();
-  }
-
-  const pageCollections = await getTranslations('page_collections');
-  const pageEvaluations = await getTranslations('page_collection_evaluations');
-  const dataset = datasetState.payload;
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: pageCollections('metadata.title'),
-            href: '/workspace/collections',
-          },
-          {
-            title: pageEvaluations('metadata.title'),
-            href: `/workspace/collections/${collectionId}/evaluations`,
-          },
-          {
-            title: dataset?.name || datasetId,
-          },
-        ]}
-      />
-      <CollectionHeader />
-      <PageContent>
-        {dataset ? (
-          <EvaluationDatasetItemsPanel
-            collectionId={collectionId}
-            dataset={dataset}
-            items={itemsState.items}
-            unavailable={itemsState.unavailable}
-            error={itemsState.error}
-          />
-        ) : null}
-      </PageContent>
-    </PageContainer>
-  );
+  notFound();
 }

--- a/web/src/app/workspace/collections/[collectionId]/evaluations/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/evaluations/page.tsx
@@ -1,60 +1,9 @@
-import { CollectionRunsPanel } from '@/components/evaluation/collection-runs-panel';
-import { EvaluationDatasetsPanel } from '@/components/evaluation/evaluation-datasets-panel';
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-} from '@/components/page-container';
-import {
-  listEvaluationDatasets,
-  listEvaluationRuns,
-} from '@/features/evaluation/server-api';
-import { getTranslations } from 'next-intl/server';
-import { CollectionHeader } from '../collection-header';
+import { notFound } from 'next/navigation';
 
 export default async function Page({
-  params,
+  params: _params,
 }: Readonly<{
   params: Promise<{ collectionId: string }>;
 }>) {
-  const { collectionId } = await params;
-  const pageCollections = await getTranslations('page_collections');
-  const pageEvaluations = await getTranslations('page_collection_evaluations');
-
-  const [datasets, runs] = await Promise.all([
-    listEvaluationDatasets(collectionId),
-    listEvaluationRuns({ collectionId }),
-  ]);
-
-  return (
-    <PageContainer>
-      <PageHeader
-        breadcrumbs={[
-          {
-            title: pageCollections('metadata.title'),
-            href: '/workspace/collections',
-          },
-          {
-            title: pageEvaluations('metadata.title'),
-          },
-        ]}
-      />
-      <CollectionHeader />
-      <PageContent className="flex flex-col gap-6">
-        <EvaluationDatasetsPanel
-          collectionId={collectionId}
-          items={datasets.items}
-          unavailable={datasets.unavailable}
-          error={datasets.error}
-        />
-        <CollectionRunsPanel
-          collectionId={collectionId}
-          datasets={datasets.items}
-          runs={runs.items}
-          unavailable={runs.unavailable}
-          error={runs.error}
-        />
-      </PageContent>
-    </PageContainer>
-  );
+  notFound();
 }


### PR DESCRIPTION
## Summary\n- remove the collection-level Evaluations tab from the collection header\n- return notFound for collection evaluation pages and bot evaluation pages so direct frontend routes are blocked\n\n## Validation\n- web/yarn lint --quiet\n- web/yarn type-check --pretty false\n- git diff --check