### PR TITLE
fix(task-17): wire cross-domain DI seams in indexing-worker process

### DIFF
--- a/aperag/app.py
+++ b/aperag/app.py
@@ -34,8 +34,8 @@ configure_process_observability(observability_config)
 from fastapi import FastAPI  # noqa: E402
 from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 
+from aperag.bootstrap import wire_cross_domain_di_seams
 from aperag.domains.agent_runtime.api.routes import router as agent_runtime_router
-from aperag.domains.agent_runtime.runtime import set_prompt_template_ops as _ar_set_prompt_template_ops
 from aperag.domains.conversation.api.openai_routes import router as openai_router
 from aperag.domains.conversation.api.routes import (
     bots_router as bots_v2_router,
@@ -43,48 +43,19 @@ from aperag.domains.conversation.api.routes import (
 from aperag.domains.conversation.api.routes import (
     chat_router as chat_router,
 )
-from aperag.domains.conversation.service.bot_service import set_quota_ops as _conv_set_quota_ops
 from aperag.domains.evaluation.api.routes import router as evaluation_v2_router
 from aperag.domains.governance.api.apikeys_routes import router as apikeys_router
 from aperag.domains.governance.api.audit_routes import router as audit_router
 from aperag.domains.governance.api.quota_routes import router as quota_router
 from aperag.domains.identity.api.auth_routes import router as auth_router
 from aperag.domains.identity.api.config_routes import router as config_router
-from aperag.domains.identity.service.user_manager import (
-    set_bot_init_ops as _id_set_bot_init_ops,
-)
-from aperag.domains.identity.service.user_manager import (
-    set_chat_init_ops as _id_set_chat_init_ops,
-)
-from aperag.domains.identity.service.user_manager import (
-    set_quota_init_ops as _id_set_quota_init_ops,
-)
 from aperag.domains.knowledge_base.api.export_routes import router as export_router
 from aperag.domains.knowledge_base.api.routes import router as knowledge_base_router
 from aperag.domains.knowledge_base.api.settings_routes import router as settings_router
-from aperag.domains.knowledge_base.service.collection_service import (
-    set_marketplace_collection_ops as _kb_set_marketplace_collection_ops,
-)
-from aperag.domains.knowledge_base.service.collection_service import (
-    set_marketplace_ops as _kb_set_marketplace_ops,
-)
-from aperag.domains.knowledge_base.service.collection_service import (
-    set_quota_ops as _kb_set_quota_ops,
-)
-from aperag.domains.knowledge_base.service.collection_service import (
-    set_search_pipeline_ops as _kb_set_search_pipeline_ops,
-)
 from aperag.domains.knowledge_graph.api.routes import router as knowledge_graph_router
 from aperag.domains.marketplace.api.routes import router as marketplace_router
-from aperag.domains.marketplace.service.marketplace_collection_service import (
-    marketplace_collection_service as _legacy_marketplace_collection_service,
-)
-from aperag.domains.marketplace.service.marketplace_service import (
-    marketplace_service as _legacy_marketplace_service,
-)
 from aperag.domains.model_platform.api.llm_routes import router as llm_router
 from aperag.domains.model_platform.api.prompts_routes import router as prompts_router
-from aperag.domains.model_platform.api.prompts_routes import set_prompt_crud_ops as _set_prompt_crud_ops
 from aperag.domains.model_platform.api.providers_v2_routes import router as providers_v2_router
 from aperag.domains.retrieval.api.routes import router as retrieval_router
 from aperag.domains.web_access.api.routes import router as web_access_router
@@ -93,159 +64,12 @@ from aperag.llm.litellm_track import register_custom_llm_track
 from aperag.mcp import mcp_server
 from aperag.openapi_spec import custom_generate_unique_id
 from aperag.server.health import router as health_router
-from aperag.service.quota_service import quota_service as _legacy_quota_service
-from aperag.service.search_pipeline_service import search_pipeline_service as _legacy_search_pipeline_service
 
-# Wire the knowledge_base domain's consumer-owned Protocol DI slots
-# (Phase 3 Step 5b2c). All four legacy service singletons now
-# structurally satisfy the KB Protocols directly — Phase 4 Step 4-S4
-# dropped the transitional ``_MarketplaceCollectionOpsAdapter`` once
-# the ``marketplace_collection_service`` move renamed
-# ``_check_marketplace_access`` to the public ``check_marketplace_access``
-# per msg=6ab7d211 Q2.
-_kb_set_marketplace_ops(_legacy_marketplace_service)
-_kb_set_marketplace_collection_ops(_legacy_marketplace_collection_service)
-_kb_set_search_pipeline_ops(_legacy_search_pipeline_service)
-_kb_set_quota_ops(_legacy_quota_service)
-
-# Wire the conversation domain's consumer-owned QuotaOps DI slot for
-# ``bot_service``. ``quota_service`` is a standalone-infrastructure
-# module with no natural domain home, so the Protocol + DI seam is
-# the permanent integration point. The singleton structurally
-# satisfies the narrower conversation ``QuotaOps`` Protocol
-# (``check_and_consume_quota`` + ``release_quota``) directly.
-_conv_set_quota_ops(_legacy_quota_service)
-
-# Wire the agent_runtime domain's consumer-owned PromptTemplateOps DI
-# slot. ``prompt_template_service`` is a standalone-infrastructure
-# module (no natural domain home), so the Protocol + DI seam is the
-# permanent integration point — an adapter exposes the three Protocol
-# methods onto the singleton + module-level ``build_agent_query_prompt``
-# helper.
-from aperag.service.prompt_template_service import (  # noqa: E402
-    build_agent_query_prompt as _legacy_build_agent_query_prompt,
-)
-from aperag.service.prompt_template_service import (  # noqa: E402
-    prompt_template_service as _legacy_prompt_template_service,
-)
-
-
-class _PromptTemplateOpsAdapter:
-    async def resolve_agent_system_prompt(self, *, bot, user_id):
-        return await _legacy_prompt_template_service.resolve_agent_system_prompt(bot=bot, user_id=user_id)
-
-    async def resolve_agent_query_prompt(self, *, bot, user_id):
-        return await _legacy_prompt_template_service.resolve_agent_query_prompt(bot=bot, user_id=user_id)
-
-    def build_agent_query_prompt(self, chat_id, *, agent_message, user, template=None, has_chat_files=False):
-        return _legacy_build_agent_query_prompt(
-            chat_id,
-            agent_message=agent_message,
-            user=user,
-            template=template,
-            has_chat_files=has_chat_files,
-        )
-
-
-_ar_set_prompt_template_ops(_PromptTemplateOpsAdapter())
-
-# Wire the model_platform domain's prompt user-CRUD Protocol seam
-# (Phase 8 #49 G3, D7 v2 hard-cut). The same ``prompt_template_service``
-# singleton already wired into agent_runtime structurally satisfies
-# the model_platform ``PromptCRUDOps`` Protocol — the user-CRUD method
-# names map 1:1, so no adapter is needed.
-_set_prompt_crud_ops(_legacy_prompt_template_service)
-
-
-# Wire the identity domain's consumer-owned Protocol DI slots (Phase
-# 4 Step 4-S7d). ``UserManager.on_after_register`` invokes three
-# side effects — default bot + default chat collection + per-user
-# quota seed — through ``BotInitOps`` / ``ChatInitOps`` /
-# ``QuotaInitOps``. The three concrete providers live in legacy
-# ``aperag/service/`` today; Phase 5 moves bot_service and
-# chat_collection_service into the conversation domain while quota
-# stays legacy per msg=896584ee. Thin adapters below expose the
-# public Protocol surface (e.g. ``create_default_bot_for_user``)
-# onto the concrete services' existing method names; the adapters
-# collapse when Phase 5 conversation services land at the canonical
-# location.
-class _BotInitOpsAdapter:
-    async def create_default_bot_for_user(self, user_id: str) -> None:
-        # Lazy imports keep ``aperag/app.py`` start-up cost low and
-        # avoid pulling the KB domain services into the identity DI
-        # wiring path before the app is constructed.
-        from aperag.domains.conversation.db.models import BotType
-        from aperag.domains.conversation.schemas import BotCreate
-        from aperag.domains.conversation.service.bot_service import bot_service
-
-        bot_create = BotCreate(
-            title="Default Agent Bot",
-            type=BotType.AGENT,
-            description="Default agent bot created on registration.",
-            collection_ids=[],
-        )
-        await bot_service.create_bot(user=user_id, bot_in=bot_create, skip_quota_check=True)
-
-        # Wave 10 §K.13: register-time creation of the per-user
-        # hidden summary bot used by ``collection_regen_service``
-        # Stage 1. Same transaction as the user's default agent bot
-        # so a successful registration always provides both. The
-        # ``collection_regen_service`` keeps a defense-in-depth
-        # ``get_or_create_summary_bot_for_user`` lazy fallback for
-        # the edge case where this hook fails (registration does
-        # not roll back on init-hook errors per
-        # ``user_manager.py:137``).
-        await self._create_summary_bot_for_user(user_id)
-
-    @staticmethod
-    async def _create_summary_bot_for_user(user_id: str) -> None:
-        """Create the hidden ``BotType.SUMMARY, is_system=True`` row
-        for ``user_id``. Bypasses the user-facing ``bot_service.create_bot``
-        because (a) ``BotCreate.type`` is ``Literal["agent"]`` so
-        the public schema can't express ``"summary"``, and (b) system
-        bots intentionally skip user-quota / user-visibility logic.
-        """
-        from aperag.config import get_async_session
-        from aperag.domains.conversation.db.models import Bot, BotStatus, BotType
-
-        bot = Bot(
-            user=user_id,
-            title="Summary Generation Bot",
-            type=BotType.SUMMARY,
-            description="System-managed bot for collection summary regen (Wave 10 §K.13).",
-            status=BotStatus.ACTIVE,
-            config='{"agent": {"system_prompt_template": null}}',
-            is_system=True,
-        )
-        async for session in get_async_session():
-            session.add(bot)
-            try:
-                await session.commit()
-            except Exception:  # noqa: BLE001
-                # Concurrent register-time race or backfill migration
-                # already created the row — let the partial unique
-                # index reject silently. The lazy fallback in the
-                # regen service will fetch the existing row on first
-                # use.
-                await session.rollback()
-            return
-
-
-class _ChatInitOpsAdapter:
-    async def create_default_chat_for_user(self, user_id: str) -> None:
-        from aperag.domains.conversation.service.chat_collection_service import chat_collection_service
-
-        await chat_collection_service.initialize_user_chat_collection(user_id)
-
-
-class _QuotaInitOpsAdapter:
-    async def initialize_user_quota(self, user_id: str) -> None:
-        await _legacy_quota_service.initialize_user_quotas(user_id)
-
-
-_id_set_bot_init_ops(_BotInitOpsAdapter())
-_id_set_chat_init_ops(_ChatInitOpsAdapter())
-_id_set_quota_init_ops(_QuotaInitOpsAdapter())
+# Wire every cross-domain DI seam. ``aperag/cli/indexing_worker.py``
+# calls the same helper at startup so the API and indexing-worker
+# processes share an identical seam set; the boundary test
+# ``tests/boundaries/test_worker_di_parity.py`` enforces parity.
+wire_cross_domain_di_seams()
 
 
 # Initialize MCP server integration with stateless HTTP to fix OpenAI tool call sequence issues

--- a/aperag/bootstrap/__init__.py
+++ b/aperag/bootstrap/__init__.py
@@ -1,0 +1,163 @@
+"""Cross-process bootstrap helpers for the ApeRAG runtime.
+
+Both ``aperag/app.py`` (API process) and ``aperag/cli/indexing_worker.py``
+(indexing-worker process) must wire the same set of cross-domain DI
+seams before any request / queue payload is served. PR #1884 (task #17)
+split the two processes apart but only ported the worker entrypoints —
+the DI setters stayed inline in ``app.py`` and were never invoked in
+the worker process. The worker would crash the moment it executed any
+code path that called ``_get_prompt_template_ops()`` /
+``_get_quota_ops()`` / ``_get_marketplace_ops()`` (collection summary
+regen, agent runtime, quota check). e2e-http-provider surfaced it; this
+module hot-fixes the gap.
+
+``wire_cross_domain_di_seams`` is the single source of truth for the
+ten setters. ``tests/boundaries/test_worker_di_parity.py`` AST-greps
+both entry points to enforce that they call this function — no future
+process split can drift again.
+"""
+
+from __future__ import annotations
+
+from aperag.domains.agent_runtime.runtime import set_prompt_template_ops as _ar_set_prompt_template_ops
+from aperag.domains.conversation.service.bot_service import set_quota_ops as _conv_set_quota_ops
+from aperag.domains.identity.service.user_manager import (
+    set_bot_init_ops as _id_set_bot_init_ops,
+)
+from aperag.domains.identity.service.user_manager import (
+    set_chat_init_ops as _id_set_chat_init_ops,
+)
+from aperag.domains.identity.service.user_manager import (
+    set_quota_init_ops as _id_set_quota_init_ops,
+)
+from aperag.domains.knowledge_base.service.collection_service import (
+    set_marketplace_collection_ops as _kb_set_marketplace_collection_ops,
+)
+from aperag.domains.knowledge_base.service.collection_service import (
+    set_marketplace_ops as _kb_set_marketplace_ops,
+)
+from aperag.domains.knowledge_base.service.collection_service import (
+    set_quota_ops as _kb_set_quota_ops,
+)
+from aperag.domains.knowledge_base.service.collection_service import (
+    set_search_pipeline_ops as _kb_set_search_pipeline_ops,
+)
+from aperag.domains.marketplace.service.marketplace_collection_service import (
+    marketplace_collection_service as _legacy_marketplace_collection_service,
+)
+from aperag.domains.marketplace.service.marketplace_service import (
+    marketplace_service as _legacy_marketplace_service,
+)
+from aperag.domains.model_platform.api.prompts_routes import set_prompt_crud_ops as _set_prompt_crud_ops
+from aperag.service.prompt_template_service import (
+    build_agent_query_prompt as _legacy_build_agent_query_prompt,
+)
+from aperag.service.prompt_template_service import (
+    prompt_template_service as _legacy_prompt_template_service,
+)
+from aperag.service.quota_service import quota_service as _legacy_quota_service
+from aperag.service.search_pipeline_service import search_pipeline_service as _legacy_search_pipeline_service
+
+
+class _PromptTemplateOpsAdapter:
+    async def resolve_agent_system_prompt(self, *, bot, user_id):
+        return await _legacy_prompt_template_service.resolve_agent_system_prompt(bot=bot, user_id=user_id)
+
+    async def resolve_agent_query_prompt(self, *, bot, user_id):
+        return await _legacy_prompt_template_service.resolve_agent_query_prompt(bot=bot, user_id=user_id)
+
+    def build_agent_query_prompt(self, chat_id, *, agent_message, user, template=None, has_chat_files=False):
+        return _legacy_build_agent_query_prompt(
+            chat_id,
+            agent_message=agent_message,
+            user=user,
+            template=template,
+            has_chat_files=has_chat_files,
+        )
+
+
+class _BotInitOpsAdapter:
+    async def create_default_bot_for_user(self, user_id: str) -> None:
+        from aperag.domains.conversation.db.models import BotType
+        from aperag.domains.conversation.schemas import BotCreate
+        from aperag.domains.conversation.service.bot_service import bot_service
+
+        bot_create = BotCreate(
+            title="Default Agent Bot",
+            type=BotType.AGENT,
+            description="Default agent bot created on registration.",
+            collection_ids=[],
+        )
+        await bot_service.create_bot(user=user_id, bot_in=bot_create, skip_quota_check=True)
+
+        await self._create_summary_bot_for_user(user_id)
+
+    @staticmethod
+    async def _create_summary_bot_for_user(user_id: str) -> None:
+        """Create the hidden ``BotType.SUMMARY, is_system=True`` row for ``user_id``.
+
+        Bypasses the user-facing ``bot_service.create_bot`` because (a)
+        ``BotCreate.type`` is ``Literal["agent"]`` so the public schema
+        can't express ``"summary"``, and (b) system bots intentionally
+        skip user-quota / user-visibility logic.
+        """
+        from aperag.config import get_async_session
+        from aperag.domains.conversation.db.models import Bot, BotStatus, BotType
+
+        bot = Bot(
+            user=user_id,
+            title="Summary Generation Bot",
+            type=BotType.SUMMARY,
+            description="System-managed bot for collection summary regen (Wave 10 §K.13).",
+            status=BotStatus.ACTIVE,
+            config='{"agent": {"system_prompt_template": null}}',
+            is_system=True,
+        )
+        async for session in get_async_session():
+            session.add(bot)
+            try:
+                await session.commit()
+            except Exception:  # noqa: BLE001
+                # Concurrent register-time race / backfill migration
+                # already created the row; let the partial unique index
+                # reject silently. The lazy fallback in the regen
+                # service will fetch the existing row on first use.
+                await session.rollback()
+            return
+
+
+class _ChatInitOpsAdapter:
+    async def create_default_chat_for_user(self, user_id: str) -> None:
+        from aperag.domains.conversation.service.chat_collection_service import chat_collection_service
+
+        await chat_collection_service.initialize_user_chat_collection(user_id)
+
+
+class _QuotaInitOpsAdapter:
+    async def initialize_user_quota(self, user_id: str) -> None:
+        await _legacy_quota_service.initialize_user_quotas(user_id)
+
+
+def wire_cross_domain_di_seams() -> None:
+    """Wire every cross-domain DI seam that ``app.py`` used to set inline.
+
+    Idempotent — module-level setters overwrite the previous binding
+    each time. Safe to call from both the API entrypoint and the
+    indexing-worker entrypoint.
+    """
+    _kb_set_marketplace_ops(_legacy_marketplace_service)
+    _kb_set_marketplace_collection_ops(_legacy_marketplace_collection_service)
+    _kb_set_search_pipeline_ops(_legacy_search_pipeline_service)
+    _kb_set_quota_ops(_legacy_quota_service)
+
+    _conv_set_quota_ops(_legacy_quota_service)
+
+    _ar_set_prompt_template_ops(_PromptTemplateOpsAdapter())
+    _set_prompt_crud_ops(_legacy_prompt_template_service)
+
+    _id_set_bot_init_ops(_BotInitOpsAdapter())
+    _id_set_chat_init_ops(_ChatInitOpsAdapter())
+    _id_set_quota_init_ops(_QuotaInitOpsAdapter())
+
+
+__all__ = ["wire_cross_domain_di_seams"]

--- a/aperag/cli/indexing_worker.py
+++ b/aperag/cli/indexing_worker.py
@@ -33,6 +33,7 @@ import logging
 import signal
 
 # ziang msg=4ea65100 #1: 用现有 module-level ``settings``, 不引 ``get_settings()`` helper.
+from aperag.bootstrap import wire_cross_domain_di_seams
 from aperag.config import settings, sync_engine
 from aperag.indexing import (
     InMemoryWorkQueue,
@@ -59,7 +60,13 @@ from aperag.indexing.quota import (
     RedisQuotaBackend,
 )
 from aperag.indexing.worker_factory import ProductionWorkerFactory
+from aperag.llm.litellm_track import register_custom_llm_track
 from aperag.objectstore.base import get_object_store
+from aperag.observability import (
+    build_observability_config,
+    configure_logging,
+    configure_process_observability,
+)
 from aperag.observability.metrics import shutdown_metrics_provider
 
 logger = logging.getLogger(__name__)
@@ -71,6 +78,15 @@ async def _amain() -> None:
     跟 ``aperag/app.py`` lifespan 老路径行为完全等价: 选 queue / quota /
     metrics emitter 的 dispatch 逻辑相同; 启动 7 modality worker + parse +
     reconciler + cleanup 共 10 个 asyncio 后台任务; SIGTERM 时优雅退出.
+
+    跨进程 DI parity: ``wire_cross_domain_di_seams()`` 跟 ``app.py`` 启动
+    时调的同一个 helper, 把 10 个 cross-domain Protocol seam 全 wire 上
+    (PromptTemplateOps / KB marketplace + quota + search_pipeline / conv
+    quota / agent_runtime / model_platform prompt CRUD / identity init).
+    PR #1884 task #17 hard cut 把 worker 拆出 API 进程时漏 port 这步,
+    worker 一走 collection summary regen / agent runtime / quota 路径就
+    挂在 ``*Ops not wired`` AttributeError. boundary test
+    ``tests/boundaries/test_worker_di_parity.py`` 钉死两进程同集合.
     """
     shutdown = asyncio.Event()
 
@@ -78,6 +94,11 @@ async def _amain() -> None:
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, shutdown.set)
+
+    # 跨进程 DI parity. 必须先于任何 worker entrypoint 启动 — 否则
+    # parse/summary/cleanup 路径 BLPOP 出 payload 后调
+    # ``_get_*_ops()`` 时 raise.
+    wire_cross_domain_di_seams()
 
     # ziang msg=4ea65100 #2 + 跟 app.py 现有写法一致: ``QuotaPolicyRegistry``
     # 直接构造, ``RedisQuotaBackend(quota_redis, quota_registry)`` /
@@ -200,11 +221,21 @@ async def _amain() -> None:
 
 
 def main() -> None:
-    """``python -m aperag.cli.indexing_worker`` sync entrypoint."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    """``python -m aperag.cli.indexing_worker`` sync entrypoint.
+
+    Process-level setup (Weston 三分类 类 2): same observability +
+    LiteLLM tracking that ``aperag/app.py`` configures at module load.
+    Worker process must mirror these so structured logs / OTLP traces /
+    LiteLLM custom-track callbacks match between API and worker. The
+    only ``app.py`` calls intentionally **not** mirrored are
+    ``configure_fastapi`` and ``register_exception_handlers`` (类 3
+    FastAPI-only).
+    """
+    observability_config = build_observability_config(settings)
+    configure_logging(observability_config)
+    configure_process_observability(observability_config)
+    register_custom_llm_track()
+
     asyncio.run(_amain())
 
 

--- a/tests/boundaries/test_worker_di_parity.py
+++ b/tests/boundaries/test_worker_di_parity.py
@@ -1,0 +1,173 @@
+"""Process-split DI parity boundary gate.
+
+Task #17 (PR #1884) split the ApeRAG runtime into two processes: the
+FastAPI API process (``aperag/app.py``) and the indexing-worker
+process (``aperag/cli/indexing_worker.py``). The two entry points
+must wire the **same** set of cross-domain Protocol DI seams, or the
+worker process crashes the moment it executes any code path (parse /
+summary regen / agent runtime / quota check) that calls
+``_get_*_ops()``.
+
+The hot-fix moved the 10 setter calls into a single helper
+``aperag.bootstrap.wire_cross_domain_di_seams``; both processes now
+call that helper. This boundary test enforces three properties:
+
+1. ``aperag/app.py`` and ``aperag/cli/indexing_worker.py`` both call
+   ``wire_cross_domain_di_seams`` at the module/entrypoint level.
+2. The helper itself wires every domain Protocol setter that the API
+   process used to wire inline. AST-walks ``aperag/bootstrap/__init__.py``
+   for ``set_*_ops`` callable patterns.
+3. FastAPI-only setup (``configure_fastapi`` / ``register_exception_handlers``)
+   never leaks into the worker entry point.
+
+Per Lesson #11 v5 (entry-point migration sub-check) +
+Weston 三分类框架 (必须 port / process-level 决策 / FastAPI-only 排除).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_PY = REPO_ROOT / "aperag" / "app.py"
+CLI_PY = REPO_ROOT / "aperag" / "cli" / "indexing_worker.py"
+BOOTSTRAP_PY = REPO_ROOT / "aperag" / "bootstrap" / "__init__.py"
+
+# 类 3 (FastAPI-only) — must NOT appear in the worker entry point.
+FASTAPI_ONLY_CALLS = frozenset(
+    {
+        "configure_fastapi",
+        "register_exception_handlers",
+    }
+)
+
+
+def _collect_called_canonical_names(path: Path) -> set[str]:
+    """Return the canonical (originally-imported) names of every
+    callable invoked at module level OR inside any function whose name
+    matches ``main`` / ``_amain`` / ``lifespan`` / ``combined_lifespan``.
+
+    The "canonical" name is the imported symbol — e.g. for
+    ``from foo import bar as _foo_bar`` followed by ``_foo_bar(...)``
+    we record ``"bar"``. This makes the assertion robust against
+    different files using different local aliases for the same setter.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = alias.name
+
+    interesting_function_names = {"main", "_amain", "lifespan", "combined_lifespan"}
+
+    def _is_interesting_node(candidate: ast.AST) -> bool:
+        if isinstance(candidate, ast.AsyncFunctionDef | ast.FunctionDef):
+            return candidate.name in interesting_function_names
+        return False
+
+    called: set[str] = set()
+
+    def _visit_call(call: ast.Call) -> None:
+        func = call.func
+        if isinstance(func, ast.Name) and func.id in aliases:
+            called.add(aliases[func.id])
+
+    # Module-level statements first.
+    for stmt in tree.body:
+        for sub in ast.walk(stmt):
+            if isinstance(sub, ast.Call):
+                _visit_call(sub)
+
+    # Then walk into the entry-point lifespan / main functions —
+    # `aperag/app.py` keeps router wiring inside module-level but
+    # leaves room for future setter calls from inside lifespan, and
+    # `aperag/cli/indexing_worker.py` does its DI wiring inside
+    # ``_amain``.
+    for node in ast.walk(tree):
+        if _is_interesting_node(node):
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Call):
+                    _visit_call(sub)
+
+    return called
+
+
+def _collect_setter_names_from_bootstrap() -> set[str]:
+    """Find every ``set_*_ops`` invocation inside the bootstrap helper.
+
+    These are the canonical setter names that ``app.py`` used to call
+    inline; the helper now owns them. A worker entry point that calls
+    ``wire_cross_domain_di_seams`` therefore reaches the same set.
+    """
+    tree = ast.parse(BOOTSTRAP_PY.read_text(encoding="utf-8"))
+
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = alias.name
+
+    setters: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            canonical = aliases.get(node.func.id, node.func.id)
+            if canonical.startswith("set_") and canonical.endswith("_ops"):
+                setters.add(canonical)
+    return setters
+
+
+def test_app_and_cli_worker_both_call_wire_cross_domain_di_seams():
+    app_calls = _collect_called_canonical_names(APP_PY)
+    cli_calls = _collect_called_canonical_names(CLI_PY)
+    helper = "wire_cross_domain_di_seams"
+    assert helper in app_calls, (
+        f"aperag/app.py must call {helper}() at module level so the API process "
+        "wires every cross-domain DI seam before serving requests."
+    )
+    assert helper in cli_calls, (
+        f"aperag/cli/indexing_worker.py must call {helper}() at startup so the "
+        "indexing-worker process wires the same set of seams as the API process. "
+        "PR #1884 (task #17) regressed this; e2e-http-provider hit "
+        "RuntimeError: PromptTemplateOps not wired in the worker container."
+    )
+
+
+def test_bootstrap_helper_wires_at_least_the_known_critical_seams():
+    """Failing this test means the helper stopped wiring a seam that
+    was wired before the hot-fix. Add the new setter to the helper or
+    update the canonical list with a clear migration note.
+    """
+    wired = _collect_setter_names_from_bootstrap()
+    expected_subset = {
+        # knowledge_base
+        "set_marketplace_ops",
+        "set_marketplace_collection_ops",
+        "set_search_pipeline_ops",
+        "set_quota_ops",
+        # agent_runtime / model_platform prompt CRUD
+        "set_prompt_template_ops",
+        "set_prompt_crud_ops",
+        # identity init hooks
+        "set_bot_init_ops",
+        "set_chat_init_ops",
+        "set_quota_init_ops",
+    }
+    missing = expected_subset - wired
+    assert not missing, (
+        "aperag/bootstrap/__init__.py:wire_cross_domain_di_seams "
+        f"stopped calling {sorted(missing)}. Either re-wire it or update "
+        "this test with the migration note explaining why the seam is gone."
+    )
+
+
+def test_fastapi_only_setup_does_not_leak_into_cli_worker():
+    cli_calls = _collect_called_canonical_names(CLI_PY)
+    leaked = FASTAPI_ONLY_CALLS & cli_calls
+    assert not leaked, (
+        f"aperag/cli/indexing_worker.py must not call {sorted(leaked)} — those are "
+        "FastAPI-only setup hooks. The worker process has no FastAPI app instance; "
+        "leaking these into the CLI is a Weston 类 3 violation."
+    )


### PR DESCRIPTION
## Summary
Hot-fix for the task #17 (PR #1884) regression that caused `RuntimeError: PromptTemplateOps not wired` inside the `aperag-indexing-worker` container. PR #1884 split the runtime into two processes but only ported the worker entrypoints — the cross-domain Protocol DI setters stayed inline in `aperag/app.py` and were never invoked in `aperag/cli/indexing_worker.py`. The worker container started, but as soon as it executed any path that touched `_get_prompt_template_ops()` / `_get_quota_ops()` / `_get_marketplace_ops()` (collection summary regen, agent runtime, quota check) it crashed. e2e-http-provider exposed it on the post-#1884 main with the same 1/3-pass-2/3-fail signature on PR #1885 / #1890 / #1891.

Per Lesson #11 v5 entry-point migration sub-check + Weston 三分类框架.

## Changes

**类 1 — must mirror across processes (the actual fix):**
- New `aperag/bootstrap/__init__.py` module owning the four adapter classes (`_PromptTemplateOpsAdapter` / `_BotInitOpsAdapter` / `_ChatInitOpsAdapter` / `_QuotaInitOpsAdapter`) and `wire_cross_domain_di_seams()` — single source of truth for all ten setter calls (KB marketplace + marketplace_collection + search_pipeline + quota; conv quota; agent_runtime PromptTemplateOps; model_platform PromptCRUDOps; identity bot/chat/quota init).
- `aperag/app.py`: drop the inline adapter classes + setter calls in favour of one call to `wire_cross_domain_di_seams()`.
- `aperag/cli/indexing_worker.py`: call `wire_cross_domain_di_seams()` at startup so the worker process wires the same seam set as the API.

**类 2 — process-level decision (mirrored deliberately):**
- `aperag/cli/indexing_worker.py` now also calls `configure_logging(observability_config)`, `configure_process_observability(observability_config)`, and `register_custom_llm_track()` — the same per-process setup that `aperag/app.py` already runs. The worker emits the same structured logs / OTLP traces / LiteLLM custom-track callbacks as the API.

**类 3 — explicitly excluded (FastAPI-only):**
- `configure_fastapi(app, observability_config)` and `register_exception_handlers(app)` stay only in `aperag/app.py`. The worker has no FastAPI app instance.

**Boundary gate:**
- `tests/boundaries/test_worker_di_parity.py` AST-walks both entrypoints and the bootstrap helper, asserting (1) both call `wire_cross_domain_di_seams`, (2) the helper still wires every known critical setter, (3) FastAPI-only setup never leaks into the worker. Designed per huangheng's sketch + 符炫炜's three refinements (walks lifespan / `_amain` / `main` bodies, recognises canonical names through aliases, externalises the FastAPI-only allowlist).

## Test plan
- [x] `uvx ruff@0.15.12 check / format --check aperag/bootstrap aperag/app.py aperag/cli/indexing_worker.py tests/boundaries/test_worker_di_parity.py` — passed
- [x] `uv run python -c "import aperag.app; import aperag.cli.indexing_worker"` — OK
- [x] `uv run --extra test python -m pytest tests/boundaries/test_worker_di_parity.py tests/boundaries/test_api_no_cleanup.py tests/unit_test/test_app_lifespan_no_workers.py -q` — 11 passed
- [ ] CI lint-and-unit green
- [ ] CI e2e-http-smoke green
- [ ] CI e2e-http-provider green (this is the gate — the regression target)
- [ ] After merge, rebase #1885 / #1886 / #1889 / #1890 / #1891 and confirm e2e-http-provider goes green on each

🤖 Generated with [Claude Code](https://claude.com/claude-code)