### PR TITLE
docs(architecture): integrate task #17 + Phase 2 sediment into overview

### DIFF
--- a/docs/zh-CN/architecture/overview.md
+++ b/docs/zh-CN/architecture/overview.md
@@ -13,9 +13,10 @@ description: ApeRAG 后端架构入口 — 从哪开始读、去哪找什么
 
 - **代码按业务职责分 12 个 domain**：`identity` · `governance` · `model_platform` · `marketplace` · `knowledge_base` · `indexing` · `retrieval` · `knowledge_graph` · `conversation` · `agent_runtime` · `evaluation` · `web_access`。
 - **每个 domain 自成一格**：自己的 DB 模型 · 自己的 Pydantic schema · 自己的 service · 自己的 FastAPI 路由，都在 `aperag/domains/<domain>/` 下。
-- **跨 domain 依赖有明确规则**：provider 已搬进 `aperag/domains/` 的直接 import；没搬进的通过 consumer 自持 `Protocol` + module-level DI slot + `aperag/app.py` startup 注入。
+- **跨 domain 依赖有明确规则**：provider 已搬进 `aperag/domains/` 的直接 import；没搬进的通过 consumer 自持 `Protocol` + module-level DI slot + 共享 bootstrap helper（`aperag/bootstrap/__init__.py`）注入。
 - **有测试守住边界**：`tests/unit_test/test_modularization_boundaries.py` 实现 G1–G19 共 20 条边界测试，跟 `make lint` / `make test-unit` 一起跑在 CI。
 - **HTTP API 全程字节稳定**：`scripts/export_openapi.py --check` 在整个重构过程每次 squash merge 都通过。
+- **运行时分两个独立进程部署**（task #17 hard cut，2026-04-29 ship）：`aperag-api` 只跑 FastAPI HTTP 入口 + 轻量入队；`aperag-indexing-worker` 跑 parse / vector / fulltext / graph_facts / graph_vectors / summary / vision / reconciler / cleanup 等 10 条 lane。两进程通过 single-source-of-truth `wire_cross_domain_di_seams()` helper 保证 DI parity，受 `tests/boundaries/test_worker_di_parity.py` AST 等价性 gate 守护。
 
 详细的 phase 产出、domain 清单、gate 列表、permanent seam 定义见 [`docs/modularization/architecture.md`](../../modularization/architecture.md)（英文，canonical source-of-truth，本目录所有文档都以它为基准）。
 
@@ -46,11 +47,12 @@ description: ApeRAG 后端架构入口 — 从哪开始读、去哪找什么
 
 ## 当前架构为什么这样组织
 
-三条约束决定了现在的布局：
+四条约束决定了现在的布局：
 
 - **业务职责清晰可定位**：把代码按业务 domain 聚类（`aperag/domains/<d>/`），而不是按层（`service/` / `models/` / `views/`）。新人看到一个 endpoint 能在一个目录里找齐 DB / schema / 业务 / 路由。
 - **跨 domain 依赖显式且可测**：`aperag/domains/**` 内禁止 import 旧聚合层（G1）；跨 domain 访问只有两种形态——provider-in-domain 直接 import、或 consumer-owned Protocol + DI 槽。`tests/unit_test/test_modularization_boundaries.py` 里 20 条 pytest 锁住全部边界规则（G1–G19 + CRITICAL_WIRINGS），跟 `make test-unit` 一起跑，违反 import 会红在 CI。
-- **永久性的跨切面基础设施有独立接入点**：跨 domain 的基础设施（配额、prompt template）不塞进某个 domain，也不偷偷下沉到共享层，而是用 **permanent DI seam**（`QuotaOps` / `PromptTemplateOps`）显式注入。两条 seam 的启动时 wiring 由 `aperag/app.py` 负责、同样受 boundary 测试保护。
+- **永久性的跨切面基础设施有独立接入点**：跨 domain 的基础设施（配额、prompt template、marketplace、search pipeline、identity init、prompt CRUD 等共 10 条 DI seam）不塞进某个 domain，也不偷偷下沉到共享层，而是用 **permanent DI seam** 显式注入。两进程（API + indexing-worker）共享 `aperag/bootstrap/__init__.py` 里的 `wire_cross_domain_di_seams()` 单一调用契约，受 boundary 测试 AST 等价性 gate（`tests/boundaries/test_worker_di_parity.py`）守护，避免「source 进程加了新 seam，target 进程漏 wire」类 cross-process drift。
+- **运行时执行面与请求入口物理分离**：FastAPI HTTP 入口与索引/清理 worker 不能共进程（task #17 hard cut 强制约束）。重型 LLM 调用占用 event loop 会让 `/health` 超时被 kubelet 重启 → 503 风暴；连接池、并发预算、健康探针的语义按进程角色（API vs worker）分别定义。详细 invariant lock 见 [`task-system-invariants.md`](./task-system-invariants.md)（6 hard gate / 6 YAGNI 边界 / 4 escape hatch 触发条件 / cross-process DI parity）。
 
 外部契约零漂移是硬要求：HTTP API（OpenAPI）、前端 typed client、数据库迁移历史在整个重构过程保持字节级稳定。
 
