### PR TITLE
ci: bound core workflow runtime

### DIFF
--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -11,9 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -23,12 +23,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ───────────────────────────────────────────────────────
   # Job 1: Graph store compatibility (PG always, Neo4j/Nebula opt-in)
   # ───────────────────────────────────────────────────────
   graph-compat:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -172,6 +176,7 @@ jobs:
   # ───────────────────────────────────────────────────────
   vector-compat:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- add explicit read-only token permissions to lint/unit and backend compat workflows
- add conservative job timeouts to lint/unit and backend compat jobs so stuck runners fail predictably

## Validation
- ruby YAML parse for touched workflows
- git diff --check
- pre-commit make lint

Part of SRE task #15 infrastructure cleanup.