### PR TITLE
perf(web): lazy load user quota editor

### DIFF
--- a/web/src/app/admin/users/user-quota-action.tsx
+++ b/web/src/app/admin/users/user-quota-action.tsx
@@ -1,252 +1,59 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-} from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { Progress } from '@/components/ui/progress';
+import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  getUserQuota as getUserQuotaApi,
-  recalculateUserQuota,
-  updateUserQuota,
-} from '@/features/admin/client-api';
-import type {
-  QuotaUpdateRequest,
-  QuotaUpdateResponse,
-  UserQuotaInfo,
-} from '@/features/admin/types';
 import type { User } from '@/features/identity/types';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { Slot } from '@radix-ui/react-slot';
-import _ from 'lodash';
-import { Gauge } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import dynamic from 'next/dynamic';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
-import * as z from 'zod';
-
-const quotaSchema = z.object({
-  max_collection_count: z.number().min(1),
-  max_document_count: z.number().min(1),
-  max_document_count_per_collection: z.number().min(1),
-  max_bot_count: z.number().min(1),
-});
+const UserQuotaDialogContent = dynamic(
+  () =>
+    import('./user-quota-dialog-content').then((mod) => ({
+      default: mod.UserQuotaDialogContent,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <DialogContent className="border-border/70 max-w-3xl rounded-xl p-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="flex w-full flex-col gap-2">
+              <Skeleton className="h-[14px] w-1/2 rounded-md" />
+              <Skeleton className="h-[36px] w-full rounded-md" />
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    ),
+  },
+);
 
 export const UserQuotaAction = ({
   user,
   children,
 }: {
   user: User;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }) => {
-  const [userQuotaInfo, setUserQuotaInfo] = useState<UserQuotaInfo>();
-  const [visible, setVisible] = useState<boolean>(false);
-  const quotaInfo = _.orderBy(userQuotaInfo?.quotas, ['quota_type'], ['desc']);
-  const admin_users = useTranslations('admin_users');
-  const page_quota = useTranslations('page_quota');
-  const common_action = useTranslations('common.action');
-
-  const form = useForm<z.infer<typeof quotaSchema>>({
-    resolver: zodResolver(quotaSchema),
-    defaultValues: {
-      max_collection_count: 0,
-      max_document_count: 0,
-      max_document_count_per_collection: 0,
-      max_bot_count: 0,
-    },
-  });
-
-  const getUserQuota = useCallback(async () => {
-    if (!user.id) return;
-    const data = await getUserQuotaApi(user.id);
-
-    data.quotas.forEach((quota) => {
-      form.setValue(
-        quota.quota_type as keyof QuotaUpdateRequest,
-        quota.quota_limit,
-      );
-    });
-
-    setUserQuotaInfo(data);
-  }, [form, user.id]);
-
-  const handleUpdateQuota = useCallback(
-    async (values: z.infer<typeof quotaSchema>) => {
-      const { data: params, error } = quotaSchema.safeParse(values);
-      if (!user.id || error) return;
-
-      const res = await updateUserQuota(user.id, params);
-      if (res.success) {
-        toast.success(res.message);
-        setVisible(false);
-      }
-    },
-    [user.id],
-  );
-
-  const handleRecalculate = useCallback(async () => {
-    if (!user.id) return;
-    // `recalculateUserQuota` returns `unknown` (backend response not typed in
-    // public OpenAPI; see features/admin/client-api.ts note). Narrow at the
-    // call-site to read the success/message fields produced at runtime.
-    const res = (await recalculateUserQuota(user.id)) as QuotaUpdateResponse;
-    if (res?.success) {
-      toast.success(res.message);
-      getUserQuota();
-    }
-  }, [getUserQuota, user.id]);
-
-  const content = useMemo(() => {
-    if (_.isEmpty(quotaInfo)) {
-      return (
-        <>
-          {_.times(4).map((index) => {
-            return (
-              <div key={index} className="flex w-full flex-col gap-2">
-                <Skeleton className="h-[14px] w-1/2 rounded-md" />
-                <Skeleton className="h-[36px] w-full rounded-md" />
-              </div>
-            );
-          })}
-        </>
-      );
-    } else {
-      return quotaInfo?.map((info) => {
-        const percent =
-          info.quota_limit !== 0
-            ? (info.current_usage * 100) / info.quota_limit
-            : 0;
-        return (
-          <FormField
-            key={info.quota_type}
-            control={form.control}
-            name={info.quota_type as keyof QuotaUpdateRequest}
-            render={({ field }) => {
-              // @ts-expect-error i18n error
-              const label = page_quota(info.quota_type);
-              return (
-                <div className="border-border/70 bg-muted rounded-xl border p-4">
-                  <FormItem>
-                    <div className="mb-3 flex items-start justify-between gap-3">
-                      <div>
-                        <FormLabel className="font-medium">{label}</FormLabel>
-                        <div className="text-muted-foreground mt-1 text-xs">
-                          {page_quota('usage')}: {info.current_usage}
-                        </div>
-                      </div>
-                      <div className="bg-accent-soft text-accent-ink flex size-9 shrink-0 items-center justify-center rounded-lg">
-                        <Gauge className="size-4" />
-                      </div>
-                    </div>
-                    <FormControl>
-                      <Input
-                        className="bg-background/70 rounded-xl font-mono"
-                        type="number"
-                        {...field}
-                        onChange={(e) => {
-                          const v = Number(e.currentTarget.value);
-                          field.onChange(v);
-                        }}
-                      />
-                    </FormControl>
-                  </FormItem>
-                  <div className="my-3">
-                    <Progress className="bg-border h-1.5" value={percent} />
-                  </div>
-                  <div className="text-muted-foreground flex flex-row justify-between font-mono text-xs">
-                    <div>
-                      {page_quota('limit')}: {info.quota_limit}
-                    </div>
-                    <div>{percent.toFixed(2)}%</div>
-                  </div>
-                </div>
-              );
-            }}
-          />
-        );
-      });
-    }
-  }, [form.control, page_quota, quotaInfo]);
-
-  useEffect(() => {
-    if (visible) {
-      getUserQuota();
-    }
-  }, [getUserQuota, visible]);
+  const [visible, setVisible] = useState(false);
 
   return (
-    <Dialog open={visible} onOpenChange={() => setVisible(false)}>
+    <Dialog open={visible} onOpenChange={setVisible}>
       <DialogTrigger asChild>
         <Slot
-          onClick={(e) => {
+          onClick={(event) => {
             setVisible(true);
-            e.preventDefault();
+            event.preventDefault();
           }}
         >
           {children}
         </Slot>
       </DialogTrigger>
-      <DialogContent className="border-border/70 max-w-3xl rounded-xl p-0">
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleUpdateQuota)}>
-            <DialogHeader className="border-border/70 border-b px-6 py-5">
-              <DialogTitle className="font-serif text-2xl font-normal">
-                {admin_users('user_quotas')}
-              </DialogTitle>
-              <DialogDescription asChild>
-                <div className="text-muted-foreground mt-2 flex flex-wrap gap-2 text-sm">
-                  {user.username && <span>{user.username}</span>}
-                  {user.email && (
-                    <span className="font-mono">{user.email}</span>
-                  )}
-                </div>
-              </DialogDescription>
-            </DialogHeader>
-
-            <div className="grid gap-4 px-6 py-6 md:grid-cols-2">{content}</div>
-
-            <DialogFooter className="border-border/70 flex flex-col border-t px-6 py-4 sm:flex-row sm:justify-between">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => handleRecalculate()}
-                disabled={_.isEmpty(quotaInfo)}
-              >
-                {admin_users('user_quotas_recalculate')}
-              </Button>
-              <div className="flex gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setVisible(false)}
-                >
-                  {common_action('cancel')}
-                </Button>
-                <Button type="submit" disabled={_.isEmpty(quotaInfo)}>
-                  {common_action('save')}
-                </Button>
-              </div>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
+      {visible ? (
+        <UserQuotaDialogContent user={user} onClose={() => setVisible(false)} />
+      ) : null}
     </Dialog>
   );
 };

