### PR TITLE
task #17: indexing runtime hard cut (协作 PR — 团队多人编辑)

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -267,32 +267,31 @@ async def combined_lifespan(app: FastAPI):
     deployment topology. Tier-3 horizontal scale-out runs separate
     worker processes; that wiring lives in a future ops launcher.
     """
-    indexing_runtime_tasks: list[asyncio.Task[None]] = []
-    indexing_shutdown: asyncio.Event | None = None
+    # task #17 (PR #1884) hard cut: API 进程不再启动 worker / reconciler /
+    # cleanup task — 这些迁到独立 ``indexing-worker`` deployment 跑
+    # ``python -m aperag.cli.indexing_worker``. API 只保留 queue / quota /
+    # metrics 给 enqueue 用, 不需要 ``indexing_runtime_tasks`` /
+    # ``indexing_shutdown`` event 了.
 
     if settings.indexing_mode == "async":
         # Lazy imports — pulling the indexing runtime symbols at app
         # start-up time keeps ``aperag/app.py`` cold-start fast and
         # confines the import surface to the wired branch.
+        # task #17 (PR #1884): API 进程不再启动任何 indexing worker /
+        # reconciler / cleanup loop — 改由独立 ``indexing-worker``
+        # deployment 跑 ``python -m aperag.cli.indexing_worker``. API
+        # 只保留轻量 enqueue runtime (queue + quota_backend + metrics +
+        # IndexingRuntime), 不构造 ProductionWorkerFactory, 不创建
+        # worker / reconciler / cleanup task. 见
+        # ``docs/zh-CN/architecture/task-system-hard-cut-v8.md``.
         from aperag.config import sync_engine
         from aperag.indexing import (
             InMemoryWorkQueue,
             NoopMetricsEmitter,
             OTLPMetricsEmitter,
             RedisWorkQueue,
-            run_cleanup_loop,
-            run_fulltext_worker,
-            run_graph_facts_worker,
-            run_graph_vectors_worker,
-            run_graph_worker,
-            run_parse_worker,
-            run_reconcile_loop,
-            run_summary_worker,
-            run_vector_worker,
-            run_vision_worker,
         )
 
-        indexing_shutdown = asyncio.Event()
         # Wave 4 T4: dispatch on ``INDEXING_QUEUE_BACKEND`` setting
         # (default ``inmemory`` for backward-compat single-pod
         # deployments; production multi-pod sets ``redis`` to enable
@@ -373,87 +372,20 @@ async def combined_lifespan(app: FastAPI):
             quota_redis = None
             quota_backend = InMemoryQuotaBackend(quota_registry)
 
-        # Worker factory — per-task lazy construction. The async
-        # worker entrypoints (``run_*_worker``) call this closure on
-        # every BLPOP'd payload to materialise the concrete
-        # :class:`ModalityWorker` for that ``(collection, modality)``
-        # pair. ``ProductionWorkerFactory`` resolves the collection
-        # row, picks the right backend (Qdrant / Elasticsearch +
-        # configured embedder / completion model), and constructs the
-        # worker — all backed by the existing build helpers
-        # (``get_collection_embedding_service_sync`` /
-        # ``get_vector_db_connector`` / ``get_object_store``) so this
-        # is composition, not re-implementation. Construction failures
-        # raise :class:`WorkerFactoryError`; the orchestrator runner
-        # catches that and finalises the row FAILED so §I.2 retry
-        # picks it up. Per architect msg=7782ebe0.
-        from aperag.indexing.worker_factory import ProductionWorkerFactory
-
-        worker_factory = ProductionWorkerFactory(engine=engine)
-
-        worker_kwargs = dict(
-            engine=engine,
-            queue=queue,
-            worker_factory=worker_factory,
-            shutdown=indexing_shutdown,
-        )
-        indexing_runtime_tasks.append(asyncio.create_task(run_vector_worker(**worker_kwargs)))
-        indexing_runtime_tasks.append(asyncio.create_task(run_fulltext_worker(**worker_kwargs)))
-        indexing_runtime_tasks.append(asyncio.create_task(run_graph_worker(**worker_kwargs)))
-        indexing_runtime_tasks.append(asyncio.create_task(run_graph_facts_worker(**worker_kwargs)))
-        indexing_runtime_tasks.append(asyncio.create_task(run_graph_vectors_worker(**worker_kwargs)))
-        indexing_runtime_tasks.append(asyncio.create_task(run_summary_worker(**worker_kwargs)))
-        indexing_runtime_tasks.append(asyncio.create_task(run_vision_worker(**worker_kwargs)))
-
-        # Wave 4 T3 chunk 2: parse worker reads ``q:parse``, runs
-        # :class:`DocParser`, and dispatches the per-modality jobs.
-        # Without this, the upload handler's :func:`push_parse` call
-        # would land in Redis with no consumer — the per-modality
-        # rows would never get inserted and documents would stay
-        # PENDING forever. The object store factory is async per the
-        # production resolver signature; this closure adapts the
-        # synchronous ``get_object_store`` helper into the
-        # ``ObjectStoreFactory`` shape :func:`run_parse_worker`
-        # expects.
-        from aperag.objectstore.base import get_object_store
-
-        async def _resolve_object_store():
-            return await asyncio.to_thread(get_object_store)
-
-        indexing_runtime_tasks.append(
-            asyncio.create_task(
-                run_parse_worker(
-                    engine=engine,
-                    queue=queue,
-                    object_store_factory=_resolve_object_store,
-                    shutdown=indexing_shutdown,
-                )
-            )
-        )
-        indexing_runtime_tasks.append(
-            asyncio.create_task(
-                run_reconcile_loop(
-                    engine=engine,
-                    queue=queue,
-                    shutdown=indexing_shutdown,
-                )
-            )
-        )
-        # Wave 4 T2: cleanup loop now consumes a per-row worker
-        # factory so each ``DocumentIndex`` row is cleaned against the
-        # right per-(collection, modality) backend. Without this the
-        # cleanup loop ran with ``workers={}`` and silently skipped
-        # every backend delete (Qdrant points / ES docs / graph
-        # entities leaked forever after document or collection delete).
-        indexing_runtime_tasks.append(
-            asyncio.create_task(
-                run_cleanup_loop(
-                    engine=engine,
-                    worker_factory=worker_factory.build_for_cleanup_row,
-                    shutdown=indexing_shutdown,
-                )
-            )
-        )
+        # task #17 (PR #1884) hard cut: API 进程不再构造 ProductionWorkerFactory
+        # 也不启动 worker / reconciler / cleanup task. 这些都迁到独立
+        # ``indexing-worker`` deployment (``python -m aperag.cli.indexing_worker``).
+        # API 只保留轻量 enqueue runtime: queue (push to broker) +
+        # quota_backend (检查租户配额) + metrics_emitter (上报 SLI).
+        #
+        # cleanup_worker_factory 之前由 ``ProductionWorkerFactory.build_for_cleanup_row``
+        # 提供给 IndexingRuntime, 让 service 层能在 API 请求路径直接执行
+        # backend cleanup. task #17 hard gate (ziang msg=cecb0d88 + huangheng
+        # msg=f97b7c5f #6) 显式禁止 API 请求路径执行重型 cleanup — 改成只
+        # 标记 DB intent (``Document.status=DELETED + gmt_deleted``), worker
+        # cleanup loop 异步扫描完成. 因此 API 这里 ``cleanup_worker_factory=None``,
+        # service 层调 cleanup 必须返回 no-op (由 task #19 ziang 的 cleanup
+        # SoT 改造保证).
 
         # Stash on app state so request handlers can dispatch via the
         # same queue / engine the workers consume.
@@ -469,9 +401,9 @@ async def combined_lifespan(app: FastAPI):
 
         # Service-layer callers (aperag/domains/**) consume the same
         # triple through the process-wide IndexingRuntime singleton —
-        # they don't have a Request handle for app.state. Workers map
-        # is empty in the async-default deployment; T3.3 follow-up
-        # populates concrete factories per modality.
+        # they don't have a Request handle for app.state.
+        # task #17: workers={} 已经是空; cleanup_worker_factory=None 强制
+        # service 层不再在 API 请求路径执行重型 backend cleanup.
         from aperag.indexing.runtime import IndexingRuntime, set_runtime
 
         set_runtime(
@@ -480,7 +412,7 @@ async def combined_lifespan(app: FastAPI):
                 queue=queue,
                 workers={},
                 metrics_emitter=metrics_emitter,
-                cleanup_worker_factory=worker_factory.build_for_cleanup_row,
+                cleanup_worker_factory=None,
                 quota_backend=quota_backend,
             )
         )
@@ -496,12 +428,11 @@ async def combined_lifespan(app: FastAPI):
         async with mcp_app.lifespan(app):
             yield
     finally:
-        if indexing_shutdown is not None:
-            indexing_shutdown.set()
-        if indexing_runtime_tasks:
-            # Drain in-flight worker / reconciler / cleanup loops with
-            # a short grace window so a SIGTERM does not abort mid-task.
-            await asyncio.gather(*indexing_runtime_tasks, return_exceptions=True)
+        # task #17 hard cut: API 进程没有 worker / reconciler / cleanup task
+        # 需要 drain — 这些都在独立 ``indexing-worker`` pod, 由它的
+        # ``aperag/cli/indexing_worker.py`` 自己 SIGTERM handler 处理.
+        # API 这里只关 queue + quota redis client + metrics provider.
+
         # Wave 4 T4: release the indexing queue's underlying connection
         # pool (Redis client owns one); InMemoryWorkQueue has no
         # ``close`` so guard with hasattr.

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -92,6 +92,7 @@ from aperag.exception_handlers import register_exception_handlers
 from aperag.llm.litellm_track import register_custom_llm_track
 from aperag.mcp import mcp_server
 from aperag.openapi_spec import custom_generate_unique_id
+from aperag.server.health import router as health_router
 from aperag.service.quota_service import quota_service as _legacy_quota_service
 from aperag.service.search_pipeline_service import search_pipeline_service as _legacy_search_pipeline_service
 
@@ -495,13 +496,7 @@ register_exception_handlers(app)
 register_custom_llm_track()
 
 
-# Health check endpoint
-@app.get("/health")
-async def health_check():
-    """Simple health check endpoint for container health monitoring"""
-    return {"status": "healthy", "service": "aperag-api"}
-
-
+app.include_router(health_router)
 app.include_router(auth_router, prefix="/api/v2/auth")
 app.include_router(export_router, prefix="/api/v2")  # KB-domain export router (Phase 8 #47 G1, D7 v2 hard-cut)
 app.include_router(audit_router, prefix="/api/v2")  # Governance: audit-logs (hard-cut to v2 in #50)

--- a/aperag/app.py
+++ b/aperag/app.py
@@ -496,7 +496,7 @@ register_exception_handlers(app)
 register_custom_llm_track()
 
 
-app.include_router(health_router)
+app.include_router(health_router, prefix="/health")
 app.include_router(auth_router, prefix="/api/v2/auth")
 app.include_router(export_router, prefix="/api/v2")  # KB-domain export router (Phase 8 #47 G1, D7 v2 hard-cut)
 app.include_router(audit_router, prefix="/api/v2")  # Governance: audit-logs (hard-cut to v2 in #50)

--- a/aperag/cli/__init__.py
+++ b/aperag/cli/__init__.py
@@ -1,0 +1,5 @@
+"""ApeRAG CLI 子命令.
+
+task #17 部署架构 hard cut: ``aperag.cli.indexing_worker`` 启动独立
+indexing worker 进程, API pod 不再启动 worker / reconciler / cleanup loop.
+"""

--- a/aperag/cli/indexing_worker.py
+++ b/aperag/cli/indexing_worker.py
@@ -1,0 +1,189 @@
+"""task #17 (PR #1884): 独立 indexing worker 进程入口.
+
+ApeRAG 部署架构 hard cut. ``aperag/app.py`` lifespan 不再启动任何
+indexing worker / reconciler / cleanup loop. 取而代之, ``indexing-worker``
+deployment 跑这个 CLI, 进程内启动跟原 lifespan 等价的 10 个 asyncio
+后台任务 (7 modality worker + parse + reconciler + cleanup).
+
+为什么拆 deployment:
+* 新加坡 503 根因 (huangzhangshu task #13 + msg=b3bf4733): API + 重型
+  indexing worker 共进程, graph 索引压力把 ``/health`` / 事件循环 / 线程池
+  / DB 连接池一起拖死, kubelet 杀 pod, ALB 503.
+* hard cut 拆开后: API pod 只做 HTTP 路由 + 轻量入队, 不再受 worker 资源
+  压力影响; ``/health/live`` / ``/health/ready`` 永远稳定.
+* DocumentIndex 仍是业务状态真源, RedisWorkQueue 跨进程 transport, 跟
+  既有 reconciler 5-stage / RedisQuotaBackend 完全兼容 (per ziang
+  msg=5eedb951 代码审计).
+
+跟 ``aperag/app.py`` 老 lifespan 行为完全等价 — 选 queue / quota / metrics
+emitter 的 dispatch 逻辑跟 app.py 同款, 只是搬到独立进程, 不引入新概念.
+
+启动: ``python -m aperag.cli.indexing_worker`` (Helm
+``indexing-worker-deployment.yaml`` 的 args).
+
+退出: SIGTERM / SIGINT 触发 graceful shutdown — 等所有 in-flight 任务
+drain 完, 关闭 RedisWorkQueue / quota redis, 退出.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import signal
+
+# ziang msg=4ea65100 #1: 用现有 module-level ``settings``, 不引 ``get_settings()`` helper.
+from aperag.config import settings, sync_engine
+from aperag.indexing import (
+    InMemoryWorkQueue,
+    NoopMetricsEmitter,
+    OTLPMetricsEmitter,
+    RedisWorkQueue,
+    run_cleanup_loop,
+    run_fulltext_worker,
+    run_graph_facts_worker,
+    run_graph_vectors_worker,
+    run_graph_worker,
+    run_parse_worker,
+    run_reconcile_loop,
+    run_summary_worker,
+    run_vector_worker,
+    run_vision_worker,
+)
+
+# ziang #1: ``ProductionWorkerFactory`` 从 ``aperag.indexing.worker_factory`` 直接 import,
+# 不通过 ``aperag.indexing`` 间接 (跟 app.py 现有写法一致).
+from aperag.indexing.quota import (
+    InMemoryQuotaBackend,
+    QuotaPolicyRegistry,
+    RedisQuotaBackend,
+)
+from aperag.indexing.worker_factory import ProductionWorkerFactory
+from aperag.objectstore.base import get_object_store
+
+logger = logging.getLogger(__name__)
+
+
+async def _amain() -> None:
+    """worker 主循环.
+
+    跟 ``aperag/app.py`` lifespan 老路径行为完全等价: 选 queue / quota /
+    metrics emitter 的 dispatch 逻辑相同; 启动 7 modality worker + parse +
+    reconciler + cleanup 共 10 个 asyncio 后台任务; SIGTERM 时优雅退出.
+    """
+    shutdown = asyncio.Event()
+
+    # SIGTERM / SIGINT 优雅退出. kubelet 默认 30s grace period.
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, shutdown.set)
+
+    # ziang msg=4ea65100 #2 + 跟 app.py 现有写法一致: ``QuotaPolicyRegistry``
+    # 直接构造, ``RedisQuotaBackend(quota_redis, quota_registry)`` /
+    # ``InMemoryQuotaBackend(quota_registry)``.
+    quota_registry = QuotaPolicyRegistry()
+    quota_redis = None
+
+    # 选 queue (生产 redis, dev inmemory). 跟 app.py 同款 dispatch.
+    if settings.indexing_queue_backend.lower() == "redis":
+        queue = RedisWorkQueue(redis_url=settings.indexing_queue_redis_url)
+    else:
+        queue = InMemoryWorkQueue()
+
+    # 选 quota backend (生产 redis 跨副本共享 token bucket, dev inmemory).
+    if settings.indexing_quota_backend.lower() == "redis":
+        from redis import asyncio as redis_asyncio
+
+        quota_redis = redis_asyncio.from_url(
+            settings.indexing_quota_redis_url,
+            encoding="utf-8",
+            decode_responses=False,
+        )
+        quota_backend = RedisQuotaBackend(quota_redis, quota_registry)
+    else:
+        quota_backend = InMemoryQuotaBackend(quota_registry)
+    del quota_backend  # 当前 worker entrypoint 不直接消费 quota_backend, 但保留引用让 redis 不被 close.
+
+    # 选 metrics emitter (生产 OTLP, dev noop).
+    if settings.indexing_metrics_emitter.lower() == "otlp":
+        metrics_emitter = OTLPMetricsEmitter()
+    else:
+        metrics_emitter = NoopMetricsEmitter()
+    del metrics_emitter  # 同上, 跟 app.py 一致语义.
+
+    # ProductionWorkerFactory: per-task 懒构造. worker entrypoint 在 BLPOP 出
+    # payload 后调用, 按 (collection_id, modality) 构造 ModalityWorker.
+    worker_factory = ProductionWorkerFactory(engine=sync_engine)
+    worker_kwargs = dict(
+        engine=sync_engine,
+        queue=queue,
+        worker_factory=worker_factory,
+        shutdown=shutdown,
+    )
+
+    async def _resolve_object_store():
+        """sync ``get_object_store`` 的 async wrapper, 跟 app.py 行为一致."""
+        return await asyncio.to_thread(get_object_store)
+
+    # 启动 10 个后台任务. 顺序跟 app.py lifespan 一致 (per ziang msg=7ff9efd7
+    # #4 含 legacy graph lane).
+    tasks: list[asyncio.Task[None]] = [
+        asyncio.create_task(run_vector_worker(**worker_kwargs)),
+        asyncio.create_task(run_fulltext_worker(**worker_kwargs)),
+        # legacy ``graph`` lane 兼容期保留 (PR #1871 §4.5 老 GRAPH 模态行
+        # 不会自动迁移到 graph_facts/graph_vectors). 删除留给单独 spec.
+        asyncio.create_task(run_graph_worker(**worker_kwargs)),
+        asyncio.create_task(run_graph_facts_worker(**worker_kwargs)),
+        asyncio.create_task(run_graph_vectors_worker(**worker_kwargs)),
+        asyncio.create_task(run_summary_worker(**worker_kwargs)),
+        asyncio.create_task(run_vision_worker(**worker_kwargs)),
+        asyncio.create_task(
+            run_parse_worker(
+                engine=sync_engine,
+                queue=queue,
+                object_store_factory=_resolve_object_store,
+                shutdown=shutdown,
+            ),
+        ),
+        asyncio.create_task(
+            run_reconcile_loop(engine=sync_engine, queue=queue, shutdown=shutdown),
+        ),
+        asyncio.create_task(
+            run_cleanup_loop(
+                engine=sync_engine,
+                worker_factory=worker_factory.build_for_cleanup_row,
+                shutdown=shutdown,
+            ),
+        ),
+    ]
+
+    logger.info(
+        "indexing-worker started: 10 tasks (vector/fulltext/graph/graph_facts/"
+        "graph_vectors/summary/vision/parse/reconciler/cleanup)"
+    )
+
+    await shutdown.wait()
+    logger.info("indexing-worker shutdown signal received, draining %d tasks...", len(tasks))
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+    # 关闭 RedisWorkQueue / quota redis. 失败 swallow (跟 app.py 同样模式).
+    if hasattr(queue, "close"):
+        with contextlib.suppress(Exception):
+            await queue.close()
+    if quota_redis is not None:
+        with contextlib.suppress(Exception):
+            await quota_redis.aclose()
+    logger.info("indexing-worker shutdown complete")
+
+
+def main() -> None:
+    """``python -m aperag.cli.indexing_worker`` sync entrypoint."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    asyncio.run(_amain())
+
+
+if __name__ == "__main__":
+    main()

--- a/aperag/cli/indexing_worker.py
+++ b/aperag/cli/indexing_worker.py
@@ -60,6 +60,7 @@ from aperag.indexing.quota import (
 )
 from aperag.indexing.worker_factory import ProductionWorkerFactory
 from aperag.objectstore.base import get_object_store
+from aperag.observability.metrics import shutdown_metrics_provider
 
 logger = logging.getLogger(__name__)
 
@@ -102,14 +103,17 @@ async def _amain() -> None:
         quota_backend = RedisQuotaBackend(quota_redis, quota_registry)
     else:
         quota_backend = InMemoryQuotaBackend(quota_registry)
-    del quota_backend  # 当前 worker entrypoint 不直接消费 quota_backend, 但保留引用让 redis 不被 close.
+    # quota_backend / metrics_emitter 当前 worker entrypoint 不直接 acquire (跟 app.py
+    # 现状一致, 真正 acquire 接线点是 task #24). 保留构造让 quota_redis 引用不被
+    # 提前回收, 也保证 OTLP MeterProvider 在 worker 启动时就 install.
+    _ = quota_backend
 
     # 选 metrics emitter (生产 OTLP, dev noop).
     if settings.indexing_metrics_emitter.lower() == "otlp":
         metrics_emitter = OTLPMetricsEmitter()
     else:
         metrics_emitter = NoopMetricsEmitter()
-    del metrics_emitter  # 同上, 跟 app.py 一致语义.
+    _ = metrics_emitter
 
     # ProductionWorkerFactory: per-task 懒构造. worker entrypoint 在 BLPOP 出
     # payload 后调用, 按 (collection_id, modality) 构造 ModalityWorker.
@@ -164,7 +168,26 @@ async def _amain() -> None:
 
     await shutdown.wait()
     logger.info("indexing-worker shutdown signal received, draining %d tasks...", len(tasks))
-    await asyncio.gather(*tasks, return_exceptions=True)
+
+    # cuiwenbo msg=f7868d2c #3 + Weston msg=ce324047 #2: 给 graceful drain 设 25s 上限
+    # (kubelet 默认 30s grace), 超时强制 cancel, 避免某个 worker 不响应 shutdown
+    # event 时挂到 SIGKILL 丢 in-flight 状态.
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*tasks, return_exceptions=True),
+            timeout=25.0,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("indexing-worker shutdown timeout after 25s, cancelling %d tasks", len(tasks))
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    # cuiwenbo msg=f7868d2c #2 + Weston msg=ce324047 #1: flush OTLP MeterProvider,
+    # 否则 PeriodicExportingMetricReader 残留样本会随 worker 退出丢失 (跟 app.py
+    # finally 段调 shutdown_metrics_provider 等价).
+    with contextlib.suppress(Exception):
+        await asyncio.to_thread(shutdown_metrics_provider)
 
     # 关闭 RedisWorkQueue / quota redis. 失败 swallow (跟 app.py 同样模式).
     if hasattr(queue, "close"):

--- a/aperag/domains/knowledge_base/service/document_service.py
+++ b/aperag/domains/knowledge_base/service/document_service.py
@@ -276,34 +276,6 @@ async def _resolve_parser_config_for_collection(collection_id: str, session: Asy
     return parser_config
 
 
-async def _delete_document_indexes(*, document_id: str) -> None:
-    """Replacement for legacy ``document_index_manager.
-    delete_document_indexes``.
-
-    Wave 3 T3.1 chunk 3: routes to
-    :func:`aperag.indexing.cleanup.cleanup_for_deleted_documents` which
-    handles the modality fan-out (graph lineage cleanup vs flat
-    backend delete) + DELETEs the ``document_index`` rows.
-    """
-    from aperag.indexing.cleanup import cleanup_for_deleted_documents
-    from aperag.indexing.runtime import get_runtime
-
-    runtime = get_runtime()
-    if runtime is None:
-        logger.warning(
-            "_delete_document_indexes(document=%s): IndexingRuntime not installed; skipping cleanup",
-            document_id,
-        )
-        return
-
-    await cleanup_for_deleted_documents(
-        engine=runtime.engine,
-        workers=runtime.workers,
-        worker_factory=runtime.cleanup_worker_factory,
-        document_ids=[document_id],
-    )
-
-
 def _trigger_index_reconciliation():
     """No-op — Wave 3 T3.1 chunk 3.
 
@@ -920,24 +892,36 @@ class DocumentService:
             logger.warning(f"Document {document_id} not found for deletion, skipping.")
             return
 
-        # Cleanup all per-modality index rows + backend state (Wave 3
-        # T3.1 chunk 3: routes to ``aperag.indexing.cleanup.
-        # cleanup_for_deleted_documents`` which handles the modality
-        # fan-out + DELETEs the ``document_index`` rows).
-        await _delete_document_indexes(document_id=document.id)
+        # task #17 (PR #1884) hard gate (ziang msg=cecb0d88 + huangheng
+        # msg=f97b7c5f #6 + Weston msg=4e74f4f4 BLOCKER 4):
+        # **API 请求路径不能直接执行重型 cleanup**.
+        #
+        # 老代码 (Wave 3 T3.1) 在这里同步调:
+        #   1. ``cleanup_for_deleted_documents()`` — graph lineage 清理 +
+        #      Qdrant/ES/Neo4j 后端 delete + DocumentIndex 行删除
+        #   2. ``async_obj_store.delete_objects_by_prefix()`` — 对象存储
+        #      整个文档 prefix 下所有文件 (original / chunks / kg.jsonl /
+        #      summary / vision artifact)
+        # 这两条路径都是重型 IO (Qdrant 删点 / ES delete-by-query / Neo4j
+        # cypher / S3 list+delete), 在 API 请求路径上同步跑会:
+        # - 占用 API 进程的 DB 连接池 + 事件循环 + 线程池, 跟 graph 索引
+        #   worker 共进程时把 ``/health`` 一起拖死 (新加坡 503 同根)
+        # - rollout 时新 API 还在做删除, 老 API 已经收到 SIGTERM
+        # - object store provider 慢/超时把 API 删除请求一起拖慢
+        #
+        # 修法: API 只**标记 DB intent** (``Document.status=DELETED`` +
+        # ``gmt_deleted``); 重型 cleanup (含 object store prefix delete)
+        # 由独立 ``indexing-worker`` deployment 的 cleanup loop 异步
+        # 扫描 ``Document.status=DELETED + DocumentIndex rows`` 自动跑.
+        #
+        # cleanup intent 真源 = DB (per ziang msg=cecb0d88: Redis 队列只是
+        # 可丢 transport, 丢消息时 cleanup loop 仍能从 DB 补回来).
+        #
+        # 异步 cleanup 实施在 task #19 (@ziang) 的 ``aperag/indexing/cleanup.py``
+        # 加 deleted Document scan + ``tests/boundaries/test_api_no_cleanup.py``
+        # grep CI gate.
 
-        # Delete from object store
-        async_obj_store = get_async_object_store()
-        metadata = json.loads(document.doc_metadata) if document.doc_metadata else {}
-        if metadata.get("object_path"):
-            try:
-                # Use delete_objects_by_prefix to remove all related files (original, chunks, etc.)
-                await async_obj_store.delete_objects_by_prefix(document.object_store_base_path())
-                logger.info(f"Deleted objects from object store with prefix: {document.object_store_base_path()}")
-            except Exception as e:
-                logger.warning(f"Failed to delete objects for document {document.id} from object store: {e}")
-
-        # Mark document as deleted
+        # Mark document as deleted (durable cleanup intent in DB).
         document.status = DocumentStatus.DELETED
         document.gmt_deleted = utc_now()
         session.add(document)

--- a/aperag/indexing/__init__.py
+++ b/aperag/indexing/__init__.py
@@ -27,9 +27,11 @@ from aperag.indexing.base import DeriveResult, ModalityWorker
 from aperag.indexing.cleanup import (
     CLEANUP_INTERVAL_SECONDS,
     ORPHAN_COOLDOWN_SECONDS,
+    cleanup_deleted_document_intents,
     cleanup_for_deleted_collections,
     cleanup_for_deleted_documents,
     cleanup_orphan_parse_versions,
+    find_deleted_document_cleanup_targets,
     find_orphan_parse_versions,
     run_cleanup_loop,
 )
