### PR TITLE
feat(model-platform): add model scenario allowlists

### DIFF
--- a/aperag/domains/conversation/service/bot_service.py
+++ b/aperag/domains/conversation/service/bot_service.py
@@ -101,6 +101,17 @@ class BotService:
             if not collections or len(collections) != len(collection_ids):
                 raise ResourceNotFoundException("Collection", collection_ids)
 
+    async def validate_agent_model(self, user: str, bot_config: BotConfig):
+        completion = bot_config.agent.completion if bot_config and bot_config.agent else None
+        if not completion or not completion.model_id:
+            return
+        from aperag.domains.model_platform.schemas import ModelUseScenario
+        from aperag.domains.model_platform.service.model_service import model_platform_service
+
+        await model_platform_service.ensure_model_allowed_for_scenario(
+            user, completion.model_id, ModelUseScenario.AGENT_CHAT
+        )
+
     async def create_bot(self, user: str, bot_in: BotCreate, skip_quota_check: bool = False) -> Bot:
         bot_type = bot_in.type or BotType.AGENT
         if bot_type != BotType.AGENT:
@@ -111,6 +122,7 @@ class BotService:
                 await _get_quota_ops().check_and_consume_quota(user, "max_bot_count", 1, session)
 
             await self.validate_collections(user, bot_in.config)
+            await self.validate_agent_model(user, bot_in.config)
 
             config_str = "{}"
             if bot_in.config:
@@ -164,6 +176,7 @@ class BotService:
             new_config_str = json.dumps(bot_in.config.model_dump(exclude_none=True))
 
         await self.validate_collections(user, bot_in.config)
+        await self.validate_agent_model(user, bot_in.config)
 
         async def _update_bot_atomically(session):
             from sqlalchemy import select

--- a/aperag/domains/knowledge_base/service/collection_service.py
+++ b/aperag/domains/knowledge_base/service/collection_service.py
@@ -157,6 +157,23 @@ class CollectionService:
         else:
             self.db_ops = AsyncDatabaseOps(session)  # Create custom instance for transaction control
 