--- a/web/src/app/admin/users/user-quota-dialog-content.tsx
+++ b/web/src/app/admin/users/user-quota-dialog-content.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  getUserQuota as getUserQuotaApi,
+  recalculateUserQuota,
+  updateUserQuota,
+} from '@/features/admin/client-api';
+import type {
+  QuotaUpdateRequest,
+  QuotaUpdateResponse,
+  UserQuotaInfo,
+} from '@/features/admin/types';
+import type { User } from '@/features/identity/types';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Gauge } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import * as z from 'zod';
+
+const quotaSchema = z.object({
+  max_collection_count: z.number().min(1),
+  max_document_count: z.number().min(1),
+  max_document_count_per_collection: z.number().min(1),
+  max_bot_count: z.number().min(1),
+});
+
+const sortQuotaInfo = (quotaInfo?: UserQuotaInfo['quotas']) =>
+  [...(quotaInfo ?? [])].sort((left, right) =>
+    String(right.quota_type).localeCompare(String(left.quota_type)),
+  );
+
+export const UserQuotaDialogContent = ({
+  user,
+  onClose,
+}: {
+  user: User;
+  onClose: () => void;
+}) => {
+  const [userQuotaInfo, setUserQuotaInfo] = useState<UserQuotaInfo>();
+  const quotaInfo = useMemo(
+    () => sortQuotaInfo(userQuotaInfo?.quotas),
+    [userQuotaInfo?.quotas],
+  );
+  const hasQuotaInfo = quotaInfo.length > 0;
+  const admin_users = useTranslations('admin_users');
+  const page_quota = useTranslations('page_quota');
+  const common_action = useTranslations('common.action');
+
+  const form = useForm<z.infer<typeof quotaSchema>>({
+    resolver: zodResolver(quotaSchema),
+    defaultValues: {
+      max_collection_count: 0,
+      max_document_count: 0,
+      max_document_count_per_collection: 0,
+      max_bot_count: 0,
+    },
+  });
+
+  const getUserQuota = useCallback(async () => {
+    if (!user.id) return;
+    const data = await getUserQuotaApi(user.id);
+
+    data.quotas.forEach((quota) => {
+      form.setValue(
+        quota.quota_type as keyof QuotaUpdateRequest,
+        quota.quota_limit,
+      );
+    });
+
+    setUserQuotaInfo(data);
+  }, [form, user.id]);
+
+  const handleUpdateQuota = useCallback(
+    async (values: z.infer<typeof quotaSchema>) => {
+      const { data: params, error } = quotaSchema.safeParse(values);
+      if (!user.id || error) return;
+
+      const res = await updateUserQuota(user.id, params);
+      if (res.success) {
+        toast.success(res.message);
+        onClose();
+      }
+    },
+    [onClose, user.id],
+  );
+
+  const handleRecalculate = useCallback(async () => {
+    if (!user.id) return;
+    // `recalculateUserQuota` returns `unknown` (backend response not typed in
+    // public OpenAPI; see features/admin/client-api.ts note). Narrow at the
+    // call-site to read the success/message fields produced at runtime.
+    const res = (await recalculateUserQuota(user.id)) as QuotaUpdateResponse;
+    if (res?.success) {
+      toast.success(res.message);
+      getUserQuota();
+    }
+  }, [getUserQuota, user.id]);
+
+  const content = useMemo(() => {
+    if (!hasQuotaInfo) {
+      return (
+        <>
+          {Array.from({ length: 4 }).map((_, index) => {
+            return (
+              <div key={index} className="flex w-full flex-col gap-2">
+                <Skeleton className="h-[14px] w-1/2 rounded-md" />
+                <Skeleton className="h-[36px] w-full rounded-md" />
+              </div>
+            );
+          })}
+        </>
+      );
+    }
+
+    return quotaInfo.map((info) => {
+      const percent =
+        info.quota_limit !== 0
+          ? (info.current_usage * 100) / info.quota_limit
+          : 0;
+      return (
+        <FormField
+          key={info.quota_type}
+          control={form.control}
+          name={info.quota_type as keyof QuotaUpdateRequest}
+          render={({ field }) => {
+            // @ts-expect-error i18n error
+            const label = page_quota(info.quota_type);
+            return (
+              <div className="border-border/70 bg-muted rounded-xl border p-4">
+                <FormItem>
+                  <div className="mb-3 flex items-start justify-between gap-3">
+                    <div>
+                      <FormLabel className="font-medium">{label}</FormLabel>
+                      <div className="text-muted-foreground mt-1 text-xs">
+                        {page_quota('usage')}: {info.current_usage}
+                      </div>
+                    </div>
+                    <div className="bg-accent-soft text-accent-ink flex size-9 shrink-0 items-center justify-center rounded-lg">
+                      <Gauge className="size-4" />
+                    </div>
+                  </div>
+                  <FormControl>
+                    <Input
+                      className="bg-background/70 rounded-xl font-mono"
+                      type="number"
+                      {...field}
+                      onChange={(event) => {
+                        const value = Number(event.currentTarget.value);
+                        field.onChange(value);
+                      }}
+                    />
+                  </FormControl>
+                </FormItem>
+                <div className="my-3">
+                  <Progress className="bg-border h-1.5" value={percent} />
+                </div>
+                <div className="text-muted-foreground flex flex-row justify-between font-mono text-xs">
+                  <div>
+                    {page_quota('limit')}: {info.quota_limit}
+                  </div>
+                  <div>{percent.toFixed(2)}%</div>
+                </div>
+              </div>
+            );
+          }}
+        />
+      );
+    });
+  }, [form.control, hasQuotaInfo, page_quota, quotaInfo]);
+
+  useEffect(() => {
+    getUserQuota();
+  }, [getUserQuota]);
+
+  return (
+    <DialogContent className="border-border/70 max-w-3xl rounded-xl p-0">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleUpdateQuota)}>
+          <DialogHeader className="border-border/70 border-b px-6 py-5">
+            <DialogTitle className="font-serif text-2xl font-normal">
+              {admin_users('user_quotas')}
+            </DialogTitle>
+            <DialogDescription asChild>
+              <div className="text-muted-foreground mt-2 flex flex-wrap gap-2 text-sm">
+                {user.username && <span>{user.username}</span>}
+                {user.email && <span className="font-mono">{user.email}</span>}
+              </div>
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 px-6 py-6 md:grid-cols-2">{content}</div>
+
+          <DialogFooter className="border-border/70 flex flex-col border-t px-6 py-4 sm:flex-row sm:justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleRecalculate()}
+              disabled={!hasQuotaInfo}
+            >
+              {admin_users('user_quotas_recalculate')}
+            </Button>
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={onClose}>
+                {common_action('cancel')}
+              </Button>
+              <Button type="submit" disabled={!hasQuotaInfo}>
+                {common_action('save')}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </Form>
+    </DialogContent>
+  );
+};

