### PR TITLE
polish(graph): prefer vector search and version hybrid layout cache

### DIFF
--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -728,12 +728,17 @@ class GraphService:
         if not entities:
             return [], {}, [], False
 
+        graph_vector_cache_state = await self._graph_vector_cache_state(collection_id=collection_id)
+        if not self._graph_vector_state_allows_embedding_layout(graph_vector_cache_state):
+            return [], {}, entities, False
+
         cache_key = self._embedding_projection_cache_key(
             collection_id=collection_id,
             backend_type=backend_type,
             max_entities=max_entities,
             collection_config=getattr(db_collection, "config", None),
             entities=entities,
+            graph_vector_cache_state=graph_vector_cache_state,
         )
         cached = await self._load_embedding_projection_cache(collection_id=collection_id, cache_key=cache_key)
         if cached is not None:
@@ -837,14 +842,15 @@ class GraphService:
             )
             point_entities.append(entity)
 
-        await self._save_embedding_projection_cache(
-            collection_id=collection_id,
-            cache_key=cache_key,
-            backend_type=backend_type,
-            max_entities=max_entities,
-            points=points,
-            cluster_labels=cluster_labels,
-        )
+        if self._graph_vector_state_allows_embedding_layout(graph_vector_cache_state):
+            await self._save_embedding_projection_cache(
+                collection_id=collection_id,
+                cache_key=cache_key,
+                backend_type=backend_type,
+                max_entities=max_entities,
+                points=points,
+                cluster_labels=cluster_labels,
+            )
 
         return points, cluster_labels, point_entities, False
 
@@ -856,6 +862,7 @@ class GraphService:
         max_entities: int,
         collection_config: Any,
         entities: list[Any],
