### PR TITLE
build(web): run frontend standalone with node

### DIFF
--- a/docs/zh-CN/deployment/build-docker-image.md
+++ b/docs/zh-CN/deployment/build-docker-image.md
@@ -20,7 +20,7 @@ ApeRAG 由两个独立镜像组成，`docker-compose.yml` 里分别对应 `api` 
 | 镜像 | 用途 | Dockerfile | 基础镜像 |
 |------|------|-----------|---------|
 | `apecloud/aperag` | FastAPI API 进程 + 独立 indexing-worker 进程 | [`Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/Dockerfile) | `python:3.11.13-slim`（多阶段 + uv） |
-| `apecloud/aperag-frontend` | Next.js standalone 构建产物 + PM2 runtime | [`web/Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/web/Dockerfile) | `node:20.18.0-alpine` |
+| `apecloud/aperag-frontend` | Next.js standalone 构建产物 + Node.js runtime | [`web/Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/web/Dockerfile) | `node:20.18.0-alpine` |
 
 默认镜像仓库是 `apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com`（阿里云张家口）；`docker-compose.yml` 在本机使用时会回退到 Docker Hub（`${REGISTRY:-docker.io}`）。
 
@@ -118,7 +118,7 @@ Entrypoint 是 [`scripts/entrypoint.sh`](https://github.com/apecloud/ApeRAG/blob
 
 ## 前端镜像细节
 
-[`web/Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/web/Dockerfile) 是一个 runtime-only 的镜像：它假设 `web/build/` 已经在宿主机上构建好，直接把它拷进容器，再装 PM2、用 `pm2-runtime start server.js` 启动。
+[`web/Dockerfile`](https://github.com/apecloud/ApeRAG/blob/main/web/Dockerfile) 是一个 runtime-only 的镜像：它假设 `web/build/` 已经在宿主机上构建好，直接把它拷进容器，用 Next.js standalone 产物里的 `server.js` 启动。镜像不再额外安装 PM2，避免 runtime image build 阶段产生不必要的 npm/yarn 网络依赖。
 
 所以完整的前端构建流程是两步：
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,8 +5,6 @@ WORKDIR /app
 
 COPY ./build ./
 
-RUN yarn global add pm2
-
 ENV HOSTNAME="0.0.0.0"
 ENV NODE_ENV=production
 ENV PORT=3000
@@ -15,5 +13,4 @@ EXPOSE 3000
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
-CMD ["pm2-runtime", "start", "server.js"]
-
+CMD ["node", "server.js"]

--- a/web/scripts/build.mjs
+++ b/web/scripts/build.mjs
@@ -25,29 +25,6 @@ lsof -t -i:3000 | xargs kill
 \`\`\`
 
 
-# deploy with pm2
-
-\`\`\`
-yarn global add pm2
-\`\`\`
-
-
-## start
-\`\`\`
-pm2 start /path/to/server.js
-\`\`\`
-
-## logs
-\`\`\`
-pm2 list
-pm2 logs
-\`\`\`
-
-## stop
-\`\`\`
-pm2 stop server
-\`\`\`
-
 `;
 
 /**


### PR DESCRIPTION
## Summary
- remove the runtime image `yarn global add pm2` step from `web/Dockerfile`
- run the Next.js standalone server directly with `node server.js`
- update the generated standalone readme template and deployment docs to match the Node runtime

## Why
The frontend Dockerfile is runtime-only: `web/build/` is prepared before image build. Installing PM2 during the image build adds an avoidable package-manager/network dependency and extra runtime content for a single-process container. Next.js standalone output is designed to run with `node server.js`.

## Validation
- `docker build -t aperag-frontend-node-runtime-test ./web`
- `docker run -d --name aperag-frontend-node-runtime-test -p 3011:3000 -e API_SERVER_ENDPOINT=http://127.0.0.1:8000 aperag-frontend-node-runtime-test`
- `curl http://127.0.0.1:3011/` -> 200
- `docker logs --tail 40 aperag-frontend-node-runtime-test` showed Next.js ready on `0.0.0.0:3000`
- `docker rm -f aperag-frontend-node-runtime-test`
- `cd web && node --check scripts/build.mjs`
- `git diff --check`
