### PR TITLE
fix(web): unblock release frontend build

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,7 @@
 import createMDXPlugin from '@next/mdx';
 import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
+import path from 'node:path';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 
@@ -33,6 +34,19 @@ const nextConfig: NextConfig = {
   modularizeImports: {},
 
   transpilePackages: [],
+
+  webpack: (config) => {
+    config.resolve ??= {};
+    config.resolve.alias = {
+      ...(config.resolve.alias ?? {}),
+      '@/cosmograph/style.module.css$': path.resolve(
+        process.cwd(),
+        'node_modules/@cosmograph/cosmograph/cosmograph/style.module.css.js'
+      ),
+    };
+
+    return config;
+  },
 };
 
 const withNextIntl = createNextIntlPlugin({

--- a/web/scripts/build.mjs
+++ b/web/scripts/build.mjs
@@ -73,7 +73,7 @@ const copyDir = (src, dest) => {
   };
 
   if (!fs.existsSync(dest)) {
-    fs.mkdirSync(dest);
+    fs.mkdirSync(dest, { recursive: true });
   }
   copy(src, dest);
 };


### PR DESCRIPTION
## Summary
- add an exact webpack alias for Cosmograph's internal '@/cosmograph/style.module.css' import so Next does not route it through the app '@/src/*' alias
- make the standalone build packaging script create nested destination directories recursively

## Validation
- cd web && rm -rf build && yarn build
- git diff --check

Fixes the frontend failure in release run https://github.com/apecloud/ApeRAG/actions/runs/25087568995.