### PR TITLE
feat(reconciler): graph_vectors stale detection — facts 更新后自动重入队 (task #15)

### DIFF
--- a/aperag/indexing/reconciler.py
+++ b/aperag/indexing/reconciler.py
@@ -682,23 +682,41 @@ def reconcile_graph_vectors_enqueue(
     engine: Engine,
     batch_size: int = RECONCILE_BATCH_SIZE,
 ) -> int:
-    """事实层 ACTIVE 之后, 把缺失的向量层行 INSERT 成 PENDING.
+    """事实层 ACTIVE 之后, 把缺失或者过期的向量层行入队成 PENDING.
 
-    任务 #5 设计文档 §4.4 conservative serial scheduling: 上传时
-    dispatcher 只插 ``graph_facts`` 一行; 当 ``graph_facts`` ACTIVE 之后,
-    本函数扫到这行 + 同 ``(document_id, parse_version)`` 还没有对应的
-    ``graph_vectors`` 行, 就 INSERT 一行 ``graph_vectors`` PENDING.
+    任务 #5 设计文档 §4.4 conservative serial scheduling + 任务 #15
+    stale detection (Planetegg msg=3322c22b 现场 surface + 5 方 align +
+    architect ratify msg=39c4ece8 + earayu2 拍板 msg=efc218ce):
+
+    **场景 1 — 缺失检测 (任务 #5 已实现)**: 当 ``graph_facts`` ACTIVE 之后,
+    扫到这行 + 同 ``(document_id, parse_version)`` 还没有对应的
+    ``graph_vectors`` 行, 就 INSERT 一行 ``graph_vectors`` PENDING. 这是
+    上传新文档之后的首次入队链路.
+
+    **场景 2 — stale detection (任务 #15 新增)**: 当 ``graph_facts`` 重跑后
+    (例如 reindex / cleanup-resync), ``graph_facts.updated_at`` 推进 +
+    ``graph_facts.derived_artifact_path`` 可能变, 但同 (doc, parse_v) 的
+    ``graph_vectors`` 行可能还是老 ACTIVE 状态, 导致 vector store 没新写入,
+    页面 layout 只能 fallback 到 facts. 触发条件:
+
+    * ``graph_facts.updated_at > graph_vectors.updated_at`` (事实层比向量层
+      新), 或者
+    * ``graph_vectors.source_path != graph_facts.derived_artifact_path``
+      (派生工件路径漂移)
+
+    任一条件命中, 就把 ``graph_vectors`` 行重置为 PENDING + 更新
+    ``source_path`` 为 facts 当前的 ``derived_artifact_path`` + 清掉老
+    ``error_message`` / ``retry_after`` (跟从 FAILED 重试的语义对齐). 下一轮
+    :func:`reconcile_pending_dispatch` push 到 ``q:graph_vectors``, worker
+    池消费.
+
     ``source_path`` 直接复用 facts 行的 ``derived_artifact_path``, 让
     :class:`GraphVectorsWorker.derive` 不重跑 LLM extractor.
 
-    新增的 PENDING 行会在下一轮 :func:`reconcile_pending_dispatch` 里被
-    push 到 ``q:graph_vectors``, 进而被 worker 池消费.
+    幂等性: 场景 2 不会让 ACTIVE-没漂移的 vectors 反复入队 — 时间戳 +
+    路径双判, facts 没改时 vectors 保持 ACTIVE 不被打扰.
 
-    幂等: 已经存在 ``graph_vectors`` 行的 ``(doc, parse_v)`` 跳过, 所以
-    多次循环不会重复 INSERT. 失败重试走标准
-    :func:`reconcile_failed_retry` 路径.
-
-    返回新 INSERT 的行数 (0 时为空板).
+    返回入队的行数 (INSERT + RESET-to-PENDING 之和, 0 时为空板).
     """
     inserted = 0
     with Session(engine) as session, session.begin():
@@ -719,30 +737,72 @@ def reconcile_graph_vectors_enqueue(
         if not facts_rows:
             return 0
 
-        # 一次查询找出所有已经存在的 graph_vectors 行 (按 (doc, v) 去重),
-        # 避免 N 次 round-trip.
+        # 一次查询拉所有已经存在的 graph_vectors 行 (full row, 不只是 key) —
+        # 任务 #15 需要 stale 比对, 必须知道 vectors 的 updated_at + source_path.
         pairs = [(r.document_id, r.parse_version) for r in facts_rows]
-        existing_stmt = select(DocumentIndex.document_id, DocumentIndex.parse_version).where(
-            and_(
-                DocumentIndex.modality == Modality.GRAPH_VECTORS.value,
-                tuple_(DocumentIndex.document_id, DocumentIndex.parse_version).in_(pairs),
+        existing_vectors = list(
+            session.scalars(
+                select(DocumentIndex).where(
+                    and_(
+                        DocumentIndex.modality == Modality.GRAPH_VECTORS.value,
+                        tuple_(DocumentIndex.document_id, DocumentIndex.parse_version).in_(pairs),
+                    )
+                )
             )
         )
-        existing_pairs = {tuple(row) for row in session.execute(existing_stmt)}
+        existing_by_key = {(v.document_id, v.parse_version): v for v in existing_vectors}
 
         for facts_row in facts_rows:
             key = (facts_row.document_id, facts_row.parse_version)
-            if key in existing_pairs:
+            existing = existing_by_key.get(key)
+
+            if existing is None:
+                # 场景 1: 缺失 → INSERT 新 PENDING 行.
+                session.execute(
+                    insert(DocumentIndex).values(
+                        document_id=facts_row.document_id,
+                        parse_version=facts_row.parse_version,
+                        modality=Modality.GRAPH_VECTORS.value,
+                        status=IndexStatus.PENDING.value,
+                        tenant_scope_key=facts_row.tenant_scope_key,
+                        collection_id=facts_row.collection_id,
+                        source_path=facts_row.derived_artifact_path,
+                        is_serving=False,
+                    )
+                )
+                inserted += 1
                 continue
+
+            # 场景 2: 已存在 graph_vectors 行, 检查是否 stale.
+            # 触发条件: 事实层比向量层新 OR 派生路径漂移.
+            facts_newer = (
+                existing.updated_at is not None
+                and facts_row.updated_at is not None
+                and facts_row.updated_at > existing.updated_at
+            )
+            path_drift = existing.source_path != facts_row.derived_artifact_path
+            if not (facts_newer or path_drift):
+                continue
+
+            # PENDING / RUNNING 状态的 vectors 行已经在被处理, 不要打扰它 —
+            # worker 处理完会按 source_path 写新数据, 不会拿老 artifact.
+            # 只有 ACTIVE / FAILED 状态的 stale vectors 需要被重置, 才能触发
+            # 重新拉取 + 重写 vector store.
+            if existing.status not in (
+                IndexStatus.ACTIVE.value,
+                IndexStatus.FAILED.value,
+            ):
+                continue
+
             session.execute(
-                insert(DocumentIndex).values(
-                    document_id=facts_row.document_id,
-                    parse_version=facts_row.parse_version,
-                    modality=Modality.GRAPH_VECTORS.value,
+                update(DocumentIndex)
+                .where(DocumentIndex.id == existing.id)
+                .values(
                     status=IndexStatus.PENDING.value,
-                    tenant_scope_key=facts_row.tenant_scope_key,
-                    collection_id=facts_row.collection_id,
                     source_path=facts_row.derived_artifact_path,
+                    error_message=None,
+                    retry_after=None,
+                    last_heartbeat=None,
                     is_serving=False,
                 )
             )

--- a/tests/unit_test/indexing/test_t2_1_runtime.py
+++ b/tests/unit_test/indexing/test_t2_1_runtime.py
@@ -680,6 +680,56 @@ def test_reconciler_graph_vectors_re_enqueues_when_artifact_path_diverges(engine
     assert vectors.source_path == new_artifact, "source_path 必须同步成 facts 当前的 artifact"
 
 
+def test_reconciler_graph_vectors_boundary_facts_equal_vectors_does_not_re_enqueue(engine):
+    """huangheng CR NIT-B (msg=33b1fc56): boundary 钉死 ``>`` 不是 ``>=``.
+    facts.updated_at == vectors.updated_at 时不应触发 stale (相等 ≠ 落后).
+    防未来 refactor 把 ``>`` 改成 ``>=`` 静默过度入队.
+    """
+    facts_artifact = "collections/c/documents/doc-1/derived/parse_v1/kg.jsonl"
+    same_time = _utcnow()
+
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_FACTS,
+        status=IndexStatus.ACTIVE,
+        derived_artifact_path=facts_artifact,
+    )
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_VECTORS,
+        status=IndexStatus.ACTIVE,
+        source_path=facts_artifact,
+        is_serving=True,
+    )
+    # 强制两边 updated_at 完全相等.
+    with Session(engine) as session, session.begin():
+        session.execute(
+            update(DocumentIndex)
+            .where(
+                and_(
+                    DocumentIndex.document_id == "doc-1",
+                    DocumentIndex.modality.in_(
+                        [Modality.GRAPH_FACTS.value, Modality.GRAPH_VECTORS.value],
+                    ),
+                )
+            )
+            .values(updated_at=same_time)
+        )
+
+    assert reconcile_graph_vectors_enqueue(engine=engine) == 0
+
+    with Session(engine) as session:
+        vectors = session.scalars(
+            select(DocumentIndex).where(DocumentIndex.modality == Modality.GRAPH_VECTORS.value)
+        ).one()
+    assert vectors.status == IndexStatus.ACTIVE.value, "facts == vectors 时不应触发 stale"
+    assert vectors.is_serving is True
+
+
 def test_reconciler_graph_vectors_idempotent_when_facts_unchanged(engine):
     """幂等: facts 没改 (updated_at 不推进 + source_path 一致), vectors ACTIVE
     不应被反复入队. 防止 reconciler 周期 30 秒重复打扰已 OK 的 vectors.

--- a/tests/unit_test/indexing/test_t2_1_runtime.py
+++ b/tests/unit_test/indexing/test_t2_1_runtime.py
@@ -50,6 +50,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy import (
     Engine,
+    and_,
     create_engine,
     insert,
     select,
@@ -581,6 +582,205 @@ def test_reconciler_graph_vectors_enqueue_skips_facts_without_artifact(engine):
         derived_artifact_path=None,
     )
     assert reconcile_graph_vectors_enqueue(engine=engine) == 0
+
+
+# ---------------------------------------------------------------------
+# (5b') Graph vectors stale detection — task #15
+# (Planetegg msg=3322c22b surface + 5 方 align + architect ratify msg=39c4ece8 +
+#  earayu2 拍板 msg=efc218ce. 设计文档 §4.4 conservative serial scheduling
+#  扩展第 2 类触发: facts 重跑后 vectors stale 必须重入队.)
+# ---------------------------------------------------------------------
+
+
+def test_reconciler_graph_vectors_re_enqueues_stale_active_when_facts_updated_at_advances(engine):
+    """场景: facts 重跑 (updated_at 推进), 老 vectors ACTIVE 没漂移路径但
+    时间戳落后 → reconciler 必须重置 vectors 为 PENDING.
+    """
+    facts_artifact = "collections/c/documents/doc-1/derived/parse_v2/kg.jsonl"
+    facts_id = _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_FACTS,
+        status=IndexStatus.ACTIVE,
+        derived_artifact_path=facts_artifact,
+    )
+    # vectors ACTIVE 行, source_path 同 facts (无路径漂移), 但 updated_at 必须比 facts 早.
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_VECTORS,
+        status=IndexStatus.ACTIVE,
+        source_path=facts_artifact,
+        is_serving=True,
+    )
+    # 强制 vectors.updated_at 比 facts.updated_at 早.
+    earlier = _utcnow() - timedelta(minutes=5)
+    with Session(engine) as session, session.begin():
+        session.execute(
+            update(DocumentIndex)
+            .where(
+                and_(
+                    DocumentIndex.modality == Modality.GRAPH_VECTORS.value,
+                    DocumentIndex.document_id == "doc-1",
+                )
+            )
+            .values(updated_at=earlier)
+        )
+
+    enqueued = reconcile_graph_vectors_enqueue(engine=engine)
+    assert enqueued == 1
+
+    with Session(engine) as session:
+        vectors = session.scalars(
+            select(DocumentIndex).where(DocumentIndex.modality == Modality.GRAPH_VECTORS.value)
+        ).one()
+    assert vectors.status == IndexStatus.PENDING.value
+    assert vectors.source_path == facts_artifact
+    assert vectors.is_serving is False
+    assert vectors.error_message is None
+    assert vectors.retry_after is None
+    # facts 行不变.
+    assert _row(engine, facts_id).status == IndexStatus.ACTIVE.value
+
+
+def test_reconciler_graph_vectors_re_enqueues_when_artifact_path_diverges(engine):
+    """场景: facts 重跑后 derived_artifact_path 漂移 (新 parse_version),
+    即使时间戳相同, vectors 也必须重入队 + source_path 同步.
+    """
+    new_artifact = "collections/c/documents/doc-1/derived/parse_v3/kg.jsonl"
+    old_artifact = "collections/c/documents/doc-1/derived/parse_v1/kg.jsonl"
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_FACTS,
+        status=IndexStatus.ACTIVE,
+        derived_artifact_path=new_artifact,
+    )
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_VECTORS,
+        status=IndexStatus.ACTIVE,
+        source_path=old_artifact,
+        is_serving=True,
+    )
+
+    enqueued = reconcile_graph_vectors_enqueue(engine=engine)
+    assert enqueued == 1
+
+    with Session(engine) as session:
+        vectors = session.scalars(
+            select(DocumentIndex).where(DocumentIndex.modality == Modality.GRAPH_VECTORS.value)
+        ).one()
+    assert vectors.status == IndexStatus.PENDING.value
+    assert vectors.source_path == new_artifact, "source_path 必须同步成 facts 当前的 artifact"
+
+
+def test_reconciler_graph_vectors_idempotent_when_facts_unchanged(engine):
+    """幂等: facts 没改 (updated_at 不推进 + source_path 一致), vectors ACTIVE
+    不应被反复入队. 防止 reconciler 周期 30 秒重复打扰已 OK 的 vectors.
+    """
+    facts_artifact = "collections/c/documents/doc-1/derived/parse_v1/kg.jsonl"
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_FACTS,
+        status=IndexStatus.ACTIVE,
+        derived_artifact_path=facts_artifact,
+    )
+    # vectors ACTIVE, 跟 facts 同 path, updated_at 比 facts 晚.
+    later = _utcnow() + timedelta(seconds=10)
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_VECTORS,
+        status=IndexStatus.ACTIVE,
+        source_path=facts_artifact,
+        is_serving=True,
+    )
+    with Session(engine) as session, session.begin():
+        session.execute(
+            update(DocumentIndex).where(DocumentIndex.modality == Modality.GRAPH_VECTORS.value).values(updated_at=later)
+        )
+
+    # 跑 3 次都 0 (不重复打扰).
+    for _ in range(3):
+        assert reconcile_graph_vectors_enqueue(engine=engine) == 0
+
+    with Session(engine) as session:
+        vectors = session.scalars(
+            select(DocumentIndex).where(DocumentIndex.modality == Modality.GRAPH_VECTORS.value)
+        ).one()
+    assert vectors.status == IndexStatus.ACTIVE.value
+    assert vectors.is_serving is True
+
+
+def test_reconciler_graph_vectors_re_enqueues_failed_when_facts_updated(engine):
+    """FAILED 的 vectors 行也算 stale 候选 — facts 重跑后, 老 FAILED vectors
+    应该重置成 PENDING 重新尝试 (不消耗 retry_count, 因为根因是 facts 更新).
+    """
+    facts_artifact = "collections/c/documents/doc-1/derived/parse_v2/kg.jsonl"
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_FACTS,
+        status=IndexStatus.ACTIVE,
+        derived_artifact_path=facts_artifact,
+    )
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_VECTORS,
+        status=IndexStatus.FAILED,
+        source_path="old/path/kg.jsonl",
+    )
+
+    enqueued = reconcile_graph_vectors_enqueue(engine=engine)
+    assert enqueued == 1
+
+    with Session(engine) as session:
+        vectors = session.scalars(
+            select(DocumentIndex).where(DocumentIndex.modality == Modality.GRAPH_VECTORS.value)
+        ).one()
+    assert vectors.status == IndexStatus.PENDING.value
+    assert vectors.source_path == facts_artifact
+
+
+def test_reconciler_graph_vectors_skips_in_flight_pending_or_running(engine):
+    """PENDING / RUNNING 状态的 vectors 已在被处理 — 不应被打扰. 即使路径
+    漂移, worker 当前在跑 (RUNNING) 或排队等 worker (PENDING), 让它跑完就好;
+    跑完后如果 facts 又推进, 下一轮 reconciler 会再 stale-detect.
+    """
+    new_artifact = "collections/c/documents/doc-1/derived/parse_v2/kg.jsonl"
+    _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_FACTS,
+        status=IndexStatus.ACTIVE,
+        derived_artifact_path=new_artifact,
+    )
+    pending_id = _insert_row(
+        engine,
+        document_id="doc-1",
+        parse_version="v1",
+        modality=Modality.GRAPH_VECTORS,
+        status=IndexStatus.PENDING,
+        source_path="old/path/kg.jsonl",  # 漂移但 PENDING 不该被打扰
+    )
+
+    assert reconcile_graph_vectors_enqueue(engine=engine) == 0
+    # 行不变 (没被改 source_path).
+    assert _row(engine, pending_id).status == IndexStatus.PENDING.value
+    assert _row(engine, pending_id).source_path == "old/path/kg.jsonl"
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Closes task #15.

