### PR TITLE
test: add provider e2e shape shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ help:
 	@printf "  make test-http-up-compose / test-http-down-compose\n"
 	@printf "  make test-http-smoke-compose / test-http-full-compose\n"
 	@printf "  make test-http-smoke-compose-{lite,qdrant-neo4j,qdrant-nebula}   (per-shape shortcuts)\n"
+	@printf "  make test-http-full-compose-{lite,qdrant-neo4j,qdrant-nebula}    (provider-aware per-shape shortcuts)\n"
 	@printf "  make test-http-up-k8s / test-http-down-k8s\n"
 	@printf "  make test-http-smoke-k8s / test-http-full-k8s\n"
 	@printf "  make benchmark-graph-extraction   Run manual OpenRouter KG extraction benchmark\n\n"
@@ -213,6 +214,7 @@ static-check:
 	test-http-bootstrap test-http-smoke test-http-full \
 	test-http-up-compose test-http-down-compose test-http-smoke-compose test-http-full-compose \
 	test-http-smoke-compose-lite test-http-smoke-compose-qdrant-neo4j test-http-smoke-compose-qdrant-nebula \
+	test-http-full-compose-lite test-http-full-compose-qdrant-neo4j test-http-full-compose-qdrant-nebula \
 	test-http-up-k8s test-http-down-k8s test-http-smoke-k8s test-http-full-k8s
 test-all: test-unit test-integration test-e2e
 
@@ -312,6 +314,15 @@ test-http-smoke-compose-qdrant-neo4j:
 
 test-http-smoke-compose-qdrant-nebula:
 	@SHAPE=qdrant-nebula ./tests/e2e_http/scripts/run_compose_smoke.sh
+
+test-http-full-compose-lite:
+	@SHAPE=lite ./tests/e2e_http/scripts/run_compose_full.sh
+
+test-http-full-compose-qdrant-neo4j:
+	@SHAPE=qdrant-neo4j ./tests/e2e_http/scripts/run_compose_full.sh
+
+test-http-full-compose-qdrant-nebula:
+	@SHAPE=qdrant-nebula ./tests/e2e_http/scripts/run_compose_full.sh
 
 test-http-up-k8s:
 	@./tests/e2e_http/runners/k8s/up.sh

--- a/tests/e2e_http/README.md
+++ b/tests/e2e_http/README.md
@@ -76,6 +76,16 @@ export E2E_OPENROUTER_API_KEY=...
 ./tests/e2e_http/scripts/run_compose_full.sh
 ```
 
+Provider-aware local flow for a named deployment shape:
+
+```bash
+export E2E_ALIBABACLOUD_API_KEY=...
+export E2E_OPENROUTER_API_KEY=...
+make test-http-full-compose-lite
+make test-http-full-compose-qdrant-nebula
+make test-http-full-compose-qdrant-neo4j
+```
+
 Typical local flow against a Kubernetes-backed environment:
 
 ```bash


### PR DESCRIPTION
## What

Add provider-aware per-shape Make targets for the HTTP E2E Compose suite:

- `make test-http-full-compose-lite`
- `make test-http-full-compose-qdrant-nebula`
- `make test-http-full-compose-qdrant-neo4j`

Also document the new local flow in `tests/e2e_http/README.md`.

## Why

CI already runs provider-aware full tests per deployment shape, but local Make shortcuts only covered shape-specific smoke tests. These targets make it easier to reproduce a specific provider matrix failure locally without remembering the exact `SHAPE=...` invocation.

## Validation

- `make -n test-http-full-compose-lite`
- `make -n test-http-full-compose-qdrant-nebula`
- `make -n test-http-full-compose-qdrant-neo4j`
- `git diff --check`
- pre-commit `make lint`
