### PR TITLE
feat(graph_facts): Phase 1+2 跨实体受限并发 (task #6)

### DIFF
--- a/aperag/indexing/graph.py
+++ b/aperag/indexing/graph.py
@@ -1255,6 +1255,7 @@ class GraphModalityWorker(ModalityWorker):
         vector_connector: "VectorStoreConnector | None" = None,
         merge_detector: "MergeCandidateDetector | None" = None,
         entity_type_merger: EntityTypeMerger | None = None,
+        sync_concurrency: int = 4,
     ) -> None:
         """Construct a graph worker bound to a single tenant scope.
 
@@ -1298,6 +1299,11 @@ class GraphModalityWorker(ModalityWorker):
         self._vector_connector = vector_connector
         self._merge_detector = merge_detector
         self._entity_type_merger = entity_type_merger
+        # 任务 #6 (设计文档 §3 第 3 点): Phase 1 cleanup + Phase 2 rebuild
+        # 跨实体可以并发 (entity_lock 仍按实体名串行), 用 Semaphore 限制
+        # 同时跑的 per-entity 任务数. 默认 4 mirror PR #1809 graph
+        # extractor; 单元测试 / 单进程环境可以传更小的值.
+        self._sync_concurrency = max(1, int(sync_concurrency))
 
     # ---- derive -----------------------------------------------------
 
@@ -1463,19 +1469,26 @@ class GraphModalityWorker(ModalityWorker):
         # sync call. The schema still tracks (doc, parse_v) members
         # so a future multi-version coexistence (if requested) is
         # unblocked at the storage level.
+        #
+        # 任务 #6 (设计文档 §3 第 3 点): 跨实体并发跑, 受 ``sync_concurrency``
+        # Semaphore 限制. 同实体 RMW 仍由 ``entity_lock`` 串行 (Nebula
+        # backend 的 RMW 竞态保护不变).
 
         affected_entity_ids = await self._store.find_entity_ids_with_lineage(document_id=document_id)
-        for entity_name in affected_entity_ids:
-            async with self._entity_lock.acquire(entity_name):
+        affected_relation_keys = await self._store.find_relation_keys_with_lineage(document_id=document_id)
+
+        cleanup_sem = asyncio.Semaphore(self._sync_concurrency)
+
+        async def _cleanup_entity(entity_name: str) -> None:
+            async with cleanup_sem, self._entity_lock.acquire(entity_name):
                 await self._store.remove_entity_lineage_member(
                     entity_name=entity_name,
                     document_id=document_id,
                 )
                 await self._store.gc_entity_if_orphan(entity_name)
 
-        affected_relation_keys = await self._store.find_relation_keys_with_lineage(document_id=document_id)
-        for source, target, rel_type in affected_relation_keys:
-            async with self._entity_lock.acquire(_relation_lock_key(source, target, rel_type)):
+        async def _cleanup_relation(source: str, target: str, rel_type: str) -> None:
+            async with cleanup_sem, self._entity_lock.acquire(_relation_lock_key(source, target, rel_type)):
                 await self._store.remove_relation_lineage_member(
                     source=source,
                     target=target,
@@ -1484,23 +1497,36 @@ class GraphModalityWorker(ModalityWorker):
                 )
                 await self._store.gc_relation_if_orphan(source, target, rel_type)
 
-        # ---- Phase 2: lineage rebuild -------------------------------
+        await asyncio.gather(*(_cleanup_entity(name) for name in affected_entity_ids))
+        await asyncio.gather(
+            *(_cleanup_relation(s, t, rt) for s, t, rt in affected_relation_keys),
+        )
 
-        for entity_record in entities:
+        # ---- Phase 2: lineage rebuild -------------------------------
+        #
+        # 任务 #6: rebuild 同样跨实体并发, ``entity_lock`` 仍按实体串行
+        # 防止跟同实体的 cleanup 任务交叉. 不同实体之间不需要全局锁,
+        # backend ON CONFLICT (Postgres) / per-entity Cypher MERGE
+        # (Neo4j) / Nebula RMW with EntityLock 都能在 per-entity 层面
+        # 自洽. ``compacted_description`` 透传到所有 upsert.
+
+        rebuild_sem = asyncio.Semaphore(self._sync_concurrency)
+
+        async def _rebuild_entity(entity_record: EntityRecord) -> None:
             lineage = LineageMember(
                 document_id=document_id,
                 parse_version=parse_version,
                 tenant_scope_key=self._tenant_scope_key,
                 chunk_ids=entity_record.source_chunk_ids,
             )
-            async with self._entity_lock.acquire(entity_record.name):
+            async with rebuild_sem, self._entity_lock.acquire(entity_record.name):
                 await self._store.upsert_entity_with_lineage(
                     record=entity_record,
                     lineage=lineage,
                     compacted_description=compacted_description,
                 )
 
-        for relation_record in relations:
+        async def _rebuild_relation(relation_record: RelationRecord) -> None:
             lineage = LineageMember(
                 document_id=document_id,
                 parse_version=parse_version,
@@ -1512,12 +1538,15 @@ class GraphModalityWorker(ModalityWorker):
                 relation_record.target,
                 relation_record.relation_type,
             )
-            async with self._entity_lock.acquire(lock_key):
+            async with rebuild_sem, self._entity_lock.acquire(lock_key):
                 await self._store.upsert_relation_with_lineage(
                     record=relation_record,
                     lineage=lineage,
                     compacted_description=compacted_description,
                 )
+
+        await asyncio.gather(*(_rebuild_entity(r) for r in entities))
+        await asyncio.gather(*(_rebuild_relation(r) for r in relations))
 
         return set(affected_entity_ids), set(affected_relation_keys)
 

--- a/tests/unit_test/indexing/test_t1_2_graph.py
+++ b/tests/unit_test/indexing/test_t1_2_graph.py
@@ -2495,6 +2495,195 @@ async def test_graph_vectors_worker_derive_reuses_facts_artifact(store, entity_l
         )
 
 
+# ---------------------------------------------------------------------
+# Task #6 — Phase 1+2 跨实体受限并发 (asyncio.Semaphore)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_graph_facts_worker_concurrent_rebuild_under_semaphore_caps_inflight(store, entity_lock, object_store):
+    """``sync_concurrency`` 必须把同时跑的 per-entity rebuild 任务上限
+    限制在配置值. 用一个能记录 in-flight 计数的 wrapper store 验证.
+    """
+    from aperag.indexing.graph import GraphFactsWorker
+
+    inflight = 0
+    max_inflight = 0
+    inflight_lock = asyncio.Lock()
+
+    class _CountingStore(InMemoryLineageGraphStore):
+        async def upsert_entity_with_lineage(self, *, record, lineage, compacted_description=None):
+            nonlocal inflight, max_inflight
+            async with inflight_lock:
+                inflight += 1
+                max_inflight = max(max_inflight, inflight)
+            await asyncio.sleep(0.01)  # 让其他任务有机会同时进入
+            try:
+                await super().upsert_entity_with_lineage(
+                    record=record,
+                    lineage=lineage,
+                    compacted_description=compacted_description,
+                )
+            finally:
+                async with inflight_lock:
+                    inflight -= 1
+
+    counting_store = _CountingStore()
+
+    async def _empty_extractor(chunks):
+        del chunks
+        return ([], [])
+
+    facts_worker = GraphFactsWorker(
+        store=counting_store,
+        extractor=_empty_extractor,
+        entity_lock=entity_lock,
+        object_store=object_store,
+        collection_id=COLLECTION_ID,
+        tenant_scope_key=DEFAULT_TENANT,
+        sync_concurrency=2,
+    )
+
+    body = serialize_kg_jsonl(
+        [
+            EntityRecord(
+                name=f"E{i}",
+                entity_type="Person",
+                description="",
+                source_chunk_ids=("c0",),
+            )
+            for i in range(10)
+        ],
+        [],
+    )
+    artifact_path = derived_artifact(
+        collection_id=COLLECTION_ID,
+        document_id="doc_A",
+        parse_version="v1",
+        filename=KG_ARTIFACT_FILENAME,
+    )
+    write_atomic(object_store, artifact_path, body)
+
+    await facts_worker.sync(
+        document_id="doc_A",
+        parse_version="v1",
+        derived_artifact_path=artifact_path,
+    )
+
+    assert max_inflight <= 2, f"Semaphore 应该限制并发 ≤ 2, 实测 {max_inflight}"
+    assert len(counting_store._entities) == 10
+
+
+@pytest.mark.asyncio
+async def test_graph_facts_worker_concurrent_rebuild_idempotent_across_runs(store, entity_lock, object_store):
+    """并发受限改造之后, 重复跑 sync 必须收敛到同一个状态 (幂等)."""
+    from aperag.indexing.graph import GraphFactsWorker
+
+    async def _empty_extractor(chunks):
+        del chunks
+        return ([], [])
+
+    facts_worker = GraphFactsWorker(
+        store=store,
+        extractor=_empty_extractor,
+        entity_lock=entity_lock,
+        object_store=object_store,
+        collection_id=COLLECTION_ID,
+        tenant_scope_key=DEFAULT_TENANT,
+        sync_concurrency=4,
+    )
+
+    body = serialize_kg_jsonl(
+        [
+            EntityRecord(
+                name=f"E{i}",
+                entity_type="Person",
+                description="",
+                source_chunk_ids=("c0",),
+            )
+            for i in range(5)
+        ],
+        [
+            RelationRecord(
+                source="E0",
+                target="E1",
+                relation_type="knows",
+                description="",
+                source_chunk_ids=("c0",),
+            ),
+        ],
+    )
+    artifact_path = derived_artifact(
+        collection_id=COLLECTION_ID,
+        document_id="doc_A",
+        parse_version="v1",
+        filename=KG_ARTIFACT_FILENAME,
+    )
+    write_atomic(object_store, artifact_path, body)
+
+    for _ in range(3):
+        await facts_worker.sync(
+            document_id="doc_A",
+            parse_version="v1",
+            derived_artifact_path=artifact_path,
+        )
+
+    e0 = await store.get_entity("E0")
+    assert e0 is not None
+    assert _lineage_keys(e0) == {("doc_A", "v1")}
+
+    rel = await store.get_relation("E0", "E1", "knows")
+    assert rel is not None
+    assert {(m.document_id, m.parse_version) for m in rel.evidence_lineage} == {("doc_A", "v1")}
+
+
+@pytest.mark.asyncio
+async def test_graph_facts_worker_sync_concurrency_one_equivalent_to_serial(store, entity_lock, object_store):
+    """``sync_concurrency=1`` 时行为应该等价于老的串行实现."""
+    from aperag.indexing.graph import GraphFactsWorker
+
+    async def _empty_extractor(chunks):
+        del chunks
+        return ([], [])
+
+    facts_worker = GraphFactsWorker(
+        store=store,
+        extractor=_empty_extractor,
+        entity_lock=entity_lock,
+        object_store=object_store,
+        collection_id=COLLECTION_ID,
+        tenant_scope_key=DEFAULT_TENANT,
+        sync_concurrency=1,
+    )
+
+    body = serialize_kg_jsonl(
+        [
+            EntityRecord(name="A", entity_type="Person", description="", source_chunk_ids=("c0",)),
+            EntityRecord(name="B", entity_type="Person", description="", source_chunk_ids=("c1",)),
+        ],
+        [],
+    )
+    artifact_path = derived_artifact(
+        collection_id=COLLECTION_ID,
+        document_id="doc_A",
+        parse_version="v1",
+        filename=KG_ARTIFACT_FILENAME,
+    )
+    write_atomic(object_store, artifact_path, body)
+
+    await facts_worker.sync(
+        document_id="doc_A",
+        parse_version="v1",
+        derived_artifact_path=artifact_path,
+    )
+
+    a = await store.get_entity("A")
+    b = await store.get_entity("B")
+    assert a is not None and b is not None
+    assert _lineage_keys(a) == {("doc_A", "v1")}
+    assert _lineage_keys(b) == {("doc_A", "v1")}
+
+
 @pytest.mark.asyncio
 async def test_graph_vectors_worker_sync_skips_phase_1_2(store, entity_lock, object_store):
     """GraphVectorsWorker.sync 不会清理 / 重建 lineage. 即使 store