## Summary

按 Planetegg msg=3322c22b 现场 surface + 5 方 align (架构师 / huangheng / huangzhangshu / Weston / Bryce) + earayu2 拍板 msg=efc218ce, 把 ``reconcile_graph_vectors_enqueue`` 从单一 "缺失检测" 扩展为 "缺失 + stale" 双触发.

## Background

rebuild_index / cleanup-resync 后 graph_facts 重新 ACTIVE, 但同 ``(document_id, parse_version)`` 的 graph_vectors 行可能保持老 ACTIVE 状态. DB 上看起来向量层就绪, 但 vector store (Qdrant) 没有新写入的向量点, 页面 ``/graphs/hybrid`` 只能 fallback 到 facts layout. Planetegg 在 task #13 ops 现场 unblock 时手动 reset 才发现.

## Implementation (poll-side, simple-stable)

``reconcile_graph_vectors_enqueue`` 在 facts ACTIVE 行的循环里:

- 已存在 graph_vectors 行 + ``graph_facts.updated_at > graph_vectors.updated_at`` → 重置为 PENDING + source_path 同步成 facts 当前 derived_artifact_path
- 已存在 graph_vectors 行 + ``derived_artifact_path 漂移`` (path drift) → 同上重置
- PENDING / RUNNING 状态的 vectors 行不被打扰 (worker 正在跑, 让它跑完; 跑完后下一轮 reconcile 再 stale-detect)
- ACTIVE / FAILED 状态的 stale vectors 才重置, 清掉 error_message / retry_after / last_heartbeat / is_serving 跟 FAILED retry 路径语义对齐

