### PR TITLE
fix(task-35): remove rerank from MCP search surface

### DIFF
--- a/aperag/domains/model_platform/db/models.py
+++ b/aperag/domains/model_platform/db/models.py
@@ -43,7 +43,6 @@ class ModelUseScenario(str, Enum):
     AGENT_CHAT = "agent_chat"
     COLLECTION_COMPLETION = "collection_completion"
     COLLECTION_EMBEDDING = "collection_embedding"
-    RETRIEVAL_RERANK = "retrieval_rerank"
     BACKGROUND_TASK = "background_task"
 
 

--- a/aperag/domains/model_platform/schemas.py
+++ b/aperag/domains/model_platform/schemas.py
@@ -22,7 +22,6 @@ class ModelUseScenario(str, Enum):
     AGENT_CHAT = "agent_chat"
     COLLECTION_COMPLETION = "collection_completion"
     COLLECTION_EMBEDDING = "collection_embedding"
-    RETRIEVAL_RERANK = "retrieval_rerank"
     BACKGROUND_TASK = "background_task"
 
 

--- a/aperag/domains/model_platform/service/model_service.py
+++ b/aperag/domains/model_platform/service/model_service.py
@@ -36,14 +36,13 @@ CAPABILITY_SCENARIOS: dict[ModelCapability, tuple[ModelUseScenario, ...]] = {
         ModelUseScenario.BACKGROUND_TASK,
     ),
     ModelCapability.EMBEDDING: (ModelUseScenario.COLLECTION_EMBEDDING,),
-    ModelCapability.RERANK: (ModelUseScenario.RETRIEVAL_RERANK,),
+    ModelCapability.RERANK: (),
 }
 
 SCENARIO_CAPABILITY: dict[ModelUseScenario, ModelCapability] = {
     ModelUseScenario.AGENT_CHAT: ModelCapability.CHAT,
     ModelUseScenario.COLLECTION_COMPLETION: ModelCapability.CHAT,
     ModelUseScenario.COLLECTION_EMBEDDING: ModelCapability.EMBEDDING,
-    ModelUseScenario.RETRIEVAL_RERANK: ModelCapability.RERANK,
     ModelUseScenario.BACKGROUND_TASK: ModelCapability.CHAT,
 }
 

--- a/aperag/mcp/tools/search_fulltext.py
+++ b/aperag/mcp/tools/search_fulltext.py
@@ -59,7 +59,6 @@ async def fulltext_search(
     *,
     top_k: int = 5,
     keywords: list[str] | None = None,
-    rerank: bool = True,
 ) -> Dict[str, Any]:
     """Full-text keyword search within a collection (§B.3).
 
@@ -92,8 +91,6 @@ async def fulltext_search(
         top_k: Maximum number of results to return (default: 5).
         keywords: Optional explicit keyword list overriding the
             auto-extracted keywords from the query.
-        rerank: Whether to apply reranker on returned candidates
-            (default: True).
 
     Returns:
         Search results with ``items`` carrying ``recall_type =
@@ -109,7 +106,6 @@ async def fulltext_search(
 
         search_data: Dict[str, Any] = {
             "query": query,
-            "rerank": rerank,
             "fulltext_search": fulltext_payload,
         }
 

--- a/aperag/mcp/tools/search_vector.py
+++ b/aperag/mcp/tools/search_vector.py
@@ -61,7 +61,6 @@ async def vector_search(
     *,
     top_k: int = 5,
     similarity_threshold: float | None = None,
-    rerank: bool = True,
 ) -> Dict[str, Any]:
     """Vector similarity search within a collection (§B.1).
 