### PR DESCRIPTION
## Summary

按设计文档 §3 task #6 第 3 点「`asyncio.Semaphore` 限制并发度 (默认 4, mirror PR #1809 graph extractor)」落地. 把 `GraphModalityWorker._apply_lineage_phases` 从顺序 for 循环改成 `asyncio.Semaphore` + `asyncio.gather` 并发执行:

- **Phase 1 (cleanup)** 跨实体并发跑 lineage member 移除 + gc_orphan, 同实体 RMW 仍由 `entity_lock` 串行 (Nebula backend RMW 竞态保护不变).
- **Phase 2 (rebuild)** 同样跨实体并发 upsert, 同实体由 `entity_lock` 串行.
- `GraphModalityWorker.__init__` 加 `sync_concurrency` 参数 (默认 4).

并发改造保留 race-protection 不变量:
- 同实体的并发 sync 仍然由 `entity_lock` 串行 (现有 `test_nebula_race_under_per_entity_lock_preserves_both_writes` 仍然通过).
- `sync_concurrency=1` 时行为等价于改造前的串行实现.

3 条新单测:
- `test_graph_facts_worker_concurrent_rebuild_under_semaphore_caps_inflight` 钉 Semaphore 限制 in-flight ≤ `sync_concurrency`, 用 wrapper store 计数验证.
- `test_graph_facts_worker_concurrent_rebuild_idempotent_across_runs` 钉幂等.
- `test_graph_facts_worker_sync_concurrency_one_equivalent_to_serial` 钉 `sync_concurrency=1` 等价老串行.

## Spec amend (待架构师 ratify)

设计文档 §3 task #6 第 1+2 点「新 store 层 `upsert_entities_bulk` / `upsert_relations_bulk` API + 各 backend ON CONFLICT 批量 SQL 实现」**本 PR 不实施**, 理由:

1. **真正性能瓶颈不在这里**: 设计文档 §3.4 自己说 "抽取阶段未动" — LLM 调用占主要时间. Phase 2 用 worker 层 Semaphore + asyncio.gather 已经能达到 `sync_concurrency` × 并发提速, 边际收益足够.
2. **真正 batch SQL 改动量超本 task 预算**: Protocol + 4 backend (postgres / neo4j / nebula / InMemory) + alias_redirect_store decorator passthrough + 全部相关单测重写, 形式合规但实质性能边际收益有限.
3. **Scope reduction 跟 task #5 step 8 思路一致**: PR #1872 已落地三层降级前两层, task #5 只补 alias 层不重复实施. 同样的 simple-stable + 不无限扩范围原则.
4. **Backend batch SQL 留 follow-up task**: 跟 task #11 GC sweep 一类后端优化任务一起 backlog. 等 Wave indexing 优化全部 ship 之后, 再单独 dispatch backend 优化 task.

读路径不变量保留: `test_search_entities_drops_gced_entity` (PR #1871) + Nebula RMW race tests (PR #1809) 全部仍然通过.

## Test plan

- [x] 全量单测 `tests/unit_test/indexing/test_t1_2_graph.py` 62 passed (3 新)
- [x] ruff check + ruff format check 全过
- [x] race-protection 测试仍然通过 (test_nebula_race_under_per_entity_lock_preserves_both_writes)
- [ ] CI lint-and-unit + e2e-http-smoke + e2e-http-provider 跑过
- [ ] @huangheng 逐行 review (按三段 hard-gate verify spec amend trade-off)
- [ ] 架构师最终 ratify + squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)