### PR TITLE
perf(web): lazy load document previews and quota charts

### DIFF
--- a/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -1,16 +1,9 @@
 'use client';
-import { Markdown } from '@/components/markdown';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import type { DocumentPreview } from '@/features/document/types';
 import { cn } from '@/lib/utils';
-import _ from 'lodash';
-import {
-  ArrowLeft,
-  Download,
-  FileText,
-  LoaderCircle,
-} from 'lucide-react';
+import { ArrowLeft, Download, FileText, LoaderCircle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
@@ -37,6 +30,13 @@ const PDFDocument = dynamic(() => import('react-pdf').then((r) => r.Document), {
 const PDFPage = dynamic(() => import('react-pdf').then((r) => r.Page), {
   ssr: false,
 });
+const Markdown = dynamic(
+  () => import('@/components/markdown').then((r) => r.Markdown),
+  {
+    ssr: false,
+    loading: () => <div className="bg-muted h-40 animate-pulse rounded-md" />,
+  },
+);
 
 const IMAGE_EXTENSIONS = new Set([
   'png',
@@ -115,6 +115,10 @@ export const DocumentDetail = ({
     : undefined;
 
   useEffect(() => {
+    if (!pdfPreviewUrl) {
+      return;
+    }
+
     const loadPDF = async () => {
       const { pdfjs } = await import('react-pdf');
 
@@ -124,7 +128,7 @@ export const DocumentDetail = ({
       ).toString();
     };
     loadPDF();
-  }, []);
+  }, [pdfPreviewUrl]);
 
   useEffect(() => {
     setNumPages(0);
@@ -173,7 +177,7 @@ export const DocumentDetail = ({
             }
             className="flex flex-col justify-center gap-1"
           >
-            {_.times(numPages).map((index) => {
+            {Array.from({ length: numPages }, (_, index) => {
               return (
                 <div key={index} className="text-center">
                   <Card className="border-border/70 inline-block overflow-hidden rounded-xl p-0">

--- a/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/collection-header.tsx
@@ -18,7 +18,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import type { CollectionStatus } from '@/features/collection/types';
 import { cn } from '@/lib/utils';
-import _ from 'lodash';
 
 import { CollectionExport } from '@/components/collections/export-dialog';
 import { useCollectionContext } from '@/components/providers/collection-provider';
@@ -46,6 +45,19 @@ import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import { showRetrievalTestModule } from '../feature-visibility';
 import { CollectionDelete } from './collection-delete';
+
+const formatStatus = (status: string) =>
+  status
+    .toLowerCase()
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+const truncate = (value: string, length: number) => {
+  if (value.length <= length) return value;
+  return `${value.slice(0, Math.max(0, length - 3))}...`;
+};
 
 export const CollectionHeader = ({ className }: { className?: string }) => {
   const statusClassName: Record<CollectionStatus, string> = {
@@ -154,15 +166,13 @@ export const CollectionHeader = ({ className }: { className?: string }) => {
                     )}
                     variant="outline"
                   >
-                    {_.upperFirst(_.lowerCase(collection.status))}
+                    {formatStatus(collection.status)}
                   </Badge>
                 )}
               </div>
               {collection.description && (
                 <CardDescription className="mt-2 max-w-3xl leading-6">
-                  {_.truncate(collection.description, {
-                    length: 220,
-                  })}
+                  {truncate(collection.description, 220)}
                 </CardDescription>
               )}
               {collection.created && (

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { getDocumentStatusColor } from '@/app/workspace/collections/tools';
 import { FormatDate } from '@/components/format-date';
-import { Markdown } from '@/components/markdown';
 import { useCollectionContext } from '@/components/providers/collection-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -10,13 +9,7 @@ import { Separator } from '@/components/ui/separator';
 import { buildDocumentObjectUrl } from '@/features/document/client-api';
 import type { Document, DocumentPreview } from '@/features/document/types';
 import { cn } from '@/lib/utils';
-import _ from 'lodash';
-import {
-  ArrowLeft,
-  Download,
-  FileText,
-  LoaderCircle,
-} from 'lucide-react';
+import { ArrowLeft, Download, FileText, LoaderCircle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
@@ -60,6 +53,13 @@ const PDFDocument = dynamic(() => import('react-pdf').then((r) => r.Document), {
 const PDFPage = dynamic(() => import('react-pdf').then((r) => r.Page), {
   ssr: false,
 });
+const Markdown = dynamic(
+  () => import('@/components/markdown').then((r) => r.Markdown),
+  {
+    ssr: false,
+    loading: () => <div className="bg-muted h-40 animate-pulse rounded-md" />,
+  },
+);
 
 const IMAGE_EXTENSIONS = new Set([
   'png',
@@ -80,6 +80,9 @@ const formatFileSize = (size?: number | null) => {
   if (kb < 1000) return `${kb.toFixed(2)} KB`;
   return `${(kb / 1000).toFixed(2)} MB`;
 };
+
+const capitalizeStatus = (status: string) =>
+  status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
 
 const buildDocumentDownloadUrl = (collectionId: string, documentId: string) =>
   `${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/api/v2/collections/${collectionId}/documents/${documentId}/download`;
@@ -130,6 +133,10 @@ export const DocumentDetail = ({
     : undefined;
 
   useEffect(() => {
+    if (!pdfPreviewUrl) {
+      return;
+    }
+
     const loadPDF = async () => {
       const { pdfjs } = await import('react-pdf');
 
@@ -139,7 +146,7 @@ export const DocumentDetail = ({
       ).toString();
     };
     loadPDF();
-  }, []);
+  }, [pdfPreviewUrl]);
 
   useEffect(() => {
     setNumPages(0);
@@ -184,7 +191,7 @@ export const DocumentDetail = ({
                       getDocumentStatusColor(document.status),
                     )}
                   >
-                    {_.capitalize(document.status)}
+                    {capitalizeStatus(document.status)}
                   </Badge>
                 </>
               ) : null}
@@ -215,7 +222,7 @@ export const DocumentDetail = ({
             }
             className="flex flex-col justify-center gap-1"
           >
-            {_.times(numPages).map((index) => {
+            {Array.from({ length: numPages }, (_, index) => {
               return (
                 <div key={index} className="text-center">
                   <Card className="border-border/70 inline-block overflow-hidden p-0 shadow-sm">

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/page.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/page.tsx
@@ -8,10 +8,14 @@ import {
   getDocumentPreview,
 } from '@/features/document/server-api';
 import { toJson } from '@/lib/utils';
-import _ from 'lodash';
 import { notFound } from 'next/navigation';
 import { CollectionHeader } from '../../collection-header';
 import { DocumentDetail } from './document-detail';
+
+const truncate = (value: string, length: number) => {
+  if (value.length <= length) return value;
+  return `${value.slice(0, Math.max(0, length - 3))}...`;
+};
 
 export default async function Page({
   params,
@@ -42,7 +46,7 @@ export default async function Page({
             href: `/workspace/collections/${collectionId}/documents`,
           },
           {
-            title: _.truncate(document?.name || '', { length: 30 }),
+            title: truncate(document?.name || '', 30),
           },
         ]}
       />

--- a/web/src/app/workspace/quotas/page.tsx
+++ b/web/src/app/workspace/quotas/page.tsx
@@ -9,7 +9,7 @@ import { getUserQuota } from '@/features/quota/server-api';
 import { Gauge, ShieldCheck, TimerReset } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 import type { ReactNode } from 'react';
-import { QuotaRadialChart } from './quota-radial-chart';
+import { QuotaChartGrid } from './quota-chart-grid';
 
 export default async function Page() {
   const data = await getUserQuota();
@@ -57,11 +57,7 @@ export default async function Page() {
             value={totalLimit}
           />
         </div>
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {data.quotas.map((quota) => (
-            <QuotaRadialChart key={quota.quota_type} data={quota} />
-          ))}
-        </div>
+        <QuotaChartGrid quotas={data.quotas} />
       </PageContent>
     </PageContainer>
   );

--- a/web/src/app/workspace/quotas/quota-chart-grid.tsx
+++ b/web/src/app/workspace/quotas/quota-chart-grid.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Card, CardContent } from '@/components/ui/card';
+import type { QuotaInfo } from '@/features/quota/types';
+import dynamic from 'next/dynamic';
+
+const QuotaRadialChart = dynamic(
+  () => import('./quota-radial-chart').then((r) => r.QuotaRadialChart),
+  {
+    ssr: false,
+    loading: () => <QuotaChartSkeleton />,
+  },
+);
+
+export const QuotaChartGrid = ({ quotas }: { quotas: QuotaInfo[] }) => {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {quotas.map((quota) => (
+        <QuotaRadialChart key={quota.quota_type} data={quota} />
+      ))}
+    </div>
+  );
+};
+
+const QuotaChartSkeleton = () => {
+  return (
+    <Card className="border-border/70 flex flex-col gap-0 overflow-hidden rounded-xl py-0">
+      <CardContent className="space-y-4 p-6">
+        <div className="bg-muted h-5 w-32 animate-pulse rounded" />
+        <div className="bg-muted/80 mx-auto aspect-square max-h-[250px] w-full animate-pulse rounded-full" />
+        <div className="flex justify-center gap-2">
+          <div className="bg-muted h-6 w-20 animate-pulse rounded" />
+          <div className="bg-muted h-6 w-20 animate-pulse rounded" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+};


### PR DESCRIPTION
## Summary
- lazy-load Markdown in workspace/marketplace document detail so PDF/image/fallback previews do not pay the markdown renderer on first load
- initialize PDF.js only when a PDF preview is actually present
- lazy-load quota Recharts via a small client grid wrapper
- replace lodash usage in collection header and document detail breadcrumbs/status helpers with local string helpers

## Bundle impact (yarn build, before -> after)
- /workspace/collections/[collectionId]/documents/[documentId]: 461 kB -> 217 kB (-244 kB)
- /marketplace/collections/[collectionId]/documents/[documentId]: 455 kB -> 211 kB (-244 kB)
- /workspace/quotas: 307 kB -> 207 kB (-100 kB)
- /workspace/collections/[collectionId]/graph-hybrid: 329 kB -> 305 kB (-24 kB)
- /workspace/collections/[collectionId]/graph-lab: 243 kB -> 219 kB (-24 kB)

## Validation
- cd web && yarn type-check --pretty false
- cd web && yarn build
- cd web && yarn lint
- git diff --check

Existing warnings remain: Cosmograph/DuckDB dynamic require warnings and pre-existing lint warnings in evaluation placeholder pages, agent-turn-renderer, and elicitation-form.