### PR TITLE
fix(chat): refresh agent model list without hard reload

### DIFF
--- a/tests/unit_test/test_web_typed_api_contract.py
+++ b/tests/unit_test/test_web_typed_api_contract.py
@@ -6,16 +6,22 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def test_server_typed_client_uses_api_root_not_legacy_v1_base_path():
     server_client = REPO_ROOT / "web/src/lib/api/typed/server.ts"
+    browser_client = REPO_ROOT / "web/src/lib/api/typed/browser.ts"
     env_template = REPO_ROOT / "web/deploy/env.local.template"
     configmap = REPO_ROOT / "web/deploy/yaml/configmap.yaml"
 
     server_source = server_client.read_text()
+    browser_source = browser_client.read_text()
 
     assert "API_SERVER_BASE_PATH" in env_template.read_text()
     assert "API_SERVER_BASE_PATH" in configmap.read_text()
     assert "API_SERVER_BASE_PATH" not in server_source
     assert "process.env.API_SERVER_ENDPOINT || 'http://localhost:8000'" in server_source
     assert "if (!response.ok)" in server_source
+    assert "cache: 'no-store'" in server_source
+    assert "cache: 'no-store'" in browser_source
+    assert "request.cache || 'no-store'" not in server_source
+    assert "request.cache || 'no-store'" not in browser_source
 
 
 def test_api_key_feature_uses_v2_typed_api_boundary():
@@ -294,7 +300,12 @@ def test_provider_feature_uses_v2_typed_api_boundary():
     assert "from '@/features/providers/client-api'" in bot_provider
     assert "from '@/features/providers/types'" in bot_provider
     assert "getScenarioModels(" in bot_provider
+    assert "providerModelsReload" in bot_provider
     assert "getAvailableModels(" not in joined
+
+    provider_client = sources[REPO_ROOT / "web/src/features/providers/client-api.ts"]
+    assert "getModels({ scenario })" in provider_client
+    assert "params: { query: input }" in provider_client
 
 
 def test_prompt_feature_uses_v2_typed_api_boundary():
@@ -1182,6 +1193,7 @@ def test_phase1_fe_complete_identity_auth_admin_audit_adapter_boundary():
     assert "from '@/api'" not in chat_input
     assert "apiClient.chatDocumentsApi" not in chat_input
     assert "from '@/features/bot/client-api'" in chat_input
+    assert "providerModelsReload?.()" in chat_input
     bot_client_api = (REPO_ROOT / "web/src/features/bot/client-api.ts").read_text()
     assert "uploadChatDocument" in bot_client_api
     assert "getChatDocument" in bot_client_api

--- a/web/src/components/chat/chat-input.tsx
+++ b/web/src/components/chat/chat-input.tsx
@@ -1,11 +1,3 @@
-import {
-  getChatDocument,
-  uploadChatDocument,
-} from '@/features/bot/client-api';
-import type { ChatDetails } from '@/features/bot/types';
-import type { Collection } from '@/features/collection/types';
-import type { UploadDocumentStatus } from '@/features/document/types';
-import type { ModelSpec } from '@/features/providers/types';
 import { PageContent } from '@/components/page-container';
 import { useBotContext } from '@/components/providers/bot-provider';
 import { Button } from '@/components/ui/button';
@@ -34,6 +26,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { getChatDocument, uploadChatDocument } from '@/features/bot/client-api';
+import type { ChatDetails } from '@/features/bot/types';
+import type { Collection } from '@/features/collection/types';
+import type { UploadDocumentStatus } from '@/features/document/types';
+import type { ModelSpec } from '@/features/providers/types';
 import { cn } from '@/lib/utils';
 import { useInterval } from 'ahooks';
 import { motion } from 'framer-motion';