@@ -298,7 +300,9 @@ __all__ = [
     "CLEANUP_INTERVAL_SECONDS",
     "ORPHAN_COOLDOWN_SECONDS",
     "find_orphan_parse_versions",
+    "find_deleted_document_cleanup_targets",
     "cleanup_orphan_parse_versions",
+    "cleanup_deleted_document_intents",
     "cleanup_for_deleted_documents",
     "cleanup_for_deleted_collections",
     "run_cleanup_loop",

--- a/aperag/indexing/cleanup.py
+++ b/aperag/indexing/cleanup.py
@@ -88,7 +88,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable, Mapping, Optional
 
-from sqlalchemy import Engine, and_, delete, func, select
+from sqlalchemy import Engine, and_, delete, func, or_, select
 from sqlalchemy.orm import Session
 
 from aperag.indexing.base import ModalityWorker
@@ -202,6 +202,20 @@ class CleanupWorkerResolution:
 
     worker: Optional[ModalityWorker]
     transient: bool
+
+
+@dataclass(frozen=True)
+class DeletedDocumentCleanupTarget:
+    """Durable DB-backed cleanup intent for task #17.
+
+    API delete only tombstones the ``Document`` row. The worker cleanup
+    loop reconstructs the object-store prefix from the DB row and uses
+    remaining ``DocumentIndex`` rows as the retry signal for backend
+    cleanup.
+    """
+
+    document_id: str
+    object_store_prefix: str
 
 
 async def _resolve_cleanup_worker(
@@ -586,6 +600,127 @@ def _select_rows_for_documents(engine: Engine, document_ids: list[str]) -> list[
         return list(session.scalars(select(DocumentIndex).where(DocumentIndex.document_id.in_(document_ids))))
 
 
+def find_deleted_document_cleanup_targets(
+    *,
+    engine: Engine,
+    batch_size: int = CLEANUP_BATCH_SIZE,
+) -> list[DeletedDocumentCleanupTarget]:
+    """Return deleted documents that still have index rows to clean.
+
+    Task #17 moves heavy document delete cleanup out of the API request
+    path. The durable intent source is the DB:
+
+    - ``Document.status = DELETED`` or ``Document.gmt_deleted IS NOT NULL``
+    - at least one remaining ``DocumentIndex`` row for that document
+
+    Redis cleanup wakeups, if any are added later, are only transport.
+    This scan must be sufficient on its own after Redis loss.
+    """
+    from aperag.domains.knowledge_base.db.models import Document, DocumentStatus
+
+    with Session(engine) as session:
+        indexed_documents = (
+            select(
+                DocumentIndex.document_id.label("document_id"),
+                func.min(DocumentIndex.updated_at).label("oldest_index_updated_at"),
+            )
+            .group_by(DocumentIndex.document_id)
+            .subquery()
+        )
+        stmt = (
+            select(Document)
+            .join(indexed_documents, indexed_documents.c.document_id == Document.id)
+            .where(
+                or_(
+                    Document.status == DocumentStatus.DELETED,
+                    Document.gmt_deleted.is_not(None),
+                )
+            )
+            .order_by(indexed_documents.c.oldest_index_updated_at, Document.id)
+            .limit(batch_size)
+        )
+        return [
+            DeletedDocumentCleanupTarget(
+                document_id=document.id,
+                object_store_prefix=document.object_store_base_path(),
+            )
+            for document in session.scalars(stmt)
+        ]
+
+
+async def cleanup_deleted_document_intents(
+    *,
+    engine: Engine,
+    workers: Optional[Mapping[Modality, ModalityWorker]] = None,
+    worker_factory: Optional[WorkerFactoryForRow] = None,
+    batch_size: int = CLEANUP_BATCH_SIZE,
+    object_store: Any | None = None,
+) -> dict[str, int]:
+    """Cleanup tombstoned documents discovered from DB state.
+
+    This is task #17's worker-owned replacement for the previous API
+    request-path cleanup. Object-store prefix deletion runs first; if it
+    fails, the ``DocumentIndex`` rows are intentionally left in place so
+    the next cleanup cycle can retry from the same DB intent.
+    """
+    targets = await asyncio.to_thread(
+        find_deleted_document_cleanup_targets,
+        engine=engine,
+        batch_size=batch_size,
+    )
+    counts = {
+        "documents_seen": len(targets),
+        "object_store_deleted": 0,
+        "object_store_deferred": 0,
+        "backend_deleted": 0,
+        "graph_lineage_cleaned": 0,
+        "rows_deleted": 0,
+        "backend_skipped": 0,
+        "transient_deferred": 0,
+    }
+    if not targets:
+        return counts
+
+    if object_store is None:
+        from aperag.objectstore.base import get_object_store
+
+        object_store = await asyncio.to_thread(get_object_store)
+
+    ready_document_ids: list[str] = []
+    for target in targets:
+        try:
+            await asyncio.to_thread(object_store.delete_objects_by_prefix, target.object_store_prefix)
+            counts["object_store_deleted"] += 1
+            ready_document_ids.append(target.document_id)
+        except Exception as exc:  # noqa: BLE001 — leave rows for retry
+            logger.exception(
+                "cleanup object-store prefix delete failed document=%s prefix=%s: %s",
+                target.document_id,
+                target.object_store_prefix,
+                exc,
+            )
+            counts["object_store_deferred"] += 1
+
+    if not ready_document_ids:
+        return counts
+
+    sub_counts = await cleanup_for_deleted_documents(
+        engine=engine,
+        workers=workers,
+        worker_factory=worker_factory,
+        document_ids=ready_document_ids,
+    )
+    for key in (
+        "backend_deleted",
+        "graph_lineage_cleaned",
+        "rows_deleted",
+        "backend_skipped",
+        "transient_deferred",
+    ):
+        counts[key] += sub_counts[key]
+    return counts
+
+
 async def _cleanup_graph_lineage_for_document(worker: ModalityWorker, document_id: str) -> None:
     """Remove all graph lineage members for ``document_id``.
 
@@ -762,10 +897,13 @@ async def run_cleanup_loop(
 ) -> None:
     """Run cleanup scans every ``interval_seconds``.
 
-    Two scans per cycle (Wave 3 Pattern B integration per architect
+    Three scans per cycle (Wave 3 Pattern B integration per architect
     msg=3890c9d7):
 
     - :func:`cleanup_orphan_parse_versions` — orphan parse_v GC (path A)
+    - :func:`cleanup_deleted_document_intents` — task #17 DB-backed
+      document delete cleanup, including object-store prefix deletion
+      and backend cleanup outside the API request path
     - :func:`cleanup_expired_documents_hook` — soft-delete documents
       stuck in UPLOADED status > 1 day (replaces legacy
       ``cleanup_expired_documents_task`` Celery beat schedule)
@@ -796,6 +934,28 @@ async def run_cleanup_loop(
         except Exception as exc:  # noqa: BLE001 — keep loop alive
             logger.exception("cleanup cycle failed: %s", exc)
         try:
+            counts = await cleanup_deleted_document_intents(
+                engine=engine,
+                workers=workers,
+                worker_factory=worker_factory,
+            )
+            if any(counts.values()):
+                logger.info(
+                    "cleanup deleted documents: documents_seen=%d object_store_deleted=%d "
+                    "object_store_deferred=%d backend_deleted=%d graph_lineage_cleaned=%d "
+                    "rows_deleted=%d backend_skipped=%d transient_deferred=%d",
+                    counts["documents_seen"],
+                    counts["object_store_deleted"],
+                    counts["object_store_deferred"],
+                    counts["backend_deleted"],
+                    counts["graph_lineage_cleaned"],
+                    counts["rows_deleted"],
+                    counts["backend_skipped"],
+                    counts["transient_deferred"],
+                )
+        except Exception as exc:  # noqa: BLE001 — keep loop alive
+            logger.exception("cleanup deleted-document cycle failed: %s", exc)
+        try:
             await cleanup_expired_documents_hook()
         except Exception as exc:  # noqa: BLE001 — Pattern B hook never crashes loop
             logger.exception("cleanup_expired_documents_hook failed: %s", exc)
@@ -824,10 +984,12 @@ __all__ = [
     "CLEANUP_INTERVAL_SECONDS",
     "ORPHAN_COOLDOWN_SECONDS",
     "WorkerFactoryForRow",
+    "cleanup_deleted_document_intents",
     "cleanup_expired_documents_hook",
     "cleanup_for_deleted_collections",
     "cleanup_for_deleted_documents",
     "cleanup_orphan_parse_versions",
+    "find_deleted_document_cleanup_targets",
     "find_orphan_parse_versions",
     "run_cleanup_loop",
 ]

--- a/aperag/server/__init__.py
+++ b/aperag/server/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/aperag/server/__init__.py
+++ b/aperag/server/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/aperag/server/health.py
+++ b/aperag/server/health.py
@@ -1,0 +1,132 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import hmac
+import os
+import time
+from typing import Any
+
+from fastapi import APIRouter, Header
+from fastapi.responses import JSONResponse
+from sqlalchemy import create_engine, text
+
+from aperag.config import get_sync_database_url, settings
+
+DIAGNOSTICS_TOKEN_ENV = "HEALTH_DIAGNOSTICS_TOKEN"
+DIAGNOSTICS_TIMEOUT_SECONDS = 2.0
+DIAGNOSTICS_DB_POOL_TIMEOUT_SECONDS = 1
+DIAGNOSTICS_DB_CONNECT_TIMEOUT_SECONDS = 1
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+async def health_check() -> dict[str, str]:
+    """Legacy compatibility endpoint for existing probes."""
+    return {"status": "healthy", "service": "aperag-api"}
+
+
+@router.get("/health/live")
+async def live_check() -> dict[str, str]:
+    return {"status": "live", "service": "aperag-api"}
+
+
+@router.get("/health/ready")
+async def ready_check() -> dict[str, str]:
+    return {"status": "ready", "service": "aperag-api"}
+
+
+@router.get("/health/diagnostics", include_in_schema=False)
+async def diagnostics_check(x_internal_token: str | None = Header(default=None)) -> JSONResponse:
+    token = os.getenv(DIAGNOSTICS_TOKEN_ENV)
+    if not token:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "unavailable",
+                "service": "aperag-api",
+                "detail": f"{DIAGNOSTICS_TOKEN_ENV} is not configured",
+            },
+        )
+    if not x_internal_token or not hmac.compare_digest(x_internal_token, token):
+        return JSONResponse(
+            status_code=401,
+            content={"status": "unauthorized", "service": "aperag-api"},
+        )
+
+    started = time.perf_counter()
+    database = await _run_database_probe()
+    status = "healthy" if database["ok"] else "unhealthy"
+    response_status = 200 if database["ok"] else 503
+    return JSONResponse(
+        status_code=response_status,
+        content={
+            "status": status,
+            "service": "aperag-api",
+            "checks": {"database": database},
+            "elapsed_ms": round((time.perf_counter() - started) * 1000, 2),
+        },
+    )
+
+
+async def _run_database_probe() -> dict[str, Any]:
+    started = time.perf_counter()
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(_probe_database),
+            timeout=DIAGNOSTICS_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        return {
+            "ok": False,
+            "elapsed_ms": round((time.perf_counter() - started) * 1000, 2),
+            "error": f"database probe timed out after {DIAGNOSTICS_TIMEOUT_SECONDS}s",
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "elapsed_ms": round((time.perf_counter() - started) * 1000, 2),
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+    return {
+        "ok": True,
+        "elapsed_ms": round((time.perf_counter() - started) * 1000, 2),
+    }
+
+
+def _probe_database() -> None:
+    sync_database_url = get_sync_database_url(settings.database_url)
+    engine_kwargs: dict[str, Any] = {
+        "echo": settings.debug,
+        "pool_pre_ping": True,
+    }
+    if not sync_database_url.startswith("sqlite"):
+        engine_kwargs.update(
+            {
+                "pool_size": 1,
+                "max_overflow": 0,
+                "pool_timeout": DIAGNOSTICS_DB_POOL_TIMEOUT_SECONDS,
+                "connect_args": {"connect_timeout": DIAGNOSTICS_DB_CONNECT_TIMEOUT_SECONDS},
+            }
+        )
+
+    engine = create_engine(sync_database_url, **engine_kwargs)
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+    finally:
+        engine.dispose()
+

--- a/aperag/server/health.py
+++ b/aperag/server/health.py
@@ -32,23 +32,23 @@ DIAGNOSTICS_DB_CONNECT_TIMEOUT_SECONDS = 1
 router = APIRouter(tags=["health"])
 
 
-@router.get("/health")
+@router.get("/")
 async def health_check() -> dict[str, str]:
     """Legacy compatibility endpoint for existing probes."""
     return {"status": "healthy", "service": "aperag-api"}
 
 
-@router.get("/health/live")
+@router.get("/live")
 async def live_check() -> dict[str, str]:
     return {"status": "live", "service": "aperag-api"}
 
 
-@router.get("/health/ready")
+@router.get("/ready")
 async def ready_check() -> dict[str, str]:
     return {"status": "ready", "service": "aperag-api"}
 
 
-@router.get("/health/diagnostics", include_in_schema=False)
+@router.get("/diagnostics", include_in_schema=False)
 async def diagnostics_check(x_internal_token: str | None = Header(default=None)) -> JSONResponse:
     token = os.getenv(DIAGNOSTICS_TOKEN_ENV)
     if not token:

--- a/aperag/server/health.py
+++ b/aperag/server/health.py
@@ -32,7 +32,7 @@ DIAGNOSTICS_DB_CONNECT_TIMEOUT_SECONDS = 1
 router = APIRouter(tags=["health"])
 
 
-@router.get("/")
+@router.get("")
 async def health_check() -> dict[str, str]:
     """Legacy compatibility endpoint for existing probes."""
     return {"status": "healthy", "service": "aperag-api"}
@@ -129,4 +129,3 @@ def _probe_database() -> None:
             connection.execute(text("SELECT 1"))
     finally:
         engine.dispose()
-

--- a/deploy/aperag/templates/_helpers.tpl
+++ b/deploy/aperag/templates/_helpers.tpl
@@ -55,6 +55,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.aperag.io/component: api
 {{- end }}
 
+{{- define "indexingWorker.labels" -}}
+app.aperag.io/component: indexing-worker
+{{- end }}
+
 {{- define "frontend.labels" -}}
 app.aperag.io/component: frontend
 {{- end }}

--- a/deploy/aperag/templates/aperag-secret.yaml
+++ b/deploy/aperag/templates/aperag-secret.yaml
@@ -24,8 +24,8 @@ stringData:
     REGISTER_MODE={{ .Values.api.env.REGISTER_MODE }}
 
     # Database connection pool
-    DB_POOL_SIZE={{ .Values.api.env.DB_POOL_SIZE }}
-    DB_MAX_OVERFLOW={{ .Values.api.env.DB_MAX_OVERFLOW }}
+    DB_POOL_SIZE={{ .Values.api.dbPoolSize | default .Values.api.env.DB_POOL_SIZE }}
+    DB_MAX_OVERFLOW={{ .Values.api.dbMaxOverflow | default .Values.api.env.DB_MAX_OVERFLOW }}
     DB_POOL_TIMEOUT={{ .Values.api.env.DB_POOL_TIMEOUT }}
     DB_POOL_RECYCLE={{ .Values.api.env.DB_POOL_RECYCLE }}
     DB_POOL_PRE_PING={{ .Values.api.env.DB_POOL_PRE_PING }}

--- a/deploy/aperag/templates/api-deployment.yaml
+++ b/deploy/aperag/templates/api-deployment.yaml
@@ -190,9 +190,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        # uploaded files volume (Wave 3 T3.1: previously shared with
-        # the celery-worker pod; now consumed solely by the in-process
-        # ``aperag.indexing`` runtime inside this api pod)
+        # Uploaded files and local object-store data. API keeps this mount
+        # for request handling and enqueueing, but task #17 moves indexing
+        # workers, reconciler, and cleanup execution into the separate
+        # indexing-worker deployment.
         - name: data
           hostPath:
             path: {{ .Values.api.dataPath }}

--- a/deploy/aperag/templates/indexing-worker-deployment.yaml
+++ b/deploy/aperag/templates/indexing-worker-deployment.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.indexingWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "aperag.labels" . | nindent 4 }}
+  name: indexing-worker
+spec:
+  replicas: {{ .Values.indexingWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "aperag.selectorLabels" . | nindent 6 }}
+      {{- include "indexingWorker.labels" . | nindent 6 }}
+  revisionHistoryLimit: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "aperag.selectorLabels" . | nindent 8 }}
+        {{- include "indexingWorker.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /data/.cache
+              mkdir -p /root/.cache
+              ln -sf /data/.cache/huggingface /root/.cache/
+              ln -sf /data/.cache/torch /root/.cache/
+              /app/scripts/entrypoint.sh python -m aperag.cli.indexing_worker
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+              value: python
+            # Helm role-specific pool settings intentionally map to the
+            # existing application env names. Do not add app-level
+            # API_DB_POOL_SIZE / INDEXING_WORKER_DB_POOL_SIZE aliases.
+            - name: DB_POOL_SIZE
+              value: {{ .Values.indexingWorker.dbPoolSize | quote }}
+            - name: DB_MAX_OVERFLOW
+              value: {{ .Values.indexingWorker.dbMaxOverflow | quote }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          name: aperag-indexing-worker
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.indexingWorker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.indexingWorker.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /data
+              name: data
+            - name: env-config
+              mountPath: /app/.env
+              subPath: .env
+              readOnly: true
+      restartPolicy: Always
+      {{- with .Values.indexingWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: data
+          hostPath:
+            path: {{ .Values.api.dataPath }}
+        - name: env-config
+          secret:
+            secretName: aperag-env
+{{- end }}

--- a/deploy/aperag/templates/indexing-worker-deployment.yaml
+++ b/deploy/aperag/templates/indexing-worker-deployment.yaml
@@ -47,6 +47,35 @@ spec:
                   fieldPath: status.hostIP
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: python
+            {{- if .Values.postgres.enabled }}
+            # entrypoint.sh waits for PostgreSQL before Python loads /app/.env,
+            # so these must be real container env vars rather than only .env
+            # entries in the mounted aperag-env Secret.
+            - name: POSTGRES_HOST
+              value: {{ .Values.postgres.POSTGRES_HOST | quote }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.postgres.POSTGRES_PORT | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.POSTGRES_DB | quote }}
+            - name: POSTGRES_USER
+              {{- if .Values.postgres.POSTGRES_CREDENTIALS_SECRET_NAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.POSTGRES_CREDENTIALS_SECRET_NAME }}
+                  key: username
+              {{- else }}
+              value: {{ .Values.postgres.POSTGRES_USER | default "postgres" | quote }}
+              {{- end }}
+            - name: POSTGRES_PASSWORD
+              {{- if .Values.postgres.POSTGRES_CREDENTIALS_SECRET_NAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.POSTGRES_CREDENTIALS_SECRET_NAME }}
+                  key: password
+              {{- else }}
+              value: {{ .Values.postgres.POSTGRES_PASSWORD | default "postgres" | quote }}
+              {{- end }}
+            {{- end }}
             # Helm role-specific pool settings intentionally map to the
             # existing application env names. Do not add app-level
             # API_DB_POOL_SIZE / INDEXING_WORKER_DB_POOL_SIZE aliases.

--- a/deploy/aperag/values.yaml
+++ b/deploy/aperag/values.yaml
@@ -99,6 +99,10 @@ api:
   # DB_MAX_OVERFLOW through aperag-secret.yaml. Keep this budget separate
   # from indexingWorker.* to avoid API/worker replica rollouts exhausting
   # PostgreSQL max_connections.
+  # task #17 intentionally lowers the API default from the old 20+40 budget:
+  # after the hard cut, API pods do HTTP/auth/enqueue work only. If production
+  # observation shows API pool saturation, raise these values with the budget
+  # formula below instead of reverting all roles to the old shared 20+40 budget.
   dbPoolSize: "5"
   dbMaxOverflow: "5"
   resources:
@@ -302,6 +306,9 @@ api:
 #   sum(replicas * (pool_size + max_overflow)) + rollout_surge_budget
 #     + diagnostics_reserved + postgres_reserved
 #     < postgres_max_connections * safety_ratio
+# Default example: API 1 * (5+5) + worker 1 * (10+10) + surge 5
+# + reserved 10 = 45. This fits a PostgreSQL safety budget of 70
+# when postgres_max_connections=100 and safety_ratio=0.7.
 # PgBouncer is a future infrastructure option and does not remove this
 # budgeting requirement.
 indexingWorker:

--- a/deploy/aperag/values.yaml
+++ b/deploy/aperag/values.yaml
@@ -94,6 +94,13 @@ neo4j:
 api:
   dataPath: /data/aperag
   replicaCount: 1
+  # Helm-level role-specific database pool budget for the API deployment.
+  # These values map to the existing application env names DB_POOL_SIZE and
+  # DB_MAX_OVERFLOW through aperag-secret.yaml. Keep this budget separate
+  # from indexingWorker.* to avoid API/worker replica rollouts exhausting
+  # PostgreSQL max_connections.
+  dbPoolSize: "5"
+  dbMaxOverflow: "5"
   resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -105,11 +112,10 @@ api:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-  # Wave 3 T3.1 chunk 3: the celery-worker pod is gone (in-process
-  # ``aperag.indexing`` runtime spawned inside this api pod by the
-  # FastAPI lifespan). The previous podAffinity-with-celery-worker rule
-  # is no longer applicable; the soft anti-affinity for spreading api
-  # replicas across nodes is preserved.
+  # task #17: API and indexing execution plane are hard-cut. API pods
+  # handle HTTP and enqueue only; indexing workers, reconciler, and cleanup
+  # loops run in indexingWorker pods. The soft anti-affinity for spreading
+  # API replicas across nodes is preserved.
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -274,7 +280,7 @@ api:
 
   livenessProbe:
     httpGet:
-      path: /health
+      path: /health/live
       port: 8000
     initialDelaySeconds: 10
     periodSeconds: 10
@@ -283,7 +289,7 @@ api:
     successThreshold: 1
   readinessProbe:
     httpGet:
-      path: /health
+      path: /health/ready
       port: 8000
     initialDelaySeconds: 5
     periodSeconds: 5
@@ -291,12 +297,33 @@ api:
     failureThreshold: 3
     successThreshold: 1
 
-# Wave 3 T3.1 chunk 3: ``celery-worker`` / ``celerybeat`` / ``flower``
-# value blocks were removed alongside the corresponding template
-# deletions. The new in-process ``aperag.indexing`` runtime
-# (worker pool + reconciler + cleanup loops) is spawned by the FastAPI
-# lifespan inside the ``api`` deployment, so no separate worker / beat
-# / monitoring pods are needed.
+# task #17: ``api`` and ``indexingWorker`` use separate DB pool budgets.
+# Before raising replica counts, verify:
+#   sum(replicas * (pool_size + max_overflow)) + rollout_surge_budget
+#     + diagnostics_reserved + postgres_reserved
+#     < postgres_max_connections * safety_ratio
+# PgBouncer is a future infrastructure option and does not remove this
+# budgeting requirement.
+indexingWorker:
+  enabled: true
+  replicaCount: 1
+  # Maps to existing DB_POOL_SIZE / DB_MAX_OVERFLOW env names in the worker
+  # container. Do not add application-level API_DB_POOL_SIZE or
+  # INDEXING_WORKER_DB_POOL_SIZE aliases.
+  dbPoolSize: "10"
+  dbMaxOverflow: "10"
+  resources: {}
+  affinity: {}
+  livenessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - pgrep -f "aperag.cli.indexing_worker" >/dev/null
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 6
 
 # Frontend configuration
 frontend:

--- a/docs/zh-CN/architecture/overview.md
+++ b/docs/zh-CN/architecture/overview.md
@@ -32,6 +32,8 @@ description: ApeRAG 后端架构入口 — 从哪开始读、去哪找什么
 | knowledge_base / indexing / retrieval / knowledge_graph 的内部结构与 ingestion / retrieval pipeline | [`architecture/indexing-retrieval-kg.md`](./indexing-retrieval-kg.md) |
 | conversation / agent_runtime / evaluation 与 prompt 架构 | [`architecture/conversation-agent-evaluation.md`](./conversation-agent-evaluation.md) |
 | 爬虫抓取 / URL 阅读相关的 `web_access` 子包 | [`architecture/web-access.md`](./web-access.md) |
+| 异步索引任务系统 hard cut 的部署边界与长期不变式 | [`architecture/task-system-invariants.md`](./task-system-invariants.md) |
+| task #17 API/Worker hard cut 执行方案、部署 runbook、状态机验收与 CR checklist | [`task-system-hard-cut-v8.md`](./task-system-hard-cut-v8.md)、[`task-17-deployment-release-runbook.md`](./task-17-deployment-release-runbook.md)、[`task-17-state-machine-validation.md`](./task-17-state-machine-validation.md)、[`task-17-cr-review-checklist.md`](./task-17-cr-review-checklist.md) |
 | 英文的 canonical 全景（20 个 boundary 测试、permanent seam、shim lifecycle、future 候选） | [`docs/modularization/architecture.md`](../../modularization/architecture.md) |
 | 我想在本地把 ApeRAG 跑起来 / 贡献代码 | [`development/development-guide.md`](../development/development-guide.md) |
 | 我想部署 ApeRAG / 配置 LLM provider | `deployment/` 目录 |

--- a/docs/zh-CN/architecture/task-17-code-changes.md
+++ b/docs/zh-CN/architecture/task-17-code-changes.md
@@ -1,0 +1,664 @@
+# task #17 代码改造章节 (Bryce 草稿, 给 @符炫炜 plug 进 v8)
+
+按 5 方共识 (架构师 + huangzhangshu + ziang + Weston + huangheng) 收敛后的实施边界. 严格遵守 ziang msg=7ff9efd7 / Weston msg=4e74f4f4 / huangheng msg=f5c4e738 一致约束:
+
+- **不**做 ``aperag/tasks/`` 大搬迁 (导致 import churn 不解线上根因)
+- **不**把应用层 hardening (graph_extractor fail-loud / 图谱 GC sweep / store bulk upsert) 塞进 task #17 主线
+- **API readiness 收紧**, 不查 PG/Redis/Qdrant (避免 kube probe 变成连接数放大器)
+- **删除路径** 从 API 请求路径迁出 (hard gate)
+- **连接池预算**用公式表示, 不 hard-code 数字
+
+---
+
+## §3.1 新增 worker 启动入口
+
+### 3.1.1 ``aperag/cli/__init__.py`` (新建)
+
+```python
+"""ApeRAG CLI subcommand registry."""
+```
+
+### 3.1.2 ``aperag/cli/indexing_worker.py`` (新建, ~80 LOC)
+
+启动 ``aperag/indexing/`` 内的所有 worker entrypoint, 依赖现有 ``aperag.indexing.{orchestrator,reconciler,cleanup}`` 模块. 不改包名, 不动 import path.
+
+```python
+"""task #17: indexing worker process 入口.
+
+ApeRAG 部署架构 hard cut 之后, indexing 执行面从 API lifespan 拆出来,
+独立 deployment + 进程跑这个 CLI. API pod 不再启动任何 indexing worker
+/ reconciler / cleanup loop.
+
+跟 ``aperag/app.py`` lifespan 中删掉的 8 + 2 = 10 个 ``asyncio.create_task``
+完全等价, 只是从 API 进程迁到独立 worker 进程, 共享 ``aperag/indexing/``
+代码 + RedisWorkQueue + RedisQuotaBackend + DocumentIndex SoT 不变.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+
+from aperag.config import get_settings, sync_engine
+from aperag.indexing import (
+    InMemoryQuotaBackend,
+    InMemoryWorkQueue,
+    NoopMetricsEmitter,
+    OTLPMetricsEmitter,
+    ProductionWorkerFactory,
+    RedisQuotaBackend,
+    RedisWorkQueue,
+    cleanup_orphan_parse_versions,
+    run_cleanup_loop,
+    run_fulltext_worker,
+    run_graph_facts_worker,
+    run_graph_vectors_worker,
+    run_graph_worker,
+    run_parse_worker,
+    run_reconcile_loop,
+    run_summary_worker,
+    run_vector_worker,
+    run_vision_worker,
+)
+from aperag.objectstore.base import get_object_store
+
+logger = logging.getLogger(__name__)
+
+
+async def _amain() -> None:
+    settings = get_settings()
+    shutdown = asyncio.Event()
+
+    # SIGTERM / SIGINT 优雅退出
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, shutdown.set)
+
+    # 选 queue / quota / metrics emitter (跟 app.py 老路径一致, 但跑在 worker 进程)
+    if settings.indexing_queue_backend == "redis":
+        queue = RedisWorkQueue(redis_url=settings.indexing_queue_redis_url)
+    else:
+        queue = InMemoryWorkQueue()  # local dev only
+
+    if settings.indexing_quota_backend == "redis":
+        from redis.asyncio import Redis
+        quota_redis = Redis.from_url(settings.indexing_quota_redis_url)
+        quota_backend = RedisQuotaBackend(quota_redis, registry=settings.indexing_quota_registry)
+    else:
+        quota_backend = InMemoryQuotaBackend()
+
+    if settings.indexing_metrics_emitter == "otlp":
+        metrics_emitter = OTLPMetricsEmitter()
+    else:
+        metrics_emitter = NoopMetricsEmitter()
+
+    worker_factory = ProductionWorkerFactory(engine=sync_engine)
+    common_kwargs = dict(
+        engine=sync_engine,
+        queue=queue,
+        worker_factory=worker_factory,
+        shutdown=shutdown,
+    )
+
+    # 启动 7 modality worker + parse + reconciler + cleanup
+    tasks = [
+        asyncio.create_task(run_vector_worker(**common_kwargs)),
+        asyncio.create_task(run_fulltext_worker(**common_kwargs)),
+        asyncio.create_task(run_graph_worker(**common_kwargs)),  # 兼容期保留 (PR #1871 §4.5)
+        asyncio.create_task(run_graph_facts_worker(**common_kwargs)),
+        asyncio.create_task(run_graph_vectors_worker(**common_kwargs)),
+        asyncio.create_task(run_summary_worker(**common_kwargs)),
+        asyncio.create_task(run_vision_worker(**common_kwargs)),
+        asyncio.create_task(
+            run_parse_worker(
+                engine=sync_engine,
+                queue=queue,
+                object_store_factory=lambda: asyncio.to_thread(get_object_store),
+                shutdown=shutdown,
+            ),
+        ),
+        asyncio.create_task(run_reconcile_loop(engine=sync_engine, queue=queue, shutdown=shutdown)),
+        asyncio.create_task(
+            run_cleanup_loop(
+                engine=sync_engine,
+                worker_factory=worker_factory.build_for_cleanup_row,
+                shutdown=shutdown,
+            ),
+        ),
+    ]
+
+    logger.info("indexing-worker started: 10 tasks (7 modality + parse + reconcile + cleanup)")
+    await shutdown.wait()
+    logger.info("indexing-worker shutdown signal received, draining tasks...")
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+    if hasattr(queue, "close"):
+        await queue.close()
+    if settings.indexing_quota_backend == "redis":
+        await quota_redis.close()
+
+
+def main() -> None:
+    """sync entrypoint for ``python -m aperag.cli.indexing_worker``."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    asyncio.run(_amain())
+
+
+if __name__ == "__main__":
+    main()
+```
+
+注意: `run_graph_worker` 仍然启动是兼容期需求 (PR #1871 §4.5 老 GRAPH 模态行不会自动迁移到 graph_facts/graph_vectors). 这是 ziang msg=7ff9efd7 第 4 点收紧的依据 — 如果未来要 retire 老 GRAPH lane, spec 单列, 不在 task #17 主线内做.
+
+---
+
+## §3.2 ``aperag/app.py`` lifespan 改造
+
+### 3.2.1 当前状态 (要删除的)
+
+(``aperag/app.py:254-530`` ``combined_lifespan`` 内)
+
+```python
+# ❌ 删除: 8 个 modality worker startup
+indexing_runtime_tasks.append(asyncio.create_task(run_vector_worker(**worker_kwargs)))
+indexing_runtime_tasks.append(asyncio.create_task(run_fulltext_worker(**worker_kwargs)))
+indexing_runtime_tasks.append(asyncio.create_task(run_graph_worker(**worker_kwargs)))
+indexing_runtime_tasks.append(asyncio.create_task(run_graph_facts_worker(**worker_kwargs)))
+indexing_runtime_tasks.append(asyncio.create_task(run_graph_vectors_worker(**worker_kwargs)))
+indexing_runtime_tasks.append(asyncio.create_task(run_summary_worker(**worker_kwargs)))
+indexing_runtime_tasks.append(asyncio.create_task(run_vision_worker(**worker_kwargs)))
+
+# ❌ 删除: parse worker
+indexing_runtime_tasks.append(
+    asyncio.create_task(run_parse_worker(...)),
+)
+
+# ❌ 删除: reconcile + cleanup loops
+indexing_runtime_tasks.append(asyncio.create_task(run_reconcile_loop(...)))
+indexing_runtime_tasks.append(asyncio.create_task(run_cleanup_loop(...)))
+
+# ❌ 删除: WorkerFactory 构造 (API 不需要)
+worker_factory = ProductionWorkerFactory(engine=engine)
+```
+
+hard cut 不留 fallback flag (e.g. `ENABLE_INDEXING_WORKERS=False` 类条件分支不要加).
+
+### 3.2.2 改造后 (保留的轻量 enqueue runtime)
+
+```python
+# ✅ 保留: 轻量 IndexingRuntime, 仅给 HTTP handler / dispatcher 用来 enqueue
+if settings.indexing_mode == "async":
+    if settings.indexing_queue_backend == "redis":
+        queue = RedisWorkQueue(redis_url=settings.indexing_queue_redis_url)
+    else:
+        queue = InMemoryWorkQueue()  # local dev only
+
+    # 注意: 不构造 worker_factory, API 进程不需要消费 task — 只 enqueue
+    set_runtime(IndexingRuntime(engine=engine, queue=queue, workers={}, ...))
+    app.state.indexing_queue = queue
+
+# 没有 indexing_runtime_tasks 列表
+# 没有 indexing_shutdown signal
+# 没有 worker / reconciler / cleanup task
+```
+
+### 3.2.3 删除的 import (hard cut)
+
+```python
+# ❌ 删除从 aperag.indexing 的 import:
+# - run_vector_worker / run_fulltext_worker / run_graph_worker / 
+#   run_graph_facts_worker / run_graph_vectors_worker / 
+#   run_summary_worker / run_vision_worker
+# - run_parse_worker
+# - run_reconcile_loop / run_cleanup_loop
+# - ProductionWorkerFactory (API 不需要)
+```
+
+净改动: API lifespan 删除 ~120 LOC, 新增 ~25 LOC. 简洁.
+
+---
+
+## §3.3 ``aperag/server/health.py`` (新建, ~60 LOC)
+
+按 Weston msg=4e74f4f4 第 3 条 + ziang msg=7ff9efd7 第 3 条收紧: API readiness 不查重型依赖, **避免 kube probe 变成连接数放大器**.
+
+```python
+"""task #17: 分层健康检查端点.
+
+按 huangzhangshu task #13 ops 现场 + Weston msg=4e74f4f4 收紧:
+
+- ``/health/live`` (liveness probe): 进程活着, 永远返回 200. 不依赖任何上游
+  (DB / Redis / Qdrant / LLM provider). kubelet 杀 pod 的唯一依据是进程死了.
+- ``/health/ready`` (readiness probe): HTTP 入口可接受请求. 不查重型依赖.
+  避免 graph worker 压力时 readiness 误判把 API pod 摘流量.
+- ``/health/diagnostics`` (admin only): 深度依赖检查 (PG / Redis / Qdrant).
+  独立 endpoint, 用 reserved 极小连接预算 + 严格短超时, 不占主业务 pool.
+  不作 kube probe 触发器, 仅供 oncall / Grafana scrape.
+
+老 ``/health`` endpoint 重定向到 ``/health/live`` 兼容老调用方 (KubeBlocks
+监控等). 新部署的 helm probe 直接用 ``/health/live`` + ``/health/ready``.
+"""
+
+from fastapi import APIRouter, Response, status
+
+router = APIRouter()
+
+
+@router.get("/health/live", tags=["health"])
+async def liveness() -> dict:
+    """Liveness probe: 进程活着即返回 200.
+    
+    不查任何上游. kubelet 杀 pod 的唯一依据是这个 endpoint 不响应.
+    """
+    return {"status": "alive"}
+
+
+@router.get("/health/ready", tags=["health"])
+async def readiness() -> dict:
+    """Readiness probe: HTTP 入口可接受请求.
+    
+    **不查 DB / Redis / Qdrant** — 避免 kube probe 变成连接数放大器.
+    业务依赖故障应该体现在请求路径里 (5xx + retry), 不应让 readiness 摘流量.
+    """
+    return {"status": "ready"}
+
+
+@router.get("/health/diagnostics", tags=["health"], include_in_schema=False)
+async def diagnostics() -> dict:
+    """深度依赖检查, admin only.
+    
+    用 reserved 极小连接预算 (max 1 PG conn + 1 Redis conn) + 严格 1s timeout,
+    **不占主业务 pool**. 仅供 oncall + Grafana scrape, **不作 kube probe**.
+    """
+    from aperag.config import get_settings
+    from sqlalchemy import text
+
+    result: dict = {"pg": "unknown", "redis": "unknown", "qdrant": "unknown"}
+
+    settings = get_settings()
+    # 用独立小预算 engine, 不污染主 pool. 短超时 1s.
+    try:
+        from sqlalchemy import create_engine
+        diag_engine = create_engine(
+            settings.database_url,
+            pool_size=1,
+            max_overflow=0,
+            pool_timeout=1,
+            connect_args={"connect_timeout": 1},
+        )
+        with diag_engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        result["pg"] = "ok"
+        diag_engine.dispose()
+    except Exception as exc:  # noqa: BLE001
+        result["pg"] = f"fail: {type(exc).__name__}"
+
+    # Redis 同款 — 独立连接 + 1s timeout.
+    try:
+        from redis.asyncio import Redis
+        r = Redis.from_url(settings.indexing_queue_redis_url, socket_timeout=1, socket_connect_timeout=1)
+        await r.ping()
+        await r.close()
+        result["redis"] = "ok"
+    except Exception as exc:  # noqa: BLE001
+        result["redis"] = f"fail: {type(exc).__name__}"
+
+    # Qdrant 也类似 (此处 omit 具体调用, 复用现有 collection 探针即可)
+    return result
+
+
+# 老 ``/health`` 重定向到 ``/health/live``, 兼容老 helm probe 配置.
+@router.get("/health", tags=["health"])
+async def legacy_health() -> dict:
+    """Legacy endpoint → ``/health/live``. 老 helm 配置兼容."""
+    return await liveness()
+```
+
+API ``app.py`` 注册 router:
+
+```python
+from aperag.server.health import router as health_router
+app.include_router(health_router)
+```
+
+helm probe 配置 (新):
+- API liveness: ``GET /health/live`` timeout=2s
+- API readiness: ``GET /health/ready`` timeout=2s
+- Worker liveness: 进程级 (无 HTTP probe), 由 deployment livenessProbe 用 exec/cmd 检查 pid 活着. 或者 worker 进程内开一个 admin port 跑 health endpoint.
+
+---
+
+## §3.4 ``document_service`` cleanup 路径迁出 API (Hard Gate)
+
+按 ziang msg=28d37634 + Weston msg=4e74f4f4 第 4 条 hard gate. **API HTTP handler 不能直接调用 ``cleanup_for_deleted_documents`` 类重型 backend cleanup**.
+
+### 3.4.1 当前问题
+
+(``aperag/domains/knowledge_base/service/document_service.py``)
+
+```python
+# ❌ 当前: API 请求路径直接调用重型 cleanup
+async def _delete_document_indexes(...):
+    ...
+    # 这里会通过 runtime 触发 cleanup_for_deleted_documents()
+    # 同步遍历每个 modality 的 backend 调 delete_by_filter / 
+    # delete_by_query / 图谱 lineage cleanup
+    # API 请求路径承担 Qdrant / ES / Neo4j / Postgres 的重型 IO
+```
+
+### 3.4.2 改造方案 (薄 mark + 异步 cleanup)
+
+```python
+# ✅ 改造后: API 只标记 cleanup intent + 入队
+async def _delete_document_indexes(self, document_id: str, ...) -> None:
+    """标记文档为待清理状态 + 入队 cleanup 任务.
+    
+    重型 backend cleanup (向量库 / 全文 / 图谱 lineage / 对象存储) 
+    由 worker cleanup loop 异步执行, **不在 API 请求路径上做**.
+    """
+    async def _mark_for_cleanup(session: AsyncSession) -> None:
+        # 1. UPDATE Document SET status='DELETED' (软删除)
+        await session.execute(
+            update(Document)
+            .where(Document.id == document_id)
+            .values(status=DocumentStatus.DELETED, gmt_deleted=utc_now()),
+        )
+        
+        # 2. INSERT cleanup queue 行 (复用现有 cleanup_queue 表 / 或者
+        #    只标记 status=DELETED, 让现有 cleanup_for_deleted_documents 
+        #    定期扫描)
+    
+    await self.db_ops.execute_with_transaction(_mark_for_cleanup)
+    
+    # 3. 触发 reconciler 周期任务在下一轮 (30s 内) 处理实际 backend cleanup.
+    #    reconciler 会调 cleanup_for_deleted_documents 在 worker 进程异步跑.
+    _trigger_index_reconciliation()
+```
+
+### 3.4.3 reconciler 端补偿
+
+(``aperag/indexing/reconciler.py``) 已有 ``run_cleanup_loop`` 周期扫描 ``Document.status='DELETED'`` 的行 + 调用 ``cleanup_for_deleted_documents``. 该 cleanup loop 现在跑在 **indexing-worker pod 进程**, 不在 API 进程, 满足 hard gate.
+
+注: 当前 ``run_cleanup_loop`` 在 ``aperag/indexing/cleanup.py`` 里. 改造时需要 verify 现有 cleanup loop 已经覆盖 "API 标记 DELETED → worker 异步 cleanup" 流程, 不需要新增逻辑. 如果有 gap, 在 task #17 同 PR 内补.
+
+### 3.4.4 验收 grep gate
+
+CI grep verify: ``aperag/domains/`` 路径下不能直接调用 ``cleanup_for_deleted_documents`` / ``cleanup_orphan_parse_versions`` / 任何 Qdrant ``delete_by_filter`` / ES ``delete_by_query`` / Neo4j cypher DELETE.
+
+```bash
+grep -rn "cleanup_for_deleted_documents\|cleanup_orphan_parse_versions\|delete_by_filter\|delete_by_query" aperag/domains/
+# 应返回 0 命中 (除文档/注释)
+```
+
+---
+
+## §3.5 连接池预算拆分 (公式化, 不 hard-code)
+
+按 Weston msg=4e74f4f4 第 5 条 + ziang msg=7ff9efd7 第 5 条收紧: **不 hard-code PG max_connections 实际值**, 给配置公式让 ops 按现场 PG 限制配置.
+
+### 3.5.1 ``aperag/config.py`` 改造
+
+```python
+# 当前 (单一 pool):
+DB_POOL_SIZE: int = 20  # 老 settings, 单进程
+DB_MAX_OVERFLOW: int = 40
+
+# 改造后 (按进程类型拆分):
+API_DB_POOL_SIZE: int = 10
+API_DB_MAX_OVERFLOW: int = 10
+INDEXING_WORKER_DB_POOL_SIZE: int = 20
+INDEXING_WORKER_DB_MAX_OVERFLOW: int = 20
+
+# Engine 构造时按 process role 选预算:
+def get_engine(role: str = "api") -> Engine:
+    if role == "api":
+        pool_size = API_DB_POOL_SIZE
+        max_overflow = API_DB_MAX_OVERFLOW
+    elif role == "indexing-worker":
+        pool_size = INDEXING_WORKER_DB_POOL_SIZE
+        max_overflow = INDEXING_WORKER_DB_MAX_OVERFLOW
+    else:
+        raise ValueError(f"unknown role: {role}")
+    return create_engine(database_url, pool_size=pool_size, max_overflow=max_overflow, ...)
+```
+
+### 3.5.2 部署预算公式 (写进 helm values 注释)
+
+```yaml
+# deploy/aperag/values.yaml (新加)
+# 
+# PostgreSQL 连接预算公式:
+#   sum_per_role = api_replicas * (API_DB_POOL_SIZE + API_DB_MAX_OVERFLOW)
+#                + indexing_worker_replicas * (INDEXING_WORKER_DB_POOL_SIZE + INDEXING_WORKER_DB_MAX_OVERFLOW)
+#                + rollout_surge_budget (= max(api_replicas, worker_replicas) * (POOL + OVERFLOW))
+#                + diagnostics_reserved (= 5 per pod)
+#   
+# 必须满足: sum_per_role < postgres_max_connections * safety_ratio (建议 0.7)
+#
+# 新加坡现状 (黄章书 msg=b3bf4733): api_replicas=1, worker_replicas=1, postgres_max_connections=56
+#   1*(10+10) + 1*(20+20) + 1*(20+20) [rollout surge] + 5 = 85 > 56 * 0.7 = 39
+#   → 现场需要扩 PG max_connections 到 >= 130 或缩小 pool size.
+# 
+# 标准 4 节点环境推荐:
+#   postgres_max_connections=200 (KubeBlocks 默认), safety_ratio=0.7 → 上限 140
+#   api_replicas=2, worker_replicas=3:
+#     2*(10+10) + 3*(20+20) + 3*(20+20) + 5 = 285 → 超
+#     需要降到 api_replicas=2 + worker_replicas=2: 40 + 80 + 80 + 5 = 205 → 仍超
+#     需要 api: 5+5, worker: 10+10 + replica 数限制
+#
+# Ops 根据实际 PG max_connections 调整 pool size 或 replica count.
+
+api:
+  replicas: 2
+  env:
+    API_DB_POOL_SIZE: "10"
+    API_DB_MAX_OVERFLOW: "10"
+
+indexingWorker:
+  replicas: 1
+  env:
+    INDEXING_WORKER_DB_POOL_SIZE: "20"
+    INDEXING_WORKER_DB_MAX_OVERFLOW: "20"
+```
+
+---
+
+## §3.6 ``deploy/aperag/templates/indexing-worker-deployment.yaml`` (新建)
+
+```yaml
+{{- if .Values.indexingWorker.enabled | default true }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "aperag.fullname" . }}-indexing-worker
+  labels:
+    {{- include "aperag.labels" . | nindent 4 }}
+    app.kubernetes.io/component: indexing-worker
+spec:
+  replicas: {{ .Values.indexingWorker.replicas | default 1 }}
+  strategy:
+    type: Recreate  # worker 重启不需要 rolling, 避免连接池放大
+  selector:
+    matchLabels:
+      {{- include "aperag.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: indexing-worker
+  template:
+    metadata:
+      labels:
+        {{- include "aperag.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: indexing-worker
+    spec:
+      containers:
+        - name: indexing-worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # 关键: 启动 indexing-worker CLI 而不是 uvicorn
+          command: ["/app/scripts/entrypoint.sh"]
+          args: ["python", "-m", "aperag.cli.indexing_worker"]
+          env:
+            # 共享 ConfigMap / Secret 配置 (DB / Redis / Qdrant URL 等)
+            {{- include "aperag.commonEnv" . | nindent 12 }}
+            # worker 独立连接池预算
+            - name: INDEXING_WORKER_DB_POOL_SIZE
+              value: {{ .Values.indexingWorker.dbPoolSize | default "20" | quote }}
+            - name: INDEXING_WORKER_DB_MAX_OVERFLOW
+              value: {{ .Values.indexingWorker.dbMaxOverflow | default "20" | quote }}
+            # 标记 process role, get_engine() 据此选预算
+            - name: APERAG_PROCESS_ROLE
+              value: "indexing-worker"
+          resources:
+            {{- toYaml .Values.indexingWorker.resources | nindent 12 }}
+          # liveness probe: 进程级 (检查 python -m aperag.cli.indexing_worker 还在跑)
+          livenessProbe:
+            exec:
+              command: ["pgrep", "-f", "aperag.cli.indexing_worker"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # 不配 readiness probe — worker 没有 HTTP 入口接流量, 不需要被 kubelet 摘流量.
+          # worker 的 "ready" 状态由 reconciler / DocumentIndex 状态机驱动.
+{{- end }}
+```
+
+### 3.6.1 ``deploy/aperag/values.yaml`` (新加 indexingWorker section)
+
+```yaml
+indexingWorker:
+  enabled: true
+  replicas: 1
+  resources:
+    limits:
+      cpu: "4"
+      memory: "8Gi"
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+  dbPoolSize: 20
+  dbMaxOverflow: 20
+```
+
+### 3.6.2 ``deploy/aperag/templates/api-deployment.yaml`` 改造 (probe 升级)
+
+```yaml
+# 当前 (api-deployment.yaml line 275-292):
+livenessProbe:
+  httpGet:
+    path: /health     # ← 改成 /health/live
+    port: 8000
+readinessProbe:
+  httpGet:
+    path: /health     # ← 改成 /health/ready
+    port: 8000
+
+# 改造后:
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 8000
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 8000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 2
+  failureThreshold: 3
+```
+
+老 ``/health`` 通过 ``aperag/server/health.py`` 的 redirect 兼容 (回避 helm 旧配置缓存导致 break).
+
+---
+
+## §3.7 验收测试 (e2e + boundary)
+
+按黄章书 msg=b3bf4733 第 7 条 + huangheng msg=f5c4e738 9 条:
+
+### 3.7.1 新增测试
+
+1. ``tests/integration/test_api_pod_isolation.py``: API pod 启动后, 没有 indexing worker / reconciler / cleanup task. 用 monkeypatch + lifespan inspect 钉.
+2. ``tests/integration/test_indexing_worker_startup.py``: ``python -m aperag.cli.indexing_worker`` 启动后, 10 个 task 都跑.
+3. ``tests/integration/test_health_endpoints.py``: ``/health/live`` 永远 200 / ``/health/ready`` 永远 200 (不查重型依赖) / ``/health/diagnostics`` admin only + 隔离连接池.
+4. ``tests/integration/test_api_no_cleanup_in_request_path.py``: grep verify ``aperag/domains/`` 不直接调 ``cleanup_*`` / ``delete_by_*`` (CI gate).
+5. ``tests/integration/test_pool_budget_per_role.py``: ``get_engine(role="api")`` 跟 ``get_engine(role="indexing-worker")`` 返回不同 pool size.
+
+### 3.7.2 现有 17 单测全继承
+
+PR #1871 / #1875 / #1876 / #1877 / #1879 ship 的 17 个新单测 (graph state machine + reconciler stale + alias / json_object / lifespan wire-in) 都基于 SQLite + DocumentIndex fixture, **不依赖 worker startup 路径**, 全部继承.
+
+### 3.7.3 部署级压测验收 (黄章书 7 条)
+
+- API 在 graph worker 压力下 ``/health/live`` p99 ≤ 100ms / ``/health/ready`` p99 ≤ 100ms (不被 worker 拖慢)
+- Worker 独立重启 (kubectl delete pod) 不影响 API 服务
+- Redis 队列丢消息时 reconciler 30s 内补漏
+- 旧 parse_version 任务到达不会写坏新版本 (DocumentIndex SoT version gate)
+- rollout surge 时 PG 连接数不爆 (3.5 公式校验)
+- liveness/readiness 收紧后, kubelet 不会因 graph 压力误杀 API pod
+- worker pod 独立 deployment 之后, ``/api/v2/auth/user`` 在 graph 重负载时仍稳定
+
+---
+
+## §3.8 hard cut 删除清单 (不留兼容路径)
+
+按 earayu2 directive msg=e04d40d5 不留双路径:
+
+1. **删除** ``aperag/app.py`` lifespan 内的 8 + 2 = 10 个 ``asyncio.create_task(run_*_worker)`` / ``run_parse_worker`` / ``run_reconcile_loop`` / ``run_cleanup_loop`` 全部 startup 代码 (~120 LOC).
+2. **删除** ``aperag/app.py`` 内的 ``ProductionWorkerFactory(engine=engine)`` 构造 (API 不需要).
+3. **删除** ``aperag/app.py`` 内的 ``indexing_runtime_tasks`` list + ``indexing_shutdown`` event + shutdown 时的 ``asyncio.gather(*tasks)``.
+4. **不**保留 ``ENABLE_INDEXING_WORKERS=False`` 类 conditional flag — 不留双模式.
+5. **不**保留 ``aperag.indexing.runtime`` 内的 worker_factory injection (改成只 wire enqueue).
+6. helm 老 ``/health`` probe 路径通过 ``aperag/server/health.py`` redirect 兼容, 但 helm template **直接更新成** ``/health/live`` + ``/health/ready`` (不留模板分支).
+7. **删除** 老 ``/health`` endpoint 在 ``aperag/app.py:568-571`` 的 inline 定义 (移到 ``aperag/server/health.py``, 仅作 redirect).
+
+---
+
+## §3.9 估计工作量
+
+| 模块 | 改动量 | 时间估 |
+|---|---|---|
+| ``aperag/cli/indexing_worker.py`` (新建) | +80 LOC | 30min |
+| ``aperag/app.py`` lifespan 改造 | -120 / +25 LOC | 30min |
+| ``aperag/server/health.py`` (新建) | +60 LOC | 20min |
+| ``document_service`` cleanup 迁出 | -30 / +30 LOC | 40min |
+| ``aperag/config.py`` pool 拆分 | +20 / -5 LOC | 20min |
+| helm ``indexing-worker-deployment.yaml`` (新建) | +50 LOC | 30min |
+| helm ``api-deployment.yaml`` probe 改 | +5 / -5 LOC | 10min |
+| helm ``values.yaml`` 加 indexingWorker section | +30 LOC | 10min |
+| 5 个新 integration test | +250 LOC | 1.5h |
+| 17 个老单测继承 verify | 0 LOC | 30min |
+| 部署级压测 (验收 7 项) | 现场 | 1-2h |
+| 文档 (architecture.md fold spec lock) | +200 LOC | 30min |
+| **合计** | **+750 / -160 LOC** | **~6-7 人时** |
+
+可以**今天完成 PR + push CI + huangheng/Weston review**, 明天合并 + helm chart 发布 + 部署 + 现场压测验收.
+
+---
+
+## §3.10 风险 + 重评触发条件
+
+### 3.10.1 风险
+
+1. ``run_graph_worker`` 兼容期保留 — 如果生产没有老 GRAPH 模态行, 启动它是无害但浪费. 后续 spec 单列删除.
+2. helm 老 ``/health`` probe 仍指向老路径的旧部署版本 — ``aperag/server/health.py`` 通过 redirect 兼容.
+3. PG 连接数公式可能跟现场 KubeBlocks Postgres 限制不匹配 — values 注释里给公式, ops 调整 pool / replica.
+4. cleanup 路径迁出后, API ``DELETE /document/{id}`` 响应时间会变快 (不再同步 cleanup), 但 cleanup 完成时延变长 (受 reconciler 30s 周期影响). 接受 short-term 用户感知差异 — 用户期待是"删除提交即可", 不期待"删除立刻持久化".
+
+### 3.10.2 重评触发条件 (escape hatch architecture invariant)
+
+未来满足任意一条 → 重新评估候选 A/C/D framework 替换:
+
+1. 任务吞吐 ≥ 100/s 持续 5 分钟
+2. 跨租户公平调度成正式产品需求 (多租户抢同一 LLM provider quota)
+3. 任务优先级 / 延迟队列 / 复杂取消 / chain·chord·group 复杂工作流成正式产品需求
+4. reconciler 5-stage 维护成本 ≥ 同期 framework 升级成本 (每 quarter own-up 数 ≥ 5 / DB poll p99 latency ≥ 1s 持续 5 分钟)
+
+未达任一 → 维持候选 B + spec lock invariant.
+
+---
+
+**Bryce 草稿写完时间 ~25 分钟, 比 ETA 30-40 min 快**. 等 @符炫炜 整合进 v8 final.

--- a/docs/zh-CN/architecture/task-17-code-changes.md
+++ b/docs/zh-CN/architecture/task-17-code-changes.md
@@ -636,4 +636,4 @@ PR #1871 / #1875 / #1876 / #1877 / #1879 ship 的 17 个新单测 (graph state m
 
 ---
 
-**Bryce 草稿写完时间 ~25 分钟, 比 ETA 30-40 min 快**. 等 @符炫炜 整合进 v8 final.
+**状态**：本文档已作为 PR #1884 文档入仓；后续实现按本文、`task-system-hard-cut-v8.md` 与状态机 / 部署 / CR checklist 文档共同执行。

--- a/docs/zh-CN/architecture/task-17-code-changes.md
+++ b/docs/zh-CN/architecture/task-17-code-changes.md
@@ -40,16 +40,15 @@ import asyncio
 import logging
 import signal
 
-from aperag.config import get_settings, sync_engine
+from aperag.config import settings, sync_engine
 from aperag.indexing import (
     InMemoryQuotaBackend,
     InMemoryWorkQueue,
     NoopMetricsEmitter,
     OTLPMetricsEmitter,
-    ProductionWorkerFactory,
+    QuotaPolicyRegistry,
     RedisQuotaBackend,
     RedisWorkQueue,
-    cleanup_orphan_parse_versions,
     run_cleanup_loop,
     run_fulltext_worker,
     run_graph_facts_worker,
@@ -61,13 +60,13 @@ from aperag.indexing import (
     run_vector_worker,
     run_vision_worker,
 )
+from aperag.indexing.worker_factory import ProductionWorkerFactory
 from aperag.objectstore.base import get_object_store
 
 logger = logging.getLogger(__name__)
 
 
 async def _amain() -> None:
-    settings = get_settings()
     shutdown = asyncio.Event()
 
     # SIGTERM / SIGINT 优雅退出
@@ -84,9 +83,10 @@ async def _amain() -> None:
     if settings.indexing_quota_backend == "redis":
         from redis.asyncio import Redis
         quota_redis = Redis.from_url(settings.indexing_quota_redis_url)
-        quota_backend = RedisQuotaBackend(quota_redis, registry=settings.indexing_quota_registry)
+        quota_backend = RedisQuotaBackend(quota_redis, QuotaPolicyRegistry())
     else:
-        quota_backend = InMemoryQuotaBackend()
+        quota_redis = None
+        quota_backend = InMemoryQuotaBackend(QuotaPolicyRegistry())
 
     if settings.indexing_metrics_emitter == "otlp":
         metrics_emitter = OTLPMetricsEmitter()
@@ -234,7 +234,7 @@ if settings.indexing_mode == "async":
   避免 graph worker 压力时 readiness 误判把 API pod 摘流量.
 - ``/health/diagnostics`` (admin only): 深度依赖检查 (PG / Redis / Qdrant).
   独立 endpoint, 用 reserved 极小连接预算 + 严格短超时, 不占主业务 pool.
-  不作 kube probe 触发器, 仅供 oncall / Grafana scrape.
+  不作 kube probe 触发器, 仅供内网 / admin token / 发布脚本使用.
 
 老 ``/health`` endpoint 重定向到 ``/health/live`` 兼容老调用方 (KubeBlocks
 监控等). 新部署的 helm probe 直接用 ``/health/live`` + ``/health/ready``.
@@ -269,19 +269,19 @@ async def diagnostics() -> dict:
     """深度依赖检查, admin only.
     
     用 reserved 极小连接预算 (max 1 PG conn + 1 Redis conn) + 严格 1s timeout,
-    **不占主业务 pool**. 仅供 oncall + Grafana scrape, **不作 kube probe**.
+    **不占主业务 pool**. 仅供内网 / admin token / 发布脚本使用, **不作 kube probe**.
+    实现时必须接入已有鉴权或仅暴露在集群内网；不能把未鉴权的深度依赖探针暴露到公网。
     """
-    from aperag.config import get_settings
+    from aperag.config import get_sync_database_url, settings
     from sqlalchemy import text
 
     result: dict = {"pg": "unknown", "redis": "unknown", "qdrant": "unknown"}
 
-    settings = get_settings()
     # 用独立小预算 engine, 不污染主 pool. 短超时 1s.
     try:
         from sqlalchemy import create_engine
         diag_engine = create_engine(
-            settings.database_url,
+            get_sync_database_url(settings.database_url),
             pool_size=1,
             max_overflow=0,
             pool_timeout=1,
@@ -347,47 +347,43 @@ async def _delete_document_indexes(...):
     # API 请求路径承担 Qdrant / ES / Neo4j / Postgres 的重型 IO
 ```
 
-### 3.4.2 改造方案 (薄 mark + 异步 cleanup)
+### 3.4.2 改造方案 (薄 DB intent + worker 异步 cleanup)
 
 ```python
-# ✅ 改造后: API 只标记 cleanup intent + 入队
-async def _delete_document_indexes(self, document_id: str, ...) -> None:
-    """标记文档为待清理状态 + 入队 cleanup 任务.
-    
-    重型 backend cleanup (向量库 / 全文 / 图谱 lineage / 对象存储) 
-    由 worker cleanup loop 异步执行, **不在 API 请求路径上做**.
-    """
-    async def _mark_for_cleanup(session: AsyncSession) -> None:
-        # 1. UPDATE Document SET status='DELETED' (软删除)
-        await session.execute(
-            update(Document)
-            .where(Document.id == document_id)
-            .values(status=DocumentStatus.DELETED, gmt_deleted=utc_now()),
-        )
-        
-        # 2. INSERT cleanup queue 行 (复用现有 cleanup_queue 表 / 或者
-        #    只标记 status=DELETED, 让现有 cleanup_for_deleted_documents 
-        #    定期扫描)
-    
-    await self.db_ops.execute_with_transaction(_mark_for_cleanup)
-    
-    # 3. 触发 reconciler 周期任务在下一轮 (30s 内) 处理实际 backend cleanup.
-    #    reconciler 会调 cleanup_for_deleted_documents 在 worker 进程异步跑.
-    _trigger_index_reconciliation()
+# ✅ 改造后: API 只写 durable DB intent.
+# DocumentService._delete_document() 已经在外层 transaction 里写:
+#   Document.status = DELETED
+#   Document.gmt_deleted = utc_now()
+# 所以 _delete_document_indexes() 不再嵌套 transaction, 也不再调用
+# cleanup_for_deleted_documents().
+#
+# 重型 cleanup (向量库 / 全文 / 图谱 lineage / object store prefix delete)
+# 全部由 worker cleanup loop 异步执行.
+async def _delete_document_indexes(*, document_id: str) -> None:
+    logger.info(
+        "document=%s marked deleted; backend/object-store cleanup will be picked up by indexing-worker",
+        document_id,
+    )
 ```
 
 ### 3.4.3 reconciler 端补偿
 
-(``aperag/indexing/reconciler.py``) 已有 ``run_cleanup_loop`` 周期扫描 ``Document.status='DELETED'`` 的行 + 调用 ``cleanup_for_deleted_documents``. 该 cleanup loop 现在跑在 **indexing-worker pod 进程**, 不在 API 进程, 满足 hard gate.
+``run_cleanup_loop`` 在 ``aperag/indexing/cleanup.py`` 中运行, task #17 需要补/确认一条 durable scan:
 
-注: 当前 ``run_cleanup_loop`` 在 ``aperag/indexing/cleanup.py`` 里. 改造时需要 verify 现有 cleanup loop 已经覆盖 "API 标记 DELETED → worker 异步 cleanup" 流程, 不需要新增逻辑. 如果有 gap, 在 task #17 同 PR 内补.
+1. 扫 ``Document.status=DELETED`` 或 ``Document.gmt_deleted IS NOT NULL`` 且仍存在 ``DocumentIndex`` 行的 document.
+2. 对这些 document 调用 ``cleanup_for_deleted_documents`` 执行 backend cleanup.
+3. 同一个 worker cleanup 阶段删除 object store prefix（原 API 里的 ``delete_objects_by_prefix``），保证对象存储 IO 也不在 API 请求路径上。
+4. backend/object-store transient failure 时保留 ``DocumentIndex`` 行和 DB intent，下轮继续扫。
+5. Redis cleanup queue 如果后续新增，只能做 wake-up transport；cleanup intent 真源仍然是 DB。
+
+该 cleanup loop 跑在 **indexing-worker pod 进程**, 不在 API 进程, 满足 hard gate。
 
 ### 3.4.4 验收 grep gate
 
-CI grep verify: ``aperag/domains/`` 路径下不能直接调用 ``cleanup_for_deleted_documents`` / ``cleanup_orphan_parse_versions`` / 任何 Qdrant ``delete_by_filter`` / ES ``delete_by_query`` / Neo4j cypher DELETE.
+CI grep verify: ``aperag/domains/`` 路径下不能直接调用 ``cleanup_for_deleted_documents`` / ``cleanup_orphan_parse_versions`` / ``delete_objects_by_prefix`` / 任何 Qdrant ``delete_by_filter`` / ES ``delete_by_query`` / Neo4j cypher DELETE.
 
 ```bash
-grep -rn "cleanup_for_deleted_documents\|cleanup_orphan_parse_versions\|delete_by_filter\|delete_by_query" aperag/domains/
+grep -rn "cleanup_for_deleted_documents\|cleanup_orphan_parse_versions\|delete_objects_by_prefix\|delete_by_filter\|delete_by_query" aperag/domains/
 # 应返回 0 命中 (除文档/注释)
 ```
 
@@ -397,31 +393,15 @@ grep -rn "cleanup_for_deleted_documents\|cleanup_orphan_parse_versions\|delete_b
 
 按 Weston msg=4e74f4f4 第 5 条 + ziang msg=7ff9efd7 第 5 条收紧: **不 hard-code PG max_connections 实际值**, 给配置公式让 ops 按现场 PG 限制配置.
 
-### 3.5.1 ``aperag/config.py`` 改造
+### 3.5.1 应用代码不新增 pool env alias
 
-```python
-# 当前 (单一 pool):
-DB_POOL_SIZE: int = 20  # 老 settings, 单进程
-DB_MAX_OVERFLOW: int = 40
+应用代码继续只读取现有 ``DB_POOL_SIZE`` / ``DB_MAX_OVERFLOW`` / ``DB_POOL_TIMEOUT`` 等字段。
+task #17 不引入 ``API_DB_POOL_SIZE`` / ``INDEXING_WORKER_DB_POOL_SIZE``，也不新增
+``get_engine(role=...)``。原因是 ``aperag/config.py`` 目前在 import 时创建全局
+``async_engine`` / ``sync_engine``，role-based engine 会牵动大量全局调用方。
 
-# 改造后 (按进程类型拆分):
-API_DB_POOL_SIZE: int = 10
-API_DB_MAX_OVERFLOW: int = 10
-INDEXING_WORKER_DB_POOL_SIZE: int = 20
-INDEXING_WORKER_DB_MAX_OVERFLOW: int = 20
-
-# Engine 构造时按 process role 选预算:
-def get_engine(role: str = "api") -> Engine:
-    if role == "api":
-        pool_size = API_DB_POOL_SIZE
-        max_overflow = API_DB_MAX_OVERFLOW
-    elif role == "indexing-worker":
-        pool_size = INDEXING_WORKER_DB_POOL_SIZE
-        max_overflow = INDEXING_WORKER_DB_MAX_OVERFLOW
-    else:
-        raise ValueError(f"unknown role: {role}")
-    return create_engine(database_url, pool_size=pool_size, max_overflow=max_overflow, ...)
-```
+API 与 worker 的差异放在 Helm 层解决：两个 deployment 分别注入不同的
+``DB_POOL_SIZE`` / ``DB_MAX_OVERFLOW``，应用进程内仍然是单一配置模型。
 
 ### 3.5.2 部署预算公式 (写进 helm values 注释)
 
@@ -429,8 +409,8 @@ def get_engine(role: str = "api") -> Engine:
 # deploy/aperag/values.yaml (新加)
 # 
 # PostgreSQL 连接预算公式:
-#   sum_per_role = api_replicas * (API_DB_POOL_SIZE + API_DB_MAX_OVERFLOW)
-#                + indexing_worker_replicas * (INDEXING_WORKER_DB_POOL_SIZE + INDEXING_WORKER_DB_MAX_OVERFLOW)
+#   sum_per_role = api_replicas * (api.dbPoolSize + api.dbMaxOverflow)
+#                + indexing_worker_replicas * (indexingWorker.dbPoolSize + indexingWorker.dbMaxOverflow)
 #                + rollout_surge_budget (= max(api_replicas, worker_replicas) * (POOL + OVERFLOW))
 #                + diagnostics_reserved (= 5 per pod)
 #   
@@ -451,15 +431,13 @@ def get_engine(role: str = "api") -> Engine:
 
 api:
   replicas: 2
-  env:
-    API_DB_POOL_SIZE: "10"
-    API_DB_MAX_OVERFLOW: "10"
+  dbPoolSize: 10
+  dbMaxOverflow: 10
 
 indexingWorker:
   replicas: 1
-  env:
-    INDEXING_WORKER_DB_POOL_SIZE: "20"
-    INDEXING_WORKER_DB_MAX_OVERFLOW: "20"
+  dbPoolSize: 20
+  dbMaxOverflow: 20
 ```
 
 ---
@@ -499,14 +477,11 @@ spec:
           env:
             # 共享 ConfigMap / Secret 配置 (DB / Redis / Qdrant URL 等)
             {{- include "aperag.commonEnv" . | nindent 12 }}
-            # worker 独立连接池预算
-            - name: INDEXING_WORKER_DB_POOL_SIZE
+            # worker 独立连接池预算：Helm 值映射到应用现有 env，不新增应用层 alias
+            - name: DB_POOL_SIZE
               value: {{ .Values.indexingWorker.dbPoolSize | default "20" | quote }}
-            - name: INDEXING_WORKER_DB_MAX_OVERFLOW
+            - name: DB_MAX_OVERFLOW
               value: {{ .Values.indexingWorker.dbMaxOverflow | default "20" | quote }}
-            # 标记 process role, get_engine() 据此选预算
-            - name: APERAG_PROCESS_ROLE
-              value: "indexing-worker"
           resources:
             {{- toYaml .Values.indexingWorker.resources | nindent 12 }}
           # liveness probe: 进程级 (检查 python -m aperag.cli.indexing_worker 还在跑)
@@ -585,7 +560,7 @@ readinessProbe:
 2. ``tests/integration/test_indexing_worker_startup.py``: ``python -m aperag.cli.indexing_worker`` 启动后, 10 个 task 都跑.
 3. ``tests/integration/test_health_endpoints.py``: ``/health/live`` 永远 200 / ``/health/ready`` 永远 200 (不查重型依赖) / ``/health/diagnostics`` admin only + 隔离连接池.
 4. ``tests/integration/test_api_no_cleanup_in_request_path.py``: grep verify ``aperag/domains/`` 不直接调 ``cleanup_*`` / ``delete_by_*`` (CI gate).
-5. ``tests/integration/test_pool_budget_per_role.py``: ``get_engine(role="api")`` 跟 ``get_engine(role="indexing-worker")`` 返回不同 pool size.
+5. ``tests/integration/test_pool_budget_helm_values.py``: Helm 渲染后 API 与 indexing-worker deployment 分别注入不同 ``DB_POOL_SIZE`` / ``DB_MAX_OVERFLOW``，应用代码不新增 pool env alias.
 
 ### 3.7.2 现有 17 单测全继承
 

--- a/docs/zh-CN/architecture/task-17-code-changes.md
+++ b/docs/zh-CN/architecture/task-17-code-changes.md
@@ -207,8 +207,8 @@ if settings.indexing_mode == "async":
 
 ```python
 # ❌ 删除从 aperag.indexing 的 import:
-# - run_vector_worker / run_fulltext_worker / run_graph_worker / 
-#   run_graph_facts_worker / run_graph_vectors_worker / 
+# - run_vector_worker / run_fulltext_worker / run_graph_worker /
+#   run_graph_facts_worker / run_graph_vectors_worker /
 #   run_summary_worker / run_vision_worker
 # - run_parse_worker
 # - run_reconcile_loop / run_cleanup_loop
@@ -248,7 +248,7 @@ router = APIRouter()
 @router.get("/health/live", tags=["health"])
 async def liveness() -> dict:
     """Liveness probe: 进程活着即返回 200.
-    
+
     不查任何上游. kubelet 杀 pod 的唯一依据是这个 endpoint 不响应.
     """
     return {"status": "alive"}
@@ -257,7 +257,7 @@ async def liveness() -> dict:
 @router.get("/health/ready", tags=["health"])
 async def readiness() -> dict:
     """Readiness probe: HTTP 入口可接受请求.
-    
+
     **不查 DB / Redis / Qdrant** — 避免 kube probe 变成连接数放大器.
     业务依赖故障应该体现在请求路径里 (5xx + retry), 不应让 readiness 摘流量.
     """
@@ -267,7 +267,7 @@ async def readiness() -> dict:
 @router.get("/health/diagnostics", tags=["health"], include_in_schema=False)
 async def diagnostics() -> dict:
     """深度依赖检查, admin only.
-    
+
     用 reserved 极小连接预算 (max 1 PG conn + 1 Redis conn) + 严格 1s timeout,
     **不占主业务 pool**. 仅供内网 / admin token / 发布脚本使用, **不作 kube probe**.
     实现时必须接入已有鉴权或仅暴露在集群内网；不能把未鉴权的深度依赖探针暴露到公网。
@@ -342,7 +342,7 @@ helm probe 配置 (新):
 async def _delete_document_indexes(...):
     ...
     # 这里会通过 runtime 触发 cleanup_for_deleted_documents()
-    # 同步遍历每个 modality 的 backend 调 delete_by_filter / 
+    # 同步遍历每个 modality 的 backend 调 delete_by_filter /
     # delete_by_query / 图谱 lineage cleanup
     # API 请求路径承担 Qdrant / ES / Neo4j / Postgres 的重型 IO
 ```
@@ -407,19 +407,19 @@ API 与 worker 的差异放在 Helm 层解决：两个 deployment 分别注入�
 
 ```yaml
 # deploy/aperag/values.yaml (新加)
-# 
+#
 # PostgreSQL 连接预算公式:
 #   sum_per_role = api_replicas * (api.dbPoolSize + api.dbMaxOverflow)
 #                + indexing_worker_replicas * (indexingWorker.dbPoolSize + indexingWorker.dbMaxOverflow)
 #                + rollout_surge_budget (= max(api_replicas, worker_replicas) * (POOL + OVERFLOW))
 #                + diagnostics_reserved (= 5 per pod)
-#   
+#
 # 必须满足: sum_per_role < postgres_max_connections * safety_ratio (建议 0.7)
 #
 # 新加坡现状 (黄章书 msg=b3bf4733): api_replicas=1, worker_replicas=1, postgres_max_connections=56
 #   1*(10+10) + 1*(20+20) + 1*(20+20) [rollout surge] + 5 = 85 > 56 * 0.7 = 39
 #   → 现场需要扩 PG max_connections 到 >= 130 或缩小 pool size.
-# 
+#
 # 标准 4 节点环境推荐:
 #   postgres_max_connections=200 (KubeBlocks 默认), safety_ratio=0.7 → 上限 140
 #   api_replicas=2, worker_replicas=3:

--- a/docs/zh-CN/architecture/task-17-cr-review-checklist.md
+++ b/docs/zh-CN/architecture/task-17-cr-review-checklist.md
@@ -93,6 +93,21 @@
 - 回滚二选一：(a) Helm release 整体回滚 / (b) 先 `kubectl scale indexing-worker --replicas=0` 确认无 worker 后再回滚 API
 - 发布 checklist 加入「执行面唯一性确认」：`kubectl get deploy,pod` 验证
 
+### 6 hard gate 与具体测试文件 mapping（冬柏 msg=d56bb0f7 补充）
+
+verify 必须落到具体 test 文件锚点，不允许抽象「verify」描述：
+
+| Hard gate | 验证脚本 / test 文件 | 默认 owner |
+|-----------|---------------------|----------|
+| #1 API 不启重型执行面 | `tests/boundaries/test_app_lifespan_no_workers.py` grep CI gate + 单测 | Bryce (#20) |
+| #2 cleanup intent DB SoT | `tests/integration/test_cleanup_recovery_redis_outage.py` Redis kill + DB scan 补漏 | ziang (#19) |
+| #3 object store 迁出 API | `tests/boundaries/test_api_no_objectstore_calls.py` grep gate + 行为测试 | ziang (#19) |
+| #4 readiness 轻量 | `tests/load/test_health_endpoints_under_load.py` p95 < 500ms + DB pool 满时仍稳定 | Planetegg (#22) |
+| #5 连接池 Helm 映射 | `tests/integration/test_helm_pool_budget.py` 验证 env 透传 + 预算公式不超 | huangzhangshu (#18) |
+| #6 回滚执行面唯一 | runbook + `tests/load/test_rollback_dryrun.py`（k8s scale + 切回，验证 no double-execute）| huangzhangshu + Planetegg |
+
+owner 可调，关键是每个 gate 有可执行 test 文件锚点。CR 时 verdict 表 §七要求填具体 test commit / 行号。
+
 ---
 
 ## 三、7 条实现修正（ziang msg=4ea65100 + msg=76f6f465 + Bryce msg=981960cd accept 版）
@@ -197,6 +212,17 @@ CR cross-check 表里任何 ✅ 标注被 surface 为 false positive 时，立�
 - 发现跨边界问题先在 PR thread 点对方，不直接跨边界大改
 - 合并 gate：5 lane（implementer + 架构 + SRE + 状态机/CR + 部署）独立给 verdict，全 ack 后 squash merge
 
+### 5.5 失败注入方法规范（冬柏 msg=d56bb0f7 补充）
+
+任何「Redis 丢消息 reconciler 补漏」/「worker crash」/「DB 写失败」类失败场景测试，**禁止 mock client 绕过真路径**。必须用真实失败注入手法：
+
+- **Redis 丢消息 / Redis 重启**：`kubectl scale redis --replicas=0` 暂停 + 恢复，或 `iptables -A OUTPUT -p tcp --dport 6379 -j DROP` 模拟网络断开
+- **worker crash**：`kubectl delete pod indexing-worker-...` 强制 pod kill，verify reconciler 60s 心跳超时回收
+- **DB 写失败**：iptables 阻断 PG 端口，或临时撤销 DB 连接权限模拟 transient failure
+- **rollout surge 连接池打满**：`kubectl rollout restart api` 触发 rollout，监测 PG `max_connections` 是否被 surge 配置打满
+
+**禁止 mock 绕过原因**：mock 测出的「reconciler 能补漏」可能在真实路径上失效，因为真实路径含 Redis 客户端重连 / asyncpg 连接池行为 / k8s probe 抢占资源等 mock 不能复现的副作用。Lesson 沉淀来源：Wave 3 PR #1729 mock 路径过 + 真路径 fail。
+
 ---
 
 ## 六、CR 历史 sediment 引用
@@ -212,11 +238,11 @@ CR cross-check 表里任何 ✅ 标注被 surface 为 false positive 时，立�
 
 ## 七、task #17 PR final review verdict（待 PR 合并前填）
 
-| 检查项 | 状态 | 备注 |
-|------|------|------|
-| §一 5 cross-check 全过 | _待填_ | |
-| §二 6 hard gate 全 verify | _待填_ | |
-| §三 7 实现修正全 fold-in | _待填_ | |
+| 检查项 | 状态 | 备注（具体 test commit / 行号 / 数据） |
+|------|------|--------------------------------------|
+| §一 5 cross-check 全过 | _待填_ | 引用具体 PR diff 行号或 commit |
+| §二 6 hard gate 全 verify（每条引用具体 test 文件 + 通过截图/数据） | _待填_ | 见 §二 mapping 子表 |
+| §三 7 实现修正全 fold-in（grep 验证应用代码 0 引入双 env / 0 嵌套 transaction / 等） | _待填_ | |
 | §四 lessons 全应用 | _待填_ | |
 | 团队 5 lane LGTM ack 收齐 | _待填_ | |
 | 架构师 v8.2 docs 入仓 | _待填_ | |
@@ -224,5 +250,15 @@ CR cross-check 表里任何 ✅ 标注被 surface 为 false positive 时，立�
 | ziang 状态机/cleanup SoT 验收 docs 入仓 | _待填_ | |
 | Weston scope 一致性 verify | _待填_ | |
 | Bryce 代码主线 file-by-file align ziang 7 修正 | _待填_ | |
+| **多文档并发压测阈值通过**（Planetegg #22 主跑，需 Planetegg + 黄章书 商定具体阈值并 attach 数据到 PR thread）| _待填_ | 例：≥100 docs × 10 concurrent × 10min sustained，p95 / PG 连接数 / 队列 backlog 数据 attach |
+| **smoke regression diff = 0**（PR merge 前后同一 hurl smoke set 全 pass，新 fail = 0） | _待填_ | 对照 6 套 hurl smoke baseline 含 web_access #1794 / 模型基准 #1863 等 |
+| 失败注入用真路径不允许 mock（按 §5.5 规范） | _待填_ | 截图或 log 引用 kubectl/iptables 操作记录 |
 
 最终 verdict 由 huangheng 在 PR 合并前填，附 thread message ID 引用。
+
+---
+
+## 八、checklist 修订记录
+
+- 2026-04-29 23:54 commit `d9438f8`：huangheng 初版，5 cross-check + 6 hard gate + 7 实现修正 + lessons + 工作流 + verdict 表
+- 2026-04-30 00:05 fold-in 冬柏 msg=d56bb0f7 补充 4 条：6 hard gate test 文件 mapping 子表（§二）/ 失败注入真路径规范（§5.5）/ 压测阈值具体化 + smoke regression baseline（§七 verdict 表新增 3 行）

--- a/docs/zh-CN/architecture/task-17-cr-review-checklist.md
+++ b/docs/zh-CN/architecture/task-17-cr-review-checklist.md
@@ -1,0 +1,228 @@
+# task #17 CR review checklist（huangheng CR 角色）
+
+> 本文档定义 task #17 PR 合并前 CR 必须走完的全套检查清单。
+> 适用于 `bryce/task-17-deployment-hard-cut` 主 PR + 未来同模式架构 hard cut PR。
+> 对应方案文档：`docs/zh-CN/architecture/task-system-hard-cut-v8.md`（架构师 v8.2 final）。
+
+---
+
+## 一、5 条交叉核对（cross-check）
+
+### (a) 4 候选粒度等量
+
+候选评估文档每个候选必须填同口径表格（4 列：框架提供 / ApeRAG 必须保留 / 衔接风险 / 最终稳态产物），每列内容粒度等量。**不允许「类似候选 X，区别如下」类隐性引用**。
+
+### (b) 节间一致
+
+同一份文档内 `§x` 与 `§y` 的事实标注、数字、scope 边界必须互相一致。最常见漂移点：
+
+- Executive Summary 主线项数 vs §3 主线项数 vs §12 待 ratify 主线项数
+- §4 框架对比表的 deployment / 依赖 row vs §3 各候选 deployment 描述
+- §6 回滚策略 vs §5 发布步骤的回滚约定
+
+### (c) 数字合理
+
+代码量、测试数量、工作量人天、PG `max_connections` 等数字必须可验证（grep / wc / git blame / 现场实测），不能写「大约几千行」类模糊描述。
+
+### (d) framework claim 分级到正文
+
+任何「framework 提供 / 接管 / 天然支持」类技术声称必须分三级：
+
+- **已证实**：framework 官方文档 / source code / 本仓库 PoC 可直接 cite
+- **待验证**：仅根据 framework high-level 描述，需进一步 PoC / 集成测试
+- **需 PoC**：ApeRAG 集成层未实测，必须独立 PoC 验证
+
+不允许「framework X 可以 Y」的 unverified high-level claim 直接进正文。
+
+### (e) 推荐 evidence-grounded
+
+任何架构推荐 / 选型决策必须 ground 在具体 evidence：
+
+- 具体代码 file path / line / git blame（grep 实证）
+- 具体框架文档 URL（不只 reference 名）
+- 具体失败场景闭环时间数据（不只「快/慢」label）
+- 具体「选错会怎样」+「未来什么证据触发重评」的可量化条件
+- 不允许「我倾向 X」「X 看起来更好」类 high-level 论证
+
+---
+
+## 二、6 条架构 hard gate（CR 必卡，ziang msg=4ea65100 + msg=ad6a610d 收敛版）
+
+### gate 1：API 不启动任何重型执行面
+
+- `aperag/app.py` lifespan 不允许出现 `asyncio.create_task(run_*_worker(...))` 调用任意 modality worker / reconciler / cleanup loop
+- `grep` CI 自动化检查 `app.py` 内 `run_vector_worker` / `run_fulltext_worker` / `run_graph_worker` / `run_graph_facts_worker` / `run_graph_vectors_worker` / `run_summary_worker` / `run_vision_worker` / `run_parse_worker` / `run_reconcile_loop` / `run_cleanup_loop` 全部消失
+
+### gate 2：cleanup intent 真源是 DB
+
+- `Document.status=DELETED` / `gmt_deleted` + remaining `DocumentIndex` rows 是 cleanup intent 唯一真源
+- Redis cleanup queue 仅作 wake-up transport，可丢消息
+- `worker cleanup loop` 必须能从 DB scan 补回任何 Redis 丢失的 cleanup intent
+- `grep` CI 自动化检查 worker cleanup loop 含 DB scan 路径（`Document.status == DELETED` 或 `gmt_deleted IS NOT NULL`）
+
+### gate 3：object store cleanup 也迁出 API 请求路径
+
+- `delete_objects_by_prefix()` 重 IO 调用必须从 API HTTP request handler 移到 worker cleanup loop
+- `cleanup_for_deleted_documents()` backend cleanup 同样移出
+- `grep` CI 自动化检查 API request handler 不出现以上两类调用
+
+### gate 4：API readiness 必须轻量
+
+- API liveness：仅证明进程活，不访问 PG / Redis / Qdrant / LLM provider
+- API readiness：仅证明 HTTP 入口可接 + 短超时（建议 ≤500ms）
+- 深度依赖检查必须放 `/health/diagnostics` 独立 endpoint，使用隔离小预算连接池
+- **不允许 readiness 成为 PG / Redis / Qdrant 连接池放大器**
+- 建议：readiness 不读 PG，必要时读 PG 用独立 ≤2 连接池 + ≤200ms 超时
+
+### gate 5：连接池 Helm 层映射现有 env
+
+- 应用代码不引入 `API_DB_POOL_SIZE` / `INDEXING_WORKER_DB_POOL_SIZE` 等新 env alias
+- Helm values 字段 `api.dbPoolSize` / `indexingWorker.dbPoolSize` 直接映射应用现有 `DB_POOL_SIZE` / `DB_MAX_OVERFLOW`
+- 部署文档必须含连接池预算公式：
+
+  ```text
+  sum(replicas × (pool_size + max_overflow)) + rollout_surge_budget + reserved_connections
+    < postgres_max_connections × safety_ratio
+  ```
+
+  `safety_ratio` 建议 0.7-0.8。
+
+### gate 6：回滚执行面唯一性
+
+- 禁止单回滚 API image + 保留新 `indexing-worker` deployment（旧 API lifespan worker + 新 worker deployment 双跑）
+- 回滚二选一：(a) Helm release 整体回滚 / (b) 先 `kubectl scale indexing-worker --replicas=0` 确认无 worker 后再回滚 API
+- 发布 checklist 加入「执行面唯一性确认」：`kubectl get deploy,pod` 验证
+
+---
+
+## 三、7 条实现修正（ziang msg=4ea65100 + msg=76f6f465 + Bryce msg=981960cd accept 版）
+
+### 修正 1：使用现有 `settings` module 实例
+
+- `aperag.config.get_settings()` helper 不存在
+- 必须用现有 module 级 `settings` 实例
+- `ProductionWorkerFactory` 从 `aperag.indexing.worker_factory` import（不是 `aperag.indexing` `__init__`）
+
+### 修正 2：`QuotaPolicyRegistry` 直接创建
+
+- `settings.indexing_quota_registry` 字段不存在
+- 按 `app.py` 现有写法：`RedisQuotaBackend(quota_redis, registry=QuotaPolicyRegistry())`
+- `InMemoryQuotaBackend(QuotaPolicyRegistry())` 同理
+
+### 修正 3：连接池仅 Helm 层映射
+
+跟 gate 5 重叠 — 应用代码不引双 env alias，仅 Helm 层 values 字段映射应用现有 env。
+
+### 修正 4：`_delete_document_indexes` 不嵌套 transaction
+
+- 外层 `_delete_document` 已在 transaction 里标记 `Document.status=DELETED` / `gmt_deleted`
+- 不允许 helper 内再开 `execute_with_transaction`
+- 删除 helper 对 `cleanup_for_deleted_documents()` 的调用，改成只写 DB intent
+
+### 修正 5：object store delete 也迁出 API
+
+跟 gate 3 重叠。
+
+### 修正 6：`run_cleanup_loop` 补 deleted Document scan
+
+- 现 `run_cleanup_loop` path A 仅做 orphan parse_version GC
+- task #17 必须 verify path B/C 是否完整覆盖 `Document.status=DELETED + remaining DocumentIndex rows` scan
+- 缺则同 PR 内补，不得留作后续 task
+
+### 修正 7：`/health/diagnostics` 鉴权 + sync URL
+
+- diagnostics endpoint 必须真鉴权或仅内网暴露（`include_in_schema=False` 或 admin token）
+- PG diagnostics 的 sync engine 必须使用 `get_sync_database_url(settings.database_url)` 转换 async URL（postgresql+asyncpg → postgresql+psycopg2），不能直接传 async URL 给 `create_engine`
+
+---
+
+## 四、CR 必应用的现有 lessons
+
+### Lesson #11：runtime wire-in 5-step checklist
+
+新增 modality / worker / async consumer 必走 5 步：
+
+1. **factory 注册**：worker_factory.py 等 builder 注册
+2. **dispatcher 路由**：dispatcher.py 等 enum → queue 路由
+3. **reconciler enqueue**：状态转换什么时候补漏
+4. **lifespan startup launch**：进程启动入口（API / worker deployment lifecycle）
+5. **e2e narrative 测试**：PENDING → ACTIVE 端到端真链路 verify
+
+### Lesson #12：grep-all-callers checklist
+
+shared utility / 默认行为 / 函数签名改动必须 grep 全 caller，不允许信 PR description / function 名 framing。
+
+### Lesson #12 extension v3：架构候选评估文档 4 cross-check
+
+(a) 候选粒度等量 / (b) §x vs §y 一致 / (c) 数字合理 / (d) framework claim 分级到正文。本文档 §一 已展开。
+
+### Mini-pattern 17：跨真源状态漂移检测
+
+跨 truth source（DB / 文件 / cache / queue / 外部服务）状态依赖必须 enumerate 自动 detection 机制（cache key 含上游 version / 周期巡检 stale check / startup sanity check 三选一）。
+
+### feedback：一次性不分阶段
+
+主要架构改动接受 hard cut + schema change + break，不留兼容路径 fallback。CR 时不允许接受「先做 Phase 1 紧急止血 + Phase 2 hardening + Phase 3 产品化」类拆分。Wave-style multi-PR 每条是 complete slice 不算分阶段；hot-fix 临时 patch 例外。
+
+---
+
+## 五、CR 工作流
+
+### 5.1 PR 上线后 CR 顺序
+
+1. 拉 PR 分支 + 验证 CI 全绿
+2. 走 §一 5 条 cross-check（粒度 / 一致 / 数字 / claim / evidence）
+3. 走 §二 6 条 hard gate（API 隔离 / cleanup SoT / object store 迁出 / readiness 轻量 / 连接池 Helm / 回滚唯一）
+4. 走 §三 7 条实现修正（settings / QuotaPolicyRegistry / 连接池 / 删除 helper / object store / cleanup loop / diagnostics）
+5. 走 §四 lessons 全应用
+6. 输出 verdict：`🟢 同意通过 / 🛑 阻塞 + 具体修法 / 🟡 部分通过 + 待修小项`
+
+### 5.2 verdict 表述规范
+
+不混用英文流程词。表述用中文：
+
+- ✅ **同意通过**（同 LGTM）
+- ⏳ **阻塞**（同 BLOCKER）— 必修才能合并
+- 💡 **小修建议**（同 NIT）— 不阻塞合并
+
+技术专有名词（PR / CI / Redis / Helm / probe / DocumentIndex / framework）保留英文。
+
+### 5.3 false positive 自我修正
+
+CR cross-check 表里任何 ✅ 标注被 surface 为 false positive 时，立即在 thread 公开 own-up 并撤回 ✅ → 改为对应等级（部分通过 / 阻塞）。**不允许 silent 修正不公开**。
+
+### 5.4 cross-check 与团队协作
+
+- CR 与 implementer / 架构师 / SRE / 测试专家 / 部署侧 多人协作时，按文件边界分工不重叠
+- 发现跨边界问题先在 PR thread 点对方，不直接跨边界大改
+- 合并 gate：5 lane（implementer + 架构 + SRE + 状态机/CR + 部署）独立给 verdict，全 ack 后 squash merge
+
+---
+
+## 六、CR 历史 sediment 引用
+
+- `memory/feedback_e2e_dataflow_trace.md` Lesson #11 + Lesson #12 + extension v3
+- `memory/feedback_collab_before_solo_pr.md` 同 tag/scope 多 agent 默认 co-design 单 PR
+- `memory/feedback_object_store_path_drift.md` `OBJECT_STORE_LOCAL_ROOT_DIR` 漂移诊断 playbook
+- `memory/feedback_one_shot_no_phased_rollout.md` 一次性不分阶段 directive
+- `memory/feedback_simple_stable_deploy_and_forget.md` simple-stable + 私有化部署免维护
+- `memory/feedback_cr_must_cross_reference_arch_doc.md` CR 必对照架构文档逐条 invariant 走
+
+---
+
+## 七、task #17 PR final review verdict（待 PR 合并前填）
+
+| 检查项 | 状态 | 备注 |
+|------|------|------|
+| §一 5 cross-check 全过 | _待填_ | |
+| §二 6 hard gate 全 verify | _待填_ | |
+| §三 7 实现修正全 fold-in | _待填_ | |
+| §四 lessons 全应用 | _待填_ | |
+| 团队 5 lane LGTM ack 收齐 | _待填_ | |
+| 架构师 v8.2 docs 入仓 | _待填_ | |
+| 黄章书 部署/发布/回滚 docs 入仓 | _待填_ | |
+| ziang 状态机/cleanup SoT 验收 docs 入仓 | _待填_ | |
+| Weston scope 一致性 verify | _待填_ | |
+| Bryce 代码主线 file-by-file align ziang 7 修正 | _待填_ | |
+
+最终 verdict 由 huangheng 在 PR 合并前填，附 thread message ID 引用。

--- a/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
+++ b/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
@@ -38,6 +38,18 @@ PostgreSQL 中的业务状态仍是唯一真源：
 
 Redis 消息丢失时，worker/reconciler/cleanup loop 必须能从 DB 状态补回。
 
+### 1.3 全局并发 / quota 口径
+
+task #17 只保证 RedisQuotaBackend 的跨副本基础设施配置在 API/worker 拆分后仍可初始化运行，不承诺 worker 已经实际调用 `quota_backend.acquire()` 做跨副本限流。
+
+已知 gap：
+
+- `RedisQuotaBackend` 和 Lua atomic token bucket 已存在；
+- 当前 worker 消费路径尚未接入 `quota_backend.acquire()`；
+- collection/provider 等更细维度也不在 task #17 范围内。
+
+因此部署验收中若发现 worker 并发超过预期，应记录为 task #24 backlog 风险，不作为 task #17 hard-cut blocker。task #24 负责「图谱/索引 worker quota 接入 + 多维度扩展（collection_id/provider）跨副本限流生效」。
+
 ## 2. Helm 改造要求
 
 ### 2.1 新增 `indexing-worker-deployment.yaml`
@@ -318,4 +330,3 @@ HTTP request path 中不得出现上述重型 cleanup 调用。Redis cleanup que
 | `DocumentIndex` status counts | PENDING/RUNNING 不永久堆积 |
 | Worker restart count | 不持续增长 |
 | Worker 独立重启 | API 不受影响，任务可恢复 |
-

--- a/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
+++ b/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
@@ -271,7 +271,11 @@ HTTP request path 中不得出现上述重型 cleanup 调用。Redis cleanup que
 2. 先部署新 Helm release，包含 `api` 与 `indexing-worker` 两个 deployment。
 3. 确认新 API pod 不再启动 worker/reconciler/cleanup。
 4. 确认 `indexing-worker` pod Ready/Running，日志出现所有 lane 启动信息。
-5. 观察 10-15 分钟：
+5. 确认 API / worker 最终连接池 env 生效：
+   - `kubectl exec deploy/api -- env | grep -E 'DB_POOL_SIZE|DB_MAX_OVERFLOW'`
+   - `kubectl exec deploy/indexing-worker -- env | grep -E 'DB_POOL_SIZE|DB_MAX_OVERFLOW'`
+   - 预期 API 与 worker 分别符合 Helm `api.dbPoolSize/api.dbMaxOverflow` 与 `indexingWorker.dbPoolSize/indexingWorker.dbMaxOverflow`，不能都读旧 `api.env.DB_POOL_SIZE=20 / DB_MAX_OVERFLOW=40`。
+6. 观察 10-15 分钟：
    - API p95/p99；
    - `/health/live` / `/health/ready` 成功率；
    - `/api/v2/auth/user` 成功率；
@@ -279,8 +283,8 @@ HTTP request path 中不得出现上述重型 cleanup 调用。Redis cleanup que
    - Redis queue depth；
    - `DocumentIndex` status counts；
    - worker restart count。
-6. 执行 graph/indexing 压力场景，确认 API 不被 worker 负载拖垮。
-7. 执行 worker pod restart，确认 API 不受影响，任务可恢复。
+7. 执行 graph/indexing 压力场景，确认 API 不被 worker 负载拖垮。
+8. 执行 worker pod restart，确认 API 不受影响，任务可恢复。
 
 ### 6.3 发布中止条件
 

--- a/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
+++ b/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
@@ -330,3 +330,78 @@ HTTP request path 中不得出现上述重型 cleanup 调用。Redis cleanup que
 | `DocumentIndex` status counts | PENDING/RUNNING 不永久堆积 |
 | Worker restart count | 不持续增长 |
 | Worker 独立重启 | API 不受影响，任务可恢复 |
+
+## 9. 本地稳定性验收入口
+
+task #17 合并前必须跑一轮本地或等价测试环境稳定性验收。推荐流程：
+
+1. 部署新拓扑，确认 `api` 与 `indexing-worker` 是两个独立 Deployment。
+2. 设置环境变量并先跑轻量检查：
+
+   ```bash
+   export NO_PROXY=127.0.0.1,localhost
+   export TASK17_BASE_URL=http://127.0.0.1:8000
+   export TASK17_API_REPLICAS=2
+   export TASK17_API_DB_POOL_SIZE=5
+   export TASK17_API_DB_MAX_OVERFLOW=5
+   export TASK17_WORKER_REPLICAS=1
+   export TASK17_WORKER_DB_POOL_SIZE=10
+   export TASK17_WORKER_DB_MAX_OVERFLOW=10
+   export TASK17_POSTGRES_MAX_CONNECTIONS=100
+   ./scripts/task17_local_stability_check.sh
+   ```
+
+3. 如果是 Kubernetes 环境，补充命名空间和可选破坏性检查：
+
+   ```bash
+   export TASK17_K8S_NAMESPACE=demo
+   export TASK17_RESTART_WORKER=1
+   ./scripts/task17_local_stability_check.sh
+   ```
+
+4. 运行多文档并发上传/索引压测。压测期间与压测结束后各跑一次
+   `scripts/task17_local_stability_check.sh`，确保 worker 压力不会让 API
+   `/health/live`、`/health/ready` 或 `/api/v2/auth/user` 失稳。
+
+5. 跑现有 HTTP smoke baseline，要求 PR 前后新增失败数为 0：
+
+   ```bash
+   make test-http-smoke
+   ```
+
+### 9.1 task #17 hard gate 与验证入口对位
+
+| Hard gate | 验证入口 |
+|---|---|
+| API 不启动重型执行面 | `scripts/task17_local_stability_check.sh` Kubernetes 日志扫描 + CR grep gate |
+| cleanup intent 真源是 DB | cleanup 单测 / `tests/boundaries` grep gate；Redis 消息丢失恢复由压测补充验证 |
+| object store cleanup 迁出 API | grep gate，确保 API request path 无 `delete_objects_by_prefix()` |
+| readiness 轻量 | `scripts/task17_local_stability_check.sh` 对 `/health/live`、`/health/ready` 采样，默认 p95 ≤ 500ms |
+| 连接池 Helm 映射 | Helm template review + `scripts/task17_local_stability_check.sh` 预算公式检查 |
+| 回滚执行面唯一 | runbook §7 + Kubernetes 拓扑检查，禁止旧 API worker 与新 `indexing-worker` 双执行 |
+
+### 9.2 压测口径
+
+本轮最低验收口径：`10` 份以上文档，至少 `5` 并发上传，持续观察不少于
+`10` 分钟，覆盖 vector / fulltext / graph_facts / graph_vectors 状态推进。若测试环境
+模型或 provider 配额允许，推荐提升到 `100` 份文档、`10` 并发。
+
+验收报告必须在 PR thread 附上：
+
+- 文档数、并发数、持续时间；
+- API `/health/live` / `/health/ready` p95；
+- PostgreSQL 当前连接数与预算公式；
+- Redis queue depth 趋势；
+- `DocumentIndex` PENDING / RUNNING / ACTIVE / FAILED 计数；
+- worker 重启或 Redis 丢消息等失败注入结果。
+
+### 9.3 失败注入约定
+
+失败注入尽量走真实部署路径，不 mock Redis client 或 worker 内部函数。
+
+- worker 独立重启：`kubectl delete pod -l app.aperag.io/component=indexing-worker`
+- Redis 短暂不可用：优先使用测试环境内的网络隔离或 Redis pod restart；不能在共享线上环境直接做破坏性注入。
+- Redis 消息丢失恢复：允许手动清空测试 queue 或重启 worker 后依赖 DB scan/reconciler 补漏，但必须记录命令和恢复前后 `DocumentIndex` 计数。
+
+如果当前环境不允许破坏性注入，PR 可以先通过非破坏性检查，但必须在验收报告里明确标为
+`SKIP`，并说明替代证据。

--- a/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
+++ b/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
@@ -1,0 +1,321 @@
+# task #17 部署、发布、回滚执行方案
+
+本文是 task #17 的部署/SRE 执行 runbook。代码实现开始前，先把部署边界、连接池预算、probe 语义、发布步骤和回滚策略锁进 PR，避免实现阶段把执行面隔离做成不完整的半切换。
+
+## 1. 目标稳态
+
+### 1.1 Deployment 拓扑
+
+task #17 完成后的稳态只有两个应用执行面：
+
+| Deployment | 职责 | 启动命令 | 是否消费 indexing queue |
+|---|---|---|---|
+| `api` | HTTP API、鉴权、普通请求处理、轻量 enqueue | `/app/scripts/entrypoint.sh /app/scripts/start-api.sh` | 否，只能 enqueue |
+| `indexing-worker` | parse、vector、fulltext、graph、graph_facts、graph_vectors、summary、vision、reconciler、cleanup | `python -m aperag.cli.indexing_worker` | 是 |
+
+API 进程不得启动任何 heavy indexing execution plane：
+
+- 不启动 `run_vector_worker`
+- 不启动 `run_fulltext_worker`
+- 不启动 `run_graph_worker`
+- 不启动 `run_graph_facts_worker`
+- 不启动 `run_graph_vectors_worker`
+- 不启动 `run_summary_worker`
+- 不启动 `run_vision_worker`
+- 不启动 `run_parse_worker`
+- 不启动 `run_reconcile_loop`
+- 不启动 `run_cleanup_loop`
+
+`indexing-worker` 必须覆盖当前 `aperag/app.py` lifespan 里已有的全部 worker lane。legacy `graph` lane 继续保留；如果未来要删除，必须单独论证并补迁移测试，不在 task #17 中顺手删除。
+
+### 1.2 状态真源
+
+PostgreSQL 中的业务状态仍是唯一真源：
+
+- `DocumentIndex` 决定 indexing task 的业务状态。
+- `Document.status` / `Document.gmt_deleted` 加 remaining `DocumentIndex` rows 决定 cleanup intent。
+- Redis queue 只作为可丢失 transport，不是业务状态真源。
+
+Redis 消息丢失时，worker/reconciler/cleanup loop 必须能从 DB 状态补回。
+
+## 2. Helm 改造要求
+
+### 2.1 新增 `indexing-worker-deployment.yaml`
+
+新增 Helm template：
+
+```text
+deploy/aperag/templates/indexing-worker-deployment.yaml
+```
+
+建议字段：
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexing-worker
+spec:
+  replicas: {{ .Values.indexingWorker.replicaCount }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.aperag.io/component: indexing-worker
+    spec:
+      containers:
+        - name: aperag-indexing-worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /data/.cache
+              mkdir -p /root/.cache
+              ln -sf /data/.cache/huggingface /root/.cache/
+              ln -sf /data/.cache/torch /root/.cache/
+              /app/scripts/entrypoint.sh python -m aperag.cli.indexing_worker
+```
+
+`indexing-worker` 使用同一后端镜像，不新增 Celery/Dramatiq/RQ 依赖。
+
+### 2.2 API Deployment 改造
+
+`api` deployment 保留原 API 启动命令，只修改 probe 与连接池配置。API image 仍然挂载 `/data`，因为 API 仍需接收上传文件和 enqueue parse；但 API 请求路径不得运行 indexing worker 或 backend cleanup。
+
+`api-deployment.yaml` 中的注释要更新：不能再写 “indexing runtime spawned inside this api pod”。
+
+### 2.3 Values 新增结构
+
+`values.yaml` 增加：
+
+```yaml
+indexingWorker:
+  enabled: true
+  replicaCount: 1
+  resources: {}
+  dbPoolSize: "10"
+  dbMaxOverflow: "10"
+  livenessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - pgrep -f "aperag.cli.indexing_worker" >/dev/null
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 6
+```
+
+`api` 增加 Helm 层字段：
+
+```yaml
+api:
+  dbPoolSize: "5"
+  dbMaxOverflow: "5"
+```
+
+重要：应用代码仍只认现有 `DB_POOL_SIZE` / `DB_MAX_OVERFLOW`。Helm 层字段 `api.dbPoolSize`、`api.dbMaxOverflow`、`indexingWorker.dbPoolSize`、`indexingWorker.dbMaxOverflow` 分别映射到容器内现有 env：
+
+```yaml
+- name: DB_POOL_SIZE
+  value: {{ .Values.api.dbPoolSize | default .Values.api.env.DB_POOL_SIZE | quote }}
+- name: DB_MAX_OVERFLOW
+  value: {{ .Values.api.dbMaxOverflow | default .Values.api.env.DB_MAX_OVERFLOW | quote }}
+```
+
+worker deployment 同理映射：
+
+```yaml
+- name: DB_POOL_SIZE
+  value: {{ .Values.indexingWorker.dbPoolSize | quote }}
+- name: DB_MAX_OVERFLOW
+  value: {{ .Values.indexingWorker.dbMaxOverflow | quote }}
+```
+
+不要新增应用层 `API_DB_POOL_SIZE` / `INDEXING_WORKER_DB_POOL_SIZE` env alias。
+
+## 3. Probe 语义
+
+### 3.1 API Probe
+
+API probe 使用统一路径：
+
+| Endpoint | 用途 | 依赖检查 |
+|---|---|---|
+| `/health/live` | liveness | 不查 DB/Redis/Qdrant/ObjectStore |
+| `/health/ready` | readiness | 只证明 HTTP 入口可接，短超时，不查重依赖 |
+| `/health/diagnostics` | 人工/发布诊断 | 可查 PG/Redis/Qdrant/ObjectStore，但必须鉴权或仅内网暴露 |
+| `/health` | legacy compatibility | 指向 liveness 语义 |
+
+API readiness 不能成为连接池放大器。不得默认在 kubelet readiness 中检查 PG/Redis/Qdrant；如果未来必须检查依赖，只能用隔离的小预算连接和严格 timeout，且不能占用主业务 pool。
+
+### 3.2 Worker Probe
+
+`indexing-worker` 没有对外 HTTP 流量入口，不需要 readiness 来接入 Service 流量。建议：
+
+- liveness 使用 process-level exec probe。
+- worker 健康状态通过日志、metrics、Redis queue depth、DocumentIndex status counts 和 worker restart count 观测。
+- 不配置会因为 Redis/PG transient 抖动而让 kubelet 反复杀 worker 的重依赖 readiness。
+
+## 4. 连接池预算
+
+本轮不接 PgBouncer。先把 API/worker 连接池预算拆开并公式化，这是后续 PgBouncer 接入的前置条件。
+
+### 4.1 预算公式
+
+发布前必须满足：
+
+```text
+sum(replicas * (DB_POOL_SIZE + DB_MAX_OVERFLOW))
+  + rollout_surge_budget
+  + diagnostics_reserved
+  + postgres_reserved
+  < postgres_max_connections * safety_ratio
+```
+
+推荐 `safety_ratio <= 0.7`。`postgres_reserved` 给 PostgreSQL 内部连接、管理员连接、migration job 和临时诊断保留。
+
+### 4.2 新加坡默认建议
+
+新加坡环境已经出现过 PostgreSQL `too many clients`，默认值必须偏保守：
+
+| Role | replicas | DB_POOL_SIZE | DB_MAX_OVERFLOW | 单 pod 理论上限 |
+|---|---:|---:|---:|---:|
+| API | 2 | 5 | 5 | 10 |
+| indexing-worker | 1 | 10 | 10 | 20 |
+
+示例预算：
+
+```text
+api: 2 * (5 + 5) = 20
+worker: 1 * (10 + 10) = 20
+surge: 1 * 10 = 10
+diagnostics_reserved: 5
+postgres_reserved: 10
+total = 65
+```
+
+如果实际 `postgres_max_connections` 低于该预算所需值，则必须进一步降低 `replicaCount`、`dbPoolSize`、`dbMaxOverflow` 或调整 rollout strategy，不能靠 API/worker 共进程规避。
+
+### 4.3 PgBouncer 后续选项
+
+PgBouncer 是后续连接池基础设施方向，不阻塞 task #17。
+
+未来接入 PgBouncer 前必须验证：
+
+- transaction pooling 与当前 SQLAlchemy / asyncpg 使用方式兼容；
+- prepared statement 行为不会被 pooling mode 破坏；
+- Alembic / migration job 不经过不兼容的 transaction pooling 路径；
+- 长事务、session-level 设置、LISTEN/NOTIFY 如存在必须单独评估；
+- 接入后仍保留 API/worker 独立预算，不允许因为有 PgBouncer 就无限扩 worker replica。
+
+## 5. Cleanup 迁出 API 的部署验收
+
+API 删除路径不得直接做 backend cleanup 或 object store prefix delete。
+
+必须迁出的调用类型：
+
+- `cleanup_for_deleted_documents()`
+- vector/fulltext/graph/summary/vision backend cleanup
+- object store prefix delete，例如 `delete_objects_by_prefix()`
+
+API 只写 durable DB intent。Worker cleanup loop 或 cleanup queue 负责执行重型清理。
+
+验收要求：
+
+```text
+grep -R "cleanup_for_deleted_documents(" aperag/domains aperag/server aperag/views
+grep -R "delete_objects_by_prefix(" aperag/domains aperag/server aperag/views
+```
+
+HTTP request path 中不得出现上述重型 cleanup 调用。Redis cleanup queue 只能作为 wake-up transport；删除 Redis 消息后，worker cleanup scan 仍必须能通过 DB intent 恢复。
+
+## 6. 发布计划
+
+### 6.1 合并前检查
+
+合并 task #17 前必须完成：
+
+1. Helm template 渲染通过。
+2. `api` deployment probe 指向 `/health/live` 和 `/health/ready`。
+3. `indexing-worker` deployment 存在，启动命令为 `python -m aperag.cli.indexing_worker`。
+4. `api` 与 `indexing-worker` 分别映射到现有 `DB_POOL_SIZE` / `DB_MAX_OVERFLOW`。
+5. 文档包含连接池预算公式和环境示例。
+6. 回滚步骤包含执行面唯一性检查。
+
+### 6.2 发布步骤
+
+1. 发布前记录：
+   - current image tag；
+   - API replica count；
+   - PostgreSQL `max_connections`；
+   - 当前 active connections；
+   - Redis queue depth；
+   - `DocumentIndex` status counts。
+2. 先部署新 Helm release，包含 `api` 与 `indexing-worker` 两个 deployment。
+3. 确认新 API pod 不再启动 worker/reconciler/cleanup。
+4. 确认 `indexing-worker` pod Ready/Running，日志出现所有 lane 启动信息。
+5. 观察 10-15 分钟：
+   - API p95/p99；
+   - `/health/live` / `/health/ready` 成功率；
+   - `/api/v2/auth/user` 成功率；
+   - PG active connections；
+   - Redis queue depth；
+   - `DocumentIndex` status counts；
+   - worker restart count。
+6. 执行 graph/indexing 压力场景，确认 API 不被 worker 负载拖垮。
+7. 执行 worker pod restart，确认 API 不受影响，任务可恢复。
+
+### 6.3 发布中止条件
+
+出现任一条件即中止发布并进入回滚：
+
+- API `/health/live` 或 `/health/ready` 持续失败；
+- API `/api/v2/auth/user` p95/p99 明显劣化且和 worker rollout 同步；
+- PG active connections 接近或超过预算；
+- `indexing-worker` crashloop；
+- `DocumentIndex.RUNNING` 持续增长且 heartbeat 不更新；
+- Redis queue depth 持续增长且 worker 无消费；
+- 出现旧 API worker 与新 worker deployment 双执行。
+
+## 7. 回滚策略
+
+### 7.1 执行面唯一性 hard gate
+
+禁止只把 API image 回滚到旧版本，同时保留新 `indexing-worker` deployment 运行。
+
+原因：旧 API image 可能仍在 FastAPI lifespan 中启动 worker/reconciler/cleanup；如果新 `indexing-worker` 继续运行，会形成双执行面。
+
+允许的回滚方式只有两种：
+
+1. Helm release 整体回滚到上一版本，同时移除 `indexing-worker` deployment；
+2. 先把 `indexing-worker` scale 到 0，再回滚 API image。
+
+### 7.2 回滚步骤
+
+1. 暂停流量变更，记录当前 queue depth 与 `DocumentIndex` status counts。
+2. 选择整体 Helm rollback 或先 scale worker 到 0。
+3. 执行回滚。
+4. 验证执行面唯一：
+   - 如果回到旧 API，`indexing-worker` deployment 必须不存在或 replicas=0；
+   - 如果保留新架构，API 必须不启动 worker。
+5. 验证 API `/health` 和 `/api/v2/auth/user`。
+6. 验证 Redis queue 与 `DocumentIndex` 状态不需要人工 SQL 修复；reconciler/cleanup 应能从 DB 恢复。
+
+## 8. 发布验收信号
+
+| 信号 | 目标 |
+|---|---|
+| API `/health/live` | 稳定成功 |
+| API `/health/ready` | 稳定成功，不做重依赖检查 |
+| API `/api/v2/auth/user` | graph/indexing 压力下仍稳定 |
+| PG active connections | 小于预算公式上限 |
+| Redis queue depth | 有消费趋势，不永久增长 |
+| `DocumentIndex` status counts | PENDING/RUNNING 不永久堆积 |
+| Worker restart count | 不持续增长 |
+| Worker 独立重启 | API 不受影响，任务可恢复 |
+

--- a/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
+++ b/docs/zh-CN/architecture/task-17-deployment-release-runbook.md
@@ -367,6 +367,14 @@ task #17 合并前必须跑一轮本地或等价测试环境稳定性验收。�
    `scripts/task17_local_stability_check.sh`，确保 worker 压力不会让 API
    `/health/live`、`/health/ready` 或 `/api/v2/auth/user` 失稳。
 
+   压测期间建议打开持续采样窗口：
+
+   ```bash
+   export TASK17_OBSERVE_SECONDS=600
+   export TASK17_OBSERVE_INTERVAL_SECONDS=2
+   ./scripts/task17_local_stability_check.sh
+   ```
+
 5. 跑现有 HTTP smoke baseline，要求 PR 前后新增失败数为 0：
 
    ```bash

--- a/docs/zh-CN/architecture/task-17-state-machine-validation.md
+++ b/docs/zh-CN/architecture/task-17-state-machine-validation.md
@@ -1,0 +1,73 @@
+# task #17 状态机与失败场景验收
+
+本文档补充 task #17 API/Worker hard cut 的状态机、cleanup SoT、失败恢复和 grep gate 验收要求。它只约束本轮运行时隔离主线，不引入 Dramatiq / Celery / RQ，不改变 DocumentIndex 业务状态模型。
+
+## 1. 不变量
+
+1. **DocumentIndex 是唯一业务状态真源**：用户可见索引状态由 `DocumentIndex.status`、`parse_version`、`is_serving`、`updated_at`、`last_heartbeat`、`retry_after` 等 DB 字段决定。Redis queue 只是可丢 transport。
+2. **队列丢失必须可恢复**：`q:parse`、`q:indexing:{modality}`、未来可能出现的 cleanup queue 都不能作为唯一真源。Redis 消息丢失后，必须由 DB scan / reconciler / cleanup loop 补回。
+3. **API 不拥有重型执行面**：API 只能处理 HTTP、鉴权、轻量 enqueue 和 durable intent 写入。API 请求路径不得直接构建 `ProductionWorkerFactory`，不得启动 modality worker / reconciler / cleanup loop，不得调用 backend cleanup。
+4. **indexing-worker 拥有重型执行面**：独立 worker 进程负责 parse、vector、fulltext、graph、graph_facts、graph_vectors、summary、vision、reconciler、cleanup。
+5. **旧任务不能写回新状态**：所有 worker 成功/失败写回必须受当前 DB 行、status、parse_version、serving 语义保护。旧 parse_version、已删除 document、已 supersede row 到达时只能 no-op 或走可恢复失败路径。
+6. **cleanup intent 真源在 DB**：document delete 后的 cleanup intent 由 `Document.status=DELETED` 或 `Document.gmt_deleted IS NOT NULL` 加 remaining `DocumentIndex` rows 表示。Redis cleanup queue 如果未来新增，只能作为 wake-up transport。
+7. **object store cleanup 也不在 API 请求路径**：原 API 内的 `delete_objects_by_prefix()` 属于重 IO cleanup，必须随 backend cleanup 迁到 worker cleanup loop 或 durable cleanup worker。
+
+## 2. 五类失败场景闭环
+
+| 场景 | 检测真源 | 恢复路径 | 验收目标 |
+|---|---|---|---|
+| worker crash，Redis 消息已 BLPOP | `DocumentIndex.status=PENDING/RUNNING` + `last_heartbeat` | 未 claim 的 PENDING 由 `reconcile_pending_dispatch` 重入队；已 claim 的 RUNNING 由 `reconcile_running_reclaim` 超时转回 PENDING，再重入队 | worker pod kill 后任务最终 ACTIVE/FAILED，不永久 RUNNING；API 不受影响 |
+| worker pop 后 DB 写失败 | DB 仍是 RUNNING/PENDING，Redis 已无原消息 | heartbeat 过期或 pending scan 重新入队 | 模拟 finalize 抛错后，下一轮 reconciler 能恢复，不依赖 Redis 原消息 |
+| DB 已写 PENDING 但消息丢失 | `DocumentIndex.status=PENDING` | `reconcile_pending_dispatch` 扫 DB 入 `q:indexing:{modality}`；parse 丢失由 stuck-parse scan 重推 `q:parse` | 清空 Redis queue 后，reconciler 能把 PENDING 补回队列 |
+| Redis 重启 / 队列全丢 | DB 全量状态 | reconciler 从 PENDING / RUNNING / stale graph_vectors / failed retry 状态重建 queue | Redis flush 后不需要人工 SQL 修复，任务继续推进 |
+| 删除/重建旧任务到达 | `DocumentIndex` 当前行 + parse_version / serving 状态 + Document deleted 状态 | 旧行 claim/finalize 被拒绝或 no-op；新版本 row 不被旧任务覆盖 | 同一 document rebuild/delete 并发时，旧任务不能把新 parse_version 写成 ACTIVE |
+
+时间目标按现有默认配置写成验收上限：pending dispatch 约 30s tick；RUNNING stale reclaim 约 60s heartbeat；cleanup scan 以配置周期为准。报告和 PR 不应把这些时间写成 framework 承诺。
+
+## 3. cleanup 迁出 API 的专门验收
+
+1. API 删除 document 后快速返回，只在 DB 中持久化 `Document.status=DELETED`、`gmt_deleted` 和必要 durable intent。
+2. API 请求路径不直接调用 `cleanup_for_deleted_documents()`，不执行 `delete_objects_by_prefix()`，不构建 graph/vector/fulltext backend cleanup worker。
+3. worker cleanup loop 扫描 deleted document + remaining `DocumentIndex` rows 后执行 backend cleanup 和 object store cleanup。
+4. backend cleanup 或 object store cleanup transient failure 时，不删除 `DocumentIndex` row；下一轮继续重试。
+5. Redis cleanup queue 如果存在，只是 wake-up；删除 queue message 后，DB scan 仍能补漏。
+6. collection delete 相关 cleanup 也必须符合同一原则：API 只写 durable intent，重型级联 cleanup 由 worker 执行或由可恢复 DB scan 兜底。
+
+## 4. 必补测试
+
+1. **API boundary test**：monkeypatch `cleanup_for_deleted_documents` 和 object store `delete_objects_by_prefix` 为 fail-fast，调用 document delete，确认 API 路径不触发 backend/object-store cleanup。
+2. **worker cleanup recovery test**：构造 `Document.status=DELETED` + `DocumentIndex` rows，跑 cleanup loop 单轮，确认 backend cleanup 被 worker 执行且 rows 被清理；transient failure 时 rows 保留。
+3. **queue-loss test**：创建 PENDING row 后清空 Redis queue，跑 reconciler，确认队列被重建。
+4. **worker-crash test**：构造 RUNNING + stale heartbeat，跑 `reconcile_running_reclaim` + `reconcile_pending_dispatch`，确认恢复为可消费任务。
+5. **stale-write test**：旧 parse_version / 旧 index row 到达时，不能覆盖新 serving row。
+6. **API isolation e2e**：worker 压 graph/LLM-heavy 任务时，API `/health/live`、`/health/ready`、`/api/v2/auth/user` 响应稳定，PG 连接数不超过预算公式。
+7. **startup grep test**：`aperag/app.py` 不再 import/启动任何 `run_*_worker`、`run_reconcile_loop`、`run_cleanup_loop`；`aperag/cli/indexing_worker.py` 覆盖全部 lane。
+
+## 5. grep gate
+
+PR 合并前必须通过下面的人工或 CI 检查。允许命中测试、文档和 worker 侧实现；不允许命中 API HTTP request handler 的重型执行路径。
+
+```bash
+# API lifespan 不得启动 worker/reconciler/cleanup
+rg "asyncio\\.create_task\\(run_.*worker|run_reconcile_loop|run_cleanup_loop|ProductionWorkerFactory" aperag/app.py
+
+# API domains 不得直接执行 backend/object-store cleanup
+rg "cleanup_for_deleted_documents|cleanup_orphan_parse_versions|delete_objects_by_prefix|delete_by_filter|delete_by_query" aperag/domains/
+
+# worker CLI 必须覆盖所有当前 lane
+rg "run_(parse|vector|fulltext|graph|graph_facts|graph_vectors|summary|vision)_worker|run_reconcile_loop|run_cleanup_loop" aperag/cli/indexing_worker.py
+```
+
+## 6. 发布观测指标
+
+发布时至少观察 6 个信号：
+
+- API p95 / p99 latency
+- `/health/live` 和 `/health/ready` 成功率
+- PostgreSQL active connections
+- Redis queue depth：`q:parse` + 每个 `q:indexing:{modality}`
+- `DocumentIndex` status counts：PENDING / RUNNING / FAILED / ACTIVE
+- worker restart count
+
+任一信号异常，优先 scale worker、调低 worker pool 或暂停 worker。不得把 worker 重新塞回 API lifespan 作为回退方式。
+

--- a/docs/zh-CN/architecture/task-17-state-machine-validation.md
+++ b/docs/zh-CN/architecture/task-17-state-machine-validation.md
@@ -70,4 +70,3 @@ rg "run_(parse|vector|fulltext|graph|graph_facts|graph_vectors|summary|vision)_w
 - worker restart count
 
 任一信号异常，优先 scale worker、调低 worker pool 或暂停 worker。不得把 worker 重新塞回 API lifespan 作为回退方式。
-

--- a/docs/zh-CN/architecture/task-system-hard-cut-v8.md
+++ b/docs/zh-CN/architecture/task-system-hard-cut-v8.md
@@ -1,0 +1,337 @@
+# ApeRAG 异步任务系统重构 — v8 final 执行方案（5 方共识 + earayu2 ratify-ready）
+
+**起草**：@符炫炜 总架构师定稿
+**日期**：2026-04-29
+**版本**：v8 final — earayu2 directive msg=074b8019「今天做完明天发布」节奏 + 5 方独立 evidence-based 共识 + 全部 BLOCKER 收紧
+
+---
+
+## Executive Summary
+
+### 推荐：候选 B — 保留 ApeRAG 内嵌 task system + 一次性部署 hard cut
+
+**1 句话**：保留现有 `aperag/indexing/*` 模块位置不动 + 新增薄 `aperag/cli/indexing_worker.py` 启动入口 + 拆 API/worker deployment + probe 分层 + 连接池公式预算 + 全局并发跨副本 + 删除 cleanup 路径迁出 API + 部署级 e2e 压测验收 + spec lock fold 进 architecture.md。
+
+**不做**：
+- ❌ 不引入 Dramatiq / Celery / RQ
+- ❌ 不做 `aperag/tasks/` 包名大搬迁
+- ❌ 不把应用层 hardening 4 项混进 task #17 主 PR
+- ❌ 不留 lifespan worker fallback 双模式
+
+### 5 方独立 evidence-based 推荐 100% 收敛
+
+- 架构师 v8（本文档定稿）
+- @huangzhangshu SRE 部署侧（msg=b3bf4733 + msg=5be8396e + msg=03112f15）
+- @ziang 代码审计 origin/main=643c178c（msg=5eedb951 + msg=7ff9efd7 + msg=ba559be9 + msg=cecb0d88）
+- @huangheng CR 视角（msg=f5c4e738 + msg=5f72446f + msg=910bcca7）
+- @Weston 架构评审（msg=0d401ca7 + msg=4e74f4f4 + msg=2dae8ae9 + msg=0413ed68）
+
+5 方共识：候选 B + 4 escape hatch architecture invariant + Dramatiq/Celery/RQ 留 PoC 路径
+
+---
+
+## 一、上下文（详见 v7 §1，简版）
+
+- **新加坡 503 根因**：API + worker 共 process（黄章书 msg=0fa3489a 现场诊断）
+- **Wave 3 历史**：Celery hard-cut 删除部署 + worker 退化 in-process（`deploy/aperag/values.yaml` 显式标注）
+- **Redis 已有**：标准依赖 + KubeBlocks 维护（earayu2 msg=bf27b395）
+- **已实现 task system**：`RedisWorkQueue` (orchestrator.py 826 LOC) + `RedisQuotaBackend Lua` (quota.py 411 LOC) + `reconciler 5-stage` (reconciler.py 889 LOC) + DocumentIndex SoT + 17 单测 + 5 ship PR
+
+---
+
+## 二、不可变 hard gate（必须满足）
+
+按 @黄章书 msg=b30d07ca 7 条 + 2 层 invariant：
+
+### 2.1 黄章书 7 条现场约束
+1. API 和 worker 不能共命运
+2. probe 分层
+3. 连接池上限按进程预算
+4. 全局并发上限跨副本
+5. DocumentIndex 仍是状态 SoT
+6. 删除/重建旧任务防写回
+7. e2e 压测验收
+
+### 2.2 两层架构 invariant
+- 第 1 层 任务执行框架：消息投递 / worker 进程 / ack & retry / crash 再投递
+- 第 2 层 ApeRAG 业务状态：DocumentIndex SoT / version-token-status gate / facts↔vectors stale / serving / 用户可见 ACTIVE
+
+**第 2 层永不依赖 framework state**。
+
+---
+
+## 三、代码改造（@Bryce msg=1c46bf74 + @ziang msg=32ac48e3 详细 file-by-file）
+
+详细 file-by-file 改造见：
+- 本 PR 同 commit 的代码 diff（按 §3 总结 8 项主线改动逐一 implement）
+- @ziang msg=32ac48e3 thread 章节 + 7 项 CR 修正（msg=981960cd Bryce accept）
+- 实施时严格按 §10 mandatory checklist + §7 状态机失败场景验收
+
+### §3 总结 8 项 task #17 运行时主线改动（per Weston msg=d2c46eb7 BLOCKER 1 修订统一）
+
+1. **`aperag/cli/indexing_worker.py`** (新建 ~80 LOC) — 启动入口
+2. **`aperag/app.py`** lifespan 改造（-120 / +25 LOC）— 删 worker / reconciler / cleanup 启动
+3. **`aperag/server/health.py`** (新建 ~60 LOC) — `/health/live` + `/health/ready` + `/health/diagnostics`（鉴权 + sync URL，per ziang msg=7ae2e308 #2 统一 path 前缀；保留旧 `/health` 指 liveness 兼容老探针）
+4. **`document_service._delete_document_indexes()`** + **object store prefix delete (`delete_objects_by_prefix()`)** 也迁出 API（per huangheng msg=f97b7c5f #6 + ziang msg=1e51c082）+ `run_cleanup_loop` 补 deleted Document scan + grep CI gate（API request handler 不出现 `cleanup_for_deleted_documents` / `delete_objects_by_prefix` / `ProductionWorkerFactory` / `run_cleanup_loop` 调用）
+5. **连接池预算公式化（Helm 层 only，per ziang msg=7ae2e308 #1）**：Helm values 字段叫 `api.dbPoolSize / api.dbMaxOverflow / indexingWorker.dbPoolSize / indexingWorker.dbMaxOverflow`，**分别映射到应用现有 `DB_POOL_SIZE / DB_MAX_OVERFLOW` env**，应用代码 0 改动 0 双 env alias
+6. **Helm `indexing-worker-deployment.yaml`** 新建 + `api-deployment.yaml` probe 改造 + `values.yaml` 加 indexingWorker section
+7. **验收测试** 5 个新 integration test + 17 老单测继承 + 黄章书 7 hard gate 部署级压测
+8. **Hard cut 删除清单**（不留兼容路径，7 项）
+
+**Spec lock document fold** 进 `docs/zh-CN/architecture/task-system-hard-cut-v8.md` + `architecture.md` 加 invariant 段 — 是 task #17 同 PR 文档归档项，不计入运行时主线（per Weston BLOCKER 1 修订）。
+
+工作量估算：+750 / -160 LOC，~6-7 人时
+
+---
+
+## 四、部署改造（@huangzhangshu msg=5be8396e 完整章节）
+
+### 4.1 目标稳态
+- `api` deployment：HTTP 入口 + 轻量 enqueue，不启动 worker
+- `indexing-worker` deployment：parse / vector / fulltext / graph / graph_facts / graph_vectors / summary / vision / reconciler / cleanup 全部 lane
+
+### 4.2 Helm 文件改造
+- 新增：`indexing-worker-deployment.yaml`
+- 修改：`api-deployment.yaml` / `aperag-secret.yaml` / `values.yaml`
+- 不恢复：celery / flower 已删 deployment
+
+### 4.3 API deployment env
+- `INDEXING_MODE=async` / `INDEXING_QUEUE_BACKEND=redis` / `INDEXING_QUOTA_BACKEND=redis`
+- `DB_POOL_SIZE=<api_pool_size>` / `DB_MAX_OVERFLOW=<api_max_overflow>`
+
+### 4.4 Worker deployment env
+- 同 API + 不同 pool size / overflow
+- 启动命令：`python -m aperag.cli.indexing_worker`
+- 必须挂载与 API 相同 PVC / 配置 / Secret
+
+### 4.5 Probe 语义（关键 hard gate）
+- API liveness：`/live` 仅证明进程活，不访问 PG/Redis/Qdrant/LLM
+- API readiness：`/ready` 仅证明 HTTP 入口可接，短超时，**不能成为连接池放大器**
+- API diagnostics：`/diagnostics/dependencies` 给发布脚本 / 人工，独立小预算 + 严格 timeout
+- Worker liveness/readiness：进程 + 事件循环活；Redis queue 可连接；不做昂贵 provider 检查
+
+### 4.6 连接池预算公式
+```
+sum(replicas × (pool_size + max_overflow)) + rollout_surge_budget + reserved_connections
+  < postgres_max_connections × safety_ratio
+```
+- safety_ratio: 0.7-0.8
+- reserved_connections: 给 psql 运维 / migration 预留
+- API/worker pool 分别配置；扩容互不放大
+
+### 4.7 PgBouncer 后续选项（earayu2 msg=befa2ae5 + Weston msg=0413ed68 + huangzhangshu msg=03112f15）
+- 本轮不做（按连接池公式先解决）
+- 后续：API/worker 副本数继续增长 / PG 连接数成扩容瓶颈时引入
+- 优先 transaction pooling + 评估 SQLAlchemy / asyncpg / prepared statement / transaction pooling 兼容性
+- 接 PgBouncer 后保留 API/worker 独立预算，不允许「因有 PgBouncer 就无限加 worker replica」
+
+---
+
+## 五、发布计划（@huangzhangshu §5 完整）
+
+### 5.1 合并前检查
+1. CI 全绿
+2. Helm template 本地渲染：API 不含 worker 启动；indexing-worker deployment 存在
+3. **Grep gate**：
+   - `aperag/app.py` 不再 `asyncio.create_task(run_*_worker...)`
+   - API request handler 不直接调用 `cleanup_for_deleted_documents()`
+   - `indexing_worker.py` 覆盖全部 lane
+4. 单测覆盖 7 条 hard gate
+
+### 5.2 新加坡发布步骤
+1. 打 enterprise image
+2. 部署前读取 PG `max_connections` + 当前连接数 + 保留预算
+3. 生成 Helm values（API replicas / pool / worker replicas / pool / rollout surge）
+4. 部署到新加坡 demo
+5. API rollout → 验证公网入口
+6. Worker rollout → 验证 queue / reconciler / cleanup
+7. 触发小文档 reindex smoke
+8. 观察 10-15 分钟（API latency / `/live` / PG conn count / Redis backlog / worker logs）
+
+### 5.3 发布验收（必须全过）
+- API 在 graph 压力下 `/live` 稳定 + `/api/v2/auth/user` 401 正常
+- Worker pod 可单独重启，API 不重启不摘流
+- Redis queue 丢消息后 reconciler 能从 DB 补漏
+- 旧 parse_version/token 不能写坏新 serving
+- 删除文档 API 快速返回，重型 cleanup 由 worker 完成
+- PG 连接数满足公式预算，rollout 不爆
+- graph-heavy collection 重建时 API readiness/liveness 不超时
+
+---
+
+## 六、回滚策略（@huangzhangshu §6 + @ziang msg=3a0713d3 + msg=e015912b 双执行面 hard gate）
+
+### 6.1 回滚 binary（不允许中间态）
+
+**禁止单回滚 API image 同时保留新 `indexing-worker` deployment**（防双执行面）：旧 API image 仍会在 lifespan 启动 worker/reconciler/cleanup，跟新 worker deployment 同时跑会出现同 `DocumentIndex` 被双消费。
+
+回滚二选一：
+1. **Helm release 整体回滚**：API + worker deployment + values + probe + env 一起回到上一版
+2. **手动应急回滚**：先 `kubectl scale deployment/indexing-worker --replicas=0` 确认无 worker → 再回滚 API image
+
+### 6.2 数据状态回滚原则
+- DocumentIndex 是真源不以 Redis queue 为准
+- 旧任务到达由 parse_version/token/status gate 拦截
+- 如新 worker 写入异常，先停 worker 再判断恢复路径
+
+### 6.3 发布中止条件（任一即中止）
+- API liveness/readiness 持续失败
+- PG 连接数接近安全水位且持续上涨
+- Worker 重启循环 + 队列 backlog 快速增长
+- DocumentIndex 大量 RUNNING 卡死且 heartbeat 不更新
+- 删除/重建路径仍在 API 请求内执行重 cleanup
+
+### 6.4 发布 checklist 加入「执行面唯一性确认」
+回滚前 `kubectl get deploy,pod` confirm 不存在「旧 API lifespan worker + 新 indexing-worker deployment」共存状态。
+
+---
+
+## 七、状态机 / 失败场景验收（@ziang msg=ba559be9 完整）
+
+### 7.1 6 不变量
+1. DocumentIndex 是唯一业务状态真源
+2. 队列丢失必须可恢复
+3. API 不拥有执行面
+4. Worker 拥有重型执行面
+5. 旧任务不能写回新状态
+6. **cleanup intent 真源在 DB**：`Document.status=DELETED/gmt_deleted + DocumentIndex rows`，Redis cleanup queue 是可丢 transport（ziang msg=cecb0d88 钉死）
+
+### 7.2 5 失败场景闭环
+
+| 场景 | 检测真源 | 恢复路径 |
+|---|---|---|
+| Worker crash | DocumentIndex.status + last_heartbeat | reconciler running_reclaim 60s + pending_dispatch 30s |
+| Ack 后 DB 写失败 | DB RUNNING / Redis 已无消息 | heartbeat 过期 reclaim |
+| DB 已写 PENDING / 消息丢失 | DocumentIndex.status=PENDING | reconcile_pending_dispatch 入队 |
+| Redis 重启 / 队列全丢 | DB 全量状态 | reconciler 重建 queue |
+| 删除/重建旧任务到达 | DocumentIndex 当前行 + parse_version/serving | 旧行 claim 拒绝 / no-op |
+
+### 7.3 cleanup 迁出 API 验收
+1. API 删除文档立即返回，只持久化 `Document.status=DELETED`
+2. Worker cleanup loop 扫到 deleted document → 执行 backend cleanup
+3. Backend cleanup transient failure → 不删 DocumentIndex row → 下轮重试
+4. Redis cleanup queue 仅 wake-up
+5. **Grep hard gate**：API request path 不出现 `cleanup_for_deleted_documents(` / `ProductionWorkerFactory(` / `run_cleanup_loop(`
+
+### 7.4 必补测试 7 项（详见 ziang §7.4）
+
+### 7.5 发布观测 6 信号
+API p95/p99 / `/live` `/ready` 成功率 / PG active connections / Redis queue depth / DocumentIndex status counts / worker restart count
+
+---
+
+## 八、架构评审 verify（@Weston msg=0212ae33 8 块 review checklist）
+
+每块缺一不可：
+1. 目标稳态（API / worker / Redis / PG / Qdrant 拓扑 + 旧路径删除）
+2. 代码改造清单（具体文件 + LOC change）
+3. 不做清单（hardening / 框架替换 / module 搬迁不进主线）
+4. 部署改造清单（Helm + values + probe + rollout）
+5. 连接池预算公式
+6. 健康检查语义
+7. 测试和压测
+8. 发布和回滚计划
+
+---
+
+## 九、Spec lock fold 进 architecture.md（document only，不动代码）
+
+### 9.1 6 条 YAGNI 边界（永远不做）
+1. 任务优先级（FIFO 够）
+2. 高吞吐 broker（10k+ msg/s — ApeRAG 文档级几个/秒）
+3. 复杂队列路由 / 多 routing key
+4. 死信交换机（DLX）
+5. 任务链 / chord / group
+6. cron 调度（reconciler 30s poll 已 cover）
+
+### 9.2 4 条 escape hatch 触发条件（满足任一才升级）
+1. 任务吞吐 ≥ 100/s 持续 5 分钟
+2. 跨租户公平调度成正式产品需求
+3. 任务优先级 / 延迟队列 / 复杂取消 / chain·chord·group 复杂工作流成正式产品需求
+4. 自研代码维护成本 ≥ 同期 framework 升级总成本（每 quarter own-up ≥ 5 + DB 瓶颈 p99 latency ≥ 1s 持续 5 分钟，且已尝试索引优化 / 批量扫描 / poll 分片 / 连接池预算后仍无法解决）
+
+未达任一 → 永远不引入 framework 替换。
+
+### 9.3 后续独立切片候选（不在 v8 ratify 默认项，需单独批准启动，per Weston msg=d2c46eb7 BLOCKER 2 修订）
+
+以下是已识别的有价值 follow-up 切片，**不属于 task #17 主 PR 必做**，**不默认进同 batch ship**：
+
+- **候选 task #18**: collection 配置校验（防 task #13 类 ops issue）
+- **候选 task #19**: graph_extractor.py:184 fail-loud（own-up #4 follow-up）
+- **候选 task #20**: 图谱向量点 GC sweep（task #11 落地）
+- **候选 task #21**: 图谱 store bulk upsert API（task #6 spec amend）
+
+每条都是独立完整切片，需 earayu2 单独批准启动。**不混进 task #17 发布风险**。如 earayu2 同意启动，每条作独立 task + 独立 PR + 独立 review + 独立 ship 节奏。
+
+### 9.4 PgBouncer 后续选项（不在 task #17）
+
+按 §4.7 评估 + 兼容性测试，作为后续基础设施切片。
+
+---
+
+## 十、CR mandatory checklist（@huangheng msg=910bcca7 + msg=5f72446f）
+
+task #17 主 PR + 子 PR 来时按以下检查走 CR：
+
+### 10.1 5 个 cross-check
+- (a) 4 候选粒度等量
+- (b) 节间一致
+- (c) 数字合理
+- (d) 框架声称分级
+- (e) 推荐 evidence-based
+
+### 10.2 mandatory checklist
+- Lesson #11（5-step runtime wire-in）
+- Lesson #12（grep-all-callers）
+- Lesson #12 extension v3（a-e 5 条）
+- Mini-pattern 17（跨真源状态漂移检测 — cleanup 路径同款 SoT 原则）
+- one-shot-no-phased（接受 hard cut + schema break）
+
+### 10.3 5 hard gate（CR 必卡）
+1. API 不启动任何重型执行面（grep `aperag/app.py` lifespan）
+2. cleanup 真源必须 DB（grep cleanup loop 主路径）
+3. cleanup 不在 API 请求路径（grep API request handler）
+4. Readiness 不成连接池放大器
+5. 连接池公式化（不 hard-code）
+
+---
+
+## 十一、节奏 + 团队分工
+
+按 earayu2 directive「今天做完明天发布」：
+
+| Milestone | 内容 | 责任 | ETA |
+|---|---|---|---|
+| M1 | v8 final ratify | 架构师定稿 + earayu2 ratify | **现在** |
+| M2 | task #17 主 task + 子 task 创建 | @不穷 | ratify 后立即 |
+| M3 | 代码实施 | @Bryce 主线 + @明书 / @cuiwenbo 协助 | 今晚 |
+| M4 | 部署改造（Helm） | @huangzhangshu | 今晚 |
+| ~~M5~~ | ~~task #18-21~~ | （后续独立切片候选，不在 v8 ratify 默认项，需 earayu2 单独批准启动 — per Weston msg=d2c46eb7 BLOCKER 2 + ziang msg=cd4761aa） | 单独决策 |
+| M6 | CR | @huangheng 5 cross-check + @ziang 状态机 + @Weston 架构 | 今晚 |
+| M7 | 验收压测 + spec lock fold | @huangzhangshu + 架构师 | 今晚 |
+| M8 | Ship | 全员 | 明天 |
+
+---
+
+## 十二、待 earayu2 一句话 ratify
+
+按 earayu2 directive 团队 OWN 推荐 — 不让你做技术决策，只 ratify 5 方共识：
+
+1. ✅ ratify 候选 B + 8 项 task #17 主线（薄 CLI + lifespan 删 + Helm + probe + 连接池公式 + 全局并发 + cleanup 迁出 + e2e 压测）
+2. ✅ ratify §9.3 后续独立切片候选（task #18-21）作为独立 task 路径 — **是否启动**单独 product 决策（不混进 task #17 主 PR / 不阻塞主线）
+3. ✅ ratify §9.1 YAGNI 6 条 + §9.2 escape hatch 4 条作 architecture invariant
+4. ✅ ratify §6.1 回滚 binary（不允许中间态）+ §6.4 「执行面唯一性确认」checklist
+5. ✅ ratify §4.7 PgBouncer 后续选项不在 task #17
+
+批准后 @不穷 立即建 task #17-21 → @Bryce / @huangzhangshu / 团队今晚 implement → 明天 ship。
+
+---
+
+**附录**：
+- v1-v7 报告均 obsolete，本 v8 final 是定稿
+- 5 方独立 evidence-based 推荐 100% 收敛
+- 全部 BLOCKER + cross-check + Lesson refinement 收紧
+- 详细 file-by-file 改造见 Bryce 章节（thread + agent worktree 文档）
+- 详细部署 / 发布 / 回滚见 huangzhangshu §4-§6（msg=5be8396e）
+- 详细状态机 / 失败场景见 ziang §7（msg=ba559be9）
+- 详细架构评审见 Weston §8（msg=0212ae33）

--- a/docs/zh-CN/architecture/task-system-hard-cut-v8.md
+++ b/docs/zh-CN/architecture/task-system-hard-cut-v8.md
@@ -1,8 +1,8 @@
-# ApeRAG 异步任务系统重构 — v8 final 执行方案（5 方共识 + earayu2 ratify-ready）
+# ApeRAG 异步任务系统重构 — v8.2 执行方案（5 方共识 + PR 文档版）
 
 **起草**：@符炫炜 总架构师定稿
 **日期**：2026-04-29
-**版本**：v8 final — earayu2 directive msg=074b8019「今天做完明天发布」节奏 + 5 方独立 evidence-based 共识 + 全部 BLOCKER 收紧
+**版本**：v8.2 — earayu2 directive msg=074b8019「今天做完明天发布」节奏 + msg=c1c4ba2f「先补文档，协调一致后宣布开工」+ 5 方独立 evidence-based 共识 + 全部 BLOCKER 收紧
 
 ---
 
@@ -10,7 +10,9 @@
 
 ### 推荐：候选 B — 保留 ApeRAG 内嵌 task system + 一次性部署 hard cut
 
-**1 句话**：保留现有 `aperag/indexing/*` 模块位置不动 + 新增薄 `aperag/cli/indexing_worker.py` 启动入口 + 拆 API/worker deployment + probe 分层 + 连接池公式预算 + 全局并发跨副本 + 删除 cleanup 路径迁出 API + 部署级 e2e 压测验收 + spec lock fold 进 architecture.md。
+**1 句话**：保留现有 `aperag/indexing/*` 模块位置不动 + 新增薄 `aperag/cli/indexing_worker.py` 启动入口 + 拆 API/worker deployment + probe 分层 + 连接池公式预算 + 全局并发跨副本 + 删除 cleanup 路径迁出 API + 部署级 e2e 压测验收。
+
+**同 PR 文档项**：本文件归档 spec lock，并在 [`task-system-invariants.md`](./task-system-invariants.md) 补 architecture invariant；这是文档 fold-in，不计入 8 项 runtime hard cut 主线。
 
 **不做**：
 - ❌ 不引入 Dramatiq / Celery / RQ
@@ -63,7 +65,7 @@
 ## 三、代码改造（@Bryce msg=1c46bf74 + @ziang msg=32ac48e3 详细 file-by-file）
 
 详细 file-by-file 改造见：
-- 本 PR 同 commit 的代码 diff（按 §3 总结 8 项主线改动逐一 implement）
+- 本 PR 后续代码 diff（按 §3 总结 8 项主线改动逐一 implement）
 - @ziang msg=32ac48e3 thread 章节 + 7 项 CR 修正（msg=981960cd Bryce accept）
 - 实施时严格按 §10 mandatory checklist + §7 状态机失败场景验收
 
@@ -78,7 +80,7 @@
 7. **验收测试** 5 个新 integration test + 17 老单测继承 + 黄章书 7 hard gate 部署级压测
 8. **Hard cut 删除清单**（不留兼容路径，7 项）
 
-**Spec lock document fold** 进 `docs/zh-CN/architecture/task-system-hard-cut-v8.md` + `architecture.md` 加 invariant 段 — 是 task #17 同 PR 文档归档项，不计入运行时主线（per Weston BLOCKER 1 修订）。
+**Spec lock document fold** 进 `docs/zh-CN/architecture/task-system-hard-cut-v8.md` + `docs/zh-CN/architecture/task-system-invariants.md` — 是 task #17 同 PR 文档归档项，不计入运行时主线（per Weston BLOCKER 1 修订）。
 
 工作量估算：+750 / -160 LOC，~6-7 人时
 
@@ -105,9 +107,9 @@
 - 必须挂载与 API 相同 PVC / 配置 / Secret
 
 ### 4.5 Probe 语义（关键 hard gate）
-- API liveness：`/live` 仅证明进程活，不访问 PG/Redis/Qdrant/LLM
-- API readiness：`/ready` 仅证明 HTTP 入口可接，短超时，**不能成为连接池放大器**
-- API diagnostics：`/diagnostics/dependencies` 给发布脚本 / 人工，独立小预算 + 严格 timeout
+- API liveness：`/health/live` 仅证明进程活，不访问 PG/Redis/Qdrant/LLM；旧 `/health` 保留为 liveness 兼容入口
+- API readiness：`/health/ready` 仅证明 HTTP 入口可接，短超时，**不能成为连接池放大器**
+- API diagnostics：`/health/diagnostics` 给发布脚本 / 人工，独立小预算 + 严格 timeout，不作为 kube readiness 默认探针
 - Worker liveness/readiness：进程 + 事件循环活；Redis queue 可连接；不做昂贵 provider 检查
 
 ### 4.6 连接池预算公式
@@ -146,10 +148,10 @@ sum(replicas × (pool_size + max_overflow)) + rollout_surge_budget + reserved_co
 5. API rollout → 验证公网入口
 6. Worker rollout → 验证 queue / reconciler / cleanup
 7. 触发小文档 reindex smoke
-8. 观察 10-15 分钟（API latency / `/live` / PG conn count / Redis backlog / worker logs）
+8. 观察 10-15 分钟（API latency / `/health/live` / PG conn count / Redis backlog / worker logs）
 
 ### 5.3 发布验收（必须全过）
-- API 在 graph 压力下 `/live` 稳定 + `/api/v2/auth/user` 401 正常
+- API 在 graph 压力下 `/health/live` 稳定 + `/api/v2/auth/user` 401 正常
 - Worker pod 可单独重启，API 不重启不摘流
 - Redis queue 丢消息后 reconciler 能从 DB 补漏
 - 旧 parse_version/token 不能写坏新 serving
@@ -216,7 +218,7 @@ sum(replicas × (pool_size + max_overflow)) + rollout_surge_budget + reserved_co
 ### 7.4 必补测试 7 项（详见 ziang §7.4）
 
 ### 7.5 发布观测 6 信号
-API p95/p99 / `/live` `/ready` 成功率 / PG active connections / Redis queue depth / DocumentIndex status counts / worker restart count
+API p95/p99 / `/health/live` `/health/ready` 成功率 / PG active connections / Redis queue depth / DocumentIndex status counts / worker restart count
 
 ---
 
@@ -234,7 +236,7 @@ API p95/p99 / `/live` `/ready` 成功率 / PG active connections / Redis queue d
 
 ---
 
-## 九、Spec lock fold 进 architecture.md（document only，不动代码）
+## 九、Spec lock fold 进 architecture 文档（document only，不动代码）
 
 ### 9.1 6 条 YAGNI 边界（永远不做）
 1. 任务优先级（FIFO 够）
@@ -302,36 +304,36 @@ task #17 主 PR + 子 PR 来时按以下检查走 CR：
 
 | Milestone | 内容 | 责任 | ETA |
 |---|---|---|---|
-| M1 | v8 final ratify | 架构师定稿 + earayu2 ratify | **现在** |
-| M2 | task #17 主 task + 子 task 创建 | @不穷 | ratify 后立即 |
-| M3 | 代码实施 | @Bryce 主线 + @明书 / @cuiwenbo 协助 | 今晚 |
-| M4 | 部署改造（Helm） | @huangzhangshu | 今晚 |
+| M1 | v8.2 文档补齐进 PR #1884 | 全员按文件边界补文档 | **现在** |
+| M2 | 文档协调一致 + earayu2 宣布开工 | 全员给 ready / blocker | 文档 ready 后 |
+| M3 | 代码实施 | @Bryce 主线 + @明书 / @cuiwenbo 协助 | 开工后 |
+| M4 | 部署改造（Helm） | @huangzhangshu | 开工后 |
 | ~~M5~~ | ~~task #18-21~~ | （后续独立切片候选，不在 v8 ratify 默认项，需 earayu2 单独批准启动 — per Weston msg=d2c46eb7 BLOCKER 2 + ziang msg=cd4761aa） | 单独决策 |
-| M6 | CR | @huangheng 5 cross-check + @ziang 状态机 + @Weston 架构 | 今晚 |
-| M7 | 验收压测 + spec lock fold | @huangzhangshu + 架构师 | 今晚 |
+| M6 | CR | @huangheng 5 cross-check + @ziang 状态机 + @Weston 架构 | 实施后 |
+| M7 | 验收压测 + spec lock fold | @huangzhangshu + 架构师 | 实施后 |
 | M8 | Ship | 全员 | 明天 |
 
 ---
 
-## 十二、待 earayu2 一句话 ratify
+## 十二、文档 ready 后待 earayu2 宣布开工
 
-按 earayu2 directive 团队 OWN 推荐 — 不让你做技术决策，只 ratify 5 方共识：
+按 earayu2 directive 团队 OWN 推荐 — 技术方案由团队收敛；本 PR 当前先补齐文档并协调一致：
 
-1. ✅ ratify 候选 B + 8 项 task #17 主线（薄 CLI + lifespan 删 + Helm + probe + 连接池公式 + 全局并发 + cleanup 迁出 + e2e 压测）
-2. ✅ ratify §9.3 后续独立切片候选（task #18-21）作为独立 task 路径 — **是否启动**单独 product 决策（不混进 task #17 主 PR / 不阻塞主线）
-3. ✅ ratify §9.1 YAGNI 6 条 + §9.2 escape hatch 4 条作 architecture invariant
-4. ✅ ratify §6.1 回滚 binary（不允许中间态）+ §6.4 「执行面唯一性确认」checklist
-5. ✅ ratify §4.7 PgBouncer 后续选项不在 task #17
+1. 候选 B + 8 项 task #17 主线已作为团队推荐进入 PR 文档（薄 CLI + lifespan 删 + Helm + probe + 连接池公式 + 全局并发 + cleanup 迁出 + e2e 压测）
+2. §9.3 后续独立切片候选（task #18-21）只保留为后续路径；**是否启动**需单独 product 决策
+3. §9.1 YAGNI 6 条 + §9.2 escape hatch 4 条作为 architecture invariant
+4. §6.1 回滚 binary（不允许中间态）+ §6.4 「执行面唯一性确认」作为发布硬门槛
+5. §4.7 PgBouncer 是后续基础设施选项，不在 task #17 主线
 
-批准后 @不穷 立即建 task #17-21 → @Bryce / @huangzhangshu / 团队今晚 implement → 明天 ship。
+task #17 已创建并由 @Bryce claim。PR #1884 先补齐本文档、部署 runbook、状态机验收文档并协调一致；待 @earayu2 宣布开工后，再按 task #17 主线实现。task #18-21 仅作为后续候选，需单独批准。
 
 ---
 
 **附录**：
-- v1-v7 报告均 obsolete，本 v8 final 是定稿
+- v1-v7 报告均 obsolete，本 v8.2 是 PR 文档版定稿
 - 5 方独立 evidence-based 推荐 100% 收敛
 - 全部 BLOCKER + cross-check + Lesson refinement 收紧
-- 详细 file-by-file 改造见 Bryce 章节（thread + agent worktree 文档）
+- 详细 file-by-file 改造见本 PR 内 `docs/zh-CN/architecture/task-17-code-changes.md` 及后续代码 diff
 - 详细部署 / 发布 / 回滚见 huangzhangshu §4-§6（msg=5be8396e）
 - 详细状态机 / 失败场景见 ziang §7（msg=ba559be9）
 - 详细架构评审见 Weston §8（msg=0212ae33）

--- a/docs/zh-CN/architecture/task-system-invariants.md
+++ b/docs/zh-CN/architecture/task-system-invariants.md
@@ -1,0 +1,127 @@
+# ApeRAG 异步任务系统 — Architecture Invariants
+
+**作用**：本文档锁定 ApeRAG 异步任务系统的不可变 architecture invariants，未来 PR review 必引用，防止 incremental drift。
+
+**起源**：task #17 v8 spec lock fold（详见 `task-system-hard-cut-v8.md`）。
+
+---
+
+## 1. 部署架构 invariant
+
+### 1.1 API / worker 进程隔离
+- `api` deployment 只跑 FastAPI HTTP 入口 + 轻量 enqueue，**永远不启动重型 indexing worker / reconciler / cleanup loop**
+- `indexing-worker` deployment 跑全部 indexing 执行面（parse / vector / fulltext / graph / graph_facts / graph_vectors / summary / vision / reconciler / cleanup）
+- 任何让 API 进程启动重型后台任务的代码 = BLOCKER
+
+### 1.2 健康检查不能成为连接池放大器
+- `/health/live`：仅证明进程活，不访问 PG / Redis / Qdrant / LLM provider
+- `/health/ready`：仅证明 HTTP 入口可接 + 短超时，**不访问深度依赖**
+- `/health/diagnostics`：人工/发布脚本用，独立小预算 + 严格 timeout，**不能作为 kubelet probe 默认路径**
+- 任何让 readiness 默认检查 PG / Redis / Qdrant 的代码 = BLOCKER
+
+### 1.3 连接池预算公式（不允许 hard-code）
+```
+sum(replicas × (pool_size + max_overflow)) + rollout_surge_budget + reserved_connections
+  < postgres_max_connections × safety_ratio
+```
+- safety_ratio: 0.7-0.8
+- API/worker pool 分别配置；扩容 API 不应同步放大 worker 连接，反之亦然
+
+### 1.4 回滚执行面唯一性（双执行面 hard gate）
+- **禁止**单回滚 API image 同时保留新 `indexing-worker` deployment
+- 回滚 binary：(1) Helm release 整体回滚 OR (2) 先 `kubectl scale deployment/indexing-worker --replicas=0` → 再回滚 API image
+- 发布 checklist 必须含「执行面唯一性确认」: `kubectl get deploy,pod` confirm 不存在双执行面共存
+
+---
+
+## 2. 业务状态 invariant
+
+### 2.1 DocumentIndex 是唯一业务状态真源
+- `DocumentIndex.status / parse_version / is_serving / updated_at / last_heartbeat / retry_after` 决定用户可见索引状态
+- Redis 队列只做可丢 transport
+- 任何让队列/broker state 跟 DB state 双真源的设计 = BLOCKER
+
+### 2.2 cleanup intent 真源在 DB
+- `Document.status=DELETED / gmt_deleted + DocumentIndex rows` 是 cleanup intent SoT
+- Redis cleanup queue（如有）只能是可丢 transport，丢消息时 worker cleanup scan 必须能从 DB 补回
+
+### 2.3 API 不拥有重型执行面
+- API request handler 不得直接调用 `cleanup_for_deleted_documents` / `delete_objects_by_prefix` / `ProductionWorkerFactory(...)` / `run_cleanup_loop`
+- API 删除文档：只标记 `Document.status=DELETED + gmt_deleted` 进 DB；重型 cleanup（向量库 / 对象存储 prefix delete）由 worker cleanup loop 异步执行
+- grep CI gate：`grep -rn 'cleanup_for_deleted_documents\|delete_objects_by_prefix\|ProductionWorkerFactory\|run_cleanup_loop' aperag/api/ aperag/views/` 必须为空
+
+### 2.4 旧任务防写回（version/token gate）
+- worker 成功/失败写回必须受 DocumentIndex 当前行 + status + parse_version + is_serving 语义保护
+- 旧 parse_version / 已删除 document / 已 supersede 行到达只能 no-op 或失败进入可恢复路径
+
+---
+
+## 3. 任务系统选型 invariant
+
+### 3.1 不引入新的 task queue framework
+- 不引入 Celery / RQ / Dramatiq / 等成熟 framework
+- 保留现有 ApeRAG 内嵌 RedisWorkQueue + RedisQuotaBackend Lua + reconciler 5-stage + DocumentIndex SoT
+
+### 3.2 6 条 YAGNI 边界（永远不做）
+1. 任务优先级（FIFO 够用）
+2. 高吞吐 broker（10k+ msg/s — ApeRAG 文档级几个/秒）
+3. 复杂队列路由 / 多 routing key
+4. 死信交换机（DLX）
+5. 任务链 / chord / group
+6. cron 调度（reconciler 30s poll 已 cover）
+
+### 3.3 4 条 escape hatch 触发条件（满足任一才允许重评 framework）
+1. 任务吞吐 ≥ 100/s 持续 5 分钟（reconciler poll 跟不上）
+2. 跨租户公平调度成正式产品需求（多 tenant 抢同一 LLM provider quota）
+3. 任务优先级 / 延迟队列 / 复杂取消 / chain·chord·group 复杂工作流成正式产品需求
+4. 自研代码维护成本 ≥ 同期 framework 升级总成本（每 quarter own-up ≥ 5 + DB 瓶颈 p99 latency ≥ 1s 持续 5 分钟，且已尝试索引优化 / 批量扫描 / poll 分片 / 连接池预算后仍无法解决）
+
+未达任一 → 永远不引入 framework 替换。
+
+### 3.4 PgBouncer 后续选项
+- 本轮 task #17 不做（按连接池公式先解决）
+- 后续：API/worker 副本数继续增长 / PG 连接数成扩容瓶颈时引入
+- 优先 transaction pooling + 评估 SQLAlchemy / asyncpg / prepared statement / Alembic / 长事务 / session-level settings 兼容性
+- 接入后保留 API/worker 独立预算，**不允许「因有 PgBouncer 就无限加 worker replica」**
+
+---
+
+## 4. CR mandatory checklist
+
+任意修改 task system 相关代码 / 部署 / 文档的 PR 必经过：
+
+### 4.1 5 cross-check
+1. 候选/方案粒度等量（不允许「类似 X」隐性引用）
+2. 同文档不同 section 一致性（fact label cross-check）
+3. fact 数字合理性挑战（不只 label spectrum 还有数字本身）
+4. framework claim 分级标注 enforcement（已证实 / 待验证 / 需 PoC，到正文级别）
+5. 推荐 evidence-grounded（具体代码 file path / line / git blame / framework 文档 URL / 失败场景闭环时间）
+
+### 4.2 mandatory pattern checklist
+- Lesson #11（5-step runtime wire-in）
+- Lesson #12（grep-all-callers）+ extension v3（a-e 5 条）
+- Mini-pattern 17（跨真源状态漂移检测）
+- one-shot-no-phased（接受 hard cut + schema break）
+
+### 4.3 6 hard gate（每 PR 必卡）
+1. API 不启动任何重型执行面（grep `aperag/app.py` lifespan）
+2. cleanup 真源必须 DB（grep cleanup loop 主路径）
+3. cleanup 不在 API 请求路径（grep API request handler）
+4. Readiness 不成连接池放大器
+5. 连接池公式化（不 hard-code）
+6. 回滚执行面唯一性
+
+---
+
+## 5. 关联文档
+
+- task #17 spec: `task-system-hard-cut-v8.md`
+- task #17 代码改造: `task-17-code-changes.md`
+- 状态机/失败场景验收: `task-17-state-machine-validation.md`（待 ziang 补）
+- 部署/发布/回滚 runbook: 待 huangzhangshu 补
+
+---
+
+**起草**：@符炫炜 总架构师
+**日期**：2026-04-29
+**版本**：v1（task #17 PR #1884 同 commit fold-in）

--- a/docs/zh-CN/architecture/task-system-invariants.md
+++ b/docs/zh-CN/architecture/task-system-invariants.md
@@ -115,10 +115,11 @@ sum(replicas × (pool_size + max_overflow)) + rollout_surge_budget + reserved_co
 
 ## 5. 关联文档
 
-- task #17 spec: `task-system-hard-cut-v8.md`
-- task #17 代码改造: `task-17-code-changes.md`
-- 状态机/失败场景验收: `task-17-state-machine-validation.md`（待 ziang 补）
-- 部署/发布/回滚 runbook: 待 huangzhangshu 补
+- task #17 spec: [`task-system-hard-cut-v8.md`](./task-system-hard-cut-v8.md)
+- task #17 代码改造: [`task-17-code-changes.md`](./task-17-code-changes.md)
+- 状态机/失败场景验收: [`task-17-state-machine-validation.md`](./task-17-state-machine-validation.md)
+- 部署/发布/回滚 runbook: [`task-17-deployment-release-runbook.md`](./task-17-deployment-release-runbook.md)
+- CR checklist: [`task-17-cr-review-checklist.md`](./task-17-cr-review-checklist.md)
 
 ---
 

--- a/scripts/task17_local_stability_check.sh
+++ b/scripts/task17_local_stability_check.sh
@@ -22,6 +22,8 @@ TASK17_BASE_URL="${TASK17_BASE_URL:-${E2E_BASE_URL:-http://127.0.0.1:8000}}"
 TASK17_HEALTH_SAMPLES="${TASK17_HEALTH_SAMPLES:-20}"
 TASK17_HEALTH_P95_MS="${TASK17_HEALTH_P95_MS:-500}"
 TASK17_CURL_TIMEOUT_SECONDS="${TASK17_CURL_TIMEOUT_SECONDS:-3}"
+TASK17_OBSERVE_SECONDS="${TASK17_OBSERVE_SECONDS:-0}"
+TASK17_OBSERVE_INTERVAL_SECONDS="${TASK17_OBSERVE_INTERVAL_SECONDS:-2}"
 
 TASK17_API_REPLICAS="${TASK17_API_REPLICAS:-2}"
 TASK17_API_DB_POOL_SIZE="${TASK17_API_DB_POOL_SIZE:-5}"
@@ -136,6 +138,9 @@ check_endpoint_latency() {
       return
     fi
     printf '%s\n' "${ms}" >>"${tmp}"
+    if [[ "${TASK17_OBSERVE_SECONDS}" != "0" && "${i}" -lt "${samples}" ]]; then
+      sleep "${TASK17_OBSERVE_INTERVAL_SECONDS}"
+    fi
   done
 
   local p95 p99
@@ -157,10 +162,21 @@ check_health_contract() {
     return
   fi
 
+  local samples="${TASK17_HEALTH_SAMPLES}"
+  if [[ "${TASK17_OBSERVE_SECONDS}" != "0" ]]; then
+    samples="$(
+      awk -v duration="${TASK17_OBSERVE_SECONDS}" -v interval="${TASK17_OBSERVE_INTERVAL_SECONDS}" \
+        'BEGIN { printf "%d\n", int((duration + interval - 0.000001) / interval) }'
+    )"
+    if [[ "${samples}" -lt 1 ]]; then
+      samples=1
+    fi
+  fi
+
   log "Checking API probe endpoints at ${TASK17_BASE_URL}"
-  check_endpoint_latency "/health"
-  check_endpoint_latency "/health/live"
-  check_endpoint_latency "/health/ready"
+  check_endpoint_latency "/health" "${samples}"
+  check_endpoint_latency "/health/live" "${samples}"
+  check_endpoint_latency "/health/ready" "${samples}"
 
   if [[ -n "${TASK17_DIAGNOSTICS_URL}" ]]; then
     local auth_args=()

--- a/scripts/task17_local_stability_check.sh
+++ b/scripts/task17_local_stability_check.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# task #17 SRE acceptance helper.
+#
+# This script is intentionally deployment-agnostic: it can validate a local
+# docker-compose target, a port-forwarded Kubernetes target, or the Singapore
+# demo target. It focuses on the runtime hard-cut signals that are easy to
+# verify from outside the app:
+#   - API health probes stay light and fast.
+#   - API/worker DB pool budgets fit under PostgreSQL max_connections.
+#   - Kubernetes topology has a separate indexing-worker deployment.
+#   - Optional worker restart does not disturb the API health endpoints.
+#
+# Heavy product indexing load is driven by the separate load/e2e scripts. Run
+# this script before, during, and after that load to catch API health and pool
+# regressions while indexing pressure is present.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TASK17_BASE_URL="${TASK17_BASE_URL:-${E2E_BASE_URL:-http://127.0.0.1:8000}}"
+TASK17_HEALTH_SAMPLES="${TASK17_HEALTH_SAMPLES:-20}"
+TASK17_HEALTH_P95_MS="${TASK17_HEALTH_P95_MS:-500}"
+TASK17_CURL_TIMEOUT_SECONDS="${TASK17_CURL_TIMEOUT_SECONDS:-3}"
+
+TASK17_API_REPLICAS="${TASK17_API_REPLICAS:-2}"
+TASK17_API_DB_POOL_SIZE="${TASK17_API_DB_POOL_SIZE:-5}"
+TASK17_API_DB_MAX_OVERFLOW="${TASK17_API_DB_MAX_OVERFLOW:-5}"
+TASK17_WORKER_REPLICAS="${TASK17_WORKER_REPLICAS:-1}"
+TASK17_WORKER_DB_POOL_SIZE="${TASK17_WORKER_DB_POOL_SIZE:-10}"
+TASK17_WORKER_DB_MAX_OVERFLOW="${TASK17_WORKER_DB_MAX_OVERFLOW:-10}"
+TASK17_ROLLOUT_SURGE_BUDGET="${TASK17_ROLLOUT_SURGE_BUDGET:-10}"
+TASK17_DIAGNOSTICS_RESERVED="${TASK17_DIAGNOSTICS_RESERVED:-5}"
+TASK17_POSTGRES_RESERVED="${TASK17_POSTGRES_RESERVED:-10}"
+TASK17_POSTGRES_MAX_CONNECTIONS="${TASK17_POSTGRES_MAX_CONNECTIONS:-100}"
+TASK17_SAFETY_RATIO="${TASK17_SAFETY_RATIO:-0.70}"
+
+TASK17_K8S_NAMESPACE="${TASK17_K8S_NAMESPACE:-}"
+TASK17_API_DEPLOYMENT="${TASK17_API_DEPLOYMENT:-api}"
+TASK17_WORKER_DEPLOYMENT="${TASK17_WORKER_DEPLOYMENT:-indexing-worker}"
+TASK17_API_SELECTOR="${TASK17_API_SELECTOR:-app.aperag.io/component=api}"
+TASK17_WORKER_SELECTOR="${TASK17_WORKER_SELECTOR:-app.aperag.io/component=indexing-worker}"
+TASK17_SCAN_API_LOGS="${TASK17_SCAN_API_LOGS:-1}"
+TASK17_RESTART_WORKER="${TASK17_RESTART_WORKER:-0}"
+
+TASK17_DATABASE_URL="${TASK17_DATABASE_URL:-${DATABASE_URL:-}}"
+TASK17_DIAGNOSTICS_URL="${TASK17_DIAGNOSTICS_URL:-}"
+TASK17_DIAGNOSTICS_BEARER_TOKEN="${TASK17_DIAGNOSTICS_BEARER_TOKEN:-}"
+
+export NO_PROXY="${NO_PROXY:-127.0.0.1,localhost}"
+
+failures=0
+skips=0
+
+log() {
+  printf '[task17] %s\n' "$*"
+}
+
+pass() {
+  printf '[task17] PASS: %s\n' "$*"
+}
+
+fail() {
+  printf '[task17] FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+skip() {
+  printf '[task17] SKIP: %s\n' "$*"
+  skips=$((skips + 1))
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+curl_probe() {
+  local path="$1"
+  local url="${TASK17_BASE_URL}${path}"
+  local response status seconds
+
+  response="$(
+    curl --silent --show-error \
+      --output /dev/null \
+      --write-out '%{http_code} %{time_total}' \
+      --max-time "${TASK17_CURL_TIMEOUT_SECONDS}" \
+      "${url}" 2>/dev/null || true
+  )"
+  status="${response%% *}"
+  seconds="${response##* }"
+
+  if [[ -z "${response}" || "${status}" == "000" || "${status}" -lt 200 || "${status}" -ge 300 ]]; then
+    return 1
+  fi
+
+  awk -v s="${seconds}" 'BEGIN { printf "%.0f\n", s * 1000 }'
+}
+
+percentile_from_file() {
+  local file="$1"
+  local percentile="$2"
+  sort -n "${file}" | awk -v p="${percentile}" '
+    { values[++n] = $1 }
+    END {
+      if (n == 0) {
+        exit 1
+      }
+      idx = int(p * n + 0.999999)
+      if (idx < 1) idx = 1
+      if (idx > n) idx = n
+      print values[idx]
+    }
+  '
+}
+
+assert_le() {
+  local actual="$1"
+  local expected="$2"
+  awk -v a="${actual}" -v e="${expected}" 'BEGIN { exit !(a <= e) }'
+}
+
+check_endpoint_latency() {
+  local path="$1"
+  local samples="${2:-${TASK17_HEALTH_SAMPLES}}"
+  local max_p95_ms="${3:-${TASK17_HEALTH_P95_MS}}"
+  local tmp
+  tmp="$(mktemp)"
+  trap 'rm -f "${tmp}"' RETURN
+
+  for ((i = 1; i <= samples; i++)); do
+    local ms
+    if ! ms="$(curl_probe "${path}")"; then
+      rm -f "${tmp}"
+      trap - RETURN
+      fail "${path} failed before collecting ${samples} samples"
+      return
+    fi
+    printf '%s\n' "${ms}" >>"${tmp}"
+  done
+
+  local p95 p99
+  p95="$(percentile_from_file "${tmp}" 0.95)"
+  p99="$(percentile_from_file "${tmp}" 0.99)"
+  rm -f "${tmp}"
+  trap - RETURN
+
+  if assert_le "${p95}" "${max_p95_ms}"; then
+    pass "${path} p95=${p95}ms p99=${p99}ms over ${samples} samples"
+  else
+    fail "${path} p95=${p95}ms exceeds ${max_p95_ms}ms over ${samples} samples"
+  fi
+}
+
+check_health_contract() {
+  if [[ "${TASK17_SKIP_HEALTH:-0}" == "1" ]]; then
+    skip "API health check disabled by TASK17_SKIP_HEALTH=1"
+    return
+  fi
+
+  log "Checking API probe endpoints at ${TASK17_BASE_URL}"
+  check_endpoint_latency "/health"
+  check_endpoint_latency "/health/live"
+  check_endpoint_latency "/health/ready"
+
+  if [[ -n "${TASK17_DIAGNOSTICS_URL}" ]]; then
+    local auth_args=()
+    if [[ -n "${TASK17_DIAGNOSTICS_BEARER_TOKEN}" ]]; then
+      auth_args+=(--header "Authorization: Bearer ${TASK17_DIAGNOSTICS_BEARER_TOKEN}")
+    fi
+    local status
+    status="$(
+      curl --silent --show-error \
+        --output /dev/null \
+        --write-out '%{http_code}' \
+        --max-time "${TASK17_CURL_TIMEOUT_SECONDS}" \
+        "${auth_args[@]}" \
+        "${TASK17_DIAGNOSTICS_URL}" 2>/dev/null || true
+    )"
+    case "${status}" in
+      200) pass "diagnostics endpoint reachable with explicit opt-in URL" ;;
+      401|403) pass "diagnostics endpoint is protected (status=${status})" ;;
+      *) fail "diagnostics endpoint unexpected status=${status}" ;;
+    esac
+  else
+    skip "diagnostics endpoint check not enabled; set TASK17_DIAGNOSTICS_URL to verify it"
+  fi
+}
+
+check_connection_budget() {
+  local api_total worker_total total allowed
+  api_total=$((TASK17_API_REPLICAS * (TASK17_API_DB_POOL_SIZE + TASK17_API_DB_MAX_OVERFLOW)))
+  worker_total=$((TASK17_WORKER_REPLICAS * (TASK17_WORKER_DB_POOL_SIZE + TASK17_WORKER_DB_MAX_OVERFLOW)))
+  total=$((api_total + worker_total + TASK17_ROLLOUT_SURGE_BUDGET + TASK17_DIAGNOSTICS_RESERVED + TASK17_POSTGRES_RESERVED))
+  allowed="$(awk -v max="${TASK17_POSTGRES_MAX_CONNECTIONS}" -v ratio="${TASK17_SAFETY_RATIO}" 'BEGIN { printf "%.0f\n", max * ratio }')"
+
+  log "DB budget: api=${api_total}, worker=${worker_total}, surge=${TASK17_ROLLOUT_SURGE_BUDGET}, diagnostics=${TASK17_DIAGNOSTICS_RESERVED}, postgres_reserved=${TASK17_POSTGRES_RESERVED}, total=${total}, allowed=${allowed}"
+
+  if ((total < allowed)); then
+    pass "DB pool budget fits under safety ratio"
+  else
+    fail "DB pool budget total=${total} is not below allowed=${allowed}; lower replicas or pool/overflow values"
+  fi
+}
+
+check_postgres_live_connections() {
+  if [[ -z "${TASK17_DATABASE_URL}" ]]; then
+    skip "PostgreSQL live connection check not enabled; set TASK17_DATABASE_URL"
+    return
+  fi
+  if ! have_cmd psql; then
+    skip "psql not found; cannot query PostgreSQL live connection counts"
+    return
+  fi
+
+  local output
+  if ! output="$(
+    psql "${TASK17_DATABASE_URL}" -v ON_ERROR_STOP=1 -Atc \
+      "SELECT current_setting('max_connections') AS max_conn,
+              count(*) FILTER (WHERE datname = current_database()) AS current_db_conn,
+              count(*) FILTER (WHERE datname = current_database() AND state = 'active') AS active_conn
+       FROM pg_stat_activity;"
+  )"; then
+    fail "PostgreSQL connection query failed"
+    return
+  fi
+
+  local max_conn current_db_conn active_conn
+  IFS='|' read -r max_conn current_db_conn active_conn <<<"${output}"
+  pass "PostgreSQL connections current_db=${current_db_conn}, active=${active_conn}, max_connections=${max_conn}"
+}
+
+kubectl_ns() {
+  kubectl -n "${TASK17_K8S_NAMESPACE}" "$@"
+}
+
+check_k8s_topology() {
+  if [[ -z "${TASK17_K8S_NAMESPACE}" ]]; then
+    skip "Kubernetes topology check not enabled; set TASK17_K8S_NAMESPACE"
+    return
+  fi
+  if ! have_cmd kubectl; then
+    skip "kubectl not found; cannot check Kubernetes topology"
+    return
+  fi
+
+  if kubectl_ns get deploy "${TASK17_API_DEPLOYMENT}" >/dev/null 2>&1; then
+    pass "API deployment exists: ${TASK17_API_DEPLOYMENT}"
+  else
+    fail "API deployment missing: ${TASK17_API_DEPLOYMENT}"
+  fi
+
+  if kubectl_ns get deploy "${TASK17_WORKER_DEPLOYMENT}" >/dev/null 2>&1; then
+    pass "indexing-worker deployment exists: ${TASK17_WORKER_DEPLOYMENT}"
+  else
+    fail "indexing-worker deployment missing: ${TASK17_WORKER_DEPLOYMENT}"
+  fi
+
+  local api_ready worker_ready
+  api_ready="$(kubectl_ns get deploy "${TASK17_API_DEPLOYMENT}" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  worker_ready="$(kubectl_ns get deploy "${TASK17_WORKER_DEPLOYMENT}" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  log "Kubernetes readyReplicas: api=${api_ready:-0}, indexing-worker=${worker_ready:-0}"
+
+  if [[ "${TASK17_SCAN_API_LOGS}" == "1" ]]; then
+    local logs
+    logs="$(kubectl_ns logs -l "${TASK17_API_SELECTOR}" --tail=500 --since=30m 2>/dev/null || true)"
+    if [[ -z "${logs}" ]]; then
+      skip "No API logs found for selector ${TASK17_API_SELECTOR}; cannot scan execution-plane uniqueness"
+    elif printf '%s\n' "${logs}" | grep -E "run_.*worker|run_reconcile_loop|run_cleanup_loop|aperag\\.cli\\.indexing_worker" >/dev/null; then
+      fail "API logs contain worker/reconciler/cleanup startup markers"
+    else
+      pass "API logs do not show worker/reconciler/cleanup startup markers"
+    fi
+  fi
+}
+
+check_worker_restart_optional() {
+  if [[ "${TASK17_RESTART_WORKER}" != "1" ]]; then
+    skip "Worker restart check not enabled; set TASK17_RESTART_WORKER=1"
+    return
+  fi
+  if [[ -z "${TASK17_K8S_NAMESPACE}" ]] || ! have_cmd kubectl; then
+    skip "Worker restart check requires TASK17_K8S_NAMESPACE and kubectl"
+    return
+  fi
+
+  local pod
+  pod="$(kubectl_ns get pod -l "${TASK17_WORKER_SELECTOR}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  if [[ -z "${pod}" ]]; then
+    fail "No indexing-worker pod found for selector ${TASK17_WORKER_SELECTOR}"
+    return
+  fi
+
+  log "Deleting indexing-worker pod ${pod} to verify API remains healthy"
+  kubectl_ns delete pod "${pod}" --wait=false >/dev/null
+  sleep 2
+  if curl_probe "/health/live" >/dev/null && curl_probe "/health/ready" >/dev/null; then
+    pass "API health stayed available immediately after indexing-worker pod deletion"
+  else
+    fail "API health failed after indexing-worker pod deletion"
+  fi
+  kubectl_ns rollout status deploy/"${TASK17_WORKER_DEPLOYMENT}" --timeout=180s >/dev/null \
+    && pass "indexing-worker deployment recovered after pod deletion" \
+    || fail "indexing-worker deployment did not recover after pod deletion"
+}
+
+main() {
+  log "Root: ${ROOT_DIR}"
+  log "Base URL: ${TASK17_BASE_URL}"
+
+  check_connection_budget
+  check_health_contract
+  check_postgres_live_connections
+  check_k8s_topology
+  check_worker_restart_optional
+
+  if ((failures > 0)); then
+    log "Completed with ${failures} failure(s), ${skips} skipped check(s)"
+    exit 1
+  fi
+
+  log "Completed successfully with ${skips} skipped optional check(s)"
+}
+
+main "$@"

--- a/tests/boundaries/test_api_no_cleanup.py
+++ b/tests/boundaries/test_api_no_cleanup.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+DOCUMENT_SERVICE = Path("aperag/domains/knowledge_base/service/document_service.py")
+APP_LIFESPAN = Path("aperag/app.py")
+
+
+def _method_source(path: Path, *, class_name: str, method_name: str) -> str:
+    source = path.read_text()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.AsyncFunctionDef | ast.FunctionDef) and item.name == method_name:
+                    return ast.get_source_segment(source, item) or ""
+    raise AssertionError(f"{class_name}.{method_name} not found in {path}")
+
+
+def _function_source(path: Path, *, function_name: str) -> str:
+    source = path.read_text()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef) and node.name == function_name:
+            return ast.get_source_segment(source, node) or ""
+    raise AssertionError(f"{function_name} not found in {path}")
+
+
+def _called_names(source: str) -> set[str]:
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        match node.func:
+            case ast.Name(id=name):
+                names.add(name)
+            case ast.Attribute(attr=name):
+                names.add(name)
+    return names
+
+
+def test_document_delete_request_path_has_no_heavy_cleanup_calls():
+    method = _method_source(DOCUMENT_SERVICE, class_name="DocumentService", method_name="_delete_document")
+
+    forbidden_calls = (
+        "cleanup_for_deleted_documents",
+        "_delete_document_indexes",
+        "delete_objects_by_prefix",
+        "get_async_object_store",
+    )
+    calls = _called_names(method)
+    for call_name in forbidden_calls:
+        assert call_name not in calls
+
+
+def test_deleted_document_indexes_helper_was_removed():
+    source = DOCUMENT_SERVICE.read_text()
+
+    assert "async def _delete_document_indexes" not in source
+    assert "def _delete_document_indexes" not in source
+
+
+def test_api_lifespan_does_not_build_cleanup_worker_factory():
+    source = APP_LIFESPAN.read_text()
+
+    assert "cleanup_worker_factory=None" in source
+    calls = _called_names(_function_source(APP_LIFESPAN, function_name="combined_lifespan"))
+    assert "build_for_cleanup_row" not in calls

--- a/tests/e2e_http/hurl/smoke/00_health.hurl
+++ b/tests/e2e_http/hurl/smoke/00_health.hurl
@@ -1,6 +1,33 @@
+# task #17 sub-task #21 (probe layering) acceptance contract pin —
+# the API-side hurl smoke must verify the three probe endpoints emerge
+# after the API/Worker hard cut deployment split:
+#
+#   /health             — kept for backward-compat with existing
+#                         k8s probes / external monitors.
+#   /health/live        — liveness; only proves the process is alive,
+#                         must not touch PG / Redis / Qdrant.
+#   /health/ready       — readiness; proves the HTTP entry can accept
+#                         requests, must not consume the main DB pool.
+#   /health/diagnostics — deep-dependency check; gated by admin auth /
+#                         intranet, NOT asserted in smoke (Planetegg
+#                         covers it from the release-validation lane
+#                         per msg=64f33ceb).
+
 GET {{base_url}}/health
 HTTP 200
 [Asserts]
 header "content-type" contains "application/json"
 jsonpath "$.status" == "healthy"
 jsonpath "$.service" == "aperag-api"
+
+GET {{base_url}}/health/live
+HTTP 200
+[Asserts]
+header "content-type" contains "application/json"
+jsonpath "$.status" == "healthy"
+
+GET {{base_url}}/health/ready
+HTTP 200
+[Asserts]
+header "content-type" contains "application/json"
+jsonpath "$.status" == "ready"

--- a/tests/e2e_http/hurl/smoke/00_health.hurl
+++ b/tests/e2e_http/hurl/smoke/00_health.hurl
@@ -24,10 +24,12 @@ GET {{base_url}}/health/live
 HTTP 200
 [Asserts]
 header "content-type" contains "application/json"
-jsonpath "$.status" == "healthy"
+jsonpath "$.status" == "live"
+jsonpath "$.service" == "aperag-api"
 
 GET {{base_url}}/health/ready
 HTTP 200
 [Asserts]
 header "content-type" contains "application/json"
 jsonpath "$.status" == "ready"
+jsonpath "$.service" == "aperag-api"

--- a/tests/integration/test_task17_cleanup_sot.py
+++ b/tests/integration/test_task17_cleanup_sot.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import Engine, create_engine, insert, select
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from aperag.db.base import Base
+from aperag.domains.knowledge_base.db.models import (
+    Collection,
+    CollectionStatus,
+    CollectionType,
+    Document,
+    DocumentStatus,
+)
+from aperag.indexing import InMemoryObjectStore, InMemoryVectorBackend, Modality, VectorModality
+from aperag.indexing.cleanup import cleanup_deleted_document_intents, find_deleted_document_cleanup_targets
+from aperag.indexing.models import DocumentIndex, IndexStatus
+
+
+@pytest.fixture
+def engine() -> Engine:
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng, tables=[Collection.__table__, Document.__table__])
+    DocumentIndex.metadata.create_all(eng, tables=[DocumentIndex.__table__])
+    return eng
+
+
+class FailingObjectStore(InMemoryObjectStore):
+    def delete_objects_by_prefix(self, prefix: str) -> None:
+        raise RuntimeError(f"object store down for {prefix}")
+
+
+def _insert_collection(session: Session, *, collection_id: str = "col-del") -> None:
+    session.add(
+        Collection(
+            id=collection_id,
+            title="Task 17 cleanup",
+            description="cleanup test collection",
+            user="user|test",
+            status=CollectionStatus.ACTIVE,
+            type=CollectionType.DOCUMENT,
+            config="{}",
+        )
+    )
+
+
+def _insert_deleted_document(
+    engine: Engine,
+    *,
+    document_id: str = "doc-del",
+    collection_id: str = "col-del",
+    status: DocumentStatus = DocumentStatus.DELETED,
+) -> str:
+    with Session(engine) as session, session.begin():
+        _insert_collection(session, collection_id=collection_id)
+        document = Document(
+            id=document_id,
+            name=f"{document_id}.txt",
+            user="user|test",
+            collection_id=collection_id,
+            status=status,
+            size=12,
+            content_hash="hash-task-17",
+            object_path=f"source/{document_id}.txt",
+            gmt_deleted=datetime.now(timezone.utc),
+        )
+        session.add(document)
+        session.flush()
+        object_prefix = document.object_store_base_path()
+        session.execute(
+            insert(DocumentIndex).values(
+                document_id=document_id,
+                parse_version="pvtask17clean1",
+                modality=Modality.VECTOR.value,
+                status=IndexStatus.ACTIVE.value,
+                tenant_scope_key="user:test",
+                source_path=f"{object_prefix}/derived/parse_pvtask17clean1/chunks.jsonl",
+                collection_id=collection_id,
+                is_serving=True,
+            )
+        )
+        return object_prefix
+
+
+def test_find_deleted_document_cleanup_targets_uses_db_intent(engine: Engine):
+    object_prefix = _insert_deleted_document(engine)
+
+    targets = find_deleted_document_cleanup_targets(engine=engine)
+
+    assert len(targets) == 1
+    assert targets[0].document_id == "doc-del"
+    assert targets[0].object_store_prefix == object_prefix
+
+
+def test_cleanup_deleted_document_intents_deletes_object_store_backend_and_rows(engine: Engine):
+    object_prefix = _insert_deleted_document(engine)
+    object_store = InMemoryObjectStore()
+    object_store.put(f"{object_prefix}/original.txt", b"source")
+    object_store.put(f"{object_prefix}/derived/parse_pvtask17clean1/chunks.jsonl", b"{}")
+    object_store.put("user-user-test/col-del/other-doc/original.txt", b"keep")
+
+    backend = InMemoryVectorBackend()
+    backend.upsert_point(
+        point_id="chunk-task-17",
+        embedding=[0.0] * 16,
+        payload={
+            "document_id": "doc-del",
+            "parse_version": "pvtask17clean1",
+            "modality": Modality.VECTOR.value,
+            "chunk_id": "chunk-task-17",
+            "text": "hello",
+        },
+    )
+    worker = VectorModality(backend=backend, store=object_store)
+
+    counts = asyncio.run(
+        cleanup_deleted_document_intents(
+            engine=engine,
+            workers={Modality.VECTOR: worker},
+            object_store=object_store,
+        )
+    )
+
+    assert counts["documents_seen"] == 1
+    assert counts["object_store_deleted"] == 1
+    assert counts["object_store_deferred"] == 0
+    assert counts["backend_deleted"] == 1
+    assert counts["rows_deleted"] == 1
+    assert object_store.list_objects_by_prefix(object_prefix) == []
+    assert object_store.obj_exists("user-user-test/col-del/other-doc/original.txt")
+    assert backend.points_for_document("doc-del") == []
+    with Session(engine) as session:
+        assert session.scalar(select(DocumentIndex).where(DocumentIndex.document_id == "doc-del")) is None
+
+
+def test_cleanup_deleted_document_intents_defers_backend_when_object_store_delete_fails(engine: Engine):
+    object_prefix = _insert_deleted_document(engine)
+    object_store = FailingObjectStore()
+    object_store.put(f"{object_prefix}/original.txt", b"source")
+
+    backend = InMemoryVectorBackend()
+    backend.upsert_point(
+        point_id="chunk-task-17",
+        embedding=[0.0] * 16,
+        payload={
+            "document_id": "doc-del",
+            "parse_version": "pvtask17clean1",
+            "modality": Modality.VECTOR.value,
+            "chunk_id": "chunk-task-17",
+            "text": "hello",
+        },
+    )
+    worker = VectorModality(backend=backend, store=object_store)
+
+    counts = asyncio.run(
+        cleanup_deleted_document_intents(
+            engine=engine,
+            workers={Modality.VECTOR: worker},
+            object_store=object_store,
+        )
+    )
+
+    assert counts["documents_seen"] == 1
+    assert counts["object_store_deleted"] == 0
+    assert counts["object_store_deferred"] == 1
+    assert counts["backend_deleted"] == 0
+    assert counts["rows_deleted"] == 0
+    assert backend.points_for_document("doc-del")
+    with Session(engine) as session:
+        assert session.scalar(select(DocumentIndex).where(DocumentIndex.document_id == "doc-del")) is not None
+    assert object_store.obj_exists(f"{object_prefix}/original.txt")

--- a/tests/load/test_concurrent_doc_upload_e2e.py
+++ b/tests/load/test_concurrent_doc_upload_e2e.py
@@ -47,9 +47,14 @@ import pytest
 
 from tests.e2e_pytest.config import (
     API_BASE_URL,
-    EMBEDDING_MODEL_CUSTOM_PROVIDER,
+    COMPLETION_MODEL_NAME,
+    COMPLETION_MODEL_PROVIDER,
+    COMPLETION_MODEL_PROVIDER_API_KEY,
+    COMPLETION_MODEL_PROVIDER_URL,
     EMBEDDING_MODEL_NAME,
     EMBEDDING_MODEL_PROVIDER,
+    EMBEDDING_MODEL_PROVIDER_API_KEY,
+    EMBEDDING_MODEL_PROVIDER_URL,
 )
 
 # ---------------------------------------------------------------------
@@ -83,6 +88,10 @@ API_HEALTH_PROBE_LATENCY_BUDGET_SECONDS: float = 0.5
 
 REQUIRES_DEPLOYMENT_RUN_TOKEN = "RUN_TASK_17_E2E"
 
+pytest_plugins = ("tests.e2e_pytest.conftest",)
+
+_TASK17_MODEL_IDS: dict[str, str] = {}
+
 pytestmark = pytest.mark.skipif(
     os.getenv(REQUIRES_DEPLOYMENT_RUN_TOKEN) != "1",
     reason=(
@@ -95,6 +104,107 @@ pytestmark = pytest.mark.skipif(
 # ---------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------
+
+
+def _provider_type(provider: str) -> str:
+    return {
+        "openrouter": "openai_compatible",
+        "alibabacloud": "dashscope",
+        "dashscope": "dashscope",
+        "openai_compatible": "openai_compatible",
+        "openai": "openai",
+        "jina": "jina",
+        "jina_ai": "jina",
+    }.get(provider, provider)
+
+
+@pytest.fixture(scope="module")
+def setup_model_service_provider(cookie_client):
+    """Configure v2 model-platform rows for the freshly registered e2e user.
+
+    The shared e2e fixture still targets the removed v1 ``llm_providers``
+    route. This deployment gate intentionally uses the current v2 model
+    platform so graph extraction can resolve collection completion and
+    embedding models by canonical ``model_id``.
+    """
+
+    def create_account(*, provider: str, base_url: str, api_key: str, suffix: str) -> str:
+        resp = cookie_client.post(
+            "/api/v2/model-accounts",
+            json={
+                "provider_type": _provider_type(provider),
+                "name": f"task17-{suffix}-{uuid.uuid4().hex[:8]}",
+                "display_name": f"Task17 {suffix}",
+                "base_url": base_url,
+                "api_key": api_key,
+            },
+        )
+        assert resp.status_code == HTTPStatus.OK, resp.text
+        return resp.json()["id"]
+
+    completion_account_id = create_account(
+        provider=COMPLETION_MODEL_PROVIDER,
+        base_url=COMPLETION_MODEL_PROVIDER_URL,
+        api_key=COMPLETION_MODEL_PROVIDER_API_KEY,
+        suffix="completion",
+    )
+    if (
+        EMBEDDING_MODEL_PROVIDER == COMPLETION_MODEL_PROVIDER
+        and EMBEDDING_MODEL_PROVIDER_URL == COMPLETION_MODEL_PROVIDER_URL
+        and EMBEDDING_MODEL_PROVIDER_API_KEY == COMPLETION_MODEL_PROVIDER_API_KEY
+    ):
+        embedding_account_id = completion_account_id
+    else:
+        embedding_account_id = create_account(
+            provider=EMBEDDING_MODEL_PROVIDER,
+            base_url=EMBEDDING_MODEL_PROVIDER_URL,
+            api_key=EMBEDDING_MODEL_PROVIDER_API_KEY,
+            suffix="embedding",
+        )
+
+    resp = cookie_client.post(
+        "/api/v2/models",
+        json={
+            "account_id": completion_account_id,
+            "provider_model_id": COMPLETION_MODEL_NAME,
+            "display_name": f"Task17 completion {COMPLETION_MODEL_NAME}",
+            "capability": "chat",
+            "context_window": 8192,
+            "extra": {"allowed_scenarios": ["collection_completion", "background_task"]},
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    _TASK17_MODEL_IDS["completion"] = resp.json()["id"]
+
+    resp = cookie_client.post(
+        "/api/v2/models",
+        json={
+            "account_id": embedding_account_id,
+            "provider_model_id": EMBEDDING_MODEL_NAME,
+            "display_name": f"Task17 embedding {EMBEDDING_MODEL_NAME}",
+            "capability": "embedding",
+            "embedding_dimensions": int(os.getenv("TASK_17_E2E_EMBEDDING_DIMENSIONS", "1536")),
+            "extra": {"allowed_scenarios": ["collection_embedding"]},
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    _TASK17_MODEL_IDS["embedding"] = resp.json()["id"]
+
+    for scenario, model_id in (
+        ("collection_completion", _TASK17_MODEL_IDS["completion"]),
+        ("background_task", _TASK17_MODEL_IDS["completion"]),
+        ("collection_embedding", _TASK17_MODEL_IDS["embedding"]),
+    ):
+        resp = cookie_client.put(
+            f"/api/v2/model-uses/{scenario}",
+            json={
+                "primary_model_id": model_id,
+                "fallback_model_ids": [],
+                "strategy": "single",
+                "enabled": True,
+            },
+        )
+        assert resp.status_code == HTTPStatus.OK, resp.text
 
 
 @pytest.fixture
@@ -116,11 +226,8 @@ def concurrent_collection(client):
             "enable_knowledge_graph": True,
             "enable_summary": False,
             "enable_vision": False,
-            "embedding": {
-                "model": EMBEDDING_MODEL_NAME,
-                "model_service_provider": EMBEDDING_MODEL_PROVIDER,
-                "custom_llm_provider": EMBEDDING_MODEL_CUSTOM_PROVIDER,
-            },
+            "embedding": {"model_id": _TASK17_MODEL_IDS["embedding"]},
+            "completion": {"model_id": _TASK17_MODEL_IDS["completion"], "temperature": 0.1},
         },
     }
     resp = client.post("/api/v2/collections", json=payload)

--- a/tests/load/test_concurrent_doc_upload_e2e.py
+++ b/tests/load/test_concurrent_doc_upload_e2e.py
@@ -1,0 +1,275 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""task #17 sub-task #22 — multi-document concurrent upload e2e load test.
+
+Acceptance gate for the API/Worker hard-cut deployment:
+- API pod must remain responsive (auth + collection list latency
+  unaffected) while N documents flow through the indexing pipeline.
+- All N documents must reach ``ACTIVE`` for the enabled modalities
+  within a wall-time budget that proves worker throughput is not
+  bottlenecked by API request handling.
+- DB connection count must stay under the configured pool budget
+  (asserted via PG ``pg_stat_activity`` count from a side channel —
+  out of scope for this script; see ``tests/load/test_pool_budget.py``
+  in @Planetegg's lane).
+
+Skipped by default; runs against a deployed ApeRAG stack. Set
+``RUN_TASK_17_E2E=1`` and the e2e_pytest config env vars (model
+providers + base url) to run.
+
+Owners: @Planetegg main task #22 / @chenyexuan co-implementer for
+this script. Cross-reviewed with @huangzhangshu (task #18 deployment
+gates) and @ziang (task #19 cleanup SoT).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import os
+import time
+import uuid
+from http import HTTPStatus
+
+import httpx
+import pytest
+
+from tests.e2e_pytest.config import (
+    API_BASE_URL,
+    EMBEDDING_MODEL_CUSTOM_PROVIDER,
+    EMBEDDING_MODEL_NAME,
+    EMBEDDING_MODEL_PROVIDER,
+)
+
+# ---------------------------------------------------------------------
+# Tunables — keep low for local-dev defaults; CI / ops override via env
+# so the same script powers both quick smoke and 100-doc burst runs.
+# ---------------------------------------------------------------------
+
+DOC_COUNT: int = int(os.getenv("TASK_17_E2E_DOC_COUNT", "20"))
+"""Number of documents to upload concurrently per run."""
+
+UPLOAD_CONCURRENCY: int = int(os.getenv("TASK_17_E2E_UPLOAD_CONCURRENCY", "10"))
+"""How many in-flight upload requests to keep against the API. The API
+must keep ``/health/live`` and ``/api/v2/auth/user`` stable while this
+load runs — that is the cascading-failure-mode the hard cut prevents."""
+
+POLL_BUDGET_SECONDS: float = float(os.getenv("TASK_17_E2E_POLL_BUDGET_SECONDS", "300"))
+"""Wall-time ceiling from upload-confirm to all-modalities-ACTIVE.
+Production SLO is 30 minutes for 100 docs (graph LLM extraction
+dominates). The default 5 min budget here covers DOC_COUNT=20 with
+embedding + fulltext + graph_facts enabled. Override for larger runs."""
+
+POLL_INTERVAL_SECONDS: float = float(os.getenv("TASK_17_E2E_POLL_INTERVAL_SECONDS", "5"))
+
+API_HEALTH_PROBE_INTERVAL_SECONDS: float = 2.0
+"""How often to sample ``/health/live`` while documents are indexing.
+Any single sample > 500ms or any non-200 response constitutes a hard
+cut regression — the API must never be blocked by worker pressure
+once the deployments are split."""
+
+API_HEALTH_PROBE_LATENCY_BUDGET_SECONDS: float = 0.5
+
+REQUIRES_DEPLOYMENT_RUN_TOKEN = "RUN_TASK_17_E2E"
+
+pytestmark = pytest.mark.skipif(
+    os.getenv(REQUIRES_DEPLOYMENT_RUN_TOKEN) != "1",
+    reason=(
+        f"deployment-aware e2e; set {REQUIRES_DEPLOYMENT_RUN_TOKEN}=1 + "
+        "tests/e2e_pytest config env vars to run against a live stack."
+    ),
+)
+
+
+# ---------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture
+def concurrent_collection(client):
+    """A collection with the modalities exercised by the burst run.
+
+    Vector + fulltext + graph_facts cover the three pipelines that
+    contend for the worker pool; vision + summary are off by default
+    so a CI run without GPU / vision provider can still exercise the
+    deployment gate.
+    """
+    payload = {
+        "title": f"task17 burst {uuid.uuid4().hex[:8]}",
+        "type": "document",
+        "config": {
+            "source": "system",
+            "enable_vector": True,
+            "enable_fulltext": True,
+            "enable_knowledge_graph": True,
+            "enable_summary": False,
+            "enable_vision": False,
+            "embedding": {
+                "model": EMBEDDING_MODEL_NAME,
+                "model_service_provider": EMBEDDING_MODEL_PROVIDER,
+                "custom_llm_provider": EMBEDDING_MODEL_CUSTOM_PROVIDER,
+            },
+        },
+    }
+    resp = client.post("/api/v2/collections", json=payload)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    coll = resp.json()
+    yield coll
+    client.delete(f"/api/v2/collections/{coll['id']}")
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+
+
+def _build_doc_body(idx: int) -> bytes:
+    """Each document is unique enough that vector / fulltext / graph
+    extraction must actually run — pure repeat content would let
+    parse_version dedup short-circuit the worker path."""
+    return (
+        f"# task #17 burst document {idx}\n\n"
+        f"This synthetic document number {idx} carries unique content so "
+        f"the indexing pipeline cannot collapse parse_version dedup. "
+        f"It mentions Alice-{idx} talking to Bob-{idx} about Project-{idx} "
+        f"so the graph extractor produces at least one entity triple per doc.\n\n"
+        f"## Section\n\n"
+        f"Paragraph two of document {idx}, with content suitable for "
+        f"chunking-window splitter.\n"
+    ).encode("utf-8")
+
+
+def _upload_one(client: httpx.Client, collection_id: str, idx: int) -> str:
+    files = {"files": (f"task17-burst-{idx:04d}.txt", _build_doc_body(idx), "text/plain")}
+    resp = client.post(f"/api/v2/collections/{collection_id}/documents", files=files)
+    assert resp.status_code == HTTPStatus.OK, f"upload {idx} failed: {resp.text}"
+    items = resp.json()["items"]
+    assert len(items) == 1
+    return items[0]["id"]
+
+
+def _all_indexes_active(item: dict, *, require_graph: bool) -> bool:
+    """A document is fully indexed once every enabled modality has
+    transitioned to ACTIVE. Graph is gated by ``require_graph`` so
+    collections without graph still exercise the same poll loop."""
+    if item.get("vector_index_status") != "ACTIVE":
+        return False
+    if item.get("fulltext_index_status") != "ACTIVE":
+        return False
+    if require_graph and item.get("graph_index_status") != "ACTIVE":
+        return False
+    return True
+
+
+def _probe_health_during_burst(probes: list[tuple[float, float, int]], stop_token: dict) -> None:
+    """Background sampler: hits ``/health/live`` every 2s while the
+    document burst runs and records (timestamp, latency, status_code).
+    Run this in a worker thread; main thread sets ``stop_token['stop']``
+    when the burst finishes."""
+    base = API_BASE_URL.rstrip("/")
+    with httpx.Client(timeout=2.0) as probe:
+        while not stop_token.get("stop"):
+            t0 = time.monotonic()
+            try:
+                resp = probe.get(f"{base}/health/live")
+                latency = time.monotonic() - t0
+                probes.append((time.time(), latency, resp.status_code))
+            except httpx.RequestError:
+                latency = time.monotonic() - t0
+                probes.append((time.time(), latency, -1))
+            time.sleep(API_HEALTH_PROBE_INTERVAL_SECONDS)
+
+
+# ---------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------
+
+
+def test_concurrent_doc_upload_indexes_under_budget(client, concurrent_collection):
+    """Multi-document burst: upload + confirm + wait-for-ACTIVE.
+
+    Asserts:
+    - All ``DOC_COUNT`` documents reach ACTIVE for vector / fulltext
+      / graph_facts within ``POLL_BUDGET_SECONDS``.
+    - ``/health/live`` stays 200 with p95 latency under
+      ``API_HEALTH_PROBE_LATENCY_BUDGET_SECONDS`` throughout the burst
+      — this is the hard cut acceptance gate (API not blocked by
+      worker pressure once the deployments are split).
+    - No upload returns 5xx or times out at the API entry point.
+    """
+    collection_id = concurrent_collection["id"]
+
+    # ---- Phase 1: parallel uploads ----
+    upload_started = time.monotonic()
+    document_ids: list[str] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=UPLOAD_CONCURRENCY) as pool:
+        futures = [pool.submit(_upload_one, client, collection_id, i) for i in range(DOC_COUNT)]
+        for fut in concurrent.futures.as_completed(futures):
+            document_ids.append(fut.result())
+    upload_elapsed = time.monotonic() - upload_started
+    assert len(document_ids) == DOC_COUNT
+    # Upload itself must not take embarrassingly long — the API path
+    # writes intent rows + enqueues, no heavy work. 30s/20-docs is a
+    # generous ceiling that catches API-side regressions.
+    assert upload_elapsed < 30.0, (
+        f"upload phase took {upload_elapsed:.1f}s for {DOC_COUNT} docs — API write path regressed?"
+    )
+
+    # ---- Phase 2: poll for indexing completion + sample API health ----
+    health_probes: list[tuple[float, float, int]] = []
+    stop_token = {"stop": False}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as probe_pool:
+        probe_pool.submit(_probe_health_during_burst, health_probes, stop_token)
+
+        deadline = time.monotonic() + POLL_BUDGET_SECONDS
+        active_doc_ids: set[str] = set()
+        last_seen: dict[str, dict] = {}
+        while time.monotonic() < deadline and len(active_doc_ids) < DOC_COUNT:
+            resp = client.get(
+                f"/api/v2/collections/{collection_id}/documents",
+                params={"page_size": DOC_COUNT * 2},
+            )
+            assert resp.status_code == HTTPStatus.OK, resp.text
+            for item in resp.json()["items"]:
+                last_seen[item["id"]] = item
+                if _all_indexes_active(item, require_graph=True):
+                    active_doc_ids.add(item["id"])
+            if len(active_doc_ids) < DOC_COUNT:
+                time.sleep(POLL_INTERVAL_SECONDS)
+
+        stop_token["stop"] = True
+
+    # ---- Phase 3: assertions ----
+    missing = [did for did in document_ids if did not in active_doc_ids]
+    assert not missing, (
+        f"{len(missing)}/{DOC_COUNT} documents did not reach ACTIVE within "
+        f"{POLL_BUDGET_SECONDS}s budget. Stuck states: "
+        f"{[(did, last_seen.get(did, {})) for did in missing[:3]]}"
+    )
+
+    # Health probe gate: all samples must be 200 + under the latency
+    # budget. The hard cut deployment promise is that worker pressure
+    # never blocks the API; if any probe sample violates this, the
+    # deployment split has not actually isolated the runtimes.
+    failed_probes = [p for p in health_probes if p[2] != 200]
+    assert not failed_probes, (
+        f"/health/live returned non-200 during burst: {[(t, lat, code) for t, lat, code in failed_probes[:5]]}"
+    )
+    slow_probes = [p for p in health_probes if p[1] > API_HEALTH_PROBE_LATENCY_BUDGET_SECONDS]
+    assert len(slow_probes) <= max(1, len(health_probes) // 20), (
+        f"/health/live latency violated {API_HEALTH_PROBE_LATENCY_BUDGET_SECONDS}s "
+        f"budget on {len(slow_probes)}/{len(health_probes)} samples — "
+        "API event loop is being blocked by worker activity."
+    )

--- a/tests/unit_test/test_app_lifespan_no_workers.py
+++ b/tests/unit_test/test_app_lifespan_no_workers.py
@@ -1,0 +1,172 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""task #17 hard gate #1 — API 进程不启动重型 indexing 执行面.
+
+Pin the API/Worker hard cut invariant at the source level so a future
+PR cannot regress by re-adding ``asyncio.create_task(run_*_worker)``
+inside ``aperag/app.py:combined_lifespan``. The runtime hard cut is
+the architectural promise that solved the Singapore 503 (huangzhangshu
+task #13): the API process only handles HTTP routing + lightweight
+enqueue, while ``indexing-worker`` deployment runs the actual workers
+out-of-process via ``python -m aperag.cli.indexing_worker``.
+
+These tests are the source-level grep gate that backs the deployment
+runbook's hard gate #1 ("API readiness probe must remain stable while
+graph indexing is under pressure"). They run in unit_test so they
+execute in the standard PR-gate suite without any deployment.
+
+The companion ``tests/unit_test/test_app_lifespan_no_workers.py``
+asserts the *positive* contract on ``aperag/cli/indexing_worker.py``
+— that file MUST start the workers + parse + reconciler + cleanup
+loops, otherwise the worker deployment would boot but consume nothing.
+
+Owners: nominally @Bryce per @huangheng task-17-cr-review-checklist
+hard-gate-to-test mapping; @chenyexuan co-implementer covers this
+slice (msg=6627eb69 in #indexing优化:5e959a2d) so Bryce can focus on
+the task #17.4 ``document_service.delete`` cleanup migration.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_PY = REPO_ROOT / "aperag" / "app.py"
+CLI_WORKER_PY = REPO_ROOT / "aperag" / "cli" / "indexing_worker.py"
+
+# Symbols that, if invoked from ``aperag/app.py``, would re-introduce
+# the API-side worker startup that the hard cut removed. The list is
+# the same set ``run_*`` entrypoints that ``aperag/cli/indexing_worker.py``
+# now owns.
+_BANNED_LIFESPAN_INVOCATIONS: tuple[str, ...] = (
+    "run_vector_worker",
+    "run_fulltext_worker",
+    "run_graph_worker",
+    "run_graph_facts_worker",
+    "run_graph_vectors_worker",
+    "run_summary_worker",
+    "run_vision_worker",
+    "run_parse_worker",
+    "run_reconcile_loop",
+    "run_cleanup_loop",
+)
+
+# ``ProductionWorkerFactory`` materialises real backends (Qdrant /
+# Elasticsearch / embedders / completion model). Constructing it from
+# the API process pulls those clients into the API event loop, which
+# is the exact scenario the hard cut fixes. The CLI worker still
+# constructs it (positive contract checked below).
+_BANNED_FACTORY_CONSTRUCTOR = "ProductionWorkerFactory("
+
+# ``IndexingRuntime.cleanup_worker_factory=...`` injection of a real
+# factory would let service-layer ``Document.delete`` run heavy
+# backend cleanup synchronously inside an API request — the exact
+# behaviour ziang msg=cecb0d88 + huangheng msg=f97b7c5f #6 banned.
+# After the hard cut the API constructs ``IndexingRuntime`` with
+# ``cleanup_worker_factory=None``; this regex catches any other
+# concrete value being assigned in app.py.
+_CLEANUP_FACTORY_ASSIGNMENT_RE = re.compile(
+    r"cleanup_worker_factory\s*=\s*(?!None\b)([A-Za-z_]\w*)",
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------
+# Negative contract — aperag/app.py must not start workers.
+# ---------------------------------------------------------------------
+
+
+def test_app_lifespan_does_not_invoke_worker_entrypoints():
+    """No ``run_*_worker`` / ``run_*_loop`` call inside ``aperag/app.py``.
+
+    Catches accidental reintroduction of any of the ten worker
+    entrypoints into the lifespan. A regression here would re-merge
+    the API and worker runtimes — the Singapore 503 root cause.
+    """
+    src = _read(APP_PY)
+    offenders = [name for name in _BANNED_LIFESPAN_INVOCATIONS if f"{name}(" in src]
+    assert not offenders, (
+        f"aperag/app.py invokes worker entrypoints that the task #17 "
+        f"hard cut moved to aperag/cli/indexing_worker.py: {offenders}. "
+        "If you intentionally re-introduce a worker into the API "
+        "process, the API/worker isolation contract is broken — "
+        "see docs/zh-CN/architecture/task-system-hard-cut-v8.md."
+    )
+
+
+def test_app_lifespan_does_not_construct_production_worker_factory():
+    """API process must not construct ``ProductionWorkerFactory``.
+
+    The factory pulls in heavy backend clients; constructing it from
+    the API event loop is what the hard cut prevents.
+    """
+    src = _read(APP_PY)
+    assert _BANNED_FACTORY_CONSTRUCTOR not in src, (
+        "aperag/app.py constructs ProductionWorkerFactory(...). The "
+        "task #17 hard cut requires this construction to live only "
+        "in aperag/cli/indexing_worker.py — see "
+        "docs/zh-CN/architecture/task-system-hard-cut-v8.md."
+    )
+
+
+def test_app_lifespan_runtime_uses_no_cleanup_factory():
+    """``IndexingRuntime(cleanup_worker_factory=...)`` in ``app.py``
+    must be ``None`` so service-layer ``Document.delete`` is forced
+    onto the worker-side cleanup loop (ziang msg=cecb0d88 / huangheng
+    msg=f97b7c5f #6 hard gate)."""
+    src = _read(APP_PY)
+    matches = _CLEANUP_FACTORY_ASSIGNMENT_RE.findall(src)
+    assert not matches, (
+        "aperag/app.py assigns cleanup_worker_factory to a concrete "
+        f"value ({matches}). After the task #17 hard cut the API must "
+        "use cleanup_worker_factory=None so the API request path "
+        "cannot run heavy backend cleanup."
+    )
+
+
+# ---------------------------------------------------------------------
+# Positive contract — aperag/cli/indexing_worker.py must start the
+# workers the hard cut moved off the API.
+# ---------------------------------------------------------------------
+
+
+def test_cli_worker_starts_every_runtime_loop():
+    """The hard cut is symmetrical: every entrypoint that ``app.py``
+    no longer invokes must be invoked by the CLI worker, otherwise
+    the worker deployment boots but consumes no queues."""
+    src = _read(CLI_WORKER_PY)
+    missing = [name for name in _BANNED_LIFESPAN_INVOCATIONS if f"{name}(" not in src]
+    assert not missing, (
+        f"aperag/cli/indexing_worker.py is missing invocations of "
+        f"{missing}. The hard cut moved these off the API but they "
+        "must still run somewhere — the CLI worker is that home. "
+        "Without them the indexing-worker deployment would not "
+        "consume the corresponding queues."
+    )
+
+
+def test_cli_worker_constructs_production_worker_factory():
+    """Symmetric positive: the CLI worker must construct the factory
+    the API no longer constructs."""
+    src = _read(CLI_WORKER_PY)
+    assert _BANNED_FACTORY_CONSTRUCTOR in src, (
+        "aperag/cli/indexing_worker.py must construct "
+        "ProductionWorkerFactory(...) — it is the worker-side owner "
+        "of the heavy backend clients after the task #17 hard cut."
+    )

--- a/tests/unit_test/test_health_endpoints.py
+++ b/tests/unit_test/test_health_endpoints.py
@@ -17,6 +17,13 @@ def test_legacy_health_endpoint_keeps_existing_payload():
     assert response.json() == {"status": "healthy", "service": "aperag-api"}
 
 
+def test_legacy_health_endpoint_does_not_redirect():
+    response = _client().get("/health", follow_redirects=False)
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy", "service": "aperag-api"}
+
+
 def test_live_and_ready_are_lightweight():
     client = _client()
 

--- a/tests/unit_test/test_health_endpoints.py
+++ b/tests/unit_test/test_health_endpoints.py
@@ -6,7 +6,7 @@ from aperag.server import health
 
 def _client() -> TestClient:
     app = FastAPI()
-    app.include_router(health.router)
+    app.include_router(health.router, prefix="/health")
     return TestClient(app)
 
 
@@ -59,4 +59,3 @@ def test_diagnostics_uses_isolated_probe_when_authorized(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()["checks"]["database"] == {"ok": True, "elapsed_ms": 1.0}
-

--- a/tests/unit_test/test_health_endpoints.py
+++ b/tests/unit_test/test_health_endpoints.py
@@ -1,0 +1,62 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aperag.server import health
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(health.router)
+    return TestClient(app)
+
+
+def test_legacy_health_endpoint_keeps_existing_payload():
+    response = _client().get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy", "service": "aperag-api"}
+
+
+def test_live_and_ready_are_lightweight():
+    client = _client()
+
+    assert client.get("/health/live").json() == {"status": "live", "service": "aperag-api"}
+    assert client.get("/health/ready").json() == {"status": "ready", "service": "aperag-api"}
+
+
+def test_diagnostics_is_hidden_from_openapi():
+    schema = _client().get("/openapi.json").json()
+
+    assert "/health/diagnostics" not in schema["paths"]
+
+
+def test_diagnostics_requires_configured_token(monkeypatch):
+    monkeypatch.delenv(health.DIAGNOSTICS_TOKEN_ENV, raising=False)
+
+    response = _client().get("/health/diagnostics")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == f"{health.DIAGNOSTICS_TOKEN_ENV} is not configured"
+
+
+def test_diagnostics_requires_matching_token(monkeypatch):
+    monkeypatch.setenv(health.DIAGNOSTICS_TOKEN_ENV, "secret")
+
+    response = _client().get("/health/diagnostics", headers={"X-Internal-Token": "wrong"})
+
+    assert response.status_code == 401
+
+
+def test_diagnostics_uses_isolated_probe_when_authorized(monkeypatch):
+    monkeypatch.setenv(health.DIAGNOSTICS_TOKEN_ENV, "secret")
+
+    async def fake_probe():
+        return {"ok": True, "elapsed_ms": 1.0}
+
+    monkeypatch.setattr(health, "_run_database_probe", fake_probe)
+
+    response = _client().get("/health/diagnostics", headers={"X-Internal-Token": "secret"})
+
+    assert response.status_code == 200
+    assert response.json()["checks"]["database"] == {"ok": True, "elapsed_ms": 1.0}
+

--- a/tests/unit_test/test_modularization_boundaries.py
+++ b/tests/unit_test/test_modularization_boundaries.py
@@ -873,28 +873,6 @@ def test_phase5_di_critical_wirings_at_app_startup():
     )
 
 
-def test_app_lifespan_launches_all_graph_indexing_worker_lanes():
-    """Graph state split adds new queue consumers, not just new factories.
-
-    Task #12 regression guard: PR #1871 registered ``graph_facts`` and
-    ``graph_vectors`` with the orchestrator/factory/reconciler, but the
-    FastAPI lifespan still launched only the legacy ``graph`` worker.
-    That leaves ``q:graph_facts`` / ``q:graph_vectors`` with producers
-    and no consumers in the real app process.
-    """
-    import aperag.indexing as indexing
-
-    for name in ("run_graph_worker", "run_graph_facts_worker", "run_graph_vectors_worker"):
-        assert hasattr(indexing, name), f"aperag.indexing must re-export {name} for app lifespan imports"
-
-    app_source = (REPO_ROOT / "aperag" / "app.py").read_text(encoding="utf-8")
-    for name in ("run_graph_worker", "run_graph_facts_worker", "run_graph_vectors_worker"):
-        assert name in app_source, f"aperag/app.py must import {name}"
-        assert f"asyncio.create_task({name}(**worker_kwargs))" in app_source, (
-            f"FastAPI lifespan must launch every graph worker lane; missing create_task for {name}"
-        )
-
-
 def test_phase5_domain_routes_never_use_pep_563_future_annotations():
     """Lesson 9a-quatuordec codification: FastAPI route modules must
     not use ``from __future__ import annotations``. PEP 563


### PR DESCRIPTION
## Summary

按 earayu2 directive (msg=53a0b121 开 PR + msg=d18b6887 所有人可修改 PR + msg=074b8019 今天做完明天发布 + msg=311edfc7 不做倾向性分析 + msg=d35739c9 团队 OWN 推荐) 开 task #17 协作式 PR.

5 方独立 evidence-based 推荐 100% 收敛 (架构师 + huangzhangshu SRE + ziang 代码审计 + Weston 架构评审 + huangheng CR + Bryce implementer): **候选 B — 保留 RedisWorkQueue + DocumentIndex SoT + 一次性 hard cut 拆 deployment + 解 503 最小改造**.

## task #17 主线 8 项 (runtime hard cut)

1. 新增 ``aperag/cli/indexing_worker.py`` (~80 LOC) 启动入口, 覆盖 app.py 全部 lane (parse / vector / fulltext / graph / graph_facts / graph_vectors / summary / vision / reconciler / cleanup)
2. API lifespan 删 worker / reconciler / cleanup 启动路径, **hard cut 不留 fallback**
3. 新增 Helm ``indexing-worker-deployment.yaml`` + 修 ``api-deployment.yaml`` probe + ``values.yaml`` indexingWorker section
4. probe 分层: API liveness 仅证明进程活, readiness 仅证明 HTTP 入口可接 + 短超时, **不查 PG/Redis/Qdrant**; 深度依赖检查放 ``/health/diagnostics`` (鉴权 + 隔离小预算 + 短 timeout)
5. 连接池预算公式化: Helm 层 ``api.dbPoolSize`` / ``indexingWorker.dbPoolSize`` 映射应用现有 ``DB_POOL_SIZE`` / ``DB_MAX_OVERFLOW`` env, **不引双 env alias** (per ziang msg=4ea65100 #3)
6. 全局并发跨副本: 复用 RedisQuotaBackend Lua token bucket + 多维度 (modality / tenant / collection / provider) 上限校验
7. **删除/重建 cleanup 从 API 请求路径迁出 (hard gate)**: ``document_service._delete_document`` 只标记 ``Document.status=DELETED + gmt_deleted``, 重型 backend cleanup (含 ``cleanup_for_deleted_documents`` + object store ``delete_objects_by_prefix``) 由 worker cleanup loop 异步执行 (per ziang msg=cecb0d88 + huangheng msg=f97b7c5f)
8. 部署级 e2e + 压测验收: 黄章书 7 hard gate (graph 压力下 API ``/health/live`` + ``/api/v2/auth/user`` 稳定 / DB 连接数不爆 / 队列积压可观测 / worker 独立重启 / 旧 parse_version 不写坏新 / Redis 队列丢消息 reconciler 补漏 / rollout 不爆 PG)

## 同 PR 文档项 (不计入 runtime 主线 8 项)

9. ``docs/zh-CN/architecture/task-system-hard-cut-v8.md`` v8 final 方案文档归档 (跟代码 + 部署一起 PR review, fold spec lock 进 architecture invariant)

## 不进 task #17 主线 (后续独立切片候选, 需 earayu2 单独 product ratify)

- task #18 collection 配置校验 (创建时校验 embedding / completion 配置)
- task #19 ``graph_extractor.py:184`` fail-loud (替代 silent return)
- task #20 图谱向量 GC sweep (清理 lineage 不存在的孤儿向量)
- task #21 store bulk upsert API (4 backend Protocol + ON CONFLICT 批量 SQL)

不进任何 task: Dramatiq / Celery / RQ 引入 (后续 PoC 路径, 4 quantitative escape hatch 触发条件作 architecture invariant); ``aperag/tasks/`` 包名搬迁 (import churn 不直接解 503).

## Architecture invariant (spec lock)

未来满足任意一条 → 重评切 framework, 否则永远不引入:

1. 任务吞吐 ≥ 100/s 持续 5 分钟
2. 跨租户公平调度成正式产品需求
3. 任务优先级 / 延迟队列 / 复杂取消 / chain·chord·group 复杂工作流成正式产品需求 (普通删除 / 重建 / 旧任务防写回继续 DocumentIndex + version-token gate 解决)
4. reconciler 5-stage 维护成本 ≥ framework 升级成本 (每 quarter own-up ≥ 5 + DB poll p99 latency ≥ 1s 持续 5 分钟, 且已尝试索引优化 / 批量扫描 / poll 分片 / 连接池预算后仍无法解决)

PgBouncer 后续选项: 接入时仍保留 API/worker 独立 pool 预算; 必要兼容性 verify (transaction pooling / asyncpg prepared statement / alembic / 长事务 / session-level settings).

## 协作 PR 模式 (按 earayu2 msg=d18b6887 + 团队 msg=cd4761aa/a09815f5/b84e2636/5836b5c5 文件边界协作)

| 责任人 | 文件边界 | 分工 |
|---|---|---|
| @Bryce | ``aperag/cli/indexing_worker.py`` / ``aperag/app.py`` lifespan / ``aperag/server/health.py`` / ``aperag/domains/knowledge_base/service/document_service.py`` cleanup 迁出 / ``aperag/indexing/cleanup.py`` 补 deleted Document scan / 单测 | 代码主线 (按 ziang msg=4ea65100 7 项 CR 修正实现) |
| @huangzhangshu | ``deploy/aperag/templates/indexing-worker-deployment.yaml`` / ``deploy/aperag/templates/api-deployment.yaml`` probe / ``deploy/aperag/values.yaml`` / 部署 / 发布 / 回滚章节 | Helm + 部署/发布/回滚 |
| @符炫炜 | ``docs/zh-CN/architecture/task-system-hard-cut-v8.md`` v8 final / ``docs/architecture.md`` invariant 段 | 文档归档 + spec lock fold |
| @ziang | ``docs/zh-CN/architecture/task-17-state-machine-validation.md`` 状态机/失败场景验收 / grep gate 测试 | 状态机 SoT + cleanup 一致性 + grep gate |
| @Weston | scope 一致性 verify (task #17 主线 8 vs task #18-21 候选 vs spec lock 文档项) + architecture hard gate | 文档 scope 口径 + architecture |
| @huangheng | 5 cross-check + Lesson #11/12/extension v3 + Mini-pattern 17 + 一次性不分阶段 mandatory checklist + final review | CR review |

按 ziang msg=4ea65100 7 项实现修正 (Bryce msg=981960cd accept):
1. 用现有 ``settings`` 不引 ``get_settings()`` helper, ``ProductionWorkerFactory`` 从 ``aperag.indexing.worker_factory`` import
2. ``RedisQuotaBackend(quota_redis, registry=QuotaPolicyRegistry())`` / ``InMemoryQuotaBackend(QuotaPolicyRegistry())`` 跟 app.py 现有写法一致
3. 连接池只在 Helm 层映射现有 env, 不引应用层双 env alias
4. ``_delete_document`` 不嵌套 transaction, 直接删除 ``cleanup_for_deleted_documents()`` 调用, API 只写 DB intent
5. Object store prefix delete 也迁出 API 请求路径 (跟 backend cleanup 一起)
6. ``run_cleanup_loop`` 实施时 grep verify 是否完整 cover ``Document.status=DELETED + DocumentIndex rows`` scan, 缺则补
7. ``/health/diagnostics`` 鉴权 (admin only / 内网) + ``get_sync_database_url(settings.database_url)`` 处理 async URL → sync URL

## Test plan

- [x] 协作 PR base 已开 (本提交) + ``docs/zh-CN/architecture/task-17-code-changes.md`` 代码改造章节入仓
- [ ] @符炫炜 v8 final 文档归档进 ``docs/zh-CN/architecture/task-system-hard-cut-v8.md``
- [ ] @Bryce 代码主线实现 (8 项)
- [ ] @huangzhangshu Helm + 部署/发布/回滚章节
- [ ] @ziang 状态机/失败场景验收章节 + grep gate 测试
- [ ] @Weston scope 一致性 + architecture hard gate verify
- [ ] @huangheng final CR review (5 cross-check + 5 mandatory checklist)
- [ ] CI lint-and-unit + 3 套 e2e-http-smoke + 3 套 e2e-http-provider 全绿
- [ ] 5 方各自 align + earayu2 ratify → squash merge → 明天发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)