### PR TITLE
perf(web): lazy-load Markdown in audit-log detail drawer

### DIFF
--- a/web/src/app/workspace/audit-logs/audit-log-detail.tsx
+++ b/web/src/app/workspace/audit-logs/audit-log-detail.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { Markdown } from '@/components/markdown';
 import {
   Drawer,
   DrawerContent,
@@ -9,7 +8,16 @@ import {
 } from '@/components/ui/drawer';
 import type { AuditLog } from '@/features/audit/types';
 import { useFormatter, useTranslations } from 'next-intl';
+import dynamic from 'next/dynamic';
 import { useMemo } from 'react';
+
+// Markdown 携带 remark/rehype/highlight 等共享大包. 只有 drawer 打开后才需要
+// 渲染 request_data / response_data 的 JSON 代码块, 拆 dynamic chunk 把
+// 它从 audit-logs 路由首屏 bundle 中移走.
+const Markdown = dynamic(
+  () => import('@/components/markdown').then((m) => ({ default: m.Markdown })),
+  { ssr: false, loading: () => null },
+);
 
 export const AuditLogDetail = ({
   auditLog,


### PR DESCRIPTION
## Summary

- Replace static `Markdown` import in `aperag/web/src/app/workspace/audit-logs/audit-log-detail.tsx` with `next/dynamic` (ssr: false, loading: null).
- `Markdown` is only used for the JSON code blocks (`request_data` / `response_data`) inside the click-to-open detail drawer, so it should not be in the route's First Load JS.

## Bundle measurement

Run on top of #1892 (mermaid lazy-load) baseline.

| Route | Before | After | Δ |
|---|---|---|---|
| `/workspace/audit-logs` | 515 kB | **270 kB** | **−245 kB** |
| `/admin/audit-logs` | 515 kB | **270 kB** | **−245 kB** |

## Test plan

- [x] `yarn build` succeeds; numbers above measured directly from build output
- [x] `yarn lint` clean (only pre-existing warnings unrelated to this change)
- [x] `yarn type-check` clean
- [ ] Local dev server: open `/workspace/audit-logs`, verify rows render normally
- [ ] Click a row, verify drawer opens and `request_data` / `response_data` Markdown JSON code blocks render correctly (Markdown chunk fetched on first open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)