### PR TITLE
[codex] Refactor provider configuration page

### DIFF
--- a/web/src/app/workspace/providers/model-platform-panel.tsx
+++ b/web/src/app/workspace/providers/model-platform-panel.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -10,241 +11,904 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
 import {
   createModel,
   createModelAccount,
+  deleteModelAccount,
+  updateModelAccount,
   updateModelUse,
+  validateModelAccount,
 } from '@/features/providers/client-api';
 import type {
   Model,
   ModelAccount,
   ModelCapability,
   ModelPlatformViewModel,
+  ModelProvider,
   ModelUseScenario,
 } from '@/features/providers/types';
+import { Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-const scenarios: { id: ModelUseScenario; label: string; capability: ModelCapability }[] = [
-  { id: 'agent_chat', label: 'Agent 对话模型', capability: 'chat' },
-  { id: 'collection_completion', label: '知识库补全模型', capability: 'chat' },
-  { id: 'collection_embedding', label: '知识库向量模型', capability: 'embedding' },
-  { id: 'retrieval_rerank', label: '检索重排模型', capability: 'rerank' },
-  { id: 'background_task', label: '后台任务模型', capability: 'chat' },
+type ModelPreset = {
+  providerType: string;
+  providerModelId: string;
+  displayName: string;
+  capability: ModelCapability;
+  contextWindow?: number;
+  embeddingDimensions?: number;
+  supportsVision?: boolean;
+  supportsToolCalling?: boolean;
+  supportsMultimodalEmbedding?: boolean;
+};
+
+type ProviderForm = {
+  name: string;
+  displayName: string;
+  baseUrl: string;
+  apiKey: string;
+};
+
+type ModelForm = {
+  providerModelId: string;
+  displayName: string;
+  capability: ModelCapability;
+};
+
+const capabilityMeta: Record<ModelCapability, { label: string }> = {
+  chat: {
+    label: '对话',
+  },
+  completion: {
+    label: '补全',
+  },
+  embedding: {
+    label: '向量',
+  },
+  rerank: {
+    label: '重排',
+  },
+};
+
+const scenarioMeta: Array<{
+  id: ModelUseScenario;
+  label: string;
+  capability: ModelCapability;
+}> = [
+  { id: 'agent_chat', label: 'Agent 对话', capability: 'chat' },
+  { id: 'collection_completion', label: '知识库问答', capability: 'chat' },
+  { id: 'collection_embedding', label: '文档向量', capability: 'embedding' },
+  { id: 'retrieval_rerank', label: '检索重排', capability: 'rerank' },
+  { id: 'background_task', label: '后台任务', capability: 'chat' },
 ];
+
+const modelCapabilityOptions: ModelCapability[] = [
+  'chat',
+  'embedding',
+  'rerank',
+];
+
+const modelPresets: ModelPreset[] = [
+  {
+    providerType: 'openai',
+    providerModelId: 'gpt-4.1',
+    displayName: 'GPT-4.1',
+    capability: 'chat',
+    contextWindow: 128000,
+    supportsVision: true,
+    supportsToolCalling: true,
+  },
+  {
+    providerType: 'openai',
+    providerModelId: 'gpt-4.1-mini',
+    displayName: 'GPT-4.1 Mini',
+    capability: 'chat',
+    contextWindow: 128000,
+    supportsVision: true,
+    supportsToolCalling: true,
+  },
+  {
+    providerType: 'openai',
+    providerModelId: 'text-embedding-3-large',
+    displayName: 'text-embedding-3-large',
+    capability: 'embedding',
+    embeddingDimensions: 3072,
+  },
+  {
+    providerType: 'openai',
+    providerModelId: 'text-embedding-3-small',
+    displayName: 'text-embedding-3-small',
+    capability: 'embedding',
+    embeddingDimensions: 1536,
+  },
+  {
+    providerType: 'dashscope',
+    providerModelId: 'qwen-plus',
+    displayName: 'Qwen Plus',
+    capability: 'chat',
+    contextWindow: 131072,
+    supportsToolCalling: true,
+  },
+  {
+    providerType: 'dashscope',
+    providerModelId: 'qwen-max',
+    displayName: 'Qwen Max',
+    capability: 'chat',
+    contextWindow: 32768,
+    supportsToolCalling: true,
+  },
+  {
+    providerType: 'dashscope',
+    providerModelId: 'text-embedding-v4',
+    displayName: 'Text Embedding v4',
+    capability: 'embedding',
+    embeddingDimensions: 1024,
+  },
+  {
+    providerType: 'dashscope',
+    providerModelId: 'gte-rerank-v2',
+    displayName: 'GTE Rerank v2',
+    capability: 'rerank',
+  },
+  {
+    providerType: 'jina',
+    providerModelId: 'jina-embeddings-v3',
+    displayName: 'Jina Embeddings v3',
+    capability: 'embedding',
+    embeddingDimensions: 1024,
+  },
+  {
+    providerType: 'jina',
+    providerModelId: 'jina-reranker-v2-base-multilingual',
+    displayName: 'Jina Reranker v2',
+    capability: 'rerank',
+  },
+  {
+    providerType: 'openai_compatible',
+    providerModelId: 'google/gemini-2.5-flash',
+    displayName: 'Gemini 2.5 Flash',
+    capability: 'chat',
+    contextWindow: 1048576,
+    supportsVision: true,
+    supportsToolCalling: true,
+  },
+  {
+    providerType: 'openai_compatible',
+    providerModelId: 'qwen/qwen3-32b',
+    displayName: 'Qwen3 32B',
+    capability: 'chat',
+    contextWindow: 131072,
+    supportsToolCalling: true,
+  },
+];
+
+const emptyModelForm: ModelForm = {
+  providerModelId: '',
+  displayName: '',
+  capability: 'chat',
+};
+
+const normalize = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const providerFormFromAccount = (
+  provider: ModelProvider | undefined,
+  account: ModelAccount | undefined,
+): ProviderForm => ({
+  name: account?.name ?? normalize(provider?.provider_type ?? ''),
+  displayName: account?.display_name ?? provider?.display_name ?? '',
+  baseUrl: account?.base_url ?? provider?.default_base_url ?? '',
+  apiKey: '',
+});
+
+const modelKey = (model: Pick<Model, 'provider_model_id' | 'capability'>) =>
+  `${model.provider_model_id}:${model.capability}`;
+
+const presetKey = (
+  preset: Pick<ModelPreset, 'providerModelId' | 'capability'>,
+) => `${preset.providerModelId}:${preset.capability}`;
 
 export function ModelPlatformPanel({ data }: { data: ModelPlatformViewModel }) {
   const router = useRouter();
-  const [account, setAccount] = useState({
-    provider_type: data.providers[0]?.provider_type ?? 'openai_compatible',
-    name: '',
-    display_name: '',
-    base_url: data.providers[0]?.default_base_url ?? '',
-    api_key: '',
-  });
-  const [model, setModel] = useState({
-    account_id: data.accounts[0]?.id ?? '',
-    provider_model_id: '',
-    display_name: '',
-    capability: 'chat' as ModelCapability,
-  });
+  const activeProviders = useMemo(
+    () => data.providers.filter((provider) => provider.enabled !== false),
+    [data.providers],
+  );
+  const [selectedProviderType, setSelectedProviderType] = useState(
+    activeProviders[0]?.provider_type ?? '',
+  );
+  const selectedProvider =
+    activeProviders.find(
+      (provider) => provider.provider_type === selectedProviderType,
+    ) ?? activeProviders[0];
+  const providerAccounts = useMemo(
+    () =>
+      data.accounts.filter(
+        (account) => account.provider_type === selectedProvider?.provider_type,
+      ),
+    [data.accounts, selectedProvider?.provider_type],
+  );
+  const primaryAccount = providerAccounts[0];
+  const providerModels = useMemo(
+    () =>
+      data.models.filter((model) =>
+        providerAccounts.some((account) => account.id === model.account_id),
+      ),
+    [data.models, providerAccounts],
+  );
+  const configuredModelKeys = useMemo(
+    () => new Set(providerModels.map(modelKey)),
+    [providerModels],
+  );
+  const providerPresets = useMemo(
+    () =>
+      modelPresets.filter(
+        (preset) => preset.providerType === selectedProvider?.provider_type,
+      ),
+    [selectedProvider?.provider_type],
+  );
+  const [providerForm, setProviderForm] = useState<ProviderForm>(
+    providerFormFromAccount(selectedProvider, primaryAccount),
+  );
+  const [modelForm, setModelForm] = useState<ModelForm>(emptyModelForm);
+  const [saving, setSaving] = useState<string | null>(null);
 
-  async function saveAccount() {
-    await createModelAccount(account);
-    toast.success('模型账号已创建');
-    router.refresh();
-  }
+  const chooseProvider = (provider: ModelProvider) => {
+    const nextAccount = data.accounts.find(
+      (account) => account.provider_type === provider.provider_type,
+    );
+    setSelectedProviderType(provider.provider_type);
+    setProviderForm(providerFormFromAccount(provider, nextAccount));
+    setModelForm(emptyModelForm);
+  };
 
-  async function saveModel() {
-    await createModel(model);
-    toast.success('模型已添加');
-    router.refresh();
-  }
+  const saveProvider = async () => {
+    if (!selectedProvider) return;
+    const displayName = providerForm.displayName.trim();
+    const name = normalize(providerForm.name || selectedProvider.provider_type);
 
-  async function saveUse(scenario: ModelUseScenario, capability: ModelCapability, modelId: string) {
-    await updateModelUse(scenario, { capability, primary_model_id: modelId });
-    toast.success('模型用途已更新');
-    router.refresh();
+    if (!name || !displayName || !providerForm.baseUrl.trim()) {
+      toast.error('请填写显示名称和 Base URL');
+      return;
+    }
+    if (!primaryAccount && !providerForm.apiKey.trim()) {
+      toast.error('请填写 API Key');
+      return;
+    }
+
+    setSaving('provider');
+    try {
+      if (primaryAccount?.id) {
+        await updateModelAccount(primaryAccount.id, {
+          name,
+          display_name: displayName,
+          base_url: providerForm.baseUrl.trim(),
+          api_key: providerForm.apiKey.trim() || undefined,
+        });
+        toast.success('Provider 配置已保存');
+      } else {
+        await createModelAccount({
+          provider_type: selectedProvider.provider_type,
+          name,
+          display_name: displayName,
+          base_url: providerForm.baseUrl.trim(),
+          api_key: providerForm.apiKey.trim(),
+        });
+        toast.success('Provider 已启用');
+      }
+      setProviderForm({ ...providerForm, apiKey: '' });
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '保存失败');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const validateProvider = async () => {
+    if (!primaryAccount?.id) return;
+    setSaving('validate');
+    try {
+      const result = await validateModelAccount(primaryAccount.id);
+      const message =
+        result?.message || (result?.ok ? '连接可用' : '连接不可用');
+      if (result?.ok) {
+        toast.success(message);
+      } else {
+        toast.error(message);
+      }
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '校验失败');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const disableProvider = async () => {
+    if (!primaryAccount?.id) return;
+    setSaving('disable-provider');
+    try {
+      await deleteModelAccount(primaryAccount.id);
+      toast.success('Provider 已停用');
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '停用失败');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const addModel = async (source: ModelPreset | ModelForm) => {
+    if (!primaryAccount?.id) {
+      toast.error('请先保存 Provider 的 API Key 和 Base URL');
+      return;
+    }
+    const providerModelId = source.providerModelId.trim();
+    const displayName = source.displayName.trim();
+    const capability = source.capability;
+
+    if (!providerModelId || !displayName) {
+      toast.error('请填写模型 ID 和显示名称');
+      return;
+    }
+    if (configuredModelKeys.has(`${providerModelId}:${capability}`)) {
+      toast.info('这个模型已经启用过了');
+      return;
+    }
+
+    setSaving(`model:${providerModelId}:${capability}`);
+    try {
+      const preset = 'contextWindow' in source ? source : undefined;
+      await createModel({
+        account_id: primaryAccount.id,
+        provider_model_id: providerModelId,
+        display_name: displayName,
+        capability,
+        context_window: preset?.contextWindow,
+        embedding_dimensions: preset?.embeddingDimensions,
+        supports_vision: Boolean(preset?.supportsVision),
+        supports_tool_calling: Boolean(preset?.supportsToolCalling),
+        supports_multimodal_embedding: Boolean(
+          preset?.supportsMultimodalEmbedding,
+        ),
+      });
+      toast.success('模型已启用');
+      if (!preset) setModelForm(emptyModelForm);
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '启用模型失败');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const saveUse = async (
+    scenario: ModelUseScenario,
+    capability: ModelCapability,
+    modelId: string,
+  ) => {
+    setSaving(`use:${scenario}`);
+    try {
+      await updateModelUse(scenario, {
+        capability,
+        primary_model_id: modelId,
+      });
+      toast.success('默认模型已更新');
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '更新失败');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  if (!selectedProvider) {
+    return (
+      <div className="rounded-lg border bg-white p-8">
+        <h2 className="text-xl font-semibold">没有可用 Provider</h2>
+        <p className="text-muted-foreground mt-2 text-sm">
+          系统还没有下发内置 Provider 模板。
+        </p>
+      </div>
+    );
   }
 
   return (
-    <div className="grid gap-6">
-      <section className="grid gap-4 md:grid-cols-3">
-        <Metric title="模型服务商" value={data.providers.length} />
-        <Metric title="模型账号" value={data.accounts.length} />
-        <Metric title="模型" value={data.models.length} />
-      </section>
+    <div className="grid gap-5">
+      <div className="grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]">
+        <ProviderSidebar
+          providers={activeProviders}
+          accounts={data.accounts}
+          selectedProvider={selectedProvider}
+          onSelect={chooseProvider}
+        />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>添加模型账号</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-3 md:grid-cols-5">
-          <Select
-            value={account.provider_type}
-            onValueChange={(providerType) => {
-              const provider = data.providers.find((item) => item.provider_type === providerType);
-              setAccount((value) => ({
-                ...value,
-                provider_type: providerType,
-                base_url: provider?.default_base_url ?? value.base_url,
-              }));
-            }}
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {data.providers.map((provider) => (
-                <SelectItem key={provider.provider_type} value={provider.provider_type}>
-                  {provider.display_name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Input placeholder="账号标识" value={account.name} onChange={(e) => setAccount({ ...account, name: e.target.value })} />
-          <Input
-            placeholder="显示名称"
-            value={account.display_name}
-            onChange={(e) => setAccount({ ...account, display_name: e.target.value })}
-          />
-          <Input
-            placeholder="Base URL"
-            value={account.base_url}
-            onChange={(e) => setAccount({ ...account, base_url: e.target.value })}
-          />
-          <Input
-            placeholder="API Key"
-            type="password"
-            value={account.api_key}
-            onChange={(e) => setAccount({ ...account, api_key: e.target.value })}
-          />
-          <Button className="md:col-span-5" onClick={saveAccount}>
-            保存模型账号
-          </Button>
-        </CardContent>
-      </Card>
+        <section className="min-w-0 rounded-lg border bg-white">
+          <ProviderHero provider={selectedProvider} account={primaryAccount} />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>添加模型</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-3 md:grid-cols-5">
-          <Select value={model.account_id} onValueChange={(accountId) => setModel({ ...model, account_id: accountId })}>
-            <SelectTrigger>
-              <SelectValue placeholder="选择模型账号" />
-            </SelectTrigger>
-            <SelectContent>
-              {data.accounts.map((item) => (
-                <SelectItem key={item.id ?? item.name} value={item.id ?? ''}>
-                  {item.display_name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Input
-            placeholder="Provider Model ID"
-            value={model.provider_model_id}
-            onChange={(e) => setModel({ ...model, provider_model_id: e.target.value })}
-          />
-          <Input
-            placeholder="显示名称"
-            value={model.display_name}
-            onChange={(e) => setModel({ ...model, display_name: e.target.value })}
-          />
-          <Select value={model.capability} onValueChange={(capability: ModelCapability) => setModel({ ...model, capability })}>
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="chat">对话</SelectItem>
-              <SelectItem value="embedding">向量</SelectItem>
-              <SelectItem value="rerank">重排</SelectItem>
-            </SelectContent>
-          </Select>
-          <Button onClick={saveModel}>添加模型</Button>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>模型用途</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-3">
-          {scenarios.map((scenario) => (
-            <ModelUseRow
-              key={scenario.id}
-              label={scenario.label}
-              capability={scenario.capability}
-              models={data.models}
-              value={data.uses.find((item) => item.scenario === scenario.id)?.primary_model_id ?? ''}
-              onChange={(modelId) => saveUse(scenario.id, scenario.capability, modelId)}
+          <div className="grid gap-8 border-t px-6 py-6">
+            <ProviderSettings
+              provider={selectedProvider}
+              account={primaryAccount}
+              form={providerForm}
+              saving={saving}
+              onChange={setProviderForm}
+              onSave={saveProvider}
+              onValidate={validateProvider}
+              onDisable={disableProvider}
             />
-          ))}
-        </CardContent>
-      </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>已配置模型</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-2">
-          {data.models.map((item) => (
-            <div key={item.id} className="flex items-center justify-between rounded-lg border p-3">
-              <div>
-                <div className="font-medium">{item.display_name}</div>
-                <div className="text-muted-foreground text-xs">{item.provider_model_id}</div>
-              </div>
-              <div className="text-muted-foreground text-xs">{item.capability}</div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+            <ModelFolder
+              account={primaryAccount}
+              configuredModels={providerModels}
+              presets={providerPresets}
+              configuredModelKeys={configuredModelKeys}
+              modelForm={modelForm}
+              saving={saving}
+              onModelFormChange={setModelForm}
+              onAddModel={addModel}
+            />
+          </div>
+        </section>
+      </div>
+
+      <DefaultModels
+        models={data.models}
+        uses={data.uses}
+        saving={saving}
+        onChange={saveUse}
+      />
     </div>
   );
 }
 
-function Metric({ title, value }: { title: string; value: number }) {
+function ProviderSidebar({
+  providers,
+  accounts,
+  selectedProvider,
+  onSelect,
+}: {
+  providers: ModelProvider[];
+  accounts: ModelAccount[];
+  selectedProvider: ModelProvider;
+  onSelect: (provider: ModelProvider) => void;
+}) {
   return (
-    <Card>
-      <CardContent className="p-4">
-        <div className="text-muted-foreground text-xs">{title}</div>
-        <div className="mt-2 text-2xl font-medium">{value}</div>
-      </CardContent>
-    </Card>
+    <aside className="rounded-lg border bg-white">
+      <div className="border-b px-5 py-4">
+        <div className="text-sm font-semibold">Providers</div>
+      </div>
+      <div className="grid gap-1 p-2">
+        {providers.map((provider) => {
+          const providerAccounts = accounts.filter(
+            (account) => account.provider_type === provider.provider_type,
+          );
+          const selected =
+            provider.provider_type === selectedProvider.provider_type;
+
+          return (
+            <button
+              key={provider.provider_type}
+              type="button"
+              onClick={() => onSelect(provider)}
+              className={cn(
+                'group grid grid-cols-[minmax(0,1fr)] items-center gap-3 rounded-md border px-4 py-3 text-left transition-colors',
+                selected
+                  ? 'border-slate-200 bg-slate-100 text-slate-950 shadow-sm'
+                  : 'border-transparent hover:bg-slate-50',
+              )}
+            >
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-medium">
+                  {provider.display_name}
+                </span>
+                <span
+                  className={cn(
+                    'text-xs',
+                    selected ? 'text-slate-500' : 'text-muted-foreground',
+                  )}
+                >
+                  {providerAccounts.length ? '已启用' : '未启用'}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
   );
 }
 
-function ModelUseRow({
-  label,
-  capability,
+function ProviderHero({
+  provider,
+  account,
+}: {
+  provider: ModelProvider;
+  account: ModelAccount | undefined;
+}) {
+  return (
+    <div className="px-6 py-6">
+      <div className="flex gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-3xl font-semibold tracking-tight">
+              {provider.display_name}
+            </h2>
+            {account ? (
+              <Badge className="bg-emerald-600 hover:bg-emerald-600">
+                已启用
+              </Badge>
+            ) : (
+              <Badge variant="secondary">未启用</Badge>
+            )}
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {provider.supported_capabilities.map((capability) => (
+              <CapabilityBadge key={capability} capability={capability} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProviderSettings({
+  provider,
+  account,
+  form,
+  saving,
+  onChange,
+  onSave,
+  onValidate,
+  onDisable,
+}: {
+  provider: ModelProvider;
+  account: ModelAccount | undefined;
+  form: ProviderForm;
+  saving: string | null;
+  onChange: (value: ProviderForm) => void;
+  onSave: () => void;
+  onValidate: () => void;
+  onDisable: () => void;
+}) {
+  return (
+    <section className="grid gap-4">
+      <SectionTitle title="API Keys" />
+      <div className="grid gap-4">
+        <div className="grid gap-3 md:grid-cols-2">
+          <Field
+            label="Display Name"
+            value={form.displayName}
+            placeholder={provider.display_name}
+            onChange={(value) => onChange({ ...form, displayName: value })}
+          />
+          <Field
+            label="Base URL"
+            value={form.baseUrl}
+            placeholder={provider.default_base_url || 'https://.../v1'}
+            onChange={(value) => onChange({ ...form, baseUrl: value })}
+          />
+        </div>
+        <Field
+          label="API Key"
+          value={form.apiKey}
+          placeholder="sk-..."
+          type="password"
+          onChange={(value) => onChange({ ...form, apiKey: value })}
+        />
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          {account?.validation_error ? (
+            <div className="text-muted-foreground text-xs">
+              上次校验失败：{account.validation_error}
+            </div>
+          ) : (
+            <div />
+          )}
+          <div className="ml-auto flex gap-2">
+            {account ? (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={onValidate}
+                  disabled={saving !== null}
+                >
+                  {saving === 'validate' ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : null}
+                  校验
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={onDisable}
+                  disabled={saving !== null}
+                >
+                  {saving === 'disable-provider' ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : null}
+                  停用
+                </Button>
+              </>
+            ) : null}
+            <Button onClick={onSave} disabled={saving !== null}>
+              {saving === 'provider' ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
+              {account ? '保存' : '启用'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ModelFolder({
+  account,
+  configuredModels,
+  presets,
+  configuredModelKeys,
+  modelForm,
+  saving,
+  onModelFormChange,
+  onAddModel,
+}: {
+  account: ModelAccount | undefined;
+  configuredModels: Model[];
+  presets: ModelPreset[];
+  configuredModelKeys: Set<string>;
+  modelForm: ModelForm;
+  saving: string | null;
+  onModelFormChange: (value: ModelForm) => void;
+  onAddModel: (source: ModelPreset | ModelForm) => void;
+}) {
+  return (
+    <section className="grid gap-4">
+      <SectionTitle title="Models" />
+      <div className="overflow-hidden rounded-lg border">
+        <div className="grid grid-cols-[minmax(0,1fr)_120px_112px] border-b bg-slate-50 px-4 py-2 text-xs font-medium text-slate-500">
+          <span>模型</span>
+          <span>能力</span>
+          <span aria-hidden />
+        </div>
+        {configuredModels.map((model) => (
+          <ModelRow key={model.id ?? model.provider_model_id} model={model} />
+        ))}
+        {presets
+          .filter((preset) => !configuredModelKeys.has(presetKey(preset)))
+          .map((preset) => {
+            const savingKey = `model:${preset.providerModelId}:${preset.capability}`;
+            return (
+              <PresetRow
+                key={`${preset.providerType}:${preset.providerModelId}:${preset.capability}`}
+                preset={preset}
+                disabled={!account || saving !== null}
+                loading={saving === savingKey}
+                onAdd={() => onAddModel(preset)}
+              />
+            );
+          })}
+        <div className="grid gap-3 border-t bg-white px-4 py-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_160px_auto] md:items-end">
+          <Field
+            label="自定义模型 ID"
+            value={modelForm.providerModelId}
+            placeholder="provider/model-id"
+            onChange={(value) =>
+              onModelFormChange({ ...modelForm, providerModelId: value })
+            }
+          />
+          <Field
+            label="显示名称"
+            value={modelForm.displayName}
+            placeholder="My Model"
+            onChange={(value) =>
+              onModelFormChange({ ...modelForm, displayName: value })
+            }
+          />
+          <div className="grid gap-2">
+            <Label>能力</Label>
+            <Select
+              value={modelForm.capability}
+              onValueChange={(capability: ModelCapability) =>
+                onModelFormChange({ ...modelForm, capability })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {modelCapabilityOptions.map((capability) => (
+                  <SelectItem key={capability} value={capability}>
+                    {capabilityMeta[capability].label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            onClick={() => onAddModel(modelForm)}
+            disabled={!account || saving !== null}
+          >
+            启用
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ModelRow({ model }: { model: Model }) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_120px_112px] items-center border-b px-4 py-3">
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium">{model.display_name}</div>
+        <div className="text-muted-foreground mt-1 truncate text-xs">
+          {model.provider_model_id}
+        </div>
+      </div>
+      <CapabilityBadge capability={model.capability} />
+      <div aria-hidden />
+    </div>
+  );
+}
+
+function PresetRow({
+  preset,
+  disabled,
+  loading,
+  onAdd,
+}: {
+  preset: ModelPreset;
+  disabled: boolean;
+  loading: boolean;
+  onAdd: () => void;
+}) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_120px_112px] items-center border-b px-4 py-3">
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium text-slate-700">
+          {preset.displayName}
+        </div>
+        <div className="text-muted-foreground mt-1 truncate text-xs">
+          {preset.providerModelId}
+        </div>
+      </div>
+      <CapabilityBadge capability={preset.capability} />
+      <div className="flex justify-end">
+        <Button size="sm" variant="outline" disabled={disabled} onClick={onAdd}>
+          {loading ? <Loader2 className="size-4 animate-spin" /> : null}
+          启用
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function DefaultModels({
   models,
+  uses,
+  saving,
+  onChange,
+}: {
+  models: Model[];
+  uses: ModelPlatformViewModel['uses'];
+  saving: string | null;
+  onChange: (
+    scenario: ModelUseScenario,
+    capability: ModelCapability,
+    modelId: string,
+  ) => void;
+}) {
+  const t = useTranslations('page_models');
+
+  return (
+    <section className="grid gap-4 rounded-lg border bg-white p-6">
+      <SectionTitle title={t('default_model.config')} />
+      <div className="grid gap-2 md:grid-cols-2">
+        {scenarioMeta.map((scenario) => {
+          const candidates = models.filter(
+            (model): model is Model & { id: string } =>
+              model.capability === scenario.capability && Boolean(model.id),
+          );
+          const value =
+            uses.find((item) => item.scenario === scenario.id)
+              ?.primary_model_id ?? '';
+          return (
+            <div
+              key={scenario.id}
+              className="grid gap-2 rounded-lg border bg-white p-3"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-medium">{scenario.label}</span>
+                <CapabilityBadge capability={scenario.capability} />
+              </div>
+              <Select
+                value={value}
+                onValueChange={(modelId) =>
+                  onChange(scenario.id, scenario.capability, modelId)
+                }
+                disabled={saving !== null || candidates.length === 0}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue
+                    placeholder={
+                      candidates.length ? '选择默认模型' : '暂无可用模型'
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {candidates.map((model) => (
+                    <SelectItem key={model.id} value={model.id}>
+                      {model.display_name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function SectionTitle({
+  title,
+  description,
+}: {
+  title: string;
+  description?: string;
+}) {
+  return (
+    <div>
+      <div className="text-sm font-semibold">{title}</div>
+      {description ? (
+        <p className="text-muted-foreground mt-1 text-xs">{description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function CapabilityBadge({ capability }: { capability: ModelCapability }) {
+  const meta = capabilityMeta[capability];
+  return (
+    <span className="inline-flex w-fit items-center rounded-md border border-slate-200 bg-white px-2 py-0.5 text-xs font-medium text-slate-600">
+      {meta.label}
+    </span>
+  );
+}
+
+function Field({
+  label,
   value,
+  placeholder,
+  type = 'text',
   onChange,
 }: {
   label: string;
-  capability: ModelCapability;
-  models: Model[];
   value: string;
-  onChange: (modelId: string) => void;
+  placeholder?: string;
+  type?: string;
+  onChange: (value: string) => void;
 }) {
-  const candidates = models.filter((model) => model.capability === capability);
   return (
-    <div className="grid items-center gap-3 md:grid-cols-[220px_1fr]">
-      <div className="text-sm font-medium">{label}</div>
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger>
-          <SelectValue placeholder="选择模型" />
-        </SelectTrigger>
-        <SelectContent>
-          {candidates.map((model) => (
-            <SelectItem key={model.id ?? model.provider_model_id} value={model.id ?? ''}>
-              {model.display_name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+    <div className="grid gap-2">
+      <Label>{label}</Label>
+      <Input
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
     </div>
   );
 }

--- a/web/src/app/workspace/providers/page.tsx
+++ b/web/src/app/workspace/providers/page.tsx
@@ -10,7 +10,7 @@ import { ModelPlatformPanel } from './model-platform-panel';
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
-    title: '大模型配置',
+    title: '模型配置',
   };
 }
 
@@ -29,11 +29,8 @@ export default async function Page() {
             Model Platform
           </div>
           <h1 className="font-serif mt-2 text-4xl leading-none font-normal tracking-normal md:text-[44px]">
-            大模型配置
+            模型配置
           </h1>
-          <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
-            配置模型服务商、模型账号、模型和模型用途。这里不再要求填写 LiteLLM dialect 或内部 provider 路由名。
-          </p>
         </div>
         <ModelPlatformPanel data={data} />
       </PageContent>

--- a/web/src/features/providers/client-api.ts
+++ b/web/src/features/providers/client-api.ts
@@ -5,6 +5,7 @@ import type {
   Model,
   ModelAccount,
   ModelAccountCreateInput,
+  ModelAccountUpdateInput,
   ModelCapability,
   ModelCreateInput,
   ModelProvider,
@@ -12,43 +13,68 @@ import type {
   ModelUseScenario,
 } from './types';
 
-const api = browserApiClient as any;
-
 export async function getModelProviders(): Promise<ModelProvider[]> {
-  const { data } = await api.GET('/api/v2/model-providers');
-  return data?.items ?? [];
+  const { data } = await browserApiClient.GET('/api/v2/model-providers');
+  return (data?.items ?? []) as ModelProvider[];
 }
 
 export async function getModelAccounts(): Promise<ModelAccount[]> {
-  const { data } = await api.GET('/api/v2/model-accounts');
-  return data?.items ?? [];
+  const { data } = await browserApiClient.GET('/api/v2/model-accounts');
+  return (data?.items ?? []) as ModelAccount[];
 }
 
 export async function createModelAccount(input: ModelAccountCreateInput) {
-  const { data } = await api.POST('/api/v2/model-accounts', { body: input });
-  return data;
-}
-
-export async function validateModelAccount(accountId: string) {
-  const { data } = await api.POST('/api/v2/model-accounts/{account_id}/validate', {
-    params: { path: { account_id: accountId } },
+  const { data } = await browserApiClient.POST('/api/v2/model-accounts', {
+    body: input,
   });
   return data;
 }
 
+export async function updateModelAccount(
+  accountId: string,
+  input: ModelAccountUpdateInput,
+) {
+  const { data } = await browserApiClient.PUT(
+    '/api/v2/model-accounts/{account_id}',
+    {
+      params: { path: { account_id: accountId } },
+      body: input,
+    },
+  );
+  return data;
+}
+
+export async function deleteModelAccount(accountId: string) {
+  await browserApiClient.DELETE('/api/v2/model-accounts/{account_id}', {
+    params: { path: { account_id: accountId } },
+  });
+}
+
+export async function validateModelAccount(accountId: string) {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/model-accounts/{account_id}/validate',
+    {
+      params: { path: { account_id: accountId } },
+    },
+  );
+  return data;
+}
+
 export async function getModels(): Promise<Model[]> {
-  const { data } = await api.GET('/api/v2/models');
-  return data?.items ?? [];
+  const { data } = await browserApiClient.GET('/api/v2/models');
+  return (data?.items ?? []) as Model[];
 }
 
 export async function createModel(input: ModelCreateInput) {
-  const { data } = await api.POST('/api/v2/models', { body: input });
+  const { data } = await browserApiClient.POST('/api/v2/models', {
+    body: input as never,
+  });
   return data;
 }
 
 export async function getModelUses(): Promise<ModelUse[]> {
-  const { data } = await api.GET('/api/v2/model-uses');
-  return data?.items ?? [];
+  const { data } = await browserApiClient.GET('/api/v2/model-uses');
+  return (data?.items ?? []) as ModelUse[];
 }
 
 export async function updateModelUse(
@@ -60,7 +86,7 @@ export async function updateModelUse(
     enabled?: boolean;
   },
 ) {
-  const { data } = await api.PUT('/api/v2/model-uses/{scenario}', {
+  const { data } = await browserApiClient.PUT('/api/v2/model-uses/{scenario}', {
     params: { path: { scenario } },
     body: {
       strategy: 'single',
@@ -68,7 +94,7 @@ export async function updateModelUse(
       primary_model_id: input.primary_model_id,
       fallback_model_ids: input.fallback_model_ids ?? [],
       capability: input.capability,
-    },
+    } as never,
   });
   return data;
 }

--- a/web/src/features/providers/server-api.ts
+++ b/web/src/features/providers/server-api.ts
@@ -8,7 +8,7 @@ import type {
 } from './types';
 
 export async function getModelPlatform(): Promise<ModelPlatformViewModel> {
-  const client = (await createServerApiClient()) as any;
+  const client = await createServerApiClient();
   const [providers, accounts, models, uses] = await Promise.all([
     client.GET('/api/v2/model-providers'),
     client.GET('/api/v2/model-accounts'),

--- a/web/src/features/providers/types.ts
+++ b/web/src/features/providers/types.ts
@@ -34,6 +34,7 @@ export type Model = {
   embedding_dimensions?: number | null;
   supports_vision?: boolean;
   supports_tool_calling?: boolean;
+  supports_multimodal_embedding?: boolean;
   status?: 'ACTIVE' | 'INACTIVE';
 };
 
@@ -61,6 +62,14 @@ export type ModelAccountCreateInput = {
   api_key: string;
 };
 
+export type ModelAccountUpdateInput = {
+  name?: string;
+  display_name?: string;
+  base_url?: string;
+  api_key?: string;
+  status?: 'ACTIVE' | 'INACTIVE';
+};
+
 export type ModelCreateInput = {
   account_id: string;
   provider_model_id: string;
@@ -73,6 +82,7 @@ export type ModelCreateInput = {
   embedding_dimensions?: number | null;
   supports_vision?: boolean;
   supports_tool_calling?: boolean;
+  supports_multimodal_embedding?: boolean;
 };
 
 export type ModelPlatformViewModel = {

--- a/web/src/i18n/en-US.json
+++ b/web/src/i18n/en-US.json
@@ -1241,7 +1241,7 @@
       "custom_llm_provider_placeholder": "Enter the llm provider"
     },
     "default_model": {
-      "config": "Default models configuration",
+      "config": "Default models",
       "help": "Clearing selection will delete the default model configuration for this scenario"
     }
   },

--- a/web/src/i18n/en-US/page_models.json
+++ b/web/src/i18n/en-US/page_models.json
@@ -67,7 +67,7 @@
     "custom_llm_provider_placeholder": "Enter the llm provider"
   },
   "default_model": {
-    "config": "Default models configuration",
+    "config": "Default models",
     "help": "Clearing selection will delete the default model configuration for this scenario"
   }
 }

--- a/web/src/i18n/zh-CN.json
+++ b/web/src/i18n/zh-CN.json
@@ -1241,7 +1241,7 @@
       "custom_llm_provider_placeholder": "请选择LLM提供商"
     },
     "default_model": {
-      "config": "默认模型配置",
+      "config": "默认模型",
       "help": "清除选择将删除此场景的默认模型配置"
     }
   },

--- a/web/src/i18n/zh-CN/page_models.json
+++ b/web/src/i18n/zh-CN/page_models.json
@@ -67,7 +67,7 @@
     "custom_llm_provider_placeholder": "请选择LLM提供商"
   },
   "default_model": {
-    "config": "默认模型配置",
+    "config": "默认模型",
     "help": "清除选择将删除此场景的默认模型配置"
   }
 }


### PR DESCRIPTION
## What changed

- Reworked the model provider settings page into a simpler provider-first layout.
- Added provider enable, save, validate, and disable actions in the UI.
- Simplified model management so providers behave like folders and models like entries under them.
- Reduced visual noise across the page: removed decorative icons, extra status marks, heavy colors, repeated helper copy, and unnecessary nested background panels.
- Moved default model configuration into a separate block and localized its title.

## Why

The previous page mixed provider accounts, models, and defaults into a busy form-heavy surface. The new layout makes the core workflow clearer: choose a provider, configure its connection, enable models, then set defaults.

## Validation

- `npm run type-check`
- `npm run lint` (passes with pre-existing unrelated warnings)
