### PR TITLE
fix(task-25): restore compose indexing worker path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ help:
 	@printf "  make stack-logs           Tail stack logs\n\n"
 	@printf "Services\n"
 	@printf "  make serve-api            Run backend API locally\n"
+	@printf "  make serve-worker         Run indexing worker locally\n"
 	@printf "  make serve-web            Run frontend locally\n\n"
 	@printf "Tests\n"
 	@printf "  make test-all             Run unit + integration + pytest E2E suites\n"
@@ -93,7 +94,7 @@ env-dev: env-install
 	@echo "   1. Activate virtual environment: source .venv/bin/activate"
 	@echo "   2. Start databases: make infra-up"
 	@echo "   3. Apply migrations: make db-migrate"
-	@echo "   4. Run services: make serve-api, make serve-web"
+	@echo "   4. Run services: make serve-api, make serve-worker, make serve-web"
 
 # Environment cleanup
 env-clean:
@@ -177,15 +178,15 @@ stack-logs:
 # Development Services
 ##################################################
 
-# Local development services
-# Wave 3 T3.1 chunk 3: ``serve-worker`` / ``serve-beat`` / ``serve-flower``
-# targets removed alongside the Celery infrastructure deletion. The
-# in-process ``aperag.indexing`` runtime (worker pool + reconciler +
-# cleanup loops) is spawned by the FastAPI lifespan when ``serve-api``
-# starts, so no separate worker / beat / monitoring command is needed.
-.PHONY: serve-api serve-web
+# Local development services. Celery-era ``serve-beat`` / ``serve-flower``
+# targets are gone; the dedicated indexing worker CLI owns worker lanes,
+# reconciler, and cleanup loops.
+.PHONY: serve-api serve-worker serve-web
 serve-api: db-migrate
 	uvicorn aperag.app:app --host 0.0.0.0 --log-config scripts/uvicorn-log-config.yaml
+
+serve-worker:
+	python -m aperag.cli.indexing_worker
 
 serve-web:
 	cd ./web && yarn dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,14 +75,41 @@ services:
     ports:
       - "3000:3000"
 
-  # Wave 3 T3.1 chunk 3: Celery infrastructure (celeryworker /
-  # celerybeat / flower) was hard-deleted alongside the
-  # ``aperag/tasks/`` + ``config/celery.py`` layers. The new
-  # in-process ``aperag.indexing`` runtime (worker pool + reconciler +
-  # cleanup loops) is spawned by the FastAPI lifespan inside the
-  # ``aperag-api`` container, so no separate worker/beat/flower
-  # containers are needed. ``run_reconcile_loop`` (30 s) replaces
-  # ``celerybeat``; ``run_*_worker`` tasks replace ``celeryworker``.
+  indexing-worker:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    image: ${REGISTRY:-docker.io}/apecloud/aperag:${VERSION:-v0.0.0-nightly}
+    container_name: aperag-indexing-worker
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      es:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+        required: false
+    volumes:
+      - ~/.cache:/root/.cache
+      - aperag-shared-data:/shared
+    env_file:
+      - .env
+      - envs/docker.env.overrides
+    environment:
+      # Keep the local compose connection budget close to the Helm split:
+      # API handles auth/enqueue; indexing-worker owns parse/index/cleanup.
+      - DB_POOL_SIZE=10
+      - DB_MAX_OVERFLOW=10
+    command: ["/app/scripts/entrypoint.sh", "python", "-m", "aperag.cli.indexing_worker"]
+    restart: on-failure
+
+  # Celery infrastructure (celeryworker / celerybeat / flower) was
+  # hard-deleted alongside the ``aperag/tasks/`` + ``config/celery.py``
+  # layers. The API no longer starts indexing workers from FastAPI
+  # lifespan; the dedicated ``indexing-worker`` service owns worker
+  # lanes, reconciler, and cleanup loops.
 
   # ==============================================
   # Infrastructure Services (always available)

--- a/docs/zh-CN/deployment/build-docker-image.md
+++ b/docs/zh-CN/deployment/build-docker-image.md
@@ -15,11 +15,11 @@ position: 1
 
 ## 镜像构成
 
