### PR TITLE
perf(web): lazy load mermaid charts

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -19,17 +19,13 @@ const nextConfig: NextConfig = {
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
 
   output: 'standalone',
+  outputFileTracingRoot: path.join(process.cwd(), '..'),
   poweredByHeader: false,
   experimental: {
     serverActions: {
       bodySizeLimit: '100mb',
     },
   },
-
-  // Will only be available on the server side
-  serverRuntimeConfig: {},
-  // Will be available on both server and client
-  publicRuntimeConfig: {},
 
   modularizeImports: {},
 
@@ -41,7 +37,7 @@ const nextConfig: NextConfig = {
       ...(config.resolve.alias ?? {}),
       '@/cosmograph/style.module.css$': path.resolve(
         process.cwd(),
-        'node_modules/@cosmograph/cosmograph/cosmograph/style.module.css.js'
+        'node_modules/@cosmograph/cosmograph/cosmograph/style.module.css.js',
       ),
     };
 

--- a/web/package.json
+++ b/web/package.json
@@ -57,7 +57,6 @@
     "d3": "^7.9.0",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.23.12",
-    "gray-matter": "^4.0.3",
     "hastscript": "^9.0.1",
     "lodash": "^4.18.0",
     "lucide-react": "^0.540.0",
@@ -80,7 +79,6 @@
     "react-number-format": "^5.4.4",
     "react-pdf": "^10.1.0",
     "react-scroll": "^1.9.3",
-    "read-yaml-file": "^2.1.0",
     "recharts": "2.15.4",
     "rehype-highlight": "^7.0.2",
     "rehype-highlight-code-lines": "^1.1.5",
@@ -96,6 +94,7 @@
     "typewriter-effect": "^2.22.0",
     "use-local-storage-state": "^19.5.0",
     "vaul": "^1.1.2",
+    "yaml": "^2.8.3",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/web/scripts/build.mjs
+++ b/web/scripts/build.mjs
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 const ROOT_DIR = process.cwd();
+const REPO_DIR = path.resolve(ROOT_DIR, '..');
 const BUILD_DIR = path.join(ROOT_DIR, 'build');
 
 const readme = `# Getting Started
@@ -95,12 +96,23 @@ const deleteDir = function (dir) {
 const deploy = () => {
   deleteDir(BUILD_DIR);
   fs.mkdirSync(BUILD_DIR);
-  copyDir(path.join(ROOT_DIR, './.next/standalone'), BUILD_DIR);
+  const standaloneDir = path.join(ROOT_DIR, './.next/standalone');
+  const nestedStandaloneDir = path.join(standaloneDir, path.basename(ROOT_DIR));
+  const standaloneSource = fs.existsSync(
+    path.join(nestedStandaloneDir, 'server.js'),
+  )
+    ? nestedStandaloneDir
+    : standaloneDir;
+  copyDir(standaloneSource, BUILD_DIR);
   copyDir(
     path.join(ROOT_DIR, './.next/static'),
     path.join(BUILD_DIR, './.next/static'),
   );
   copyDir(path.join(ROOT_DIR, './public'), path.join(BUILD_DIR, './public'));
+  const docsDir = path.join(REPO_DIR, 'docs');
+  if (fs.existsSync(docsDir)) {
+    copyDir(docsDir, path.join(BUILD_DIR, './docs'));
+  }
   fs.writeFileSync(path.join(BUILD_DIR, 'readme.md'), readme);
 };
 

--- a/web/src/components/chart-mermaid.tsx
+++ b/web/src/components/chart-mermaid.tsx
@@ -1,10 +1,9 @@
 'use client';
 import { cn } from '@/lib/utils';
-import mermaid from 'mermaid';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import panzoom from 'panzoom';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PanZoom } from 'panzoom';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import './chart-mermaid.css';
 import { Card } from './ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
@@ -14,61 +13,84 @@ export const ChartMermaid = ({ children }: { children: string }) => {
   const { resolvedTheme } = useTheme();
   const [error, setError] = useState<boolean>(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [id, setId] = useState<string>();
+  const reactId = useId();
+  const id = useMemo(
+    () => `mermaid-container-${reactId.replace(/[^a-zA-Z0-9_-]/g, '')}`,
+    [reactId],
+  );
 
   const components_dmermaid = useTranslations('components.dmermaid');
 
   const [tab, setTab] = useState<string>('graph');
 
-  const renderMermaid = useCallback(async () => {
-    const isDark = resolvedTheme === 'dark';
+  useEffect(() => {
+    let cancelled = false;
 
-    try {
-      mermaid.initialize({
-        startOnLoad: true,
-        theme: isDark ? 'dark' : 'neutral',
-        securityLevel: 'loose',
-        themeVariables: {
-          fontSize: 'inherit',
-          labelBkg: 'transparent',
-          lineColor: 'var(--input)',
+    const renderMermaid = async () => {
+      const isDark = resolvedTheme === 'dark';
 
-          // Flowchart Variables
-          nodeBorder: 'var(--border)',
-          clusterBkg: 'var(--card)',
-          clusterBorder: 'var(--input)',
-          defaultLinkColor: 'var(--input)',
-          edgeLabelBackground: 'transparent',
-          titleColor: 'var(--muted-foreground)',
-          nodeTextColor: 'var(--card-foreground)',
-        },
-        themeCSS: '.labelBkg { background: none; }',
-        flowchart: {},
-      });
-      const { svg } = await mermaid.render(`mermaid-container-${id}`, children);
-      setSvg(svg);
-      setError(false);
-    } catch (err) {
-      console.log(err);
-      setError(true);
-    }
+      try {
+        const { default: mermaid } = await import('mermaid');
+        mermaid.initialize({
+          startOnLoad: true,
+          theme: isDark ? 'dark' : 'neutral',
+          securityLevel: 'loose',
+          themeVariables: {
+            fontSize: 'inherit',
+            labelBkg: 'transparent',
+            lineColor: 'var(--input)',
+
+            // Flowchart Variables
+            nodeBorder: 'var(--border)',
+            clusterBkg: 'var(--card)',
+            clusterBorder: 'var(--input)',
+            defaultLinkColor: 'var(--input)',
+            edgeLabelBackground: 'transparent',
+            titleColor: 'var(--muted-foreground)',
+            nodeTextColor: 'var(--card-foreground)',
+          },
+          themeCSS: '.labelBkg { background: none; }',
+          flowchart: {},
+        });
+        const { svg } = await mermaid.render(id, children);
+        if (!cancelled) {
+          setSvg(svg);
+          setError(false);
+        }
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setError(true);
+        }
+      }
+    };
+
+    renderMermaid();
+
+    return () => {
+      cancelled = true;
+    };
   }, [children, id, resolvedTheme]);
 
   useEffect(() => {
-    renderMermaid();
-  }, [renderMermaid]);
+    const container = containerRef.current;
+    if (!container) return;
 
-  useEffect(() => {
-    setId(String((Math.random() * 100000).toFixed(0)));
-  }, []);
+    let disposed = false;
+    let controller: PanZoom | undefined;
 
-  useEffect(() => {
-    if (containerRef.current) {
-      panzoom(containerRef.current, {
+    import('panzoom').then(({ default: createPanZoom }) => {
+      if (disposed) return;
+      controller = createPanZoom(container, {
         minZoom: 0.5,
         maxZoom: 5,
       });
-    }
+    });
+
+    return () => {
+      disposed = true;
+      controller?.dispose();
+    };
   }, []);
 
   return (
@@ -89,7 +111,7 @@ export const ChartMermaid = ({ children }: { children: string }) => {
             <div
               ref={containerRef}
               data-error={error}
-              className={`mermaid-container-${id} flex justify-center`}
+              className={`${id} flex justify-center`}
               dangerouslySetInnerHTML={{
                 __html: svg,
               }}

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1,12 +1,24 @@
 import { getLocale } from '@/services/cookies';
 import fs from 'fs';
-import grayMatter from 'gray-matter';
 import _ from 'lodash';
 import path from 'path';
-import readYamlFile from 'read-yaml-file';
+import { parse as parseYaml } from 'yaml';
 
 const ROOT_DIR = process.cwd();
-export const DOCS_DIR = path.join(ROOT_DIR, 'docs');
+const resolveDocsDir = () => {
+  const envDocsDir = process.env.APERAG_DOCS_DIR;
+  const candidates = [
+    envDocsDir,
+    path.join(ROOT_DIR, 'docs'),
+    path.join(ROOT_DIR, '..', 'docs'),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  return (
+    candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0]
+  );
+};
+
+export const DOCS_DIR = resolveDocsDir();
 
 const getId = (pathname: string) => {
   const href = getHref(pathname);
@@ -17,8 +29,13 @@ const getId = (pathname: string) => {
 };
 
 const getHref = (pathname: string) => {
-  const url = trimSurfix(pathname.replace(ROOT_DIR, ''));
-  return url.replace(/\/(en-US|zh-CN)/, '');
+  const relativePath = path
+    .relative(DOCS_DIR, pathname)
+    .split(path.sep)
+    .join('/');
+  const routePath = relativePath.replace(/^(en-US|zh-CN)(\/|$)/, '');
+
+  return `/docs/${trimSurfix(routePath)}`.replace(/\/+/g, '/');
 };
 
 const trimSurfix = (str: string) => {
@@ -47,14 +64,25 @@ type FileMetadata = {
   keywords?: string;
   position?: number;
 };
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+const readFrontmatter = <T>(content: string): Partial<T> => {
+  const match = FRONTMATTER_PATTERN.exec(content);
+  if (!match) {
+    return {};
+  }
+
+  return (parseYaml(match[1]) as Partial<T> | null) ?? {};
+};
+
 const readFile = async (filepath: string, folder: string) => {
   const isExists = fs.existsSync(filepath);
 
   let metadata: FileMetadata = {};
 
   if (isExists) {
-    const { data } = grayMatter(fs.readFileSync(filepath, 'utf8'));
-    metadata = data as FileMetadata;
+    metadata = readFrontmatter<FileMetadata>(fs.readFileSync(filepath, 'utf8'));
   }
 
   const item: DocsSideBar = {
@@ -84,12 +112,17 @@ const readFolder = async (folderDir: string, parent: string) => {
   if (fs.existsSync(metadataFilePath)) {
     metadata = {
       ...metadata,
-      ...(await readYamlFile<FolderMetadata>(metadataFilePath)),
+      ...(parseYaml(
+        fs.readFileSync(metadataFilePath, 'utf8'),
+      ) as FolderMetadata),
     };
   }
 
-  const parentIsDocsRoot =
-    folderDir.replace(DOCS_DIR, '').split('/').length === 3;
+  const relativeFolderParts = path
+    .relative(DOCS_DIR, folderDir)
+    .split(path.sep)
+    .filter(Boolean);
+  const parentIsDocsRoot = relativeFolderParts.length === 2;
   const childrenIsParent = children.some((child) => child.type === 'folder');
 
   const item: DocsSideBar = {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4770,13 +4770,6 @@ exsolve@^1.0.7:
   resolved "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz#3b74e4c7ca5c5f9a19c3626ca857309fa99f9e9e"
   integrity sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==
 
-extend-shallow@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
-  integrity sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==
-  dependencies:
-    is-extendable "^0.1.0"
-
 extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -5161,16 +5154,6 @@ graphql@^16.8.1:
   version "16.11.0"
   resolved "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz#96d17f66370678027fdf59b2d4c20b4efaa8a633"
   integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
-
-gray-matter@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz#e893c064825de73ea1f5f7d88c7a9f7274288798"
-  integrity sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==
-  dependencies:
-    js-yaml "^3.13.1"
-    kind-of "^6.0.2"
-    section-matter "^1.0.0"
-    strip-bom-string "^1.0.0"
 
 hachure-fill@^0.5.2:
   version "0.5.2"
@@ -5641,11 +5624,6 @@ is-decimal@^2.0.0:
   resolved "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
   integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
 
-is-extendable@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
-  integrity sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==
-
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -5871,7 +5849,7 @@ js-levenshtein@1.1.6:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.1, js-yaml@>=4.1.1, js-yaml@^3.13.1, js-yaml@^4.0.0, js-yaml@^4.1.0:
+js-yaml@4.1.1, js-yaml@>=4.1.1, js-yaml@^4.1.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
@@ -5979,11 +5957,6 @@ khroma@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz#45f2ce94ce231a437cf5b63c2e886e6eb42bbbb1"
   integrity sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.3"
-  resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
-  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -7857,14 +7830,6 @@ react@19.2.1:
   resolved "https://registry.npmjs.org/react/-/react-19.2.1.tgz#8600fa205e58e2e807f6ef431c9f6492591a2700"
   integrity sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==
 
-read-yaml-file@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-2.1.0.tgz#c5866712db9ef5343b4d02c2413bada53c41c4a9"
-  integrity sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==
-  dependencies:
-    js-yaml "^4.0.0"
-    strip-bom "^4.0.0"
-
 readable-stream@^3.4.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
@@ -8256,14 +8221,6 @@ screenfull@^5.0.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
   integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
-
-section-matter@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz#e9041953506780ec01d59f292a19c7b850b84167"
-  integrity sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==
-  dependencies:
-    extend-shallow "^2.0.1"
-    kind-of "^6.0.0"
 
 seedrandom@^3.0.5:
   version "3.0.5"
@@ -8673,20 +8630,10 @@ strip-ansi@^7.0.1:
   dependencies:
     ansi-regex "^6.0.1"
 
-strip-bom-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
-  integrity sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==
-
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
-
-strip-bom@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
-  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
 strip-final-newline@^3.0.0:
   version "3.0.0"
@@ -9511,7 +9458,7 @@ yaml-ast-parser@0.0.43:
   resolved "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
   integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
 
-yaml@>=2.8.3, yaml@^2.0.0:
+yaml@>=2.8.3, yaml@^2.0.0, yaml@^2.8.3:
   version "2.8.3"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
   integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==


### PR DESCRIPTION
## Summary
- lazy-load `mermaid` and `panzoom` only when a Mermaid markdown code block is actually rendered
- set an explicit repo-level Next tracing root and remove empty deprecated runtime config
- make docs metadata parsing/runtime path work in source and generated standalone bundles
- copy root `docs/` into the custom `web/build` artifact and keep `build/server.js` stable when standalone output nests under `web/`

## Performance baseline
Measured with `cd web && yarn build` on latest main before/after this change.

| Route | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `/workspace/bots/[botId]/chats/[chatId]` | 786 kB | 586 kB | -200 kB |
| `/workspace/audit-logs` | 713 kB | 512 kB | -201 kB |
| `/workspace/collections/[collectionId]/search` | 711 kB | 510 kB | -201 kB |
| `/docs/[group]/[[...paths]]` | 651 kB | 450 kB | -201 kB |
| `/workspace/collections/[collectionId]/graph` | 684 kB | 483 kB | -201 kB |
| `/workspace/collections/[collectionId]/documents/[documentId]` | 662 kB | 461 kB | -201 kB |

## Validation
- `cd web && yarn build`
- `cd web && yarn lint` (passes with existing warnings in evaluation placeholder pages, `agent-turn-renderer.tsx`, and `elicitation-form.tsx`)
- `cd web && git diff --check`
- standalone smoke: `PORT=3021 HOSTNAME=127.0.0.1 node build/server.js`, then `curl -I /`, `/docs`, `/auth/signin` all returned 200 with no server errors

## Notes
- Remaining build warnings are from the existing `@cosmograph/react` graph-lab dependency pulling DuckDB dynamic requires. This PR does not expand that scope.
