### PR TITLE
Fix Postgres graph expansion frontier

### DIFF
--- a/aperag/indexing/graph_storage/postgres.py
+++ b/aperag/indexing/graph_storage/postgres.py
@@ -813,6 +813,7 @@ class PostgresLineageGraphStore:
             already in ``names``) for the next-hop frontier."""
             if not names:
                 return set()
+            next_frontier: set[str] = set()
             relation_stmt = select(
                 _LineageRelationRow.source,
                 _LineageRelationRow.target,

--- a/tests/unit_test/indexing/test_postgres_lineage_graph_store.py
+++ b/tests/unit_test/indexing/test_postgres_lineage_graph_store.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.indexing.graph_storage.postgres import PostgresLineageGraphStore
+
+
+class _FakeConnection:
+    def __init__(self, results: list[list[SimpleNamespace]]) -> None:
+        self._results = results
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def execute(self, _stmt):
+        return self._results.pop(0)
+
+
+class _FakeEngine:
+    def __init__(self, results: list[list[SimpleNamespace]]) -> None:
+        self._results = results
+
+    def connect(self):
+        return _FakeConnection(self._results)
+
+
+def _entity_row(name: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        entity_type="person",
+        source_lineage=[],
+        description_parts=[],
+        compacted_description=None,
+    )
+
+
+def _relation_row(source: str, target: str, relation_type: str = "knows") -> SimpleNamespace:
+    return SimpleNamespace(
+        source=source,
+        target=target,
+        relation_type=relation_type,
+        evidence_lineage=[],
+        description_parts=[],
+        compacted_description=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_expand_neighbors_initializes_frontier_for_split_relation_queries():
+    store = PostgresLineageGraphStore(
+        engine=_FakeEngine(
+            [
+                [_entity_row("Alice")],
+                [_relation_row("Alice", "Bob")],
+                [],
+                [_entity_row("Bob")],
+            ]
+        ),
+        collection_id="col-test",
+    )
+
+    entities, relations = await store.expand_neighbors_n_hops(entity_names=["Alice"], hops=1)
+
+    assert {entity.name for entity in entities} == {"Alice", "Bob"}
+    assert {(relation.source, relation.target, relation.relation_type) for relation in relations} == {
+        ("Alice", "Bob", "knows")
+    }


### PR DESCRIPTION
## Summary
- initialize the Postgres split-query expansion frontier before consuming relation rows
- add a targeted unit regression for source/target split relation queries

## Verification
- uvx ruff check --no-fix aperag/indexing/graph_storage/postgres.py tests/unit_test/indexing/test_postgres_lineage_graph_store.py
- uvx ruff format --check aperag/indexing/graph_storage/postgres.py tests/unit_test/indexing/test_postgres_lineage_graph_store.py
- uv run --extra test pytest tests/unit_test/indexing/test_postgres_lineage_graph_store.py -q
- COMPAT_PG_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/postgres uv run --extra test pytest tests/integration/compat/test_lineage_graph_compat.py::test_expand_neighbors_n_hops_returns_seed_and_relations -q
- local 3002 backend hotfix: graph_service.get_hybrid_graph(col33b6b48211a30a95, max_entities=1000) returned 107 nodes / 102 edges