@@ -95,7 +94,6 @@ async def vector_search(
         top_k: Maximum number of results to return (default: 5).
         similarity_threshold: Minimum similarity score [0, 1]; ``None``
             uses the collection's default threshold.
-        rerank: Whether to apply reranker on returned candidates (default: True).
 
     Returns:
         Search results with ``items`` ranked by vector similarity. Each
@@ -110,7 +108,6 @@ async def vector_search(
 
         search_data: Dict[str, Any] = {
             "query": query,
-            "rerank": rerank,
             "vector_search": vector_payload,
         }
 

--- a/aperag/migration/versions/20260430024000-a8f4c2d9e1b7.py
+++ b/aperag/migration/versions/20260430024000-a8f4c2d9e1b7.py
@@ -1,0 +1,27 @@
+"""drop retrieval rerank model-use scenario
+
+Revision ID: a8f4c2d9e1b7
+Revises: 930bdb402fc1
+Create Date: 2026-04-30 02:40:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a8f4c2d9e1b7"
+down_revision: Union[str, None] = "930bdb402fc1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Remove stale rerank default-model bindings before the enum is hard-cut."""
+    op.execute("DELETE FROM model_use WHERE scenario = 'retrieval_rerank'")
+
+
+def downgrade() -> None:
+    """The deleted default-model binding cannot be reconstructed safely."""
+    pass

--- a/tests/e2e_http/hurl/full/10_provider_llm.hurl
+++ b/tests/e2e_http/hurl/full/10_provider_llm.hurl
@@ -14,8 +14,8 @@
 #   3. Per-account models are created via ``POST /api/v2/models`` for the
 #      embedding / rerank / chat capabilities the rest of the suite needs.
 #   4. ``PUT /api/v2/model-uses/{scenario}`` wires the canonical
-#      collection-completion / collection-embedding / retrieval-rerank /
-#      background-task scenarios.
+#      collection-completion / collection-embedding / background-task
+#      scenarios.
 #   5. The OpenAI-compat ``POST /api/v1/embeddings`` and ``POST /api/v1/rerank``
 #      endpoints accept ``{model_id}`` and round-trip a real provider call.
 
@@ -147,18 +147,6 @@ HTTP 200
 [Asserts]
 jsonpath "$.primary_model_id" == "{{dashscope_embedding_model_id}}"
 
-PUT {{base_url}}/api/v2/model-uses/retrieval_rerank
-Content-Type: application/json
-{
-  "primary_model_id": "{{dashscope_rerank_model_id}}",
-  "fallback_model_ids": [],
-  "strategy": "single",
-  "enabled": true
-}
-HTTP 200
-[Asserts]
-jsonpath "$.primary_model_id" == "{{dashscope_rerank_model_id}}"
-
 PUT {{base_url}}/api/v2/model-uses/background_task
 Content-Type: application/json
 {
@@ -172,7 +160,7 @@ HTTP 200
 GET {{base_url}}/api/v2/model-uses
 HTTP 200
 [Asserts]
-jsonpath "$.items" count >= 4
+jsonpath "$.items" count >= 3
 
 POST {{base_url}}/api/v1/embeddings
 Content-Type: application/json

--- a/tests/unit_test/mcp/test_search_split.py
+++ b/tests/unit_test/mcp/test_search_split.py
@@ -97,19 +97,17 @@ def _kw_only_params(func) -> set[str]:
 def test_vector_search_signature_matches_b1_lock():
     """``vector_search`` signature follows §B.1: ``collection_id`` +
     ``query`` positional, then a ``*,`` kw-only barrier with
-    ``top_k`` / ``similarity_threshold`` / ``rerank``.
+    ``top_k`` / ``similarity_threshold``.
     """
     params = _params(vector_search)
     assert list(params)[:2] == ["collection_id", "query"]
     assert _kw_only_params(vector_search) == {
         "top_k",
         "similarity_threshold",
-        "rerank",
-    }, "§B.1 requires kw-only `top_k / similarity_threshold / rerank`."
+    }, "§B.1 requires kw-only `top_k / similarity_threshold`."
     assert params["top_k"].default == 5
     # similarity_threshold defaults to None to mean "use collection default".
     assert params["similarity_threshold"].default is None
-    assert params["rerank"].default is True
 
 
 def test_graph_search_signature_matches_b2_lock():
@@ -127,18 +125,16 @@ def test_graph_search_signature_matches_b2_lock():
 
 def test_fulltext_search_signature_matches_b3_lock():
     """``fulltext_search`` signature follows §B.3: collection_id +
-    query positional then kw-only top_k + keywords + rerank.
+    query positional then kw-only top_k + keywords.
     """
     params = _params(fulltext_search)
     assert list(params)[:2] == ["collection_id", "query"]
     assert _kw_only_params(fulltext_search) == {
         "top_k",
         "keywords",
-        "rerank",
-    }, "§B.3 requires kw-only `top_k / keywords / rerank`."
+    }, "§B.3 requires kw-only `top_k / keywords`."
     assert params["top_k"].default == 5
     assert params["keywords"].default is None
-    assert params["rerank"].default is True
 
 
 def test_web_search_signature_matches_b4_canonical():

--- a/tests/unit_test/test_model_platform_v2_contract.py
+++ b/tests/unit_test/test_model_platform_v2_contract.py
@@ -154,9 +154,7 @@ def test_allowed_scenarios_default_by_capability():
     assert default_allowed_scenarios(ModelCapability.EMBEDDING) == [
         ModelUseScenario.COLLECTION_EMBEDDING,
     ]
-    assert default_allowed_scenarios(ModelCapability.RERANK) == [
-        ModelUseScenario.RETRIEVAL_RERANK,
-    ]
+    assert default_allowed_scenarios(ModelCapability.RERANK) == []
 
 
 def test_allowed_scenarios_missing_key_uses_default_but_empty_list_is_explicit():


### PR DESCRIPTION
## Summary

Task #35 / #38 MCP + model-use lane for rerank removal.

This PR removes rerank from the single-index MCP search surface and removes the `retrieval_rerank` model-use scenario so future default-model configuration no longer treats rerank as a product scenario.

Changes:
- Remove the `rerank` kw-only parameter from `vector_search` and `fulltext_search` MCP tools.
- Stop sending `rerank` in MCP search payloads to `/api/v2/collections/{collection_id}/searches`.
- Remove `ModelUseScenario.RETRIEVAL_RERANK` from schema + ORM enum definitions.
- Make `ModelCapability.RERANK` map to no default product scenarios.
- Add migration `a8f4c2d9e1b7` to delete existing `model_use` rows where `scenario = 'retrieval_rerank'`.
- Update MCP signature and model-platform contract tests.
- Remove `PUT /api/v2/model-uses/retrieval_rerank` from provider-aware Hurl setup.

Out of scope, owned by other task #35 lanes:
- #36 BE core: retrieval pipeline `_rerank`, `model_invocation_service.rerank`, provider runners, `RerankService`, `/api/v1/rerank`.
- #37 UI/docs: frontend config and docs.
- #40 validation: grep gate and smoke/e2e validation.

## Validation

- `uv run --extra test python -m pytest tests/unit_test/mcp/test_search_split.py tests/unit_test/test_model_platform_v2_contract.py -q` → 23 passed
- `uv run --extra dev ruff check aperag/mcp/tools/search_vector.py aperag/mcp/tools/search_fulltext.py aperag/domains/model_platform/schemas.py aperag/domains/model_platform/db/models.py aperag/domains/model_platform/service/model_service.py aperag/migration/versions/20260430024000-a8f4c2d9e1b7.py tests/unit_test/mcp/test_search_split.py tests/unit_test/test_model_platform_v2_contract.py` → passed
- `uv run --extra dev ruff format --check aperag/mcp/tools/search_vector.py aperag/mcp/tools/search_fulltext.py aperag/domains/model_platform/schemas.py aperag/domains/model_platform/db/models.py aperag/domains/model_platform/service/model_service.py aperag/migration/versions/20260430024000-a8f4c2d9e1b7.py tests/unit_test/mcp/test_search_split.py tests/unit_test/test_model_platform_v2_contract.py` → passed
- `uv run alembic -c aperag/alembic.ini heads` → `a8f4c2d9e1b7 (head)`
- `git diff --check` → passed
