### PR TITLE
docs(task-17): align health probe references

### DIFF
--- a/docs/zh-CN/architecture/task-17-code-changes.md
+++ b/docs/zh-CN/architecture/task-17-code-changes.md
@@ -236,8 +236,9 @@ if settings.indexing_mode == "async":
   独立 endpoint, 用 reserved 极小连接预算 + 严格短超时, 不占主业务 pool.
   不作 kube probe 触发器, 仅供内网 / admin token / 发布脚本使用.
 
-老 ``/health`` endpoint 重定向到 ``/health/live`` 兼容老调用方 (KubeBlocks
-监控等). 新部署的 helm probe 直接用 ``/health/live`` + ``/health/ready``.
+老 ``/health`` endpoint 保持原 payload 并直接返回 200，兼容老调用方 (KubeBlocks
+监控等)，避免不跟随 307 redirect 的探针误判。新部署的 helm probe 直接用
+``/health/live`` + ``/health/ready``.
 """
 
 from fastapi import APIRouter, Response, status
@@ -308,18 +309,18 @@ async def diagnostics() -> dict:
     return result
 
 
-# 老 ``/health`` 重定向到 ``/health/live``, 兼容老 helm probe 配置.
-@router.get("/health", tags=["health"])
+# 老 ``/health`` 保持原 payload 并直接 200, 兼容老 helm probe 配置.
+@router.get("", tags=["health"])
 async def legacy_health() -> dict:
-    """Legacy endpoint → ``/health/live``. 老 helm 配置兼容."""
-    return await liveness()
+    """Legacy endpoint. 老 helm 配置兼容."""
+    return {"status": "healthy", "service": "aperag-api"}
 ```
 
 API ``app.py`` 注册 router:
 
 ```python
 from aperag.server.health import router as health_router
-app.include_router(health_router)
+app.include_router(health_router, prefix="/health")
 ```
 
 helm probe 配置 (新):
@@ -546,7 +547,8 @@ readinessProbe:
   failureThreshold: 3
 ```
 
-老 ``/health`` 通过 ``aperag/server/health.py`` 的 redirect 兼容 (回避 helm 旧配置缓存导致 break).
+老 ``/health`` 通过 ``aperag/server/health.py`` 保持原响应并直接 200 兼容
+(回避不跟随 redirect 的老探针配置导致 break).
 
 ---
 
@@ -587,8 +589,8 @@ PR #1871 / #1875 / #1876 / #1877 / #1879 ship 的 17 个新单测 (graph state m
 3. **删除** ``aperag/app.py`` 内的 ``indexing_runtime_tasks`` list + ``indexing_shutdown`` event + shutdown 时的 ``asyncio.gather(*tasks)``.
 4. **不**保留 ``ENABLE_INDEXING_WORKERS=False`` 类 conditional flag — 不留双模式.
 5. **不**保留 ``aperag.indexing.runtime`` 内的 worker_factory injection (改成只 wire enqueue).
-6. helm 老 ``/health`` probe 路径通过 ``aperag/server/health.py`` redirect 兼容, 但 helm template **直接更新成** ``/health/live`` + ``/health/ready`` (不留模板分支).
-7. **删除** 老 ``/health`` endpoint 在 ``aperag/app.py:568-571`` 的 inline 定义 (移到 ``aperag/server/health.py``, 仅作 redirect).
+6. helm 老 ``/health`` probe 路径通过 ``aperag/server/health.py`` 直接 200 兼容, 但 helm template **直接更新成** ``/health/live`` + ``/health/ready`` (不留模板分支).
+7. **删除** 老 ``/health`` endpoint 在 ``aperag/app.py:568-571`` 的 inline 定义 (移到 ``aperag/server/health.py``, 仅作兼容入口).
 
 ---
 
@@ -619,7 +621,7 @@ PR #1871 / #1875 / #1876 / #1877 / #1879 ship 的 17 个新单测 (graph state m
 ### 3.10.1 风险
 
 1. ``run_graph_worker`` 兼容期保留 — 如果生产没有老 GRAPH 模态行, 启动它是无害但浪费. 后续 spec 单列删除.
-2. helm 老 ``/health`` probe 仍指向老路径的旧部署版本 — ``aperag/server/health.py`` 通过 redirect 兼容.
+2. helm 老 ``/health`` probe 仍指向老路径的旧部署版本 — ``aperag/server/health.py`` 通过直接 200 兼容.
 3. PG 连接数公式可能跟现场 KubeBlocks Postgres 限制不匹配 — values 注释里给公式, ops 调整 pool / replica.
 4. cleanup 路径迁出后, API ``DELETE /document/{id}`` 响应时间会变快 (不再同步 cleanup), 但 cleanup 完成时延变长 (受 reconciler 30s 周期影响). 接受 short-term 用户感知差异 — 用户期待是"删除提交即可", 不期待"删除立刻持久化".
 

--- a/docs/zh-CN/integration/mcp.md
+++ b/docs/zh-CN/integration/mcp.md
@@ -22,7 +22,7 @@ ApeRAG 内置了一个 [Model Context Protocol (MCP)](https://modelcontextprotoc
 默认部署无需额外配置即可启用 MCP：
 
 - **Docker Compose**：`docker-compose up -d` 即可，`api` 服务的 `8000:8000` 端口同时暴露 REST API 和 MCP Server。
-- **健康检查**：`curl http://localhost:8000/health` 正常即说明主进程和 MCP 子挂载都已启动。
+- **健康检查**：`curl http://localhost:8000/health/ready` 正常即说明主进程 HTTP 入口和 MCP 子挂载都已启动；`/health` 保留为旧探针兼容入口。
 - **关闭 MCP**：目前没有提供关闭开关；MCP Server 与主进程共生。
 
 可选环境变量：

--- a/tests/e2e_http/README.md
+++ b/tests/e2e_http/README.md
@@ -17,7 +17,7 @@ Top-level layout:
 - `testdata/`: stable input files used by HTTP tests
 
 Current v1 scope:
-- Readiness endpoint: `GET /health`
+- Readiness endpoint: `GET /health/ready` (legacy `GET /health` stays available for backward compatibility)
 - Auth smoke: login, current user, logout
 - Collection smoke: create, get, list, update, delete
 - Document smoke: upload, get detail, delete

--- a/tests/e2e_http/bootstrap/bootstrap.sh
+++ b/tests/e2e_http/bootstrap/bootstrap.sh
@@ -23,13 +23,13 @@ wait_for_health() {
   local i
 
   for ((i = 1; i <= attempts; i++)); do
-    if curl --silent --show-error --fail "${E2E_BASE_URL}/health" >/dev/null; then
+    if curl --silent --show-error --fail "${E2E_BASE_URL}/health/ready" >/dev/null; then
       return 0
     fi
     sleep "${sleep_seconds}"
   done
 
-  echo "Timed out waiting for ${E2E_BASE_URL}/health" >&2
+  echo "Timed out waiting for ${E2E_BASE_URL}/health/ready" >&2
   return 1
 }
 

--- a/tests/e2e_http/runners/compose/README.md
+++ b/tests/e2e_http/runners/compose/README.md
@@ -4,7 +4,7 @@ This runner is the first convenience launcher for the HTTP E2E suite.
 
 Responsibilities:
 - start the ApeRAG environment
-- wait for `GET /health`
+- wait for `GET /health/ready`
 - leave execution of bootstrap and Hurl requests to other layers
 
 Non-responsibilities:

--- a/tests/e2e_http/runners/compose/up.sh
+++ b/tests/e2e_http/runners/compose/up.sh
@@ -105,7 +105,7 @@ echo "Compose runner starting (shape=${label}, services='${E2E_COMPOSE_SERVICES}
 docker compose ${E2E_COMPOSE_PROFILES} -f docker-compose.yml up -d --build ${E2E_COMPOSE_SERVICES}
 
 for ((i = 1; i <= E2E_HEALTH_ATTEMPTS; i++)); do
-  if curl --silent --show-error --fail "${E2E_BASE_URL}/health" >/dev/null; then
+  if curl --silent --show-error --fail "${E2E_BASE_URL}/health/ready" >/dev/null; then
     echo "Compose runner ready at ${E2E_BASE_URL} (shape=${label})"
     exit 0
   fi

--- a/tests/e2e_http/runners/k8s/README.md
+++ b/tests/e2e_http/runners/k8s/README.md
@@ -4,7 +4,7 @@ This runner keeps the same bootstrap and Hurl suite while swapping only the laun
 
 Current mode:
 - default behavior uses `kubectl port-forward` against a target service
-- the runner then waits for `GET /health`
+- the runner then waits for `GET /health/ready`
 - `down.sh` tears down the background port-forward process
 
 Key environment variables:

--- a/tests/e2e_http/runners/k8s/up.sh
+++ b/tests/e2e_http/runners/k8s/up.sh
@@ -34,7 +34,7 @@ if [[ "${E2E_K8S_USE_PORT_FORWARD:-1}" == "1" ]]; then
 fi
 
 for ((i = 1; i <= E2E_HEALTH_ATTEMPTS; i++)); do
-  if curl --silent --show-error --fail "${E2E_BASE_URL}/health" >/dev/null; then
+  if curl --silent --show-error --fail "${E2E_BASE_URL}/health/ready" >/dev/null; then
     echo "K8s runner ready at ${E2E_BASE_URL}"
     exit 0
   fi

--- a/tests/integration/test_full_indexing_pipeline.py
+++ b/tests/integration/test_full_indexing_pipeline.py
@@ -505,8 +505,8 @@ async def _run_phase1_workers_until_quiet(
     Returns a dict keyed by Modality with the final row state.
 
     Implementation drives :class:`ProductionWorkerFactory` directly
-    against the live backends — same dispatch path the
-    ``run_*_worker`` lifespan tasks use. Each modality is processed
+    against the live backends — same dispatch path the indexing-worker
+    CLI uses. Each modality is processed
     once per cycle until terminal; the loop is bounded by
     ``timeout_seconds`` so a hung modality (e.g. unreachable Qdrant)
     fails the test loud rather than blocking forever.
@@ -636,7 +636,7 @@ def test_phase1_full_pipeline_vector_fulltext_summary_active_graph_vision_failed
             runtime = get_runtime()
             assert runtime is not None and runtime.queue is not None, (
                 "Phase 1 Layer 2 requires a live IndexingRuntime — the e2e-http-compose "
-                "lane bootstraps it via FastAPI lifespan; ensure the test runs against "
+                "lane bootstraps it via the indexing-worker CLI; ensure the test runs against "
                 "the live API process."
             )
             await dispatch_indexing(
@@ -655,7 +655,7 @@ def test_phase1_full_pipeline_vector_fulltext_summary_active_graph_vision_failed
             )
 
             # Drive the pool inline so the test does not depend on the
-            # lifespan worker tasks racing with the assertion.
+            # worker CLI tasks racing with the assertion.
             finalised = await _run_phase1_workers_until_quiet(
                 engine=engine,
                 document_id=document_id,


### PR DESCRIPTION
## Summary
- update task #17 health docs to match merged behavior: legacy /health returns 200 directly, probes use /health/live and /health/ready
- switch e2e bootstrap/runner readiness waits from /health to /health/ready
- refresh stale indexing pipeline comments that still referenced FastAPI lifespan workers

## Validation
- bash -n tests/e2e_http/bootstrap/bootstrap.sh tests/e2e_http/runners/k8s/up.sh tests/e2e_http/runners/compose/up.sh
- uv run --extra test python -m pytest tests/unit_test/test_health_endpoints.py -q
- git diff --check

Slock: task #28