@@ -104,7 +101,7 @@ export const ChatInput = ({
   const { mention, bot } = useBotContext();
   const [isComposing, setIsComposing] = useState<boolean>(false);
   const { open, isMobile } = useSidebar();
-  const { providerModels, collections } = useBotContext();
+  const { providerModels, providerModelsReload, collections } = useBotContext();
   const [mentionOpen, setMentionOpen] = useState<boolean>(false);
   const locale = useLocale();
   const [query, setQuery] = useState<string>('');
@@ -148,10 +145,7 @@ export const ChatInput = ({
           }
           return [...items];
         });
-        const res = await getChatDocument(
-          chatId,
-          attachment.document_id || '',
-        );
+        const res = await getChatDocument(chatId, attachment.document_id || '');
 
         setAttachments((items) => {
           const item = items.find((item) => item.id === attachment.id);
@@ -413,42 +407,44 @@ export const ChatInput = ({
           {CHAT_FILE_UPLOAD_ENABLED && (
             <div className="flex flex-wrap gap-2">
               {attachments.map((attachment) => {
-              const extension = _.last(attachment.file.type.split('/')) || '';
-              return (
-                <div
-                  key={attachment.id}
-                  className="bg-accent group hover:bg-accent/80 relative flex flex-row items-center gap-1 rounded-md border p-1 text-xs transition-colors"
-                >
-                  <div className="size-6">
-                    {['success', 'failed'].includes(
-                      attachment.progress_status,
-                    ) ? (
-                      <FileIcon
-                        color="var(--primary)"
-                        extension={extension}
-                        {..._.get(defaultStyles, extension)}
-                      />
-                    ) : (
-                      <LoaderCircle className="size-6 animate-spin opacity-50" />
-                    )}
-                  </div>
-                  <div className="flex-1">
-                    <div className="w-30 truncate">{attachment.file.name}</div>
-                    <div className="text-muted-foreground flex flex-row justify-between">
-                      <span>
-                        {(attachment.file.size / 1000).toFixed(0) + ' Kb'}
-                      </span>
-                      <span>{attachment.progress_status}</span>
+                const extension = _.last(attachment.file.type.split('/')) || '';
+                return (
+                  <div
+                    key={attachment.id}
+                    className="bg-accent group hover:bg-accent/80 relative flex flex-row items-center gap-1 rounded-md border p-1 text-xs transition-colors"
+                  >
+                    <div className="size-6">
+                      {['success', 'failed'].includes(
+                        attachment.progress_status,
+                      ) ? (
+                        <FileIcon
+                          color="var(--primary)"
+                          extension={extension}
+                          {..._.get(defaultStyles, extension)}
+                        />
+                      ) : (
+                        <LoaderCircle className="size-6 animate-spin opacity-50" />
+                      )}
+                    </div>
+                    <div className="flex-1">
+                      <div className="w-30 truncate">
+                        {attachment.file.name}
+                      </div>
+                      <div className="text-muted-foreground flex flex-row justify-between">
+                        <span>
+                          {(attachment.file.size / 1000).toFixed(0) + ' Kb'}
+                        </span>
+                        <span>{attachment.progress_status}</span>
+                      </div>
+                    </div>
+                    <div
+                      onClick={() => handleDeleteAttachment(attachment)}
+                      className="bg-accent absolute -top-2 -right-2 z-10 flex size-6 cursor-pointer flex-col justify-center rounded-full p-1 text-center opacity-0 transition-opacity group-hover:opacity-100"
+                    >
+                      <Trash2 className="m-auto size-3 text-rose-500" />
                     </div>
                   </div>
-                  <div
-                    onClick={() => handleDeleteAttachment(attachment)}
-                    className="bg-accent absolute -top-2 -right-2 z-10 flex size-6 cursor-pointer flex-col justify-center rounded-full p-1 text-center opacity-0 transition-opacity group-hover:opacity-100"
-                  >
-                    <Trash2 className="m-auto size-3 text-rose-500" />
-                  </div>
-                </div>
-              );
+                );
               })}
             </div>
           )}
@@ -579,6 +575,11 @@ export const ChatInput = ({
                   value={modelName}
                   disabled={disabled}
                   defaultValue={modelName}
+                  onOpenChange={(open) => {
+                    if (open) {
+                      providerModelsReload?.();
+                    }
+                  }}
                   onValueChange={(v) => {
                     setModelName(v);
                   }}

--- a/web/src/components/providers/bot-provider.tsx
+++ b/web/src/components/providers/bot-provider.tsx
@@ -32,6 +32,7 @@ type BotContextProps = {
   mention: boolean;
   collections: CollectionView[];
   providerModels: ProviderModels;
+  providerModelsReload?: () => Promise<void>;
   chatDelete?: (chat: Chat) => void;
   chatCreate?: () => void;
   chatsReload?: () => void;
@@ -70,12 +71,8 @@ export const BotProvider = ({
   const [providerModels, setProviderModels] = useState<ProviderModels>([]);
   const botChatsBasePath = workspace ? '/workspace/bots' : '/bots';
 
-  const loadData = useCallback(async () => {
-    const [models, collectionsRes] = await Promise.all([
-      getScenarioModels('agent_chat'),
-      listCollections(),
-    ]);
-
+  const loadProviderModels = useCallback(async () => {
+    const models = await getScenarioModels('agent_chat');
     const items: ProviderModels = [
       {
         label: 'Chat Models',
@@ -88,9 +85,17 @@ export const BotProvider = ({
         })),
       },
     ];
-    setCollections(collectionsRes?.items ?? []);
     setProviderModels(items);
   }, []);
+
+  const loadData = useCallback(async () => {
+    const [, collectionsRes] = await Promise.all([
+      loadProviderModels(),
+      listCollections(),
+    ]);
+
+    setCollections(collectionsRes?.items ?? []);
+  }, [loadProviderModels]);
 
   const botCreate = useCallback(async () => {
     const created = await createBot({
@@ -176,6 +181,7 @@ export const BotProvider = ({
         chats,
         collections,
         providerModels,
+        providerModelsReload: loadProviderModels,
         chatDelete,
         chatCreate,
         chatsReload,

--- a/web/src/features/providers/client-api.ts
+++ b/web/src/features/providers/client-api.ts
@@ -61,8 +61,13 @@ export async function validateModelAccount(accountId: string) {
   return data;
 }
 
-export async function getModels(): Promise<Model[]> {
-  const { data } = await browserApiClient.GET('/api/v2/models');
+export async function getModels(input?: {
+  capability?: ModelCapability;
+  scenario?: ModelUseScenario;
+}): Promise<Model[]> {
+  const { data } = await browserApiClient.GET('/api/v2/models', {
+    params: { query: input },
+  });
   return (data?.items ?? []) as Model[];
 }
 
@@ -131,6 +136,6 @@ export function isModelAllowedForScenario(
 }
 
 export async function getScenarioModels(scenario: ModelUseScenario) {
-  const models = await getModels();
+  const models = await getModels({ scenario });
   return models.filter((model) => isModelAllowedForScenario(model, scenario));
 }

--- a/web/src/lib/api/typed/browser.ts
+++ b/web/src/lib/api/typed/browser.ts
@@ -41,6 +41,12 @@ export function createBrowserApiClient() {
   const client = createClient<paths>({
     baseUrl: apiBaseUrl,
     credentials: 'include',
+    fetch: (request: Request) =>
+      fetch(
+        new Request(request, {
+          cache: 'no-store',
+        }),
+      ),
   });
   client.use(errorMiddleware);
   return client;

--- a/web/src/lib/api/typed/server.ts
+++ b/web/src/lib/api/typed/server.ts
@@ -18,10 +18,14 @@ function mergeHeaders(
   return headers;
 }
 
-async function serverFetch(request: Request, cookieHeader: string, lang: string) {
+async function serverFetch(
+  request: Request,
+  cookieHeader: string,
+  lang: string,
+) {
   const response = await fetch(
     new Request(request, {
-      cache: request.cache || 'no-store',
+      cache: 'no-store',
       headers: mergeHeaders(request.headers, {
         Cookie: cookieHeader,
         Lang: lang,


### PR DESCRIPTION
## Summary
- make typed server/browser API clients explicitly use `cache: 'no-store'`
- refresh Agent Chat model candidates when the model select opens, so disabled LLMs disappear without a hard browser refresh
- use backend `?scenario=agent_chat` filtering in `getScenarioModels`

## Tests
- `yarn type-check`
- `uv run pytest tests/unit_test/test_web_typed_api_contract.py`
- pre-commit `make lint`