--- a/web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/document-index-status.tsx
@@ -3,7 +3,6 @@ import type {
   DocumentIndexStatus as DocumentIndexStatusType,
 } from '@/features/document/types';
 import { cn } from '@/lib/utils';
-import _ from 'lodash';
 import { useTranslations } from 'next-intl';
 
 const getIndexStatusBg = (status?: DocumentIndexStatusType | null) => {
@@ -24,7 +23,7 @@ export const DocumentIndexStatus = ({
   accessorKey: string;
 }) => {
   const page_documents = useTranslations('page_documents');
-  const status = _.get(document, accessorKey) as
+  const status = document[accessorKey as keyof Document] as
     | DocumentIndexStatusType
     | null
     | undefined;

--- a/web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/marketplace/collections/[collectionId]/documents/documents-table.tsx
@@ -25,16 +25,12 @@ import {
 import * as React from 'react';
 import { defaultStyles, FileIcon } from 'react-file-icon';
 
-import {
-  DOCUMENT_INDEX_TYPES,
-  type Document,
-} from '@/features/document/types';
+import { DOCUMENT_INDEX_TYPES, type Document } from '@/features/document/types';
 import type { SharedCollection } from '@/features/marketplace/types';
 
 import { DataGrid, DataGridPagination } from '@/components/data-grid';
 import { FormatDate } from '@/components/format-date';
 import { cn, objectKeys, parsePageParams } from '@/lib/utils';
-import _ from 'lodash';
 import { ChevronDown, Columns3, FileText, Search } from 'lucide-react';
 
 import { getDocumentStatusColor } from '@/app/workspace/collections/tools';
@@ -147,7 +143,8 @@ export function DocumentsTable({
           const extension =
             row.original.name?.split('.').pop()?.toLowerCase() ||
             ('unknow' as keyof typeof defaultStyles);
-          const iconProps = _.get(defaultStyles, extension);
+          const iconProps =
+            defaultStyles[extension as keyof typeof defaultStyles];
           const icon = (
             <FileIcon
               color="var(--primary)"
@@ -307,7 +304,7 @@ export function DocumentsTable({
           </DropdownMenu>
         </div>
       </div>
-      <DataGrid table={table} className="rounded-xl border-border/70" />
+      <DataGrid table={table} className="border-border/70 rounded-xl" />
       <DataGridPagination table={table} className="px-1" />
     </div>
   );

--- a/web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/document-index-status.tsx
@@ -3,7 +3,6 @@ import type {
   DocumentIndexStatus as DocumentIndexStatusType,
 } from '@/features/document/types';
 import { cn } from '@/lib/utils';
-import _ from 'lodash';
 import { useTranslations } from 'next-intl';
 
 const getIndexStatusBg = (status?: DocumentIndexStatusType | null) => {
@@ -24,7 +23,7 @@ export const DocumentIndexStatus = ({
   accessorKey: string;
 }) => {
   const page_documents = useTranslations('page_documents');
-  const status = _.get(document, accessorKey) as
+  const status = document[accessorKey as keyof Document] as
     | DocumentIndexStatusType
     | null
     | undefined;

--- a/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
@@ -33,7 +33,6 @@ import { DataGrid, DataGridPagination } from '@/components/data-grid';
 import { FormatDate } from '@/components/format-date';
 import { Badge } from '@/components/ui/badge';
 import { cn, objectKeys, parsePageParams } from '@/lib/utils';
-import _ from 'lodash';
 import {
   ChevronDown,
   Columns3,
@@ -67,10 +66,7 @@ const NON_TERMINAL_DOCUMENT_STATUSES = new Set([
   'DELETING',
 ]);
 
-const NON_TERMINAL_INDEX_STATUSES = new Set([
-  'PENDING',
-  'RUNNING',
-]);
+const NON_TERMINAL_INDEX_STATUSES = new Set(['PENDING', 'RUNNING']);
 
 const DOCUMENT_STATUS_CLASS: Record<string, string> = {
   COMPLETE: 'bg-accent-soft text-accent-ink border-accent-soft',
@@ -90,6 +86,9 @@ const formatFileSize = (size?: number | null) => {
   return `${(kb / 1000).toFixed(2)} MB`;
 };
 
+const formatStatus = (status: string) =>
+  status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+
 const DocumentStatusBadge = ({ status }: { status?: string | null }) => {
   if (!status) return null;
   return (
@@ -101,7 +100,7 @@ const DocumentStatusBadge = ({ status }: { status?: string | null }) => {
           'bg-secondary text-muted-foreground border-transparent',
       )}
     >
-      {_.capitalize(status)}
+      {formatStatus(status)}
     </Badge>
   );
 };
@@ -314,7 +313,8 @@ export function DocumentsTable({
           const extension =
             row.original.name?.split('.').pop()?.toLowerCase() ||
             ('unknow' as keyof typeof defaultStyles);
-          const iconProps = _.get(defaultStyles, extension);
+          const iconProps =
+            defaultStyles[extension as keyof typeof defaultStyles];
           const icon = (
             <FileIcon
               color="var(--primary)"

--- a/web/src/app/workspace/collections/collection-form.tsx
+++ b/web/src/app/workspace/collections/collection-form.tsx
@@ -47,7 +47,6 @@ import { getScenarioModels } from '@/features/providers/client-api';
 import type { ModelSpec } from '@/features/providers/types';
 import { cn, objectKeys } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
-import _ from 'lodash';
 import { ArrowLeft, Database, Sparkles } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import Link from 'next/link';
@@ -60,6 +59,11 @@ import { isVisibleCollectionConfigKey } from './feature-visibility';
 
 const modelSelectLabel = (m: ModelSpec) =>
   (m.display_name?.trim() || m.model_id || '').trim();
+
+const hasStringValue = (value: string | null | undefined) =>
+  value !== null && value !== undefined && value !== '';
+
+const hasModels = (group: ProviderModel) => (group.models?.length ?? 0) > 0;
 
 const modelIdInGroups = (
   groups: ProviderModel[] | undefined,
@@ -108,7 +112,7 @@ const collectionSchema = z
   .refine(
     ({ config }) => {
       if (config.enable_vector) {
-        return !_.isEmpty(config.embedding?.model_id);
+        return hasStringValue(config.embedding?.model_id);
       }
       return true;
     },
@@ -119,7 +123,7 @@ const collectionSchema = z
   .refine(
     ({ config }) => {
       if (config.enable_knowledge_graph) {
-        return !_.isEmpty(config.completion?.model_id);
+        return hasStringValue(config.completion?.model_id);
       }
       return true;
     },
@@ -402,7 +406,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
   });
   useEffect(() => {
     if (action === 'edit') return;
-    if (_.isEmpty(completionModels)) return;
+    if (!completionModels?.length) return;
 
     let defaultModel: ModelSpec | undefined;
     let currentModel: ModelSpec | undefined;
@@ -437,7 +441,7 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
   });
   useEffect(() => {
     if (action === 'edit') return;
-    if (_.isEmpty(embeddingModels)) return;
+    if (!embeddingModels?.length) return;
 
     let defaultModel: ModelSpec | undefined;
     let currentModel: ModelSpec | undefined;
@@ -671,25 +675,23 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
                             <SelectValue placeholder="Select a model" />
                           </SelectTrigger>
                           <SelectContent>
-                            {embeddingModels
-                              ?.filter((item) => _.size(item.models))
-                              .map((item) => {
-                                return (
-                                  <SelectGroup key={item.name}>
-                                    <SelectLabel>{item.label}</SelectLabel>
-                                    {item.models?.map((model) => {
-                                      return (
-                                        <SelectItem
-                                          key={model.model_id}
-                                          value={model.model_id || ''}
-                                        >
-                                          {modelSelectLabel(model)}
-                                        </SelectItem>
-                                      );
-                                    })}
-                                  </SelectGroup>
-                                );
-                              })}
+                            {embeddingModels?.filter(hasModels).map((item) => {
+                              return (
+                                <SelectGroup key={item.name}>
+                                  <SelectLabel>{item.label}</SelectLabel>
+                                  {item.models?.map((model) => {
+                                    return (
+                                      <SelectItem
+                                        key={model.model_id}
+                                        value={model.model_id || ''}
+                                      >
+                                        {modelSelectLabel(model)}
+                                      </SelectItem>
+                                    );
+                                  })}
+                                </SelectGroup>
+                              );
+                            })}
                             {modelUnavailable && field.value ? (
                               <SelectItem value={field.value} disabled>
                                 {field.value}（不允许当前场景）
@@ -746,25 +748,23 @@ export const CollectionForm = ({ action }: { action: 'add' | 'edit' }) => {
                             <SelectValue placeholder="Select a model" />
                           </SelectTrigger>
                           <SelectContent>
-                            {completionModels
-                              ?.filter((item) => _.size(item.models))
-                              .map((item) => {
-                                return (
-                                  <SelectGroup key={item.name}>
-                                    <SelectLabel>{item.label}</SelectLabel>
-                                    {item.models?.map((model) => {
-                                      return (
-                                        <SelectItem
-                                          key={model.model_id}
-                                          value={model.model_id || ''}
-                                        >
-                                          {modelSelectLabel(model)}
-                                        </SelectItem>
-                                      );
-                                    })}
-                                  </SelectGroup>
-                                );
-                              })}
+                            {completionModels?.filter(hasModels).map((item) => {
+                              return (
+                                <SelectGroup key={item.name}>
+                                  <SelectLabel>{item.label}</SelectLabel>
+                                  {item.models?.map((model) => {
+                                    return (
+                                      <SelectItem
+                                        key={model.model_id}
+                                        value={model.model_id || ''}
+                                      >
+                                        {modelSelectLabel(model)}
+                                      </SelectItem>
+                                    );
+                                  })}
+                                </SelectGroup>
+                              );
+                            })}
                             {modelUnavailable && field.value ? (
                               <SelectItem value={field.value} disabled>
                                 {field.value}（不允许当前场景）

--- a/web/src/app/workspace/collections/collection-list.tsx
+++ b/web/src/app/workspace/collections/collection-list.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/components/ui/card';
 import type { CollectionView } from '@/features/collection/types';
 import { cn } from '@/lib/utils';
-import _ from 'lodash';
 import {
   ArrowUpRight,
   Calendar,
@@ -32,6 +31,15 @@ const statusClasses: Record<string, string> = {
   ACTIVE: 'text-primary',
   INACTIVE: 'text-muted-foreground',
   DELETED: 'text-destructive',
+};
+
+const formatStatusLabel = (status?: string | null) => {
+  const label = (status ?? '')
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return label ? label.charAt(0).toUpperCase() + label.slice(1) : '';
 };
 
 export const CollectionList = ({
@@ -138,9 +146,7 @@ export const CollectionList = ({
             <CollectionCard
               key={collection.id}
               collection={collection}
-              statusLabel={_.upperFirst(
-                _.lowerCase(collection.status ?? undefined),
-              )}
+              statusLabel={formatStatusLabel(collection.status)}
             />
           ))}
         </div>
@@ -194,7 +200,7 @@ const CollectionCard = ({
 
   return (
     <Link href={href} target={isSubscribed ? '_blank' : '_self'}>
-      <Card className="group hover:border-border hover:shadow-md min-h-56 cursor-pointer gap-0 overflow-hidden rounded-xl border-border/70 py-0 transition-all hover:-translate-y-0.5">
+      <Card className="group hover:border-border border-border/70 min-h-56 cursor-pointer gap-0 overflow-hidden rounded-xl py-0 transition-all hover:-translate-y-0.5 hover:shadow-md">
         <CardHeader className="gap-4 px-5 pt-5 pb-4">
           <div className="flex items-start gap-3">
             <div className="bg-accent-soft text-accent-ink flex size-10 shrink-0 items-center justify-center rounded-lg">
@@ -237,9 +243,9 @@ const CollectionCard = ({
             <span className="truncate">
               {collection.updated || collection.created ? (
                 <FormatDate
-                  datetime={new Date(
-                    collection.updated || collection.created || '',
-                  )}
+                  datetime={
+                    new Date(collection.updated || collection.created || '')
+                  }
                 />
               ) : (
                 page_collections('no_date')


### PR DESCRIPTION
## Summary
- lazy-load the admin user quota editor dialog body so zod/react-hook-form/quota update code only loads after the quota action opens
- remove lodash whole-imports from workspace/marketplace document list pages and collection list/form helpers
- keep `documents/upload` untouched so it does not conflict with PR #1900

## Build impact
Based on main `8c31405f`:
- `/admin/users`: 274 kB -> 237 kB (-37 kB)
- `/workspace/collections/[collectionId]/documents`: 289 kB -> 264 kB (-25 kB)
- `/marketplace/collections/[collectionId]/documents`: 270 kB -> 245 kB (-25 kB)
- `/workspace/collections`: 233 kB -> 208 kB (-25 kB)
- `/workspace/collections/[collectionId]/settings`: 264 kB -> 239 kB (-25 kB)
- `/workspace/collections/new`: 257 kB -> 232 kB (-25 kB)

## Validation
- `cd web && yarn type-check --pretty false`
- `cd web && yarn lint --quiet`
- `cd web && yarn build`
- `git diff --check`