+    async def validate_collection_models(self, user: str, config) -> None:
+        if config is None:
+            return
+        from aperag.domains.model_platform.schemas import ModelUseScenario
+        from aperag.domains.model_platform.service.model_service import model_platform_service
+
+        completion = getattr(config, "completion", None)
+        if completion and completion.model_id:
+            await model_platform_service.ensure_model_allowed_for_scenario(
+                user, completion.model_id, ModelUseScenario.COLLECTION_COMPLETION
+            )
+        embedding = getattr(config, "embedding", None)
+        if embedding and embedding.model_id:
+            await model_platform_service.ensure_model_allowed_for_scenario(
+                user, embedding.model_id, ModelUseScenario.COLLECTION_EMBEDDING
+            )
+
     async def build_collection_response(self, instance: CollectionRow) -> Collection:
         """Build Collection response object for API return."""
         return Collection(
@@ -186,6 +203,7 @@ class CollectionService:
         is_validate, error_msg = validate_source_connect_config(collection_config)
         if not is_validate:
             raise ValidationException(error_msg)
+        await self.validate_collection_models(user, collection_config)
 
         # Create collection and consume quota in a single transaction
         async def _create_collection_with_quota(session):
@@ -391,6 +409,7 @@ class CollectionService:
         # users who truly need a different model should create a new collection and
         # re-ingest their data.
         self._reject_embedding_change(instance, collection)
+        await self.validate_collection_models(user, collection.config)
 
         # Direct call to repository method, which handles its own transaction
         config_str = dumpCollectionConfig(collection.config)

--- a/aperag/domains/model_platform/api/providers_v2_routes.py
+++ b/aperag/domains/model_platform/api/providers_v2_routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Path, Response
+from fastapi import APIRouter, Depends, Path, Query, Response
 
 from aperag.domains.identity.service.auth_dependencies import required_user
 from aperag.domains.model_platform.ports import AuthenticatedUser
@@ -8,6 +8,7 @@ from aperag.domains.model_platform.schemas import (
     ModelAccountCreate,
     ModelAccountList,
     ModelAccountUpdate,
+    ModelCapability,
     ModelList,
     ModelProviderList,
     ModelUpdate,
@@ -69,14 +70,23 @@ async def validate_model_account_view(
 
 @router.get("/model-accounts/{account_id}/models", response_model=ModelList)
 async def list_model_account_models_view(
-    account_id: str, user: AuthenticatedUser = Depends(required_user)
+    account_id: str,
+    capability: ModelCapability | None = Query(None),
+    scenario: ModelUseScenario | None = Query(None),
+    user: AuthenticatedUser = Depends(required_user),
 ) -> ModelList:
-    return await model_platform_service.list_models(str(user.id), account_id=account_id)
+    return await model_platform_service.list_models(
+        str(user.id), account_id=account_id, capability=capability, scenario=scenario
+    )
 
 
 @router.get("/models", response_model=ModelList)
-async def list_models_view(user: AuthenticatedUser = Depends(required_user)) -> ModelList:
-    return await model_platform_service.list_models(str(user.id))
+async def list_models_view(
+    capability: ModelCapability | None = Query(None),
+    scenario: ModelUseScenario | None = Query(None),
+    user: AuthenticatedUser = Depends(required_user),
+) -> ModelList:
+    return await model_platform_service.list_models(str(user.id), capability=capability, scenario=scenario)
 
 
 @router.post("/models", response_model=Model)

--- a/aperag/domains/model_platform/schemas.py
+++ b/aperag/domains/model_platform/schemas.py
@@ -116,6 +116,7 @@ class Model(BaseModel):
     # collection's embedder spec model and the gate self-disables.
     supports_multimodal_embedding: bool = False
     status: Literal["ACTIVE", "INACTIVE"] = "ACTIVE"
+    allowed_scenarios: list[ModelUseScenario] = Field(default_factory=list)
     extra: dict[str, Any] = Field(default_factory=dict)
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
@@ -135,6 +136,7 @@ class ModelCreate(BaseModel):
     supports_vision: bool = False
     supports_tool_calling: bool = False
     supports_multimodal_embedding: bool = False
+    allowed_scenarios: Optional[list[ModelUseScenario]] = None
     extra: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -151,6 +153,7 @@ class ModelUpdate(BaseModel):
     supports_tool_calling: Optional[bool] = None
     supports_multimodal_embedding: Optional[bool] = None
     status: Optional[Literal["ACTIVE", "INACTIVE"]] = None
+    allowed_scenarios: Optional[list[ModelUseScenario]] = None
     extra: Optional[dict[str, Any]] = None
 
 

--- a/aperag/domains/model_platform/service/model_service.py
+++ b/aperag/domains/model_platform/service/model_service.py
@@ -19,8 +19,104 @@ from aperag.domains.model_platform.schemas import (
     ModelUseUpdate,
     ModelValidationResponse,
 )
-from aperag.exceptions import PermissionDeniedError, ResourceNotFoundException
+from aperag.exceptions import PermissionDeniedError, ResourceNotFoundException, ValidationException
 from aperag.llm.runtime.resolver import infer_runner_type
+
+ALLOWED_SCENARIOS_EXTRA_KEY = "allowed_scenarios"
+
+CAPABILITY_SCENARIOS: dict[ModelCapability, tuple[ModelUseScenario, ...]] = {
+    ModelCapability.CHAT: (
+        ModelUseScenario.AGENT_CHAT,
+        ModelUseScenario.COLLECTION_COMPLETION,
+        ModelUseScenario.BACKGROUND_TASK,
+    ),
+    ModelCapability.COMPLETION: (
+        ModelUseScenario.AGENT_CHAT,
+        ModelUseScenario.COLLECTION_COMPLETION,
+        ModelUseScenario.BACKGROUND_TASK,
+    ),
+    ModelCapability.EMBEDDING: (ModelUseScenario.COLLECTION_EMBEDDING,),
+    ModelCapability.RERANK: (ModelUseScenario.RETRIEVAL_RERANK,),
+}
+
+SCENARIO_CAPABILITY: dict[ModelUseScenario, ModelCapability] = {
+    ModelUseScenario.AGENT_CHAT: ModelCapability.CHAT,
+    ModelUseScenario.COLLECTION_COMPLETION: ModelCapability.CHAT,
+    ModelUseScenario.COLLECTION_EMBEDDING: ModelCapability.EMBEDDING,
+    ModelUseScenario.RETRIEVAL_RERANK: ModelCapability.RERANK,
+    ModelUseScenario.BACKGROUND_TASK: ModelCapability.CHAT,
+}
+
+
+def _capability_value(capability) -> str:
+    return capability.value if hasattr(capability, "value") else str(capability)
+
+
+def _scenario_value(scenario) -> str:
+    return scenario.value if hasattr(scenario, "value") else str(scenario)
+
+
+def _normalise_capability(capability) -> ModelCapability:
+    if isinstance(capability, ModelCapability):
+        return capability
+    return ModelCapability(str(capability))
+
+
+def _normalise_scenario(scenario) -> ModelUseScenario:
+    if isinstance(scenario, ModelUseScenario):
+        return scenario
+    return ModelUseScenario(str(scenario))
+
+
+def default_allowed_scenarios(capability) -> list[ModelUseScenario]:
+    """Return the backward-compatible scenario set for models without explicit configuration."""
+    return list(CAPABILITY_SCENARIOS[_normalise_capability(capability)])
+
+
+def allowed_scenarios_for_model(model) -> list[ModelUseScenario]:
+    extra = model.extra or {}
+    raw = extra.get(ALLOWED_SCENARIOS_EXTRA_KEY)
+    if raw is None:
+        return default_allowed_scenarios(model.capability)
+    scenarios: list[ModelUseScenario] = []
+    for item in raw:
+        try:
+            scenario = _normalise_scenario(item)
+        except ValueError as exc:
+            raise ValidationException(f"Unknown model scenario '{item}'") from exc
+        if scenario not in scenarios:
+            scenarios.append(scenario)
+    return scenarios
+
+
+def _validate_allowed_scenarios(capability, scenarios: list[ModelUseScenario] | None) -> list[str] | None:
+    if scenarios is None:
+        return None
+    model_capability = _normalise_capability(capability)
+    valid_scenarios = set(CAPABILITY_SCENARIOS[model_capability])
+    normalised: list[ModelUseScenario] = []
+    for item in scenarios:
+        scenario = _normalise_scenario(item)
+        if scenario not in valid_scenarios:
+            raise ValidationException(
+                f"Scenario '{scenario.value}' is not valid for model capability '{model_capability.value}'"
+            )
+        if scenario not in normalised:
+            normalised.append(scenario)
+    return [scenario.value for scenario in normalised]
+
+
+def _model_extra_with_allowed_scenarios(
+    extra: dict | None,
+    capability,
+    scenarios: list[ModelUseScenario] | None,
+) -> dict:
+    next_extra = dict(extra or {})
+    allowed = _validate_allowed_scenarios(capability, scenarios)
+    if allowed is not None:
+        next_extra[ALLOWED_SCENARIOS_EXTRA_KEY] = allowed
+    return next_extra
+
 
 BUILTIN_PROVIDERS = [
     ModelProvider(
@@ -105,6 +201,7 @@ def _model_to_schema(model) -> Model:
         supports_tool_calling=model.supports_tool_calling,
         supports_multimodal_embedding=getattr(model, "supports_multimodal_embedding", False) or False,
         status=model.status,
+        allowed_scenarios=allowed_scenarios_for_model(model),
         extra=model.extra or {},
         created=model.gmt_created,
         updated=model.gmt_updated,
@@ -150,6 +247,26 @@ def _normalise_provider_type(value: str | None) -> str | None:
 
 
 class ModelPlatformService:
+    async def ensure_model_allowed_for_scenario(
+        self, user_id: str, model_id: str | None, scenario: ModelUseScenario | str
+    ) -> None:
+        if not model_id:
+            return
+        model = await async_db_ops.query_model(model_id, user_id)
+        if model is None:
+            raise ResourceNotFoundException("Model", model_id)
+        expected_capability = SCENARIO_CAPABILITY[_normalise_scenario(scenario)]
+        model_capability = _normalise_capability(model.capability)
+        if model_capability != expected_capability:
+            raise ValidationException(
+                f"Model '{model_id}' capability '{model_capability.value}' cannot be used for scenario "
+                f"'{_scenario_value(scenario)}'"
+            )
+        allowed = allowed_scenarios_for_model(model)
+        normalised_scenario = _normalise_scenario(scenario)
+        if normalised_scenario not in allowed:
+            raise ValidationException(f"Model '{model_id}' is not allowed for scenario '{normalised_scenario.value}'")
+
     async def list_providers(self) -> ModelProviderList:
         providers = await async_db_ops.query_model_providers()
         return ModelProviderList(items=[_provider_to_schema(provider) for provider in providers] or BUILTIN_PROVIDERS)
@@ -249,8 +366,20 @@ class ModelPlatformService:
             raise ResourceNotFoundException("ModelAccount", account_id)
         return ModelValidationResponse(ok=bool(account), message=None if account else "Model account not found")
 
-    async def list_models(self, user_id: str, account_id: str | None = None) -> ModelList:
+    async def list_models(
+        self,
+        user_id: str,
+        account_id: str | None = None,
+        capability: ModelCapability | None = None,
+        scenario: ModelUseScenario | None = None,
+    ) -> ModelList:
         models = await async_db_ops.query_models(user_id=user_id, account_id=account_id)
+        if scenario is not None:
+            capability = SCENARIO_CAPABILITY[scenario]
+        if capability is not None:
+            models = [model for model in models if _normalise_capability(model.capability) == capability]
+        if scenario is not None:
+            models = [model for model in models if scenario in allowed_scenarios_for_model(model)]
         return ModelList(items=[_model_to_schema(model) for model in models])
 
     async def create_model(self, user_id: str, request: ModelCreate) -> Model:
@@ -265,11 +394,50 @@ class ModelPlatformService:
         )
         payload = request.model_dump()
         payload.pop("runner_type", None)
+        allowed_scenarios = payload.pop("allowed_scenarios", None)
+        if allowed_scenarios is None and ALLOWED_SCENARIOS_EXTRA_KEY in payload.get("extra", {}):
+            allowed_scenarios = payload["extra"][ALLOWED_SCENARIOS_EXTRA_KEY]
+        payload["extra"] = _model_extra_with_allowed_scenarios(
+            payload.get("extra"),
+            request.capability,
+            allowed_scenarios,
+        )
         model = await async_db_ops.create_model(user_id=user_id, runner_type=runner_type, **payload)
         return _model_to_schema(model)
 
     async def update_model(self, model_id: str, user_id: str, request: ModelUpdate) -> Model:
-        model = await async_db_ops.update_model(model_id, user_id, request.model_dump(exclude_unset=True))
+        payload = request.model_dump(exclude_unset=True)
+        if "allowed_scenarios" in payload:
+            existing = await async_db_ops.query_model(model_id, user_id)
+            if existing is None:
+                raise ResourceNotFoundException("Model", model_id)
+            capability = payload.get("capability") or existing.capability
+            extra = dict(existing.extra or {})
+            if payload.get("extra"):
+                extra.update(payload["extra"])
+            payload["extra"] = _model_extra_with_allowed_scenarios(
+                extra,
+                capability,
+                payload.pop("allowed_scenarios"),
+            )
+        elif "capability" in payload:
+            extra = payload.get("extra")
+            if extra and ALLOWED_SCENARIOS_EXTRA_KEY in extra:
+                payload["extra"] = _model_extra_with_allowed_scenarios(
+                    extra,
+                    payload["capability"],
+                    extra[ALLOWED_SCENARIOS_EXTRA_KEY],
+                )
+        elif payload.get("extra") and ALLOWED_SCENARIOS_EXTRA_KEY in payload["extra"]:
+            existing = await async_db_ops.query_model(model_id, user_id)
+            if existing is None:
+                raise ResourceNotFoundException("Model", model_id)
+            payload["extra"] = _model_extra_with_allowed_scenarios(
+                payload["extra"],
+                existing.capability,
+                payload["extra"][ALLOWED_SCENARIOS_EXTRA_KEY],
+            )
+        model = await async_db_ops.update_model(model_id, user_id, payload)
         if model is None:
             raise ResourceNotFoundException("Model", model_id)
         return _model_to_schema(model)
@@ -283,15 +451,10 @@ class ModelPlatformService:
         return ModelUseList(items=[_model_use_to_schema(item) for item in uses])
 
     async def update_model_use(self, user_id: str, scenario: ModelUseScenario, request: ModelUseUpdate) -> ModelUse:
-        capability_by_scenario = {
-            ModelUseScenario.AGENT_CHAT: ModelCapability.CHAT,
-            ModelUseScenario.COLLECTION_COMPLETION: ModelCapability.CHAT,
-            ModelUseScenario.COLLECTION_EMBEDDING: ModelCapability.EMBEDDING,
-            ModelUseScenario.RETRIEVAL_RERANK: ModelCapability.RERANK,
-            ModelUseScenario.BACKGROUND_TASK: ModelCapability.CHAT,
-        }
+        for model_id in [request.primary_model_id, *request.fallback_model_ids]:
+            await self.ensure_model_allowed_for_scenario(user_id, model_id, scenario)
         payload = request.model_dump()
-        payload["capability"] = capability_by_scenario[scenario].value
+        payload["capability"] = SCENARIO_CAPABILITY[scenario].value
         item = await async_db_ops.upsert_model_use(user_id, scenario.value, payload)
         return _model_use_to_schema(item)
 

--- a/tests/unit_test/test_model_platform_v2_contract.py
+++ b/tests/unit_test/test_model_platform_v2_contract.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from fastapi import FastAPI
 
 from aperag.domains.model_platform.api.providers_v2_routes import router
@@ -6,7 +8,13 @@ from aperag.domains.model_platform.schemas import (
     ModelCapability,
     ModelCreate,
     ModelProvider,
+    ModelUpdate,
     ModelUseScenario,
+)
+from aperag.domains.model_platform.service.model_service import (
+    _model_extra_with_allowed_scenarios,
+    allowed_scenarios_for_model,
+    default_allowed_scenarios,
 )
 from aperag.openapi_spec import build_full_openapi_spec, custom_generate_unique_id, filter_public_openapi
 
@@ -119,3 +127,75 @@ def test_model_v2_openapi_exposes_supports_multimodal_embedding():
         assert "supports_multimodal_embedding" in properties, (
             f"{schema_name} missing supports_multimodal_embedding capability flag"
         )
+
+
+def test_model_v2_openapi_exposes_allowed_scenarios():
+    """Scenario allowlists are an API-level model property even though the
+    MVP stores them under ``Model.extra`` for DB compatibility."""
+    spec = _provider_v2_spec()
+    schemas = spec["components"]["schemas"]
+
+    for schema_name in ("Model", "ModelCreate", "ModelUpdate"):
+        assert schema_name in schemas, f"{schema_name} schema missing from v2 OpenAPI"
+        properties = schemas[schema_name].get("properties", {})
+        assert "allowed_scenarios" in properties, f"{schema_name} missing allowed_scenarios"
+
+    parameters = spec["paths"]["/api/v2/models"]["get"].get("parameters", [])
+    assert any(parameter.get("name") == "scenario" for parameter in parameters)
+    assert any(parameter.get("name") == "capability" for parameter in parameters)
+
+
+def test_allowed_scenarios_default_by_capability():
+    assert default_allowed_scenarios(ModelCapability.CHAT) == [
+        ModelUseScenario.AGENT_CHAT,
+        ModelUseScenario.COLLECTION_COMPLETION,
+        ModelUseScenario.BACKGROUND_TASK,
+    ]
+    assert default_allowed_scenarios(ModelCapability.EMBEDDING) == [
+        ModelUseScenario.COLLECTION_EMBEDDING,
+    ]
+    assert default_allowed_scenarios(ModelCapability.RERANK) == [
+        ModelUseScenario.RETRIEVAL_RERANK,
+    ]
+
+
+def test_allowed_scenarios_missing_key_uses_default_but_empty_list_is_explicit():
+    model_without_key = SimpleNamespace(capability=ModelCapability.CHAT, extra={"owner": "kept"})
+    model_with_empty_allowlist = SimpleNamespace(
+        capability=ModelCapability.CHAT,
+        extra={"allowed_scenarios": []},
+    )
+
+    assert allowed_scenarios_for_model(model_without_key) == [
+        ModelUseScenario.AGENT_CHAT,
+        ModelUseScenario.COLLECTION_COMPLETION,
+        ModelUseScenario.BACKGROUND_TASK,
+    ]
+    assert allowed_scenarios_for_model(model_with_empty_allowlist) == []
+
+
+def test_model_create_and_update_accept_allowed_scenarios_without_extra_coupling():
+    create = ModelCreate(
+        account_id="acct_1",
+        provider_model_id="qwen/qwen3-30b-a3b-instruct-2507",
+        display_name="Qwen3 30B",
+        capability=ModelCapability.CHAT,
+        allowed_scenarios=[ModelUseScenario.COLLECTION_COMPLETION],
+    )
+    update = ModelUpdate(allowed_scenarios=[ModelUseScenario.BACKGROUND_TASK])
+
+    assert create.model_dump()["allowed_scenarios"] == [ModelUseScenario.COLLECTION_COMPLETION]
+    assert update.model_dump(exclude_unset=True)["allowed_scenarios"] == [ModelUseScenario.BACKGROUND_TASK]
+    assert "allowed_scenarios" not in create.extra
+
+
+def test_allowed_scenarios_patch_preserves_other_extra_keys():
+    extra = _model_extra_with_allowed_scenarios(
+        {"owner": "ops", "notes": {"tier": "prod"}},
+        ModelCapability.CHAT,
+        [ModelUseScenario.COLLECTION_COMPLETION],
+    )
+
+    assert extra["owner"] == "ops"
+    assert extra["notes"] == {"tier": "prod"}
+    assert extra["allowed_scenarios"] == [ModelUseScenario.COLLECTION_COMPLETION.value]

--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -232,7 +232,7 @@ def test_provider_feature_uses_v2_typed_api_boundary():
 
     Migrates `components/providers/bot-provider.tsx` off the legacy
     `apiClient.defaultApi.availableModelsPost` + `ModelSpec from '@/api'` and
-    onto the existing `features/providers/*` adapter (`getAvailableModels` +
+    onto the existing `features/providers/*` adapter (`getScenarioModels` +
     `ModelSpec` from `@/features/providers/types`). The `features/providers`
     adapter was migrated in an earlier phase to the typed
     `/api/v2/providers/*` surface, so this batch only swaps the caller and
@@ -293,7 +293,8 @@ def test_provider_feature_uses_v2_typed_api_boundary():
     bot_provider = sources[REPO_ROOT / "web/src/components/providers/bot-provider.tsx"]
     assert "from '@/features/providers/client-api'" in bot_provider
     assert "from '@/features/providers/types'" in bot_provider
-    assert "getAvailableModels(" in bot_provider
+    assert "getScenarioModels(" in bot_provider
+    assert "getAvailableModels(" not in joined
 
 
 def test_prompt_feature_uses_v2_typed_api_boundary():
@@ -628,7 +629,7 @@ def test_collection_feature_uses_v2_typed_api_boundary():
     # #4 batch 5 additions: the collection-form provider call and the
     # export-dialog task calls must be gone from the four migrated
     # callers. `@/api` is banned across the migrated call-sites; the
-    # `features/providers::getAvailableModels` cross-domain adapter call
+    # `features/providers::getScenarioModels` cross-domain adapter call
     # is allowed and is not what these negative assertions target.
     form_tsx = sources[REPO_ROOT / "web/src/app/workspace/collections/collection-form.tsx"]
     list_tsx = sources[REPO_ROOT / "web/src/app/workspace/collections/collection-list.tsx"]

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -5020,6 +5020,8 @@ export interface components {
              * @enum {string}
              */
             status: "ACTIVE" | "INACTIVE";
+            /** Allowed Scenarios */
+            allowed_scenarios?: components["schemas"]["ModelUseScenario"][];
             /** Extra */
             extra?: {
                 [key: string]: unknown;
@@ -5157,6 +5159,8 @@ export interface components {
              * @default false
              */
             supports_multimodal_embedding: boolean;
+            /** Allowed Scenarios */
+            allowed_scenarios?: components["schemas"]["ModelUseScenario"][] | null;
             /** Extra */
             extra?: {
                 [key: string]: unknown;
@@ -5370,6 +5374,8 @@ export interface components {
             supports_multimodal_embedding?: boolean | null;
             /** Status */
             status?: ("ACTIVE" | "INACTIVE") | null;
+            /** Allowed Scenarios */
+            allowed_scenarios?: components["schemas"]["ModelUseScenario"][] | null;
             /** Extra */
             extra?: {
                 [key: string]: unknown;
@@ -10931,6 +10937,8 @@ export interface operations {
     model_platform_list_model_account_models_view: {
         parameters: {
             query?: {
+                capability?: components["schemas"]["ModelCapability"] | null;
+                scenario?: components["schemas"]["ModelUseScenario"] | null;
                 engine?: unknown;
             };
             header?: never;
@@ -10964,6 +10972,8 @@ export interface operations {
     model_platform_list_models_view: {
         parameters: {
             query?: {
+                capability?: components["schemas"]["ModelCapability"] | null;
+                scenario?: components["schemas"]["ModelUseScenario"] | null;
                 engine?: unknown;
             };
             header?: never;

--- a/web/src/app/workspace/collections/collection-form.tsx
+++ b/web/src/app/workspace/collections/collection-form.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-import {
-  TITLE_LANGUAGES,
-  type TitleLanguage,
-} from '@/features/collection/types';
-import type { ModelSpec } from '@/features/providers/types';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -44,11 +39,16 @@ import {
   regenCollectionSummary,
   updateCollection,
 } from '@/features/collection/client-api';
-import { getAvailableModels } from '@/features/providers/client-api';
+import {
+  TITLE_LANGUAGES,
+  type TitleLanguage,
+} from '@/features/collection/types';
+import { getScenarioModels } from '@/features/providers/client-api';
+import type { ModelSpec } from '@/features/providers/types';
 import { cn, objectKeys } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft, Database, Sparkles } from 'lucide-react';
 import _ from 'lodash';
+import { ArrowLeft, Database, Sparkles } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -60,6 +60,16 @@ import { isVisibleCollectionConfigKey } from './feature-visibility';
 
 const modelSelectLabel = (m: ModelSpec) =>
   (m.display_name?.trim() || m.model_id || '').trim();
+
+const modelIdInGroups = (
+  groups: ProviderModel[] | undefined,
+  modelId: string | null | undefined,
+) => {
+  if (!modelId || groups === undefined) return true;
+  return groups.some((group) =>
+    group.models?.some((model) => model.model_id === modelId),
+  );
+};
 
 const collectionModelSchema = z
   .object({
@@ -108,9 +118,7 @@ const collectionSchema = z
   )
   .refine(
     ({ config }) => {
-      if (
-        config.enable_knowledge_graph
-      ) {
+      if (config.enable_knowledge_graph) {
         return !_.isEmpty(config.completion?.model_id);
       }
       return true;
@@ -203,7 +211,8 @@ const CollectionGeneratedSummary = () => {
     }
   };
 
-  const text = typeof collection?.summary === 'string' ? collection.summary : '';
+  const text =
+    typeof collection?.summary === 'string' ? collection.summary : '';
 
   return (
     <FormItem>
@@ -300,39 +309,34 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
    * set completion、embedding models used in model select component
    */
   const loadModels = useCallback(async () => {
-    const models = await getAvailableModels(['chat', 'embedding']);
-    setCompletionModels(
-      [
-        {
-          label: page_collections('completion_model'),
-          name: 'chat',
-          models: models
-            .filter((m) => m.capability === 'chat')
-            .map((m) => ({
-              model_id: m.id,
-              display_name: m.display_name,
-              temperature: 0.1,
-              tags: [],
-            })),
-        },
-      ],
-    );
-    setEmbeddingModels(
-      [
-        {
-          label: page_collections('embedding_model'),
-          name: 'embedding',
-          models: models
-            .filter((m) => m.capability === 'embedding')
-            .map((m) => ({
-              model_id: m.id,
-              display_name: m.display_name,
-              temperature: 0.1,
-              tags: [],
-            })),
-        },
-      ],
-    );
+    const [completion, embedding] = await Promise.all([
+      getScenarioModels('collection_completion'),
+      getScenarioModels('collection_embedding'),
+    ]);
+    setCompletionModels([
+      {
+        label: page_collections('completion_model'),
+        name: 'chat',
+        models: completion.map((m) => ({
+          model_id: m.id,
+          display_name: m.display_name,
+          temperature: 0.1,
+          tags: [],
+        })),
+      },
+    ]);
+    setEmbeddingModels([
+      {
+        label: page_collections('embedding_model'),
+        name: 'embedding',
+        models: embedding.map((m) => ({
+          model_id: m.id,
+          display_name: m.display_name,
+          temperature: 0.1,
+          tags: [],
+        })),
+      },
+    ]);
   }, [page_collections]);
 
   /**
@@ -340,6 +344,19 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
    */
   const handleCreateOrUpdate = useCallback(
     async (values: FormValueType) => {
+      if (
+        !modelIdInGroups(completionModels, values.config.completion?.model_id)
+      ) {
+        toast.error('当前补全模型未开放给知识库问答场景，请重新选择。');
+        return;
+      }
+      if (
+        !modelIdInGroups(embeddingModels, values.config.embedding?.model_id)
+      ) {
+        toast.error('当前向量模型未开放给文档向量场景，请重新选择。');
+        return;
+      }
+
       const payload = {
         ...values,
         config: {
@@ -364,7 +381,15 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
         }
       }
     },
-    [action, collection.id, common_tips, loadCollection, router],
+    [
+      action,
+      collection.id,
+      common_tips,
+      completionModels,
+      embeddingModels,
+      loadCollection,
+      router,
+    ],
   );
 
   /**
@@ -376,17 +401,18 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
     name: 'config.completion.model_id',
   });
   useEffect(() => {
+    if (action === 'edit') return;
     if (_.isEmpty(completionModels)) return;
 
     let defaultModel: ModelSpec | undefined;
     let currentModel: ModelSpec | undefined;
-    let defaultProvider: ProviderModel | undefined;
-    let currentProvider: ProviderModel | undefined;
     completionModels?.forEach((provider) => {
       provider.models?.forEach((m) => {
+        if (!defaultModel) {
+          defaultModel = m;
+        }
         if (m.model_id === completionModelName) {
           currentModel = m;
-          currentProvider = provider;
         }
       });
     });
@@ -395,7 +421,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
       'config.completion.model_id',
       currentModel?.model_id || defaultModel?.model_id || '',
     );
-  }, [completionModelName, completionModels, form]);
+  }, [action, completionModelName, completionModels, form]);
 
   /**
    * Watch embeddingModelName
@@ -415,14 +441,13 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
 
     let defaultModel: ModelSpec | undefined;
     let currentModel: ModelSpec | undefined;
-    let defaultProvider: ProviderModel | undefined;
-    let currentProvider: ProviderModel | undefined;
-
     embeddingModels?.forEach((provider) => {
       provider.models?.forEach((m) => {
+        if (!defaultModel) {
+          defaultModel = m;
+        }
         if (m.model_id === embeddingModelName) {
           currentModel = m;
-          currentProvider = provider;
         }
       });
     });
@@ -446,7 +471,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
           onSubmit={form.handleSubmit(handleCreateOrUpdate)}
           className="flex flex-col gap-5"
         >
-          <Card className="gap-0 overflow-hidden rounded-xl border-border/70 py-0">
+          <Card className="border-border/70 gap-0 overflow-hidden rounded-xl py-0">
             <CardHeader className="border-border/70 bg-muted/60 border-b px-5 py-4">
               <div className="flex items-start gap-3">
                 <div className="bg-accent-soft text-accent-ink flex size-10 shrink-0 items-center justify-center rounded-lg">
@@ -534,7 +559,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
             </CardContent>
           </Card>
 
-          <Card className="gap-0 overflow-hidden rounded-xl border-border/70 py-0">
+          <Card className="border-border/70 gap-0 overflow-hidden rounded-xl py-0">
             <CardHeader className="border-border/70 bg-muted/60 border-b px-5 py-4">
               <CardTitle className="text-base font-medium">
                 {page_collections('index_types')}
@@ -567,9 +592,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
                               <div className="flex items-center gap-2 leading-none font-medium">
                                 {item.title}
                                 {item.disabled && (
-                                  <Badge>
-                                    {page_collections('required')}
-                                  </Badge>
+                                  <Badge>{page_collections('required')}</Badge>
                                 )}
                               </div>
                               <p className="text-muted-foreground text-sm font-medium">
@@ -592,7 +615,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
             </CardContent>
           </Card>
 
-          <Card className="gap-0 overflow-hidden rounded-xl border-border/70 py-0">
+          <Card className="border-border/70 gap-0 overflow-hidden rounded-xl py-0">
             <CardHeader className="border-border/70 bg-muted/60 border-b px-5 py-4">
               <div className="flex items-start gap-3">
                 <div className="bg-card text-primary flex size-9 shrink-0 items-center justify-center rounded-lg border">
@@ -615,6 +638,10 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
                 name="config.embedding.model_id"
                 render={({ field }) => {
                   const embeddingLocked = action === 'edit';
+                  const modelUnavailable = !modelIdInGroups(
+                    embeddingModels,
+                    field.value,
+                  );
                   return (
                     <FormItem>
                       <FormLabel>
@@ -635,6 +662,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
                           <SelectTrigger
                             className={cn(
                               'w-full md:w-7/12',
+                              modelUnavailable && 'border-red-300',
                               embeddingLocked
                                 ? 'cursor-not-allowed opacity-70'
                                 : 'cursor-pointer',
@@ -662,13 +690,26 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
                                   </SelectGroup>
                                 );
                               })}
+                            {modelUnavailable && field.value ? (
+                              <SelectItem value={field.value} disabled>
+                                {field.value}（不允许当前场景）
+                              </SelectItem>
+                            ) : null}
                           </SelectContent>
                         </Select>
                       </FormControl>
-                      <FormDescription>
-                        {embeddingLocked
-                          ? page_collections('embedding_model_locked_description')
-                          : page_collections('embedding_model_description')}
+                      <FormDescription
+                        className={modelUnavailable ? 'text-red-600' : ''}
+                      >
+                        {modelUnavailable
+                          ? embeddingLocked
+                            ? '当前向量模型未开放给文档向量场景。向量模型在编辑页不可更换，请先到模型管理恢复该场景，或新建 collection。'
+                            : '当前向量模型未开放给文档向量场景，保存前需要更换。'
+                          : embeddingLocked
+                            ? page_collections(
+                                'embedding_model_locked_description',
+                              )
+                            : page_collections('embedding_model_description')}
                       </FormDescription>
                     </FormItem>
                   );
@@ -680,53 +721,73 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
               <FormField
                 control={form.control}
                 name="config.completion.model_id"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {page_collections('completion_model')}
-                    </FormLabel>
-                    <FormControl className="ml-auto">
-                      <Select
-                        {...field}
-                        onValueChange={field.onChange}
-                        value={field.value || ''}
+                render={({ field }) => {
+                  const modelUnavailable = !modelIdInGroups(
+                    completionModels,
+                    field.value,
+                  );
+                  return (
+                    <FormItem>
+                      <FormLabel>
+                        {page_collections('completion_model')}
+                      </FormLabel>
+                      <FormControl className="ml-auto">
+                        <Select
+                          {...field}
+                          onValueChange={field.onChange}
+                          value={field.value || ''}
+                        >
+                          <SelectTrigger
+                            className={cn(
+                              'w-full cursor-pointer md:w-7/12',
+                              modelUnavailable && 'border-red-300',
+                            )}
+                          >
+                            <SelectValue placeholder="Select a model" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {completionModels
+                              ?.filter((item) => _.size(item.models))
+                              .map((item) => {
+                                return (
+                                  <SelectGroup key={item.name}>
+                                    <SelectLabel>{item.label}</SelectLabel>
+                                    {item.models?.map((model) => {
+                                      return (
+                                        <SelectItem
+                                          key={model.model_id}
+                                          value={model.model_id || ''}
+                                        >
+                                          {modelSelectLabel(model)}
+                                        </SelectItem>
+                                      );
+                                    })}
+                                  </SelectGroup>
+                                );
+                              })}
+                            {modelUnavailable && field.value ? (
+                              <SelectItem value={field.value} disabled>
+                                {field.value}（不允许当前场景）
+                              </SelectItem>
+                            ) : null}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormDescription
+                        className={modelUnavailable ? 'text-red-600' : ''}
                       >
-                        <SelectTrigger className="w-full cursor-pointer md:w-7/12">
-                          <SelectValue placeholder="Select a model" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {completionModels
-                            ?.filter((item) => _.size(item.models))
-                            .map((item) => {
-                              return (
-                                <SelectGroup key={item.name}>
-                                  <SelectLabel>{item.label}</SelectLabel>
-                                  {item.models?.map((model) => {
-                                    return (
-                                      <SelectItem
-                                        key={model.model_id}
-                                        value={model.model_id || ''}
-                                      >
-                                        {modelSelectLabel(model)}
-                                      </SelectItem>
-                                    );
-                                  })}
-                                </SelectGroup>
-                              );
-                            })}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                    <FormDescription>
-                      {page_collections('completion_model_description')}
-                    </FormDescription>
-                  </FormItem>
-                )}
+                        {modelUnavailable
+                          ? '当前补全模型未开放给知识库问答场景，保存前需要更换。'
+                          : page_collections('completion_model_description')}
+                      </FormDescription>
+                    </FormItem>
+                  );
+                }}
               />
             </CardContent>
           </Card>
 
-          <div className="flex flex-col-reverse gap-3 border-border/70 bg-background/80 py-2 sm:flex-row sm:justify-end">
+          <div className="border-border/70 bg-background/80 flex flex-col-reverse gap-3 py-2 sm:flex-row sm:justify-end">
             {action === 'add' && (
               <Button variant="outline" asChild>
                 <Link href="/workspace/collections">

--- a/web/src/app/workspace/providers/model-platform-panel.tsx
+++ b/web/src/app/workspace/providers/model-platform-panel.tsx
@@ -11,11 +11,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { cn } from '@/lib/utils';
+import { Switch } from '@/components/ui/switch';
 import {
   createModel,
   createModelAccount,
   deleteModelAccount,
+  isModelAllowedForScenario,
+  updateModel,
   updateModelAccount,
   updateModelUse,
   validateModelAccount,
@@ -28,9 +30,10 @@ import type {
   ModelProvider,
   ModelUseScenario,
 } from '@/features/providers/types';
+import { cn } from '@/lib/utils';
 import { Loader2 } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -85,6 +88,9 @@ const scenarioMeta: Array<{
   { id: 'retrieval_rerank', label: '检索重排', capability: 'rerank' },
   { id: 'background_task', label: '后台任务', capability: 'chat' },
 ];
+
+const scenariosForCapability = (capability: ModelCapability) =>
+  scenarioMeta.filter((scenario) => scenario.capability === capability);
 
 const modelCapabilityOptions: ModelCapability[] = [
   'chat',
@@ -411,6 +417,33 @@ export function ModelPlatformPanel({ data }: { data: ModelPlatformViewModel }) {
     }
   };
 
+  const saveAllowedScenario = async (
+    model: Model,
+    scenario: ModelUseScenario,
+    checked: boolean,
+  ) => {
+    if (!model.id) return;
+    const current = new Set(model.allowed_scenarios ?? []);
+    if (checked) {
+      current.add(scenario);
+    } else {
+      current.delete(scenario);
+    }
+
+    setSaving(`scenario:${model.id}:${scenario}`);
+    try {
+      await updateModel(model.id, {
+        allowed_scenarios: Array.from(current),
+      });
+      toast.success('可用场景已更新');
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '更新失败');
+    } finally {
+      setSaving(null);
+    }
+  };
+
   if (!selectedProvider) {
     return (
       <div className="rounded-lg border bg-white p-8">
@@ -456,6 +489,7 @@ export function ModelPlatformPanel({ data }: { data: ModelPlatformViewModel }) {
               saving={saving}
               onModelFormChange={setModelForm}
               onAddModel={addModel}
+              onAllowedScenarioChange={saveAllowedScenario}
             />
           </div>
         </section>
@@ -661,6 +695,7 @@ function ModelFolder({
   saving,
   onModelFormChange,
   onAddModel,
+  onAllowedScenarioChange,
 }: {
   account: ModelAccount | undefined;
   configuredModels: Model[];
@@ -670,18 +705,29 @@ function ModelFolder({
   saving: string | null;
   onModelFormChange: (value: ModelForm) => void;
   onAddModel: (source: ModelPreset | ModelForm) => void;
+  onAllowedScenarioChange: (
+    model: Model,
+    scenario: ModelUseScenario,
+    checked: boolean,
+  ) => void;
 }) {
   return (
     <section className="grid gap-4">
       <SectionTitle title="Models" />
       <div className="overflow-hidden rounded-lg border">
-        <div className="grid grid-cols-[minmax(0,1fr)_120px_112px] border-b bg-slate-50 px-4 py-2 text-xs font-medium text-slate-500">
+        <div className="grid grid-cols-[minmax(0,1fr)_120px_minmax(220px,1fr)_112px] border-b bg-slate-50 px-4 py-2 text-xs font-medium text-slate-500">
           <span>模型</span>
           <span>能力</span>
+          <span>可用场景</span>
           <span aria-hidden />
         </div>
         {configuredModels.map((model) => (
-          <ModelRow key={model.id ?? model.provider_model_id} model={model} />
+          <ModelRow
+            key={model.id ?? model.provider_model_id}
+            model={model}
+            saving={saving}
+            onAllowedScenarioChange={onAllowedScenarioChange}
+          />
         ))}
         {presets
           .filter((preset) => !configuredModelKeys.has(presetKey(preset)))
@@ -746,9 +792,22 @@ function ModelFolder({
   );
 }
 
-function ModelRow({ model }: { model: Model }) {
+function ModelRow({
+  model,
+  saving,
+  onAllowedScenarioChange,
+}: {
+  model: Model;
+  saving: string | null;
+  onAllowedScenarioChange: (
+    model: Model,
+    scenario: ModelUseScenario,
+    checked: boolean,
+  ) => void;
+}) {
+  const scenarios = scenariosForCapability(model.capability);
   return (
-    <div className="grid grid-cols-[minmax(0,1fr)_120px_112px] items-center border-b px-4 py-3">
+    <div className="grid grid-cols-[minmax(0,1fr)_120px_minmax(220px,1fr)_112px] items-center border-b px-4 py-3">
       <div className="min-w-0">
         <div className="truncate text-sm font-medium">{model.display_name}</div>
         <div className="text-muted-foreground mt-1 truncate text-xs">
@@ -756,6 +815,31 @@ function ModelRow({ model }: { model: Model }) {
         </div>
       </div>
       <CapabilityBadge capability={model.capability} />
+      <div className="flex flex-wrap gap-3">
+        {scenarios.map((scenario) => {
+          const savingKey = `scenario:${model.id}:${scenario.id}`;
+          return (
+            <label
+              key={scenario.id}
+              className="flex items-center gap-2 text-xs text-slate-700"
+            >
+              <Switch
+                checked={Boolean(
+                  model.allowed_scenarios?.includes(scenario.id),
+                )}
+                disabled={saving !== null || !model.id}
+                onCheckedChange={(checked) =>
+                  onAllowedScenarioChange(model, scenario.id, checked)
+                }
+              />
+              <span>{scenario.label}</span>
+              {saving === savingKey ? (
+                <Loader2 className="size-3 animate-spin text-slate-400" />
+              ) : null}
+            </label>
+          );
+        })}
+      </div>
       <div aria-hidden />
     </div>
   );
@@ -773,7 +857,7 @@ function PresetRow({
   onAdd: () => void;
 }) {
   return (
-    <div className="grid grid-cols-[minmax(0,1fr)_120px_112px] items-center border-b px-4 py-3">
+    <div className="grid grid-cols-[minmax(0,1fr)_120px_minmax(220px,1fr)_112px] items-center border-b px-4 py-3">
       <div className="min-w-0">
         <div className="truncate text-sm font-medium text-slate-700">
           {preset.displayName}
@@ -783,6 +867,7 @@ function PresetRow({
         </div>
       </div>
       <CapabilityBadge capability={preset.capability} />
+      <div className="text-muted-foreground text-xs">启用后按默认场景开放</div>
       <div className="flex justify-end">
         <Button size="sm" variant="outline" disabled={disabled} onClick={onAdd}>
           {loading ? <Loader2 className="size-4 animate-spin" /> : null}
@@ -817,15 +902,22 @@ function DefaultModels({
         {scenarioMeta.map((scenario) => {
           const candidates = models.filter(
             (model): model is Model & { id: string } =>
-              model.capability === scenario.capability && Boolean(model.id),
+              Boolean(model.id) &&
+              isModelAllowedForScenario(model, scenario.id),
           );
           const value =
             uses.find((item) => item.scenario === scenario.id)
               ?.primary_model_id ?? '';
+          const selectedModel = models.find((model) => model.id === value);
+          const selectedIsInvalid =
+            Boolean(value) && !candidates.some((model) => model.id === value);
           return (
             <div
               key={scenario.id}
-              className="grid gap-2 rounded-lg border bg-white p-3"
+              className={cn(
+                'grid gap-2 rounded-lg border bg-white p-3',
+                selectedIsInvalid && 'border-red-300 bg-red-50/40',
+              )}
             >
               <div className="flex items-center justify-between gap-3">
                 <span className="text-sm font-medium">{scenario.label}</span>
@@ -838,7 +930,12 @@ function DefaultModels({
                 }
                 disabled={saving !== null || candidates.length === 0}
               >
-                <SelectTrigger className="w-full">
+                <SelectTrigger
+                  className={cn(
+                    'w-full',
+                    selectedIsInvalid && 'border-red-300',
+                  )}
+                >
                   <SelectValue
                     placeholder={
                       candidates.length ? '选择默认模型' : '暂无可用模型'
@@ -846,6 +943,11 @@ function DefaultModels({
                   />
                 </SelectTrigger>
                 <SelectContent>
+                  {selectedIsInvalid && selectedModel?.id ? (
+                    <SelectItem value={selectedModel.id} disabled>
+                      {selectedModel.display_name}（不允许当前场景）
+                    </SelectItem>
+                  ) : null}
                   {candidates.map((model) => (
                     <SelectItem key={model.id} value={model.id}>
                       {model.display_name}
@@ -853,6 +955,11 @@ function DefaultModels({
                   ))}
                 </SelectContent>
               </Select>
+              {selectedIsInvalid ? (
+                <p className="text-xs text-red-600">
+                  当前默认模型未开放给这个场景，请选择一个允许的模型后再保存。
+                </p>
+              ) : null}
             </div>
           );
         })}

--- a/web/src/components/providers/bot-provider.tsx
+++ b/web/src/components/providers/bot-provider.tsx
@@ -13,7 +13,7 @@ import {
 import type { Bot, Chat, ChatDetails } from '@/features/bot/types';
 import { listCollections } from '@/features/collection/client-api';
 import type { CollectionView } from '@/features/collection/types';
-import { getAvailableModels } from '@/features/providers/client-api';
+import { getScenarioModels } from '@/features/providers/client-api';
 import type { ModelSpec } from '@/features/providers/types';
 import { useLocale } from 'next-intl';
 import { useParams, useRouter } from 'next/navigation';
@@ -72,7 +72,7 @@ export const BotProvider = ({
 
   const loadData = useCallback(async () => {
     const [models, collectionsRes] = await Promise.all([
-      getAvailableModels(['chat']),
+      getScenarioModels('agent_chat'),
       listCollections(),
     ]);
 

--- a/web/src/features/providers/client-api.ts
+++ b/web/src/features/providers/client-api.ts
@@ -9,6 +9,7 @@ import type {
   ModelCapability,
   ModelCreateInput,
   ModelProvider,
+  ModelUpdateInput,
   ModelUse,
   ModelUseScenario,
 } from './types';
@@ -72,6 +73,14 @@ export async function createModel(input: ModelCreateInput) {
   return data;
 }
 
+export async function updateModel(modelId: string, input: ModelUpdateInput) {
+  const { data } = await browserApiClient.PUT('/api/v2/models/{model_id}', {
+    params: { path: { model_id: modelId } },
+    body: input as never,
+  });
+  return data;
+}
+
 export async function getModelUses(): Promise<ModelUse[]> {
   const { data } = await browserApiClient.GET('/api/v2/model-uses');
   return (data?.items ?? []) as ModelUse[];
@@ -99,8 +108,29 @@ export async function updateModelUse(
   return data;
 }
 
-export async function getAvailableModels(capabilities: ModelCapability[] = []) {
+const scenarioCapability: Record<ModelUseScenario, ModelCapability> = {
+  agent_chat: 'chat',
+  collection_completion: 'chat',
+  collection_embedding: 'embedding',
+  retrieval_rerank: 'rerank',
+  background_task: 'chat',
+};
+
+export function getScenarioCapability(scenario: ModelUseScenario) {
+  return scenarioCapability[scenario];
+}
+
+export function isModelAllowedForScenario(
+  model: Pick<Model, 'capability' | 'allowed_scenarios'>,
+  scenario: ModelUseScenario,
+) {
+  return (
+    model.capability === scenarioCapability[scenario] &&
+    Boolean(model.allowed_scenarios?.includes(scenario))
+  );
+}
+
+export async function getScenarioModels(scenario: ModelUseScenario) {
   const models = await getModels();
-  if (!capabilities.length) return models;
-  return models.filter((model) => capabilities.includes(model.capability));
+  return models.filter((model) => isModelAllowedForScenario(model, scenario));
 }

--- a/web/src/features/providers/types.ts
+++ b/web/src/features/providers/types.ts
@@ -35,6 +35,7 @@ export type Model = {
   supports_vision?: boolean;
   supports_tool_calling?: boolean;
   supports_multimodal_embedding?: boolean;
+  allowed_scenarios?: ModelUseScenario[];
   status?: 'ACTIVE' | 'INACTIVE';
 };
 
@@ -83,6 +84,14 @@ export type ModelCreateInput = {
   supports_vision?: boolean;
   supports_tool_calling?: boolean;
   supports_multimodal_embedding?: boolean;
+  allowed_scenarios?: ModelUseScenario[];
+};
+
+export type ModelUpdateInput = {
+  display_name?: string;
+  capability?: ModelCapability;
+  allowed_scenarios?: ModelUseScenario[];
+  status?: 'ACTIVE' | 'INACTIVE';
 };
 
 export type ModelPlatformViewModel = {


### PR DESCRIPTION
## Summary
- expose `allowed_scenarios` as a top-level model API field while storing it in `model.extra.allowed_scenarios`
- add scenario-aware model filtering in the frontend and admin toggles for model scenario availability
- validate allowed scenarios when saving model-use defaults, bot agent models, and collection model config

## Compatibility
- no DB migration; models without `extra.allowed_scenarios` use service-layer defaults by capability
- explicit empty `allowed_scenarios` means the model is not available in any scenario
- runtime invocation is intentionally not hard-blocked in this phase
- `supports_tool_calling` is not used to default or restrict Agent Chat availability

## Tests
- `uv run pytest tests/unit_test/test_model_platform_v2_contract.py tests/unit_test/test_web_typed_api_contract.py`
- `yarn type-check`
- `make openapi-check`