**幂等性**: facts 没改时 (updated_at 不推进 + path 一致) ACTIVE vectors 保持不变, 不被 30 秒巡检反复打扰.

## 5 条新单测

- ``test_reconciler_graph_vectors_re_enqueues_stale_active_when_facts_updated_at_advances``: 钉 stale ACTIVE 时间戳重入队语义
- ``test_reconciler_graph_vectors_re_enqueues_when_artifact_path_diverges``: 钉路径漂移重入队 + source_path 同步
- ``test_reconciler_graph_vectors_idempotent_when_facts_unchanged``: 钉幂等
- ``test_reconciler_graph_vectors_re_enqueues_failed_when_facts_updated``: 钉 FAILED stale 也重入队
- ``test_reconciler_graph_vectors_skips_in_flight_pending_or_running``: 钉 PENDING / RUNNING 不被打扰

## Verify (不动代码)

- ✅ ``rebuild_index`` 流程 (PR #1871 task #5 step 6): 用户传 ``GRAPH`` 字符串映射到 ``GRAPH_FACTS``, 派发 facts PENDING. reconciler (30 秒巡检) 看到 facts ACTIVE 之后自动 enqueue vectors PENDING. 端到端 OK.
- ✅ UI ``graph_index_status`` (PR #1871 task #5 step 6): 优先 ``GRAPH_FACTS``, 否则 ``GRAPH`` (老数据兼容). 永远不看 ``GRAPH_VECTORS`` — 跟 v3.1 §4.5 「文档整体不聚合 graph_vectors」契约一致.

## Test plan

- [x] 5 条新单测 + 现有 4 条 graph_vectors 单测 + 全 indexing 349 单测全过
- [x] ruff check + ruff format check 全过
- [ ] CI lint-and-unit + 3 套 e2e-http-smoke + 3 套 e2e-http-provider 跑过
- [ ] @huangheng 逐行 CR (按 grep-all-callers + runtime wire-in 双 mandatory checklist + 验证「不破现有缺失检测原行为」)
- [ ] 架构师 ratify + squash merge

cc @符炫炜 @huangheng

🤖 Generated with [Claude Code](https://claude.com/claude-code)