+        graph_vector_cache_state: dict[str, Any] | None = None,
     ) -> str:
         payload = {
             "version": 1,
@@ -863,6 +870,7 @@ class GraphService:
             "backend_type": backend_type,
             "max_entities": max_entities,
             "collection_config": _stable_jsonish(collection_config),
+            "graph_vector_cache_state": _stable_jsonish(graph_vector_cache_state or {}),
             "entities": [
                 {
                     "name": getattr(entity, "name", None),
@@ -876,6 +884,85 @@ class GraphService:
         }
         encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    async def _graph_vector_cache_state(self, *, collection_id: str) -> dict[str, Any]:
+        """Return graph-vector state that must invalidate layout cache.
+
+        The hybrid embedding layout is derived from Qdrant graph entity
+        points, while the selected entity set comes from the graph facts
+        store. Those are different truth sources; the cache key must
+        carry the upstream graph-vector serving version so a facts/vectors
+        rerun cannot keep serving a partial projection.
+        """
+        from sqlalchemy import func, select
+
+        from aperag.config import get_async_session
+        from aperag.indexing.models import DocumentIndex, IndexStatus, Modality
+
+        state: dict[str, Any] = {
+            "available": True,
+            "graph_facts_active_count": 0,
+            "graph_vectors_active_count": 0,
+            "graph_vectors_latest_updated_at": None,
+        }
+        try:
+            async for session in get_async_session():
+                rows = (
+                    await session.execute(
+                        select(
+                            DocumentIndex.modality,
+                            func.count(DocumentIndex.id),
+                            func.max(DocumentIndex.updated_at),
+                        )
+                        .where(
+                            DocumentIndex.collection_id == collection_id,
+                            DocumentIndex.status == IndexStatus.ACTIVE.value,
+                            DocumentIndex.is_serving.is_(True),
+                            DocumentIndex.modality.in_(
+                                [
+                                    Modality.GRAPH_FACTS.value,
+                                    Modality.GRAPH_VECTORS.value,
+                                ]
+                            ),
+                        )
+                        .group_by(DocumentIndex.modality)
+                    )
+                ).all()
+                for modality, count, latest_updated_at in rows:
+                    if modality == Modality.GRAPH_FACTS.value:
+                        state["graph_facts_active_count"] = int(count or 0)
+                    elif modality == Modality.GRAPH_VECTORS.value:
+                        state["graph_vectors_active_count"] = int(count or 0)
+                        state["graph_vectors_latest_updated_at"] = (
+                            latest_updated_at.isoformat() if latest_updated_at is not None else None
+                        )
+                return state
+        except Exception:
+            logger.warning(
+                "Failed to read graph vector state for hybrid layout cache",
+                extra={"collection_id": collection_id},
+                exc_info=True,
+            )
+            return {"available": False}
+        return state
+
+    @staticmethod
+    def _graph_vector_state_allows_embedding_layout(graph_vector_cache_state: dict[str, Any] | None) -> bool:
+        """Avoid embedding layouts while graph vectors are partial.
+
+        During a graph-vectors rerun, some documents can become ACTIVE
+        before others. Serving or caching that intermediate projection would leave
+        the graph-hybrid page pinned to a smaller point set until another
+        cache-key change happens. If the facts layer has split-state rows,
+        only use vectors once the vector layer has at least the same ACTIVE
+        row count. Legacy graph-only data has no split facts rows, so it
+        keeps the previous best-effort behavior.
+        """
+        if not graph_vector_cache_state or graph_vector_cache_state.get("available") is False:
+            return True
+        facts_count = int(graph_vector_cache_state.get("graph_facts_active_count") or 0)
+        vectors_count = int(graph_vector_cache_state.get("graph_vectors_active_count") or 0)
+        return facts_count <= 0 or vectors_count >= facts_count
 
     async def _load_embedding_projection_cache(
         self,

--- a/aperag/indexing/graph_search_service.py
+++ b/aperag/indexing/graph_search_service.py
@@ -125,7 +125,7 @@ class GraphSearchService:
         self._collection_id = collection_id
 
     # ------------------------------------------------------------------
-    # search_entities — lexical fallback + vector recall path
+    # search_entities — vector-first path with name-driven fallback
     # ------------------------------------------------------------------
 
     async def search_entities(
@@ -135,11 +135,19 @@ class GraphSearchService:
     ) -> list[EntityWithLineage]:
         """Recall the top-K entities matching ``query``.
 
-        The graph state split can make vector recall temporarily
-        unavailable while the facts layer is already serving. Keep the
-        name-driven path useful by trying exact and lexical matches
-        before the vector layer. Empty / whitespace-only query returns
-        ``[]`` (no spurious recall — same convention as
+        Prefer entity-vector recall when the graph vector layer is
+        available. Exact / alias / lexical lookup remains in the path
+        as ranking guardrail and fallback:
+
+        * alias is resolved before vector recall so alias queries can
+          use the canonical entity name for embedding and exact boost;
+        * exact entity hits are hard-boosted to the front so a literal
+          entity-name query remains predictable;
+        * keyword/fuzzy lookup only supplements or handles vector
+          failures.
+
+        Empty / whitespace-only query returns ``[]`` (no spurious
+        recall — same convention as
         :meth:`LineageGraphStore.query_entities_by_keyword`).
         """
         text = (query or "").strip()
@@ -149,67 +157,69 @@ class GraphSearchService:
         if k <= 0:
             return []
 
+        canonical = await self._safe_resolve_alias(text)
+        query_for_embedding = canonical if canonical and canonical != text else text
+
+        exact_candidates: list[EntityWithLineage] = []
+        exact_seen: set[str] = set()
+        for candidate in (text, query_for_embedding):
+            if not candidate or candidate in exact_seen:
+                continue
+            exact_seen.add(candidate)
+            exact = await self._safe_get_exact_entity(candidate)
+            if exact is not None and exact.name not in {entity.name for entity in exact_candidates}:
+                exact_candidates.append(exact)
+
+        vector_entities: list[EntityWithLineage] = []
+        try:
+            embedding = await asyncio.to_thread(self._embedder.embed_query, query_for_embedding)
+        except Exception:
+            logger.warning("graph_search_service: embed failed for query=%r", text, exc_info=True)
+            embedding = None
+
+        if embedding is not None:
+            request = QueryRequest(
+                embedding=embedding,
+                top_k=k,
+                flt=Eq("indexer", GRAPH_ENTITY_INDEXER),
+                score_threshold=self._score_threshold or None,
+            )
+            try:
+                hits = await asyncio.to_thread(self._vector_connector.search, request)
+            except Exception:
+                logger.warning(
+                    "graph_search_service: vector search failed for query=%r",
+                    text,
+                    exc_info=True,
+                )
+                hits = []
+
+            names = self._entity_names_from_hits(hits)
+            if names:
+                vector_entities = await self._batch_get_entities(names)
+
         results: list[EntityWithLineage] = []
         seen_names: set[str] = set()
 
-        exact = await self._safe_get_exact_entity(text)
-        if exact is not None:
-            results.append(exact)
-            seen_names.add(exact.name)
-        else:
-            # 任务 #5 step 8: alias 解析兜底. 写路径已经把 alias 重定向
-            # 到 canonical, 所以 store 里只有 canonical entity 名字; 用户
-            # 搜的如果是 alias, get_entity 会 miss, 这时 alias_repo 把
-            # 名字翻译成 canonical 再查一次.
-            canonical = await self._safe_resolve_alias(text)
-            if canonical and canonical != text:
-                redirected = await self._safe_get_exact_entity(canonical)
-                if redirected is not None:
-                    results.append(redirected)
-                    seen_names.add(redirected.name)
+        def _append(entity: EntityWithLineage) -> bool:
+            if entity.name in seen_names:
+                return len(results) >= k
+            results.append(entity)
+            seen_names.add(entity.name)
+            return len(results) >= k
+
+        for entity in exact_candidates:
+            if _append(entity):
+                return results
+
+        for entity in vector_entities:
+            if _append(entity):
+                return results
 
         lexical_matches = await self._safe_query_entities_by_keyword(text, max(k - len(results), 0))
         for entity in lexical_matches:
-            if entity.name in seen_names:
-                continue
-            results.append(entity)
-            seen_names.add(entity.name)
-            if len(results) >= k:
+            if _append(entity):
                 return results
-
-        try:
-            embedding = await asyncio.to_thread(self._embedder.embed_query, text)
-        except Exception:
-            logger.warning("graph_search_service: embed failed for query=%r", text, exc_info=True)
-            return results
-
-        request = QueryRequest(
-            embedding=embedding,
-            top_k=max(k, k - len(results)),
-            flt=Eq("indexer", GRAPH_ENTITY_INDEXER),
-            score_threshold=self._score_threshold or None,
-        )
-        try:
-            hits = await asyncio.to_thread(self._vector_connector.search, request)
-        except Exception:
-            logger.warning(
-                "graph_search_service: vector search failed for query=%r",
-                text,
-                exc_info=True,
-            )
-            return results
-
-        names = self._entity_names_from_hits(hits)
-        if not names:
-            return results
-        vector_entities = await self._batch_get_entities(names)
-        for entity in vector_entities:
-            if entity.name in seen_names:
-                continue
-            results.append(entity)
-            seen_names.add(entity.name)
-            if len(results) >= k:
-                break
         return results
 
     async def _safe_get_exact_entity(self, text: str) -> EntityWithLineage | None:

--- a/tests/unit_test/domains/knowledge_graph/test_service.py
+++ b/tests/unit_test/domains/knowledge_graph/test_service.py
@@ -314,3 +314,104 @@ async def test_get_embedding_projection_uses_layout_cache(monkeypatch):
     assert [entity.name for entity in entities] == ["A"]
     assert layout_from_cache is True
     service._save_embedding_projection_cache.assert_not_called()
+
+
+async def test_get_embedding_projection_skips_cache_when_graph_vectors_partial():
+    class FakeStore:
+        async def list_entities(self, *, limit, offset):
+            assert limit == 1000
+            assert offset == 0
+            return [_entity("A", "person")]
+
+    service = GraphService()
+    service._graph_vector_cache_state = AsyncMock(
+        return_value={
+            "available": True,
+            "graph_facts_active_count": 10,
+            "graph_vectors_active_count": 4,
+        }
+    )
+    service._load_embedding_projection_cache = AsyncMock()
+    service._save_embedding_projection_cache = AsyncMock()
+
+    points, cluster_labels, entities, layout_from_cache = await service._get_embedding_projection(
+        backend_type="postgres",
+        db_collection=SimpleNamespace(id="col1"),
+        collection_id="col1",
+        store=FakeStore(),
+        max_entities=1000,
+    )
+
+    assert points == []
+    assert cluster_labels == {}
+    assert [entity.name for entity in entities] == ["A"]
+    assert layout_from_cache is False
+    service._load_embedding_projection_cache.assert_not_called()
+    service._save_embedding_projection_cache.assert_not_called()
+
+
+def test_embedding_projection_cache_key_includes_graph_vector_state():
+    service = GraphService()
+    entities = [_entity("A", "person")]
+
+    old_key = service._embedding_projection_cache_key(
+        collection_id="col1",
+        backend_type="postgres",
+        max_entities=1000,
+        collection_config={},
+        entities=entities,
+        graph_vector_cache_state={
+            "graph_facts_active_count": 1,
+            "graph_vectors_active_count": 1,
+            "graph_vectors_latest_updated_at": "2026-04-29T12:00:00+00:00",
+        },
+    )
+    new_key = service._embedding_projection_cache_key(
+        collection_id="col1",
+        backend_type="postgres",
+        max_entities=1000,
+        collection_config={},
+        entities=entities,
+        graph_vector_cache_state={
+            "graph_facts_active_count": 1,
+            "graph_vectors_active_count": 1,
+            "graph_vectors_latest_updated_at": "2026-04-29T12:30:00+00:00",
+        },
+    )
+
+    assert old_key != new_key
+
+
+def test_graph_vector_state_blocks_partial_embedding_layout_cache():
+    service = GraphService()
+
+    assert (
+        service._graph_vector_state_allows_embedding_layout(
+            {
+                "available": True,
+                "graph_facts_active_count": 10,
+                "graph_vectors_active_count": 4,
+            }
+        )
+        is False
+    )
+    assert (
+        service._graph_vector_state_allows_embedding_layout(
+            {
+                "available": True,
+                "graph_facts_active_count": 10,
+                "graph_vectors_active_count": 10,
+            }
+        )
+        is True
+    )
+    assert (
+        service._graph_vector_state_allows_embedding_layout(
+            {
+                "available": True,
+                "graph_facts_active_count": 0,
+                "graph_vectors_active_count": 0,
+            }
+        )
+        is True
+    )

--- a/tests/unit_test/indexing/test_graph_search_service.py
+++ b/tests/unit_test/indexing/test_graph_search_service.py
@@ -314,6 +314,36 @@ async def test_search_entities_returns_entities_in_hit_order():
 
 
 @pytest.mark.asyncio
+async def test_search_entities_prefers_vector_before_keyword_matches():
+    vector_hit = _entity("Vector Match")
+    keyword_hit = _entity("Keyword Match")
+    service, store, _, _ = _make_service(
+        entities={"Vector Match": vector_hit},
+        keyword_matches=[keyword_hit],
+        hits=[SearchHit(id="v1", score=0.9, payload={"entity_name": "Vector Match"})],
+    )
+
+    result = await service.search_entities("query", top_k=2)
+
+    assert [entity.name for entity in result] == ["Vector Match", "Keyword Match"]
+    assert store.query_entities_by_keyword_calls == [("query", 1)]
+
+
+@pytest.mark.asyncio
+async def test_search_entities_hard_boosts_exact_match_over_vector_hits():
+    exact = _entity("Refund")
+    vector_hit = _entity("Tax Rebate")
+    service, _, _, _ = _make_service(
+        entities={"Refund": exact, "Tax Rebate": vector_hit},
+        hits=[SearchHit(id="v1", score=0.9, payload={"entity_name": "Tax Rebate"})],
+    )
+
+    result = await service.search_entities("Refund", top_k=2)
+
+    assert [entity.name for entity in result] == ["Refund", "Tax Rebate"]
+
+
+@pytest.mark.asyncio
 async def test_search_entities_dedupes_repeated_payload_names():
     a = _entity("Alpha")
     service, store, _, _ = _make_service(
@@ -397,8 +427,8 @@ async def test_search_entities_alias_redirects_when_exact_misses():
 
 
 @pytest.mark.asyncio
-async def test_search_entities_alias_skipped_when_exact_hits():
-    """精确匹配命中时不需要走 alias 解析 — 节省一次 DB 查询."""
+async def test_search_entities_alias_pre_step_keeps_exact_hit_top_ranked():
+    """alias 解析是 vector-first 的预处理步骤; 精确命中仍然 top-1."""
     alpha = _entity("Alpha")
     alias_repo = _FakeAliasRepo({"Alpha": "Beta"})  # 故意混淆
     service, _, _, _ = _make_service(
@@ -409,8 +439,7 @@ async def test_search_entities_alias_skipped_when_exact_hits():
 
     result = await service.search_entities("Alpha")
     assert [e.name for e in result] == ["Alpha"]
-    # alias_repo 没被调用 — 第 1 层精确匹配已经命中.
-    assert alias_repo.calls == []
+    assert alias_repo.calls == ["Alpha"]
 
 
 @pytest.mark.asyncio

--- a/web/src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx
@@ -10,8 +10,8 @@ import {
   getMarketplaceGraphEntityEvidence,
   getMarketplaceGraphHybrid,
   getMarketplaceGraphRelationEvidence,
-  searchMarketplaceGraphEntities,
   searchGraphEntities,
+  searchMarketplaceGraphEntities,
 } from '@/features/knowledge-graph/client-api';
 import type {
   GraphEdge,
@@ -632,7 +632,8 @@ export const CollectionGraphHybrid = ({
     getGraphData();
   }, [getGraphData]);
 
-  // Debounced vector search against the Wave 7 entity-search endpoint.
+  // Debounced entity search. The backend chooses vector / exact /
+  // fuzzy strategies; the UI only presents one query surface.
   useEffect(() => {
     if (!searchOpen || !searchTerm.trim()) {
       setSearchResults([]);
@@ -1299,7 +1300,7 @@ export const CollectionGraphHybrid = ({
               </div>
               {searchPending && (
                 <div className="text-muted-foreground flex items-center gap-2 p-3 text-xs">
-                  <Loader2 className="size-3 animate-spin" /> 向量召回中…
+                  <Loader2 className="size-3 animate-spin" /> 查询中…
                 </div>
               )}
               {!searchPending &&


### PR DESCRIPTION
## Summary

Task #16 PR A.

- make graph entity search prefer graph-vector recall while preserving alias preprocessing and exact-name top-rank boost
- change graph-hybrid search loading text to a generic `查询中…` so the UI exposes one query surface instead of implementation details
- include graph vector serving state in the hybrid embedding-layout cache key and skip embedding layout/cache while graph vectors are only partially ACTIVE

## Invariants

- alias resolution is a pre-step, so alias queries still use the canonical entity name
- literal exact entity names remain top-1 even when vector recall returns another related entity
- facts layout remains the fallback when graph vectors are unavailable or partial
- embedding layout cache now changes when the serving graph-vector version changes

## Tests

- `uv run --extra test pytest tests/unit_test/indexing/test_graph_search_service.py tests/unit_test/domains/knowledge_graph/test_service.py -q`
- `uvx ruff check aperag/indexing/graph_search_service.py aperag/domains/knowledge_graph/service.py tests/unit_test/indexing/test_graph_search_service.py tests/unit_test/domains/knowledge_graph/test_service.py`
- `uvx ruff format --check aperag/indexing/graph_search_service.py aperag/domains/knowledge_graph/service.py tests/unit_test/indexing/test_graph_search_service.py tests/unit_test/domains/knowledge_graph/test_service.py`
- `git diff --check`
- `cd web && yarn install --frozen-lockfile && yarn type-check`
- `cd web && ./node_modules/.bin/prettier --check 'src/app/workspace/collections/[collectionId]/graph-hybrid/collection-graph-hybrid.tsx'`
