### PR TITLE
feat(graph): add graph visualization facts fallback

### DIFF
--- a/aperag/domains/knowledge_graph/api/routes.py
+++ b/aperag/domains/knowledge_graph/api/routes.py
@@ -34,8 +34,10 @@ from aperag.domains.identity.service.auth_dependencies import required_user
 from aperag.domains.knowledge_graph.schemas import (
     GraphEmbeddingMapResponse,
     GraphEntitiesSearchResponse,
+    GraphEvidenceResponse,
     GraphHybridResponse,
     GraphLabelsResponse,
+    GraphRelationEvidenceRequest,
     GraphSearchEntity,
     GraphSubgraphExpandRequest,
     GraphSubgraphExpandResponse,
@@ -378,6 +380,61 @@ async def graph_entity_detail_view(
     if result is None:
         raise HTTPException(status_code=404, detail="Entity not found")
     return result
+
+
+@router.get(
+    "/collections/{collection_id}/graphs/entities/{name}/evidence",
+    tags=["graph"],
+    response_model=GraphEvidenceResponse,
+)
+async def graph_entity_evidence_view(
+    request: Request,
+    collection_id: str,
+    name: str,
+    limit: int = 5,
+    user: AuthenticatedUser = Depends(required_user),
+) -> GraphEvidenceResponse:
+    """Return bounded source chunks for a selected graph entity."""
+    if not (1 <= limit <= 20):
+        raise HTTPException(status_code=400, detail="limit must be between 1 and 20")
+    try:
+        return await graph_service.get_entity_evidence(
+            str(user.id),
+            collection_id,
+            entity_name=name,
+            limit=limit,
+        )
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post(
+    "/collections/{collection_id}/graphs/relations/evidence",
+    tags=["graph"],
+    response_model=GraphEvidenceResponse,
+)
+async def graph_relation_evidence_view(
+    request: Request,
+    collection_id: str,
+    payload: GraphRelationEvidenceRequest = Body(...),
+    user: AuthenticatedUser = Depends(required_user),
+) -> GraphEvidenceResponse:
+    """Return bounded source chunks for a selected graph relation."""
+    try:
+        return await graph_service.get_relation_evidence(
+            str(user.id),
+            collection_id,
+            source=payload.source,
+            target=payload.target,
+            relation_type=payload.relation_type,
+            limit=payload.limit,
+        )
+    except CollectionNotFoundException:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 @router.get(

--- a/aperag/domains/knowledge_graph/schemas.py
+++ b/aperag/domains/knowledge_graph/schemas.py
@@ -103,6 +103,7 @@ class GraphEdgeProperties(BaseModel):
         description="Keywords associated with the relationship",
         examples=["书店活力,活动"],
     )
+    relation_type: Optional[str] = Field(None, description="Canonical relationship type", examples=["经营"])
     source_chunk_count: Optional[conint(ge=0)] = Field(
         None,
         description="Number of source chunks supporting this relationship; raw chunk IDs are not exposed",
@@ -440,6 +441,42 @@ class GraphSubgraphExpandResponse(BaseModel):
     )
 
 
+class GraphEvidenceChunk(BaseModel):
+    """Bounded source chunk returned when a graph item is selected."""
+
+    document_id: str = Field(..., description="Source document ID")
+    document_name: Optional[str] = Field(None, description="Source document name")
+    parse_version: str = Field(..., description="Parse version that produced the lineage member")
+    chunk_id: str = Field(..., description="Source chunk ID")
+    text: str = Field(..., description="Truncated chunk text")
+    section_path: Optional[str] = Field(None, description="Source section path")
+    heading_anchor: Optional[str] = Field(None, description="Source heading anchor")
+    page_idx: Optional[int] = Field(None, description="Source page index when available")
+
+
+class GraphEvidenceResponse(BaseModel):
+    """Lazy evidence payload for a graph node or edge."""
+
+    subject_type: Literal["entity", "relation"] = Field(..., description="Evidence subject type")
+    entity_name: Optional[str] = Field(None, description="Entity name when subject_type is entity")
+    source: Optional[str] = Field(None, description="Relation source entity")
+    target: Optional[str] = Field(None, description="Relation target entity")
+    relation_type: Optional[str] = Field(None, description="Relation type when subject_type is relation")
+    total_source_chunks: int = Field(..., ge=0, description="Total source chunk references before limiting")
+    chunks: list[GraphEvidenceChunk] = Field(..., description="Bounded source chunk snippets")
+
+
+class GraphRelationEvidenceRequest(BaseModel):
+    """Request body for lazy relation evidence lookup."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str = Field(..., description="Relation source entity")
+    target: str = Field(..., description="Relation target entity")
+    relation_type: str = Field(..., description="Relation type")
+    limit: int = Field(5, ge=1, le=20, description="Maximum evidence chunks to return")
+
+
 class GraphEmbeddingPoint(BaseModel):
     """Single point in the 2-D projection of entity vectors."""
 
@@ -512,6 +549,10 @@ class GraphHybridResponse(BaseModel):
         False,
         description="Whether the 2-D projection was served from the layout cache",
     )
+    layout_source: Literal["embedding", "facts"] = Field(
+        "embedding",
+        description="Whether node coordinates came from entity vectors or from the facts-layer fallback layout",
+    )
 
 
 __all__ = [
@@ -533,8 +574,11 @@ __all__ = [
     "GraphSearchEntity",
     "GraphRelationView",
     "GraphEntitiesSearchResponse",
+    "GraphEvidenceChunk",
+    "GraphEvidenceResponse",
     "GraphSubgraphExpandRequest",
     "GraphSubgraphExpandResponse",
+    "GraphRelationEvidenceRequest",
     "GraphEmbeddingPoint",
     "GraphEmbeddingMapRelation",
     "GraphEmbeddingMapResponse",

--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -41,6 +41,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 from dataclasses import asdict, is_dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List
@@ -54,6 +55,7 @@ if TYPE_CHECKING:
     from aperag.domains.knowledge_graph.schemas import (
         GraphEmbeddingMapResponse,
         GraphEntitiesSearchResponse,
+        GraphEvidenceResponse,
         GraphHybridResponse,
         GraphRelationView,
         GraphSearchEntity,
@@ -387,6 +389,74 @@ class GraphService:
             return None
         return _entity_to_search_view(entity)
 
+    async def get_entity_evidence(
+        self,
+        user_id: str,
+        collection_id: str,
+        *,
+        entity_name: str,
+        limit: int = 5,
+    ) -> "GraphEvidenceResponse":
+        """Return bounded source chunks for one graph entity."""
+        import asyncio
+
+        from aperag.domains.knowledge_graph.schemas import GraphEvidenceResponse
+        from aperag.indexing.worker_factory import _build_lineage_graph_store, _resolve_graph_backend_type
+
+        db_collection = await self._get_and_validate_collection(user_id, collection_id)
+        backend_type = _resolve_graph_backend_type(db_collection)
+        store = await asyncio.to_thread(_build_lineage_graph_store, backend_type=backend_type, collection=db_collection)
+        entity = await store.get_entity(entity_name)
+        members = list(getattr(entity, "source_lineage", ()) or ()) if entity is not None else []
+        chunks = await self._load_evidence_chunks(
+            user_id=user_id,
+            collection_id=collection_id,
+            members=members,
+            limit=limit,
+        )
+        return GraphEvidenceResponse(
+            subject_type="entity",
+            entity_name=entity_name,
+            total_source_chunks=_count_source_chunks(members),
+            chunks=chunks,
+        )
+
+    async def get_relation_evidence(
+        self,
+        user_id: str,
+        collection_id: str,
+        *,
+        source: str,
+        target: str,
+        relation_type: str,
+        limit: int = 5,
+    ) -> "GraphEvidenceResponse":
+        """Return bounded source chunks for one graph relation."""
+        import asyncio
+
+        from aperag.domains.knowledge_graph.schemas import GraphEvidenceResponse
+        from aperag.indexing.worker_factory import _build_lineage_graph_store, _resolve_graph_backend_type
+
+        db_collection = await self._get_and_validate_collection(user_id, collection_id)
+        backend_type = _resolve_graph_backend_type(db_collection)
+        store = await asyncio.to_thread(_build_lineage_graph_store, backend_type=backend_type, collection=db_collection)
+        relation = await store.get_relation(source, target, relation_type)
+        members = list(getattr(relation, "evidence_lineage", ()) or ()) if relation is not None else []
+        chunks = await self._load_evidence_chunks(
+            user_id=user_id,
+            collection_id=collection_id,
+            members=members,
+            limit=limit,
+        )
+        return GraphEvidenceResponse(
+            subject_type="relation",
+            source=source,
+            target=target,
+            relation_type=relation_type,
+            total_source_chunks=_count_source_chunks(members),
+            chunks=chunks,
+        )
+
     async def get_embedding_map(
         self,
         user_id: str,
@@ -467,11 +537,9 @@ class GraphService:
             max_entities=max_entities,
         )
         if not points:
-            return GraphHybridResponse(
-                nodes=[],
-                edges=[],
-                cluster_labels={},
-                is_truncated=False,
+            return await self._get_facts_layout_graph(
+                store=store,
+                max_entities=max_entities,
                 layout_from_cache=layout_from_cache,
             )
 
@@ -528,7 +596,114 @@ class GraphService:
             cluster_labels=cluster_labels,
             is_truncated=len(entities) >= max_entities,
             layout_from_cache=layout_from_cache,
+            layout_source="embedding",
         )
+
+    async def _get_facts_layout_graph(
+        self,
+        *,
+        store: Any,
+        max_entities: int,
+        layout_from_cache: bool,
+    ) -> "GraphHybridResponse":
+        """Build graph-hybrid data from facts when vectors are absent."""
+        from aperag.domains.knowledge_graph.schemas import GraphHybridNode, GraphHybridResponse
+
+        entities = await store.list_entities(limit=max_entities, offset=0)
+        if not entities:
+            return GraphHybridResponse(
+                nodes=[],
+                edges=[],
+                cluster_labels={},
+                is_truncated=False,
+                layout_from_cache=layout_from_cache,
+                layout_source="facts",
+            )
+
+        names = [entity.name for entity in entities]
+        allowed = set(names)
+        _subgraph_entities, relations = await store.expand_neighbors_n_hops(entity_names=names, hops=1)
+        relations = [rel for rel in relations if rel.source in allowed and rel.target in allowed]
+
+        adapted_entities = _adapt_lineage_entities(entities)
+        adapted_relations = _adapt_lineage_relations(relations)
+        node_items = self._to_ui_dict(adapted_entities, [], is_truncated=False)["nodes"]
+        edge_items = self._to_ui_dict([], adapted_relations, is_truncated=False)["edges"]
+
+        degree = {name: 0 for name in allowed}
+        for edge in edge_items:
+            source = str(edge["source"])
+            target = str(edge["target"])
+            if source in degree:
+                degree[source] += 1
+            if target in degree:
+                degree[target] += 1
+
+        coordinates, cluster_labels = self._facts_layout_coordinates(entities=entities, degree=degree)
+        nodes: list[GraphHybridNode] = []
+        for item in node_items:
+            node_id = str(item["id"])
+            x, y, cluster = coordinates.get(node_id, (0.0, 0.0, 0))
+            nodes.append(
+                GraphHybridNode.model_validate(
+                    {
+                        **item,
+                        "x": x,
+                        "y": y,
+                        "cluster": cluster,
+                        "value": max(8, min(22, 8 + degree.get(node_id, 0))),
+                    }
+                )
+            )
+
+        return GraphHybridResponse(
+            nodes=nodes,
+            edges=edge_items,
+            cluster_labels=cluster_labels,
+            is_truncated=len(entities) >= max_entities,
+            layout_from_cache=layout_from_cache,
+            layout_source="facts",
+        )
+
+    def _facts_layout_coordinates(
+        self,
+        *,
+        entities: list[Any],
+        degree: dict[str, int],
+    ) -> tuple[dict[str, tuple[float, float, int]], dict[str, str]]:
+        cluster_for_type: dict[str, int] = {}
+        grouped: dict[int, list[Any]] = {}
+        cluster_labels: dict[str, str] = {}
+        for entity in entities:
+            entity_type = (getattr(entity, "entity_type", None) or "unknown") or "unknown"
+            cluster = cluster_for_type.get(entity_type)
+            if cluster is None:
+                cluster = len(cluster_for_type)
+                cluster_for_type[entity_type] = cluster
+                cluster_labels[str(cluster)] = entity_type
+                grouped[cluster] = []
+            grouped[cluster].append(entity)
+
+        coordinates: dict[str, tuple[float, float, int]] = {}
+        cluster_count = max(1, len(grouped))
+        group_radius = 760.0 if cluster_count > 1 else 0.0
+        for cluster, members in grouped.items():
+            members.sort(key=lambda e: (-degree.get(e.name, 0), e.name))
+            angle = (2.0 * math.pi * cluster) / cluster_count
+            center_x = math.cos(angle) * group_radius
+            center_y = math.sin(angle) * group_radius
+            local_radius = max(120.0, 46.0 * math.sqrt(max(1, len(members))))
+            for idx, entity in enumerate(members):
+                if len(members) == 1:
+                    x = center_x
+                    y = center_y
+                else:
+                    local_angle = (2.0 * math.pi * idx) / len(members)
+                    ring = local_radius + 18.0 * (idx % 3)
+                    x = center_x + math.cos(local_angle) * ring
+                    y = center_y + math.sin(local_angle) * ring
+                coordinates[entity.name] = (float(x), float(y), cluster)
+        return coordinates, cluster_labels
 
     async def _get_embedding_projection(
         self,
@@ -785,6 +960,93 @@ class GraphService:
                 exc_info=True,
             )
 
+    async def _load_evidence_chunks(
+        self,
+        *,
+        user_id: str,
+        collection_id: str,
+        members: list[Any],
+        limit: int,
+    ) -> list[Any]:
+        from aperag.domains.knowledge_graph.schemas import GraphEvidenceChunk
+        from aperag.indexing.object_store import derived_artifact
+        from aperag.indexing.parser import read_chunks
+        from aperag.objectstore.base import get_object_store
+
+        bounded_limit = max(1, min(int(limit), 20))
+        ordered_refs: list[tuple[str, str, str]] = []
+        seen_refs: set[tuple[str, str, str]] = set()
+        for member in sorted(members, key=lambda m: (m.document_id, m.parse_version)):
+            for chunk_id in getattr(member, "chunk_ids", ()) or ():
+                ref = (str(member.document_id), str(member.parse_version), str(chunk_id))
+                if ref in seen_refs:
+                    continue
+                seen_refs.add(ref)
+                ordered_refs.append(ref)
+        if not ordered_refs:
+            return []
+
+        document_names: dict[str, str | None] = {}
+        store = get_object_store()
+        chunks_by_doc_parse: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
+        results: list[GraphEvidenceChunk] = []
+        for document_id, parse_version, chunk_id in ordered_refs:
+            if len(results) >= bounded_limit:
+                break
+            if document_id not in document_names:
+                document = await self.db_ops.query_document(user_id, collection_id, document_id)
+                if document is None:
+                    document_names[document_id] = None
+                else:
+                    document_names[document_id] = getattr(document, "name", None)
+            if document_names[document_id] is None:
+                continue
+
+            doc_parse_key = (document_id, parse_version)
+            if doc_parse_key not in chunks_by_doc_parse:
+                chunks_path = derived_artifact(
+                    collection_id=collection_id,
+                    document_id=document_id,
+                    parse_version=parse_version,
+                    filename="chunks.jsonl",
+                )
+                try:
+                    chunk_records = await asyncio.to_thread(read_chunks, store, chunks_path)
+                except Exception:
+                    logger.warning(
+                        "Failed to load graph evidence chunks collection=%s document=%s parse_version=%s",
+                        collection_id,
+                        document_id,
+                        parse_version,
+                        exc_info=True,
+                    )
+                    chunk_records = []
+                chunks_by_doc_parse[doc_parse_key] = {
+                    str(record.get("chunk_id")): record for record in chunk_records if record.get("chunk_id")
+                }
+            chunk = chunks_by_doc_parse[doc_parse_key].get(chunk_id)
+            if chunk is None:
+                continue
+            text = str(chunk.get("text") or "")
+            if len(text) > 500:
+                text = text[:500].rstrip() + "..."
+            page_idx = chunk.get("page_idx")
+            if not isinstance(page_idx, int):
+                page_idx = None
+            results.append(
+                GraphEvidenceChunk(
+                    document_id=document_id,
+                    document_name=document_names[document_id],
+                    parse_version=parse_version,
+                    chunk_id=chunk_id,
+                    text=text,
+                    section_path=chunk.get("section_path"),
+                    heading_anchor=chunk.get("heading_anchor"),
+                    page_idx=page_idx,
+                )
+            )
+        return results
+
     # --------------------------------------------------------- internal helpers
     def _optimize_graph_for_visualization(self, nodes, edges, max_nodes):
         """Pick the top ``max_nodes`` entities by degree, filter edges to
@@ -824,7 +1086,7 @@ class GraphService:
             "description",
             "source_chunk_count",
         ]
-        default_edge_fields = ["weight", "description", "keywords", "source_chunk_count"]
+        default_edge_fields = ["weight", "description", "keywords", "relation_type", "source_chunk_count"]
 
         def extract_properties(obj, fields):
             raw = {}
@@ -966,6 +1228,7 @@ def _adapt_lineage_relations(relations: list[Any]) -> List[SimpleNamespace]:
             "weight": 1.0,
             "description": description,
             "keywords": "",
+            "relation_type": rel.relation_type,
             "source_chunk_count": len(chunk_ids),
         }
         out.append(
@@ -999,6 +1262,14 @@ def _stable_jsonish(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_stable_jsonish(item) for item in value]
     return repr(value)
+
+
+def _count_source_chunks(members: list[Any]) -> int:
+    refs: set[tuple[str, str, str]] = set()
+    for member in members:
+        for chunk_id in getattr(member, "chunk_ids", ()) or ():
+            refs.add((str(member.document_id), str(member.parse_version), str(chunk_id)))
+    return len(refs)
 
 
 # ---------------------------------------------------------------------------

--- a/aperag/domains/marketplace/api/routes.py
+++ b/aperag/domains/marketplace/api/routes.py
@@ -40,7 +40,9 @@ from aperag.domains.identity.service.auth_dependencies import optional_user, req
 from aperag.domains.knowledge_graph.schemas import (
     GraphEmbeddingMapResponse,
     GraphEntitiesSearchResponse,
+    GraphEvidenceResponse,
     GraphHybridResponse,
+    GraphRelationEvidenceRequest,
     KnowledgeGraph,
 )
 from aperag.domains.knowledge_graph.service import graph_service
@@ -392,4 +394,73 @@ async def search_marketplace_collection_graph_entities(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Error searching marketplace collection graph entities {collection_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get(
+    "/marketplace/collections/{collection_id}/graph/entities/{name}/evidence",
+    tags=["graph"],
+    response_model=GraphEvidenceResponse,
+)
+async def get_marketplace_collection_graph_entity_evidence(
+    request: Request,
+    collection_id: str,
+    name: str,
+    limit: int = Query(5, ge=1, le=20),
+    user: AuthenticatedUser = Depends(optional_user),
+) -> GraphEvidenceResponse:
+    """Get bounded source chunks for a MarketplaceCollection graph entity."""
+    try:
+        user_id = str(user.id) if user else ""
+        marketplace_info = await marketplace_collection_service.check_marketplace_access(user_id, collection_id)
+        owner_user_id = marketplace_info["owner_user_id"]
+        return await graph_service.get_entity_evidence(
+            str(owner_user_id),
+            collection_id,
+            entity_name=name,
+            limit=limit,
+        )
+    except CollectionNotPublishedError:
+        raise HTTPException(status_code=404, detail="Collection not found or not published")
+    except CollectionMarketplaceAccessDeniedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error getting marketplace collection graph entity evidence {collection_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post(
+    "/marketplace/collections/{collection_id}/graph/relations/evidence",
+    tags=["graph"],
+    response_model=GraphEvidenceResponse,
+)
+async def get_marketplace_collection_graph_relation_evidence(
+    request: Request,
+    collection_id: str,
+    payload: GraphRelationEvidenceRequest,
+    user: AuthenticatedUser = Depends(optional_user),
+) -> GraphEvidenceResponse:
+    """Get bounded source chunks for a MarketplaceCollection graph relation."""
+    try:
+        user_id = str(user.id) if user else ""
+        marketplace_info = await marketplace_collection_service.check_marketplace_access(user_id, collection_id)
+        owner_user_id = marketplace_info["owner_user_id"]
+        return await graph_service.get_relation_evidence(
+            str(owner_user_id),
+            collection_id,
+            source=payload.source,
+            target=payload.target,
+            relation_type=payload.relation_type,
+            limit=payload.limit,
+        )
+    except CollectionNotPublishedError:
+        raise HTTPException(status_code=404, detail="Collection not found or not published")
+    except CollectionMarketplaceAccessDeniedError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error getting marketplace collection graph relation evidence {collection_id}: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/aperag/indexing/graph_search_service.py
+++ b/aperag/indexing/graph_search_service.py
@@ -116,7 +116,7 @@ class GraphSearchService:
         self._score_threshold = score_threshold
 
     # ------------------------------------------------------------------
-    # search_entities — vector recall path
+    # search_entities — lexical fallback + vector recall path
     # ------------------------------------------------------------------
 
     async def search_entities(
@@ -124,10 +124,13 @@ class GraphSearchService:
         query: str,
         top_k: int | None = None,
     ) -> list[EntityWithLineage]:
-        """Vector-recall the top-K entities matching ``query``.
+        """Recall the top-K entities matching ``query``.
 
-        Empty / whitespace-only query returns ``[]`` (no spurious
-        recall — same convention as
+        The graph state split can make vector recall temporarily
+        unavailable while the facts layer is already serving. Keep the
+        name-driven path useful by trying exact and lexical matches
+        before the vector layer. Empty / whitespace-only query returns
+        ``[]`` (no spurious recall — same convention as
         :meth:`LineageGraphStore.query_entities_by_keyword`).
         """
         text = (query or "").strip()
@@ -137,15 +140,32 @@ class GraphSearchService:
         if k <= 0:
             return []
 
+        results: list[EntityWithLineage] = []
+        seen_names: set[str] = set()
+
+        exact = await self._safe_get_exact_entity(text)
+        if exact is not None:
+            results.append(exact)
+            seen_names.add(exact.name)
+
+        lexical_matches = await self._safe_query_entities_by_keyword(text, max(k - len(results), 0))
+        for entity in lexical_matches:
+            if entity.name in seen_names:
+                continue
+            results.append(entity)
+            seen_names.add(entity.name)
+            if len(results) >= k:
+                return results
+
         try:
             embedding = await asyncio.to_thread(self._embedder.embed_query, text)
         except Exception:
             logger.warning("graph_search_service: embed failed for query=%r", text, exc_info=True)
-            return []
+            return results
 
         request = QueryRequest(
             embedding=embedding,
-            top_k=k,
+            top_k=max(k, k - len(results)),
             flt=Eq("indexer", GRAPH_ENTITY_INDEXER),
             score_threshold=self._score_threshold or None,
         )
@@ -157,12 +177,39 @@ class GraphSearchService:
                 text,
                 exc_info=True,
             )
-            return []
+            return results
 
         names = self._entity_names_from_hits(hits)
         if not names:
+            return results
+        vector_entities = await self._batch_get_entities(names)
+        for entity in vector_entities:
+            if entity.name in seen_names:
+                continue
+            results.append(entity)
+            seen_names.add(entity.name)
+            if len(results) >= k:
+                break
+        return results
+
+    async def _safe_get_exact_entity(self, text: str) -> EntityWithLineage | None:
+        try:
+            return await self._store.get_entity(text)
+        except Exception:
+            logger.warning("graph_search_service: exact entity lookup failed for query=%r", text, exc_info=True)
+            return None
+
+    async def _safe_query_entities_by_keyword(self, text: str, top_k: int) -> list[EntityWithLineage]:
+        if top_k <= 0:
             return []
-        return await self._batch_get_entities(names)
+        query = getattr(self._store, "query_entities_by_keyword", None)
+        if query is None:
+            return []
+        try:
+            return await query(query=text, top_k=top_k)
+        except Exception:
+            logger.warning("graph_search_service: lexical entity lookup failed for query=%r", text, exc_info=True)
+            return []
 
     @staticmethod
     def _entity_names_from_hits(hits: Iterable[SearchHit]) -> list[str]:

--- a/tests/unit_test/domains/knowledge_graph/test_service.py
+++ b/tests/unit_test/domains/knowledge_graph/test_service.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from aperag.domains.knowledge_graph.service import GraphService
+from aperag.indexing.graph import LineageMember
 
 
 def _entity(name: str, entity_type: str = "entity") -> SimpleNamespace:
@@ -141,8 +142,133 @@ async def test_get_hybrid_graph_joins_projection_and_lineage_metadata(monkeypatc
         ("B", 3.0, 4.0, 1, 9),
     ]
     assert [(edge.source, edge.target) for edge in graph.edges] == [("A", "B")]
+    assert graph.edges[0].properties.relation_type == "related_to"
     assert graph.cluster_labels == {"0": "person", "1": "organization"}
     assert graph.layout_from_cache is False
+    assert graph.layout_source == "embedding"
+
+
+async def test_get_hybrid_graph_falls_back_to_facts_layout_without_vectors(monkeypatch):
+    class FakeStore:
+        async def list_entities(self, *, limit, offset):
+            assert limit == 1000
+            assert offset == 0
+            return [_entity("A", "person"), _entity("B", "organization")]
+
+        async def expand_neighbors_n_hops(self, *, entity_names, hops):
+            assert entity_names == ["A", "B"]
+            assert hops == 1
+            return (
+                [_entity("A", "person"), _entity("B", "organization")],
+                [_relation("A", "B")],
+            )
+
+    from aperag.indexing import worker_factory
+
+    monkeypatch.setattr(worker_factory, "_resolve_graph_backend_type", lambda collection: "postgres")
+    monkeypatch.setattr(
+        worker_factory,
+        "_build_lineage_graph_store",
+        lambda *, backend_type, collection: FakeStore(),
+    )
+
+    service = GraphService()
+    service._get_and_validate_collection = AsyncMock(return_value=SimpleNamespace(id="col1"))
+
+    async def fake_projection(*, backend_type, db_collection, collection_id, store, max_entities):
+        return ([], {}, [_entity("A", "person"), _entity("B", "organization")], False)
+
+    service._get_embedding_projection = fake_projection
+
+    graph = await service.get_hybrid_graph(user_id="user1", collection_id="col1", max_entities=1000)
+
+    assert [node.id for node in graph.nodes] == ["A", "B"]
+    assert [(edge.source, edge.target) for edge in graph.edges] == [("A", "B")]
+    assert graph.cluster_labels == {"0": "person", "1": "organization"}
+    assert graph.layout_source == "facts"
+
+
+async def test_get_entity_evidence_loads_bounded_chunks(monkeypatch):
+    class FakeStore:
+        async def get_entity(self, name):
+            assert name == "A"
+            return SimpleNamespace(
+                source_lineage=[
+                    LineageMember(
+                        document_id="doc1",
+                        parse_version="v1",
+                        tenant_scope_key="tenant",
+                        chunk_ids=("c1", "c2", "c1"),
+                    ),
+                    LineageMember(
+                        document_id="missing",
+                        parse_version="v1",
+                        tenant_scope_key="tenant",
+                        chunk_ids=("ignored",),
+                    ),
+                ]
+            )
+
+    from aperag.indexing import object_store as object_store_module
+    from aperag.indexing import parser as parser_module
+    from aperag.indexing import worker_factory
+    from aperag.objectstore import base as objectstore_base
+
+    monkeypatch.setattr(worker_factory, "_resolve_graph_backend_type", lambda collection: "postgres")
+    monkeypatch.setattr(
+        worker_factory,
+        "_build_lineage_graph_store",
+        lambda *, backend_type, collection: FakeStore(),
+    )
+    monkeypatch.setattr(
+        object_store_module,
+        "derived_artifact",
+        lambda *, collection_id, document_id, parse_version, filename: (
+            f"{collection_id}/{document_id}/{parse_version}/{filename}"
+        ),
+    )
+    monkeypatch.setattr(objectstore_base, "get_object_store", lambda: object())
+    monkeypatch.setattr(
+        parser_module,
+        "read_chunks",
+        lambda store, path: [
+            {
+                "chunk_id": "c1",
+                "text": "first " * 120,
+                "section_path": "1",
+                "heading_anchor": "intro",
+                "page_idx": 3,
+            },
+            {
+                "chunk_id": "c2",
+                "text": "second",
+                "section_path": None,
+                "heading_anchor": None,
+                "page_idx": "bad",
+            },
+        ],
+    )
+
+    service = GraphService()
+    service._get_and_validate_collection = AsyncMock(return_value=SimpleNamespace(id="col1"))
+    service.db_ops.query_document = AsyncMock(
+        side_effect=[
+            SimpleNamespace(name="Document One"),
+            None,
+        ]
+    )
+
+    response = await service.get_entity_evidence(user_id="user1", collection_id="col1", entity_name="A", limit=2)
+
+    assert response.subject_type == "entity"
+    assert response.entity_name == "A"
+    assert response.total_source_chunks == 3
+    assert [chunk.chunk_id for chunk in response.chunks] == ["c1", "c2"]
+    assert response.chunks[0].document_name == "Document One"
+    assert response.chunks[0].text.endswith("...")
+    assert len(response.chunks[0].text) <= 503
+    assert response.chunks[0].page_idx == 3
+    assert response.chunks[1].page_idx is None
 
 
 async def test_get_embedding_projection_uses_layout_cache(monkeypatch):

--- a/tests/unit_test/indexing/test_graph_search_service.py
+++ b/tests/unit_test/indexing/test_graph_search_service.py
@@ -130,12 +130,15 @@ class _FakeStore:
         entities: dict[str, EntityWithLineage] | None = None,
         expansions: dict[tuple[str, ...], tuple[list[EntityWithLineage], list[RelationWithLineage]]] | None = None,
         relations: dict[tuple[str, str, str], RelationWithLineage] | None = None,
+        keyword_matches: list[EntityWithLineage] | None = None,
     ) -> None:
         self._entities = entities or {}
         self._expansions = expansions or {}
         self._relations = relations or {}
+        self._keyword_matches = keyword_matches
         self.get_entity_calls: list[str] = []
         self.get_relation_calls: list[tuple[str, str, str]] = []
+        self.query_entities_by_keyword_calls: list[tuple[str, int]] = []
 
     async def get_entity(self, entity_name: str) -> EntityWithLineage | None:
         self.get_entity_calls.append(entity_name)
@@ -144,6 +147,13 @@ class _FakeStore:
     async def get_relation(self, source: str, target: str, type: str) -> RelationWithLineage | None:
         self.get_relation_calls.append((source, target, type))
         return self._relations.get((source, target, type))
+
+    async def query_entities_by_keyword(self, *, query: str, top_k: int) -> list[EntityWithLineage]:
+        self.query_entities_by_keyword_calls.append((query, top_k))
+        if self._keyword_matches is not None:
+            return self._keyword_matches[:top_k]
+        needle = query.lower()
+        return [entity for name, entity in sorted(self._entities.items()) if needle in name.lower()][:top_k]
 
     async def expand_neighbors_n_hops(
         self,
@@ -198,13 +208,19 @@ def _make_service(
     entities: dict[str, EntityWithLineage] | None = None,
     expansions: dict[tuple[str, ...], tuple[list[EntityWithLineage], list[RelationWithLineage]]] | None = None,
     relations: dict[tuple[str, str, str], RelationWithLineage] | None = None,
+    keyword_matches: list[EntityWithLineage] | None = None,
     hits: list[SearchHit] | None = None,
     embedder: Any | None = None,
     connector: Any | None = None,
     top_k: int = 10,
     score_threshold: float = 0.0,
 ) -> tuple[GraphSearchService, _FakeStore, _FakeVectorConnector | Any, _FakeEmbedder | Any]:
-    store = _FakeStore(entities=entities, expansions=expansions, relations=relations)
+    store = _FakeStore(
+        entities=entities,
+        expansions=expansions,
+        relations=relations,
+        keyword_matches=keyword_matches,
+    )
     connector = connector if connector is not None else _FakeVectorConnector(hits=hits)
     embedder = embedder if embedder is not None else _FakeEmbedder()
     service = GraphSearchService(
@@ -272,7 +288,8 @@ async def test_search_entities_returns_entities_in_hit_order():
     result = await service.search_entities("query")
     assert [e.name for e in result] == ["Beta", "Alpha", "Gamma"]
     # Each name fetched exactly once.
-    assert sorted(store.get_entity_calls) == ["Alpha", "Beta", "Gamma"]
+    assert store.get_entity_calls[0] == "query"
+    assert sorted(store.get_entity_calls[1:]) == ["Alpha", "Beta", "Gamma"]
 
 
 @pytest.mark.asyncio
@@ -287,7 +304,7 @@ async def test_search_entities_dedupes_repeated_payload_names():
     )
     result = await service.search_entities("query")
     assert len(result) == 1
-    assert store.get_entity_calls == ["Alpha"]
+    assert store.get_entity_calls == ["query", "Alpha"]
 
 
 @pytest.mark.asyncio
@@ -321,7 +338,7 @@ async def test_search_entities_swallows_embedder_failure():
     service, store, connector, _ = _make_service(entities={}, embedder=_FailingEmbedder())
     assert await service.search_entities("query") == []
     assert connector.searches == []
-    assert store.get_entity_calls == []
+    assert store.get_entity_calls == ["query"]
 
 
 @pytest.mark.asyncio
@@ -331,7 +348,34 @@ async def test_search_entities_swallows_vector_store_failure():
     # Embedder still called; the failure happened on vector search.
     assert embedder.calls == ["query"]
     assert len(connector.searches) == 1
-    assert store.get_entity_calls == []
+    assert store.get_entity_calls == ["query"]
+
+
+@pytest.mark.asyncio
+async def test_search_entities_exact_match_works_when_embedder_fails():
+    exact = _entity("Alice")
+    service, store, connector, _ = _make_service(
+        entities={"Alice": exact},
+        embedder=_FailingEmbedder(),
+    )
+    result = await service.search_entities("Alice")
+    assert [entity.name for entity in result] == ["Alice"]
+    assert connector.searches == []
+    assert store.get_entity_calls == ["Alice"]
+
+
+@pytest.mark.asyncio
+async def test_search_entities_keyword_fallback_works_when_vector_store_fails():
+    alpha = _entity("Alpha")
+    service, store, connector, _ = _make_service(
+        entities={},
+        keyword_matches=[alpha],
+        connector=_FailingVectorConnector(),
+    )
+    result = await service.search_entities("alp")
+    assert [entity.name for entity in result] == ["Alpha"]
+    assert len(connector.searches) == 1
+    assert store.query_entities_by_keyword_calls == [("alp", 10)]
 
 
 # ---------------------------------------------------------------------

--- a/tests/unit_test/service/test_search_graph_contract.py
+++ b/tests/unit_test/service/test_search_graph_contract.py
@@ -122,6 +122,7 @@ def test_lineage_adapter_exposes_public_graph_properties_only():
         "weight": 1.0,
         "description": "relates to",
         "keywords": "",
+        "relation_type": "related_to",
         "source_chunk_count": 1,
     }
 

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -630,6 +630,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/marketplace/collections/{collection_id}/graph/entities/{name}/evidence": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Marketplace Collection Graph Entity Evidence
+         * @description Get bounded source chunks for a MarketplaceCollection graph entity.
+         */
+        get: operations["marketplace_get_marketplace_collection_graph_entity_evidence"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/marketplace/collections/{collection_id}/graph/relations/evidence": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Get Marketplace Collection Graph Relation Evidence
+         * @description Get bounded source chunks for a MarketplaceCollection graph relation.
+         */
+        post: operations["marketplace_get_marketplace_collection_graph_relation_evidence"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/settings": {
         parameters: {
             query?: never;
@@ -1127,6 +1167,46 @@ export interface paths {
         get: operations["knowledge_graph_graph_entity_detail_view"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/collections/{collection_id}/graphs/entities/{name}/evidence": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Graph Entity Evidence View
+         * @description Return bounded source chunks for a selected graph entity.
+         */
+        get: operations["knowledge_graph_graph_entity_evidence_view"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/collections/{collection_id}/graphs/relations/evidence": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Graph Relation Evidence View
+         * @description Return bounded source chunks for a selected graph relation.
+         */
+        post: operations["knowledge_graph_graph_relation_evidence_view"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2628,7 +2708,7 @@ export interface components {
             /** Peer Id */
             peer_id?: string | null;
             /** Peer Type */
-            peer_type?: ("system" | "feishu" | "weixin" | "weixin_official" | "web" | "dingtalk") | null;
+            peer_type?: ("system" | "feishu" | "weixin" | "weixin_official" | "web" | "dingtalk" | "evaluation") | null;
             /** Status */
             status?: ("active" | "archived") | null;
             /** Created */
@@ -2647,7 +2727,7 @@ export interface components {
             /** Peer Id */
             peer_id?: string | null;
             /** Peer Type */
-            peer_type?: ("system" | "feishu" | "weixin" | "weixin_official" | "web" | "dingtalk") | null;
+            peer_type?: ("system" | "feishu" | "weixin" | "weixin_official" | "web" | "dingtalk" | "evaluation") | null;
             /**
              * History
              * @description Phase 8 D8.5-BE (#92): historical conversation turns as canonical ``AgentTurnSnapshot`` envelopes — each turn carries the same ``UIMessagePart[]`` shape the FE consumes from the live SSE stream (D8 §2 wire/at-rest byte-equal). Replaces the legacy ``list[list[ChatMessage]]`` shape; FE renders historical turns with the same renderer used for live turns.
@@ -4189,6 +4269,12 @@ export interface components {
              */
             keywords?: string | null;
             /**
+             * Relation Type
+             * @description Canonical relationship type
+             * @example 经营
+             */
+            relation_type?: string | null;
+            /**
              * Source Chunk Count
              * @description Number of source chunks supporting this relationship; raw chunk IDs are not exposed
              * @example 2
@@ -4283,6 +4369,94 @@ export interface components {
             entities: components["schemas"]["GraphSearchEntity"][];
         };
         /**
+         * GraphEvidenceChunk
+         * @description Bounded source chunk returned when a graph item is selected.
+         */
+        GraphEvidenceChunk: {
+            /**
+             * Document Id
+             * @description Source document ID
+             */
+            document_id: string;
+            /**
+             * Document Name
+             * @description Source document name
+             */
+            document_name?: string | null;
+            /**
+             * Parse Version
+             * @description Parse version that produced the lineage member
+             */
+            parse_version: string;
+            /**
+             * Chunk Id
+             * @description Source chunk ID
+             */
+            chunk_id: string;
+            /**
+             * Text
+             * @description Truncated chunk text
+             */
+            text: string;
+            /**
+             * Section Path
+             * @description Source section path
+             */
+            section_path?: string | null;
+            /**
+             * Heading Anchor
+             * @description Source heading anchor
+             */
+            heading_anchor?: string | null;
+            /**
+             * Page Idx
+             * @description Source page index when available
+             */
+            page_idx?: number | null;
+        };
+        /**
+         * GraphEvidenceResponse
+         * @description Lazy evidence payload for a graph node or edge.
+         */
+        GraphEvidenceResponse: {
+            /**
+             * Subject Type
+             * @description Evidence subject type
+             * @enum {string}
+             */
+            subject_type: "entity" | "relation";
+            /**
+             * Entity Name
+             * @description Entity name when subject_type is entity
+             */
+            entity_name?: string | null;
+            /**
+             * Source
+             * @description Relation source entity
+             */
+            source?: string | null;
+            /**
+             * Target
+             * @description Relation target entity
+             */
+            target?: string | null;
+            /**
+             * Relation Type
+             * @description Relation type when subject_type is relation
+             */
+            relation_type?: string | null;
+            /**
+             * Total Source Chunks
+             * @description Total source chunk references before limiting
+             */
+            total_source_chunks: number;
+            /**
+             * Chunks
+             * @description Bounded source chunk snippets
+             */
+            chunks: components["schemas"]["GraphEvidenceChunk"][];
+        };
+        /**
          * GraphHybridNode
          * @description Node in the graph-hybrid visualization.
          */
@@ -4357,6 +4531,13 @@ export interface components {
              * @default false
              */
             layout_from_cache: boolean;
+            /**
+             * Layout Source
+             * @description Whether node coordinates came from entity vectors or from the facts-layer fallback layout
+             * @default embedding
+             * @enum {string}
+             */
+            layout_source: "embedding" | "facts";
         };
         /**
          * GraphLabelsResponse
@@ -4432,6 +4613,33 @@ export interface components {
              * @example 3
              */
             source_chunk_count?: number | null;
+        };
+        /**
+         * GraphRelationEvidenceRequest
+         * @description Request body for lazy relation evidence lookup.
+         */
+        GraphRelationEvidenceRequest: {
+            /**
+             * Source
+             * @description Relation source entity
+             */
+            source: string;
+            /**
+             * Target
+             * @description Relation target entity
+             */
+            target: string;
+            /**
+             * Relation Type
+             * @description Relation type
+             */
+            relation_type: string;
+            /**
+             * Limit
+             * @description Maximum evidence chunks to return
+             * @default 5
+             */
+            limit: number;
         };
         /**
          * GraphRelationView
@@ -7976,6 +8184,78 @@ export interface operations {
             };
         };
     };
+    marketplace_get_marketplace_collection_graph_entity_evidence: {
+        parameters: {
+            query?: {
+                limit?: number;
+                engine?: unknown;
+            };
+            header?: never;
+            path: {
+                collection_id: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GraphEvidenceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    marketplace_get_marketplace_collection_graph_relation_evidence: {
+        parameters: {
+            query?: {
+                engine?: unknown;
+            };
+            header?: never;
+            path: {
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GraphRelationEvidenceRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GraphEvidenceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     Settings_get_settings: {
         parameters: {
             query?: {
@@ -8849,6 +9129,78 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GraphSearchEntity"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    knowledge_graph_graph_entity_evidence_view: {
+        parameters: {
+            query?: {
+                limit?: number;
+                engine?: unknown;
+            };
+            header?: never;
+            path: {
+                collection_id: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GraphEvidenceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    knowledge_graph_graph_relation_evidence_view: {
+        parameters: {
+            query?: {
+                engine?: unknown;
+            };
+            header?: never;
+            path: {
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GraphRelationEvidenceRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GraphEvidenceResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx
@@ -4,13 +4,18 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
+  getGraphEntityEvidence,
   getGraphHybrid,
+  getGraphRelationEvidence,
+  getMarketplaceGraphEntityEvidence,
   getMarketplaceGraphHybrid,
+  getMarketplaceGraphRelationEvidence,
   searchMarketplaceGraphEntities,
   searchGraphEntities,
 } from '@/features/knowledge-graph/client-api';
 import type {
   GraphEdge,
+  GraphEvidenceResponse,
   GraphHybridNode,
   GraphSearchEntity,
 } from '@/features/knowledge-graph/types';
@@ -122,6 +127,37 @@ const endpointId = (endpoint: unknown) => {
   return String(endpoint || '');
 };
 
+const relationTypeOf = (edge: GraphEdge | undefined) => {
+  if (!edge) return '';
+  const relationType = edge.properties.relation_type;
+  if (typeof relationType === 'string' && relationType.trim()) {
+    return relationType;
+  }
+  return edge.type && edge.type !== 'DIRECTED' ? edge.type : '';
+};
+
+const loadEdgeEvidence = async ({
+  collectionId,
+  edge,
+  marketplace,
+}: {
+  collectionId: string;
+  edge?: GraphEdge;
+  marketplace: boolean;
+}) => {
+  const relationType = relationTypeOf(edge);
+  if (!edge || !relationType) return null;
+  const input = {
+    source: endpointId(edge.source),
+    target: endpointId(edge.target),
+    relation_type: relationType,
+    limit: 5,
+  };
+  return marketplace
+    ? getMarketplaceGraphRelationEvidence(collectionId, input)
+    : getGraphRelationEvidence(collectionId, input);
+};
+
 // PCA-positioned hybrid node — extends the backend hybrid DTO with the
 // d3-force pinned coordinates. fx/fy are
 // the d3-force "pinned" coordinates, which short-circuits the
@@ -161,6 +197,9 @@ export const CollectionGraphHybrid = ({
   const [clusterLabels, setClusterLabels] = useState<Record<number, string>>(
     {},
   );
+  const [layoutSource, setLayoutSource] = useState<'embedding' | 'facts'>(
+    'embedding',
+  );
 
   // Keep the canvas at 0×0 until the real graph container exists. The
   // graph is conditionally rendered only after useLayoutEffect measures
@@ -179,6 +218,9 @@ export const CollectionGraphHybrid = ({
   const [hoverNode, setHoverNode] = useState<HybridNode>();
   const [activeNode, setActiveNode] = useState<HybridNode>();
   const [activeEdge, setActiveEdge] = useState<GraphEdge>();
+  const [activeEvidence, setActiveEvidence] =
+    useState<GraphEvidenceResponse | null>(null);
+  const [evidencePending, setEvidencePending] = useState(false);
   const [detailCollapsed, setDetailCollapsed] = useState(false);
   const [clusterFilterExpanded, setClusterFilterExpanded] = useState(false);
 
@@ -191,8 +233,8 @@ export const CollectionGraphHybrid = ({
   const [pathPicks, setPathPicks] = useState<string[]>([]);
   const [pathPaths, setPathPaths] = useState<string[][]>([]);
 
-  // Vector search — opens an inline input + result overlay when a query
-  // is typed. Debounced so we don't hammer the search endpoint.
+  // Entity search — backend falls back to exact/fuzzy matching when graph
+  // vectors are not ready. Debounced so we don't hammer the endpoint.
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState<GraphSearchEntity[]>([]);
@@ -213,6 +255,7 @@ export const CollectionGraphHybrid = ({
       if (!hybrid || hybrid.nodes.length === 0) {
         setGraphData({ nodes: [], links: [] });
         setClusterLabels({});
+        setLayoutSource('embedding');
         return;
       }
 
@@ -225,6 +268,7 @@ export const CollectionGraphHybrid = ({
       const links: GraphEdge[] = hybrid.edges ?? [];
 
       setGraphData({ nodes, links });
+      setLayoutSource(hybrid.layout_source ?? 'embedding');
 
       const labels: Record<number, string> = {};
       for (const [k, v] of Object.entries(hybrid.cluster_labels)) {
@@ -237,6 +281,7 @@ export const CollectionGraphHybrid = ({
       setGraphData({ nodes: [], links: [] });
       setClusterLabels({});
       setActiveClusters([]);
+      setLayoutSource('embedding');
       setClusterFilterExpanded(false);
       setGraphError(getErrorMessage(error, page_graph('load_failed')));
     }
@@ -245,11 +290,53 @@ export const CollectionGraphHybrid = ({
   const handleCloseDetail = useCallback(() => {
     setActiveNode(undefined);
     setActiveEdge(undefined);
+    setActiveEvidence(null);
+    setEvidencePending(false);
     setHoverNode(undefined);
     setDetailCollapsed(false);
     setHighlightNodes(new Set());
     setHighlightLinks(new Set());
   }, []);
+
+  useEffect(() => {
+    if (typeof params.collectionId !== 'string') return;
+    const cid = params.collectionId;
+    let cancelled = false;
+
+    const loadEvidence = async () => {
+      if (!activeNode && !activeEdge) {
+        setActiveEvidence(null);
+        setEvidencePending(false);
+        return;
+      }
+
+      setActiveEvidence(null);
+      setEvidencePending(true);
+      try {
+        const evidence = activeNode
+          ? marketplace
+            ? await getMarketplaceGraphEntityEvidence(cid, activeNode.id, 5)
+            : await getGraphEntityEvidence(cid, activeNode.id, 5)
+          : await loadEdgeEvidence({
+              collectionId: cid,
+              edge: activeEdge,
+              marketplace,
+            });
+        if (cancelled) return;
+        setActiveEvidence(evidence);
+      } catch {
+        if (cancelled) return;
+        setActiveEvidence(null);
+      } finally {
+        if (!cancelled) setEvidencePending(false);
+      }
+    };
+
+    loadEvidence();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeEdge, activeNode, marketplace, params.collectionId]);
 
   // BFS — every shortest path between two node ids. Tracks `parents`
   // for each node at the discovered distance so the enumeration walks
@@ -752,6 +839,11 @@ export const CollectionGraphHybrid = ({
             fullscreen + search controls on the right. */}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
           <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+            {layoutSource === 'facts' && (
+              <span className="rounded-md border border-amber-300/70 bg-amber-50 px-1.5 py-0.5 text-amber-700">
+                事实层布局
+              </span>
+            )}
             <span className="bg-muted/60 rounded-md px-1.5 py-0.5">
               {page_graph('hybrid_entity_count', {
                 count: totalNodes.toLocaleString(),
@@ -853,7 +945,7 @@ export const CollectionGraphHybrid = ({
                   autoFocus
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  placeholder="向量搜索 …"
+                  placeholder="搜索实体 …"
                   className="h-7 w-56 pr-6 pl-7 text-xs"
                 />
                 <button
@@ -1255,6 +1347,8 @@ export const CollectionGraphHybrid = ({
               pathPaths={pathPaths}
               activeNodeEdges={activeNodeEdges}
               activeNodeNeighbors={activeNodeNeighbors}
+              evidence={activeEvidence}
+              evidencePending={evidencePending}
               nodes={graphData?.nodes ?? []}
               linksByPair={linksByPair}
               onClose={handleCloseDetail}
@@ -1292,6 +1386,8 @@ const HybridFloatingDetail = ({
   pathPaths,
   activeNodeEdges,
   activeNodeNeighbors,
+  evidence,
+  evidencePending,
   nodes,
   linksByPair,
   onClose,
@@ -1306,6 +1402,8 @@ const HybridFloatingDetail = ({
   pathPaths: string[][];
   activeNodeEdges: GraphEdge[];
   activeNodeNeighbors: HybridNode[];
+  evidence: GraphEvidenceResponse | null;
+  evidencePending: boolean;
   nodes: HybridNode[];
   linksByPair: Map<string, GraphEdge>;
   onClose: () => void;
@@ -1382,6 +1480,8 @@ const HybridFloatingDetail = ({
             node={activeNode}
             edges={activeNodeEdges}
             neighbors={activeNodeNeighbors}
+            evidence={evidence}
+            evidencePending={evidencePending}
             onSelectNode={onSelectNode}
             onSelectEdge={onSelectEdge}
           />
@@ -1390,6 +1490,8 @@ const HybridFloatingDetail = ({
         {!showPaths && !activeNode && activeEdge && (
           <EdgeContent
             edge={activeEdge}
+            evidence={evidence}
+            evidencePending={evidencePending}
             nodesById={nodesById}
             onSelectNode={onSelectNode}
           />
@@ -1438,16 +1540,72 @@ const InfoTile = ({
   </div>
 );
 
+const EvidenceSection = ({
+  evidence,
+  pending,
+}: {
+  evidence: GraphEvidenceResponse | null;
+  pending: boolean;
+}) => (
+  <section className="space-y-2">
+    <div className="flex items-center justify-between gap-2">
+      <div className="text-muted-foreground text-xs font-medium">证据片段</div>
+      {pending ? (
+        <Loader2 className="text-muted-foreground size-3.5 animate-spin" />
+      ) : (
+        evidence && <Badge variant="secondary">{evidence.chunks.length}</Badge>
+      )}
+    </div>
+    {pending ? (
+      <div className="space-y-2">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+      </div>
+    ) : evidence && evidence.chunks.length > 0 ? (
+      <div className="space-y-2">
+        {evidence.chunks.map((chunk) => (
+          <div
+            key={`${chunk.document_id}:${chunk.parse_version}:${chunk.chunk_id}`}
+            className="rounded-lg border p-2"
+          >
+            <div className="text-muted-foreground mb-1 flex items-center justify-between gap-2 text-[10px]">
+              <span className="min-w-0 truncate">
+                {chunk.document_name || chunk.document_id}
+              </span>
+              <span className="shrink-0 font-mono">{chunk.chunk_id}</span>
+            </div>
+            <p className="text-foreground/90 line-clamp-5 text-xs leading-relaxed">
+              {chunk.text}
+            </p>
+          </div>
+        ))}
+        {evidence.total_source_chunks > evidence.chunks.length && (
+          <div className="text-muted-foreground text-[10px]">
+            仅显示前 {evidence.chunks.length} 条，共{' '}
+            {evidence.total_source_chunks} 条
+          </div>
+        )}
+      </div>
+    ) : (
+      <p className="text-muted-foreground text-xs italic">暂无证据片段</p>
+    )}
+  </section>
+);
+
 const EntityContent = ({
   node,
   edges,
   neighbors,
+  evidence,
+  evidencePending,
   onSelectNode,
   onSelectEdge,
 }: {
   node: HybridNode;
   edges: GraphEdge[];
   neighbors: HybridNode[];
+  evidence: GraphEvidenceResponse | null;
+  evidencePending: boolean;
   onSelectNode: (nodeId: string) => void;
   onSelectEdge: (edge: GraphEdge) => void;
 }) => {
@@ -1488,6 +1646,8 @@ const EntityContent = ({
         <InfoTile label="关系" value={edges.length} />
         <InfoTile label="证据片段" value={sourceChunkCount} />
       </section>
+
+      <EvidenceSection evidence={evidence} pending={evidencePending} />
 
       {neighbors.length > 0 && (
         <section className="space-y-2">
@@ -1569,10 +1729,14 @@ const EntityContent = ({
 
 const EdgeContent = ({
   edge,
+  evidence,
+  evidencePending,
   nodesById,
   onSelectNode,
 }: {
   edge: GraphEdge;
+  evidence: GraphEvidenceResponse | null;
+  evidencePending: boolean;
   nodesById: Map<string, HybridNode>;
   onSelectNode: (nodeId: string) => void;
 }) => {
@@ -1581,6 +1745,7 @@ const EdgeContent = ({
   const sNode = nodesById.get(sId);
   const tNode = nodesById.get(tId);
   const description = edge.properties.description ?? null;
+  const relationType = relationTypeOf(edge);
   const weight = edge.properties.weight;
 
   return (
@@ -1598,7 +1763,7 @@ const EdgeContent = ({
 
       <section className="grid grid-cols-2 gap-2">
         <InfoTile label="权重" value={weight ?? '-'} />
-        <InfoTile label="关系类型" value={edge.type ?? '-'} />
+        <InfoTile label="关系类型" value={relationType || edge.type || '-'} />
       </section>
 
       <section className="space-y-2">
@@ -1613,6 +1778,8 @@ const EdgeContent = ({
           <p className="text-muted-foreground text-xs italic">无描述</p>
         )}
       </section>
+
+      <EvidenceSection evidence={evidence} pending={evidencePending} />
 
       <section className="space-y-2">
         <div className="text-muted-foreground text-xs font-medium">

--- a/web/src/features/knowledge-graph/client-api.ts
+++ b/web/src/features/knowledge-graph/client-api.ts
@@ -4,8 +4,10 @@ import { browserApiClient } from '@/lib/api/typed/browser';
 
 import type {
   GraphEmbeddingMapResponse,
+  GraphEvidenceResponse,
   GraphHybridResponse,
   GraphLabelsResponse,
+  GraphRelationEvidenceRequest,
   GraphSearchEntity,
   KnowledgeGraph,
   MergeSuggestionItem,
@@ -155,6 +157,37 @@ export async function searchGraphEntities(
   return data?.entities ?? [];
 }
 
+export async function getGraphEntityEvidence(
+  collectionId: string,
+  name: string,
+  limit = 5,
+): Promise<GraphEvidenceResponse | null> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/collections/{collection_id}/graphs/entities/{name}/evidence',
+    {
+      params: {
+        path: { collection_id: collectionId, name },
+        query: { limit },
+      },
+    },
+  );
+  return data ?? null;
+}
+
+export async function getGraphRelationEvidence(
+  collectionId: string,
+  input: GraphRelationEvidenceRequest,
+): Promise<GraphEvidenceResponse | null> {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/collections/{collection_id}/graphs/relations/evidence',
+    {
+      params: { path: { collection_id: collectionId } },
+      body: input,
+    },
+  );
+  return data ?? null;
+}
+
 export async function getMarketplaceKnowledgeGraph(
   collectionId: string,
   options?: {
@@ -229,6 +262,37 @@ export async function searchMarketplaceGraphEntities(
     },
   );
   return data?.entities ?? [];
+}
+
+export async function getMarketplaceGraphEntityEvidence(
+  collectionId: string,
+  name: string,
+  limit = 5,
+): Promise<GraphEvidenceResponse | null> {
+  const { data } = await browserApiClient.GET(
+    '/api/v2/marketplace/collections/{collection_id}/graph/entities/{name}/evidence',
+    {
+      params: {
+        path: { collection_id: collectionId, name },
+        query: { limit },
+      },
+    },
+  );
+  return data ?? null;
+}
+
+export async function getMarketplaceGraphRelationEvidence(
+  collectionId: string,
+  input: GraphRelationEvidenceRequest,
+): Promise<GraphEvidenceResponse | null> {
+  const { data } = await browserApiClient.POST(
+    '/api/v2/marketplace/collections/{collection_id}/graph/relations/evidence',
+    {
+      params: { path: { collection_id: collectionId } },
+      body: input,
+    },
+  );
+  return data ?? null;
 }
 
 export async function getMergeSuggestions(

--- a/web/src/features/knowledge-graph/types.ts
+++ b/web/src/features/knowledge-graph/types.ts
@@ -17,6 +17,12 @@ export type GraphEdgeProperties = NonNullable<
 export type GraphSearchEntity = NonNullable<
   components['schemas']['GraphSearchEntity']
 >;
+export type GraphEvidenceResponse = NonNullable<
+  components['schemas']['GraphEvidenceResponse']
+>;
+export type GraphRelationEvidenceRequest = NonNullable<
+  components['schemas']['GraphRelationEvidenceRequest']
+>;
 export type GraphEmbeddingMapResponse = NonNullable<
   components['schemas']['GraphEmbeddingMapResponse']
 >;


### PR DESCRIPTION
## Summary
- keep `/graphs/hybrid` usable when graph vectors are not ready by falling back to facts-layer layout
- expose real relation type plus lazy entity/relation evidence chunk APIs for graph visualization
- render selected node/edge evidence in the hybrid graph detail panel and use name-driven search fallback before vector recall

## Tests
- `uv run pytest tests/unit_test/domains/knowledge_graph/test_service.py tests/unit_test/indexing/test_graph_search_service.py`
- `uv run ruff check aperag/domains/knowledge_graph/api/routes.py aperag/domains/knowledge_graph/schemas.py aperag/domains/knowledge_graph/service.py aperag/domains/marketplace/api/routes.py aperag/indexing/graph_search_service.py tests/unit_test/domains/knowledge_graph/test_service.py tests/unit_test/indexing/test_graph_search_service.py`
- `cd web && yarn api:v2:types`
- `cd web && yarn type-check`

Task: #9