-ApeRAG 由两个独立镜像组成，`docker-compose.yml` 里分别对应 `api` / `celeryworker` / `celerybeat` / `flower`（共用后端镜像）和 `frontend`：
+ApeRAG 由两个独立镜像组成，`docker-compose.yml` 里分别对应 `api` / `indexing-worker`（共用后端镜像）和 `frontend`：
 
 | 镜像 | 用途 | Dockerfile | 基础镜像 |
 |------|------|-----------|---------|
-| `apecloud/aperag` | FastAPI 主进程 + Celery worker/beat/flower | [`Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/Dockerfile) | `python:3.11.13-slim`（多阶段 + uv） |
+| `apecloud/aperag` | FastAPI API 进程 + 独立 indexing-worker 进程 | [`Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/Dockerfile) | `python:3.11.13-slim`（多阶段 + uv） |
 | `apecloud/aperag-frontend` | Next.js standalone 构建产物 + PM2 runtime | [`web/Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/web/Dockerfile) | `node:20.18.0-alpine` |
 
 默认镜像仓库是 `apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com`（阿里云张家口）；`docker-compose.yml` 在本机使用时会回退到 Docker Hub（`${REGISTRY:-docker.io}`）。
@@ -114,7 +114,7 @@ make build VERSION=v1.2.3 BUILDX_PLATFORM=linux/amd64
 - Runtime 镜像里不保留 `build-essential` / `git` / `uv` 等构建工具，面向最终用户的镜像保持较小体积
 - 依赖层 (`uv sync`) 与代码层 (`COPY . /app`) 分离，只改业务代码不会使依赖缓存失效
 
-Entrypoint 是 [`scripts/entrypoint.sh`](https://github.com/apecloud/ApeRAG/blob/main/scripts/entrypoint.sh)，会先等 PostgreSQL 起来、确保 `pgvector` 扩展存在，再 `exec` 真正的启动命令（`scripts/start-api.sh` / `scripts/start-celery-worker.sh` 等）。
+Entrypoint 是 [`scripts/entrypoint.sh`](https://github.com/apecloud/ApeRAG/blob/main/scripts/entrypoint.sh)，会先等 PostgreSQL 起来、确保 `pgvector` 扩展存在，再 `exec` 真正的启动命令（`scripts/start-api.sh` 或 `python -m aperag.cli.indexing_worker`）。
 
 ## 前端镜像细节
 
@@ -131,7 +131,9 @@ Entrypoint 是 [`scripts/entrypoint.sh`](https://github.com/apecloud/ApeRAG/blob
 
 ## Docker Compose
 
-打完镜像后，根目录的 [`docker-compose.yml`](https://github.com/apecloud/ApeRAG/blob/main/docker-compose.yml) 是最常用的 orchestration 入口。除了 `api` / `celeryworker` / `celerybeat` / `flower` / `frontend`，还包含所有必需的基础设施服务：`postgres`（含 pgvector）、`redis`、`qdrant`、`es`（Elasticsearch 带 IK 分词器）。
+打完镜像后，根目录的 [`docker-compose.yml`](https://github.com/apecloud/ApeRAG/blob/main/docker-compose.yml) 是最常用的 orchestration 入口。除了 `api` / `indexing-worker` / `frontend`，还包含所有必需的基础设施服务：`postgres`（含 pgvector）、`redis`、`qdrant`、`es`（Elasticsearch 带 IK 分词器）。
+
+`api` 只负责 HTTP 请求、认证和任务入队；`indexing-worker` 负责 parse / vector / fulltext / graph / graph_facts / graph_vectors / summary / vision worker lanes，以及 reconciler 和 cleanup loop。默认 `docker compose up -d` 会同时启动这两个后端进程。
 
 两个可选图数据库服务通过 Docker Compose profile 控制，默认不启动：
 

--- a/docs/zh-CN/getting-started/quickstart.md
+++ b/docs/zh-CN/getting-started/quickstart.md
@@ -87,10 +87,10 @@ ApeRAG 需要可用的模型才能完成问答和部分索引任务。你可以�
 如果索引长时间没有完成，优先查看：
 
 ```bash
-docker-compose logs -f api celeryworker
+docker compose logs -f api indexing-worker
 ```
 
-如果部署中有单独 worker 服务，也需要查看 worker 日志。
+其中 `api` 只负责 HTTP 请求与任务入队，`indexing-worker` 负责解析、索引、reconciler 和 cleanup。
 
 ## 5. 发起第一次问答
 

--- a/docs/zh-CN/reference/how-to-debug.md
+++ b/docs/zh-CN/reference/how-to-debug.md
@@ -1,11 +1,11 @@
 ---
 title: 调试指南
-description: 使用 IDE 或命令行调试 ApeRAG 后端 API 与 Celery worker。
+description: 使用 IDE 或命令行调试 ApeRAG 后端 API 与 indexing worker。
 ---
 
 # 调试指南
 
-本文说明如何在本地调试 ApeRAG 后端 API 和 Celery 异步任务。示例以 PyCharm 为主，但命令同样适用于 VS Code 或其他 IDE。
+本文说明如何在本地调试 ApeRAG 后端 API 和 indexing worker。示例以 PyCharm 为主，但命令同样适用于 VS Code 或其他 IDE。
 
 ## 准备本地环境
 
@@ -22,7 +22,6 @@ make db-migrate
 ```bash
 make serve-api
 make serve-worker
-make serve-beat
 make serve-web
 ```
 
@@ -61,12 +60,12 @@ uvicorn aperag.app:app --host 0.0.0.0 --log-config scripts/uvicorn-log-config.ya
 
 ![backend.jpeg](../images/backend.jpeg)
 
-## 调试 Celery worker
+## 调试 indexing worker
 
-Celery 入口是：
+indexing worker 入口是：
 
 ```text
-config.celery
+aperag.cli.indexing_worker
 ```
 
 常规本地 worker 命令：
@@ -75,10 +74,10 @@ config.celery
 make serve-worker
 ```
 
-调试断点时建议使用单进程池，避免任务跑在子进程或线程中导致断点不稳定：
+命令行等价启动：
 
 ```bash
-celery -A config.celery worker -l INFO --pool=solo
+python -m aperag.cli.indexing_worker
 ```
 
 PyCharm 配置建议：
@@ -86,30 +85,14 @@ PyCharm 配置建议：
 | 配置项 | 值 |
 | --- | --- |
 | 类型 | Python |
-| 名称 | `celery` |
+| 名称 | `indexing-worker` |
 | Python 解释器 | 项目 `.venv/bin/python` |
-| 脚本路径 | `celery` 可执行文件 |
-| 参数 | `-A config.celery worker -l INFO --pool=solo` |
+| 模块或脚本 | 以模块方式运行 `aperag.cli.indexing_worker` |
+| 参数 | 无 |
 | 工作目录 | 项目根目录 |
 | 环境变量 | `PYTHONUNBUFFERED=1;PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` |
 
-![celery.jpeg](../images/celery.jpeg)
-
-## 调试 beat / 定时任务
-
-如果任务依赖 Celery beat 调度，需要同时启动 beat：
-
-```bash
-make serve-beat
-```
-
-或手动启动：
-
-```bash
-celery -A config.celery beat -l INFO
-```
-
-调试这类问题时，建议分开启动 API、worker 和 beat，避免多个进程日志混在一起。
+调试索引问题时，建议分开启动 API 和 worker，避免 HTTP 请求日志与索引执行日志混在一起。
 
 ## 断点建议
 
@@ -117,7 +100,7 @@ celery -A config.celery beat -l INFO
 | --- | --- |
 | API 请求参数不符合预期 | 对应 `aperag/domains/**/api/routes.py` handler |
 | 业务逻辑结果不符合预期 | 对应 `aperag/domains/<domain>/service/**` |
-| 异步任务没有执行 | Celery task 定义处和调用 task 的 service 处 |
+| 异步任务没有执行 | `aperag.indexing` queue / worker / reconciler / cleanup 路径 |
 | 文档处理或索引异常 | knowledge_base / indexing 相关 service 和 worker 流程 |
 | 对话或智能体异常 | conversation / agent_runtime 相关 service |
 
@@ -131,7 +114,7 @@ celery -A config.celery beat -l INFO
 
 - IDE 使用的是项目 `.venv/bin/python`；
 - 工作目录是项目根目录；
-- Celery worker 调试时使用了 `--pool=solo`；
+- API 和 indexing worker 已分开启动，断点打在当前进程里；
 - 请求实际进入的是当前启动的本地服务，而不是 Docker Compose 或远端服务。
 
 ### 数据库迁移未执行
@@ -148,14 +131,13 @@ make db-migrate
 make db-check
 ```
 
-### 任务卡住或没有消费
+### 索引任务卡住或没有消费
 
-检查 Redis、worker 和 beat 是否都在运行：
+检查 Redis 和 worker 是否都在运行：
 
 ```bash
 make infra-up
 make serve-worker
-make serve-beat
 ```
 
 如果使用 Docker Compose 启动整套系统，则查看对应容器日志：

--- a/tests/e2e_http/runners/compose/up.sh
+++ b/tests/e2e_http/runners/compose/up.sh
@@ -38,8 +38,8 @@ else
   GRAPH_DB_TYPE="${GRAPH_DB_TYPE:-postgresql}"
 
   case "${VECTOR_DB_TYPE}" in
-    qdrant)   default_services="postgres redis es qdrant api" ;;
-    pgvector) default_services="postgres redis es api" ;;
+    qdrant)   default_services="postgres redis es qdrant api indexing-worker" ;;
+    pgvector) default_services="postgres redis es api indexing-worker" ;;
     *)
       echo "VECTOR_DB_TYPE must be one of: qdrant, pgvector (got '${VECTOR_DB_TYPE}')" >&2
       exit 2

--- a/tests/e2e_http/shapes/lite.env
+++ b/tests/e2e_http/shapes/lite.env
@@ -6,5 +6,5 @@
 # serves traffic without any optional storage backend.
 SHAPE_VECTOR_DB_TYPE=pgvector
 SHAPE_GRAPH_DB_TYPE=postgresql
-SHAPE_COMPOSE_SERVICES="postgres redis es api"
+SHAPE_COMPOSE_SERVICES="postgres redis es api indexing-worker"
 SHAPE_COMPOSE_PROFILES=""

--- a/tests/e2e_http/shapes/qdrant-nebula.env
+++ b/tests/e2e_http/shapes/qdrant-nebula.env
@@ -4,5 +4,5 @@
 # via the "nebula" compose profile).
 SHAPE_VECTOR_DB_TYPE=qdrant
 SHAPE_GRAPH_DB_TYPE=nebula
-SHAPE_COMPOSE_SERVICES="postgres redis es qdrant api"
+SHAPE_COMPOSE_SERVICES="postgres redis es qdrant api indexing-worker"
 SHAPE_COMPOSE_PROFILES="--profile nebula"

--- a/tests/e2e_http/shapes/qdrant-neo4j.env
+++ b/tests/e2e_http/shapes/qdrant-neo4j.env
@@ -4,5 +4,5 @@
 # Graph data lives in Neo4j (activated via the "neo4j" compose profile).
 SHAPE_VECTOR_DB_TYPE=qdrant
 SHAPE_GRAPH_DB_TYPE=neo4j
-SHAPE_COMPOSE_SERVICES="postgres redis es qdrant api"
+SHAPE_COMPOSE_SERVICES="postgres redis es qdrant api indexing-worker"
 SHAPE_COMPOSE_PROFILES="--profile neo4j"


### PR DESCRIPTION
## Summary
- add an `indexing-worker` service to the default Docker Compose stack so local compose has a consumer after the API/worker hard cut
- restore `make serve-worker` as `python -m aperag.cli.indexing_worker` and update local dev hints
- include `indexing-worker` in e2e compose service lists and update quickstart/build/debug docs away from Celery/API-lifespan worker wording

## Validation
- `bash -n tests/e2e_http/runners/compose/up.sh scripts/entrypoint.sh scripts/start-api.sh`
- `cp envs/env.template .env && docker compose -f docker-compose.yml config >/tmp/aperag-compose-config.out && rm .env`
- `make -n serve-worker`
- `git diff --check`

## Notes
- Health endpoint script/doc cleanup is handled separately by PR #1886 / task #28. This PR only covers compose/Makefile/default local worker topology.