@@ -75,4 +77,4 @@ description: ApeRAG 后端架构入口 — 从哪开始读、去哪找什么
 
 ---
 
-*本文档基线：`origin/main @ 10cabcf`（PR #1637 merged）；canonical SSoT 基线 `origin/main @ 28a9f531`（PR #1635 Phase 6 merged）。本目录其他文档随 `docs/modularization/architecture.md` 更新而维护；结构性不变式若发生变更，先改 canonical SSoT，再回头更新本目录。*
+*本文档基线：`origin/main @ f13eb80`（task #17 hard cut + Phase 2 sediment 全 merged，含 PR #1884 / #1893 / #1885-#1891）；canonical SSoT 基线 `origin/main @ 28a9f531`（PR #1635 Phase 6 merged）。本目录其他文档随 `docs/modularization/architecture.md` 更新而维护；结构性不变式若发生变更，先改 canonical SSoT，再回头更新本目录。task #17 后新增的 cross-process DI parity / 部署进程拆分等不变式，落在 `task-system-invariants.md` 与 `task-17-cr-review-checklist.md`。*

--- a/docs/zh-CN/architecture/overview.md
+++ b/docs/zh-CN/architecture/overview.md
@@ -16,7 +16,7 @@ description: ApeRAG 后端架构入口 — 从哪开始读、去哪找什么
 - **跨 domain 依赖有明确规则**：provider 已搬进 `aperag/domains/` 的直接 import；没搬进的通过 consumer 自持 `Protocol` + module-level DI slot + 共享 bootstrap helper（`aperag/bootstrap/__init__.py`）注入。
 - **有测试守住边界**：`tests/unit_test/test_modularization_boundaries.py` 实现 G1–G19 共 20 条边界测试，跟 `make lint` / `make test-unit` 一起跑在 CI。
 - **HTTP API 全程字节稳定**：`scripts/export_openapi.py --check` 在整个重构过程每次 squash merge 都通过。
-- **运行时分两个独立进程部署**（task #17 hard cut，2026-04-29 ship）：`aperag-api` 只跑 FastAPI HTTP 入口 + 轻量入队；`aperag-indexing-worker` 跑 parse / vector / fulltext / graph_facts / graph_vectors / summary / vision / reconciler / cleanup 等 10 条 lane。两进程通过 single-source-of-truth `wire_cross_domain_di_seams()` helper 保证 DI parity，受 `tests/boundaries/test_worker_di_parity.py` AST 等价性 gate 守护。
+- **运行时分两个独立进程部署**（task #17 hard cut，2026-04-29 ship）：`aperag-api` 只跑 FastAPI HTTP 入口 + 轻量入队；`aperag-indexing-worker` 跑 parse / vector / fulltext / graph / graph_facts / graph_vectors / summary / vision / reconciler / cleanup 共 10 条 lane。两进程通过 single-source-of-truth `wire_cross_domain_di_seams()` helper 保证 DI parity，受 `tests/boundaries/test_worker_di_parity.py` AST 等价性 gate 守护。
 
 详细的 phase 产出、domain 清单、gate 列表、permanent seam 定义见 [`docs/modularization/architecture.md`](../../modularization/architecture.md)（英文，canonical source-of-truth，本目录所有文档都以它为基准）。
 


### PR DESCRIPTION
## Summary

把 task #17 (API/indexing-worker hard cut) 与 Phase 2 sediment 整合进 `docs/zh-CN/architecture/overview.md` 顶层架构叙事，作为一等架构不变式呈现，而不只是导航表里的一行。

per earayu2 msg=eb95612a directive (phase 2 启动) + PM 不穷 msg=407bb42d (架构师 standby ratify 后写 architecture.md overview)。

## 改动 (4 处, 1 文件)

1. **一句话定位** 加 5th 条 runtime topology: `aperag-api` + `aperag-indexing-worker` 两进程独立部署 + 10 lane 列举 + cross-process DI parity AST gate
2. **当前架构** 三条约束 → 四条约束: 新增「执行面与请求入口物理分离」(task #17 hard cut), 解释「为什么不能共进程」(503 风暴根因) + cross-link `task-system-invariants.md` 详细 invariant lock
3. **DI seam 描述更新**: 从 2 条 (QuotaOps / PromptTemplateOps) 扩展到 10 条 (含 marketplace / search pipeline / identity init / prompt CRUD), 启动时 wiring 改为 共享 helper, AST gate 守护 cross-process drift
4. **基线 commit 更新**: 10cabcf → f13eb80 (Phase 2 sediment 全 merged), 末尾补 task #17 invariant 落点 cross-link

不重写 nav table (Weston PR #1888 已加 task #17 docs 行); 只补 overview 顶层架构叙事缺失部分。详细 invariant lock 仍在 task-system-invariants.md 与 task-17-cr-review-checklist.md。

## Test plan

- [x] git diff --check (whitespace) passed
- [x] 顶层叙事跟 PR #1884 / PR #1893 / PR #1888 实际 merge 内容一致
- [x] cross-link 路径正确
- [ ] huangheng CR / drift cross-link review (per standing offer msg=b7adf68d)
- [ ] Weston 三分类框架等价性 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)