### PR TITLE
docs(task-32): refresh MCP docs for split search

### DIFF
--- a/docs/zh-CN/integration/dify.md
+++ b/docs/zh-CN/integration/dify.md
@@ -16,7 +16,7 @@ ApeRAG 是一款具备多模态索引、AI 智能体、MCP 支持及可扩展 K8
 
 ## 集成原理
 
-ApeRAG 侧没有 Dify 专属的适配代码，整条链路完全基于标准的 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)：Dify 的 Agent 节点支持把任意 MCP Server 挂成工具集，ApeRAG 启动时就内置了一个 MCP Server（路径 `/mcp/`，与 REST API 共生于 8000 端口）。Dify Agent 通过 HTTP + `Authorization: Bearer <ApeRAG API Key>` 直接调用 ApeRAG 的 5 个工具：知识库检索、聊天文件检索、网页搜索、网页抓取、知识库列表。
+ApeRAG 侧没有 Dify 专属的适配代码，整条链路完全基于标准的 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)：Dify 的 Agent 节点支持把任意 MCP Server 挂成工具集，ApeRAG 启动时就内置了一个 MCP Server（路径 `/mcp/`，与 REST API 共生于 8000 端口）。Dify Agent 通过 HTTP + `Authorization: Bearer <ApeRAG API Key>` 直接调用 ApeRAG 的集合/文档元数据、向量/全文/图谱检索、Graph 实体/关系查询、文档读取、网页搜索与网页抓取工具。
 
 如果想先了解 ApeRAG MCP 的架构细节与客户端配置通用说明，参见 [MCP 集成指南](./mcp.md)；每个工具的完整参数与返回 schema 见 [MCP API 参考](./mcp-api.md)。
 
@@ -70,7 +70,7 @@ ApeRAG 侧没有 Dify 专属的适配代码，整条链路完全基于标准的 
 
 ### 2.3 配置成功
 
-Dify 会自动拉取 ApeRAG MCP Server 暴露的工具清单。配置成功后应能看到 `list_collections`、`search_collection`、`search_chat_files`、`web_search`、`web_read` 五个工具。
+Dify 会自动拉取 ApeRAG MCP Server 暴露的工具清单。配置成功后应能看到集合/文档、检索、Graph、文档读取和网页相关工具，例如 `list_collections`、`vector_search`、`fulltext_search`、`graph_search`、`query_graph_entities`、`read_document_chunk`、`web_search`、`web_read`。
 
 <div align="center">
   <img src="/images/zh-CN/dify/step2-mcp-success.png" alt="MCP 配置成功" width="800" />
@@ -108,7 +108,7 @@ Dify 会自动拉取 ApeRAG MCP Server 暴露的工具清单。配置成功后�
 
 ### Prompt 参考
 
-下列 Prompt 针对 ApeRAG 现有的 5 个 MCP 工具（`list_collections` / `search_collection` / `search_chat_files` / `web_search` / `web_read`）编写，可直接贴到 Dify Agent 的系统提示词位置：
+下列 Prompt 针对 ApeRAG 当前 MCP 工具集编写，可直接贴到 Dify Agent 的系统提示词位置：
 
 ```markdown
 # ApeRAG 智能助手
@@ -132,18 +132,34 @@ Dify 会自动拉取 ApeRAG MCP Server 暴露的工具清单。配置成功后�
 4. **清晰归属**：始终标注来源
 
 ### 搜索执行
-- **知识库搜索**：默认同时开启向量、全文、图谱、摘要、视觉五种检索方式
+- **知识库搜索**：按问题选择 `vector_search` / `fulltext_search` / `graph_search`，必要时多路调用后综合判断
+- **Graph 推理**：需要实体和关系时先用 `query_graph_entities` 找实体，再用 `expand_graph_subgraph` 扩展关系；拿到 `evidence_refs` 后用 `read_document_chunk` 读取原文证据
 - **结果处理逻辑**：
   1. 执行搜索
-  2. 如结果包含实体 / 关系数据（`recall_type == "graph_search"`），在回复正文中显式说明涉及的实体与关系
-  3. 忽略不相关结果
+  2. 读取最相关 chunk 或章节作为证据
+  3. 如使用 Graph 工具，在回复正文中说明涉及的实体与关系
+  4. 忽略不相关结果
 
 ## 可用工具
 
 ### 知识管理
 - `list_collections()`：发现可用知识源
-- `search_collection(collection_id, query, ...)`：**[主要工具]** 在持久化知识库中进行混合搜索
-- `search_chat_files(chat_id, query, ...)`：**[仅限聊天]** 仅搜索用户在本次聊天会话中临时上传的文件
+- `list_documents(collection_id, ...)`：查看知识库里的文档
+- `get_document_metadata(collection_id, document_id)`：确认文档索引状态和 chunk 数
+
+### 检索与 Graph
+- `vector_search(collection_id, query, ...)`：语义相似度检索，返回可读取的 chunk evidence
+- `fulltext_search(collection_id, query, ...)`：关键词 / 短语检索
+- `graph_search(collection_id, query, ...)`：图谱相关 chunk 检索
+- `query_graph_entities(collection_id, query, ...)`：查找相关实体
+- `expand_graph_subgraph(collection_id, entity_names, ...)`：扩展实体关系
+- `get_entity_detail(collection_id, name)`：读取单实体详情
+
+### 文档读取
+- `read_document_chunk(collection_id, document_id, chunk_id)`：读取 chunk 原文
+- `read_document_outline(collection_id, document_id)`：读取标题树
+- `read_document_section(collection_id, document_id, ...)`：读取章节
+- `read_document(collection_id, document_id, ...)`：读取整篇解析 Markdown
 
 ### 网络智能
 - `web_search(query, ...)`：多引擎网络搜索
@@ -178,6 +194,6 @@ Dify 会自动拉取 ApeRAG MCP Server 暴露的工具清单。配置成功后�
 ## 相关链接
 
 - [MCP 集成指南](./mcp.md) — ApeRAG MCP Server 架构、认证和通用客户端接入
-- [MCP API 参考](./mcp-api.md) — 5 个工具的完整参数/返回 schema
+- [MCP API 参考](./mcp-api.md) — MCP 工具的完整参数/返回 schema
 - [OpenAI 兼容 API](./openai-compat.md) — 另一条可用于 Dify 自定义模型接入的路径
 - **GitHub**：[apecloud/ApeRAG](https://github.com/apecloud/ApeRAG)

--- a/docs/zh-CN/integration/mcp-api.md
+++ b/docs/zh-CN/integration/mcp-api.md
@@ -5,7 +5,7 @@ description: Model Context Protocol API 文档
 
 # MCP API
 
-ApeRAG 通过 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 对外提供标准化的工具接口，让 AI 助手（Claude Desktop、Cursor、Dify 等）能够直接访问你的知识库。
+ApeRAG 通过 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 对外提供标准化工具接口，让 AI 助手（Claude Desktop、Cursor、Dify 等）能够直接访问知识库、Graph RAG、文档读取和网页工具。
 
 ## 快速开始
 
@@ -33,283 +33,348 @@ ApeRAG 通过 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 1. **HTTP Authorization 头**（推荐）：`Authorization: Bearer your-api-key`
 2. **环境变量**（备用）：`APERAG_API_KEY=your-api-key`
 
-> **获取 API Key**：登录 ApeRAG 后，在设置页面创建或复制你的 API Key
+> **获取 API Key**：登录 ApeRAG 后，在设置页面创建或复制你的 API Key。
 
-## 可用工具
+## 工具总览
 
-### 1. list_collections
+| 分类 | 工具 | 粒度 | 主要用途 |
+|------|------|------|----------|
+| 集合元数据 | `list_collections` | collection | 列出可访问知识库 |
+| 集合元数据 | `get_collection_metadata` | collection | 查看知识库索引模式、文档数等 |
+| 文档元数据 | `list_documents` | document | 分页列出知识库内文档 |
+| 文档元数据 | `get_document_metadata` | document | 查看单文档索引状态、chunk 数、媒体类型 |
+| 检索 | `vector_search` | chunk | 语义相似度检索 |
+| 检索 | `fulltext_search` | chunk | 关键词 / 短语检索 |
+| 检索 | `graph_search` | chunk | 图谱相关 chunk 证据检索 |
+| Graph | `query_graph_entities` | entity | 根据自然语言查询相关实体 |
+| Graph | `expand_graph_subgraph` | entity/relation | 从实体扩展邻居与关系 |
+| Graph | `get_entity_detail` | entity | 获取单个实体详情 |
+| 文档读取 | `read_document_chunk` | chunk | 按 `document_id + chunk_id` 读取 chunk 原文 |
+| 文档读取 | `read_document` | document | 读取整篇解析 Markdown，可带 byte range |
+| 文档读取 | `read_document_outline` | document/section | 读取文档标题树 |
+| 文档读取 | `read_document_section` | section | 读取指定章节 |
+| 网络 | `web_search` | web | 搜索互联网 |
+| 网络 | `web_read` | web | 读取 URL 正文 |
 
-列出所有可访问的知识库。
+## 组合原则
 
-**参数**：无
+### Chunk-level search
 
-**返回**：
+`vector_search`、`fulltext_search`、`graph_search` 都返回 chunk-level `SearchResult`。返回项的 `metadata` 用于继续读取原文：
+
+```python
+hits = vector_search(collection_id="col_1", query="部署策略", top_k=5)
+top = hits["items"][0]
+
+chunk = read_document_chunk(
+    collection_id=top["metadata"]["collection_id"],
+    document_id=top["metadata"]["document_id"],
+    chunk_id=top["metadata"]["chunk_id"],
+)
+```
+
+- `vector_search`：适合自然语言、同义表达、模糊语义问题。
+- `fulltext_search`：适合专有名词、编号、精确短语。
+- `graph_search`：适合需要图谱语义但最终要拿原文证据的问题。
+
+### Graph element tools
+
+`query_graph_entities`、`expand_graph_subgraph`、`get_entity_detail` 返回 Graph 元素，不等同于 chunk-level search：
+
+- `query_graph_entities`：按语义查找实体，适合先找候选实体。
+- `expand_graph_subgraph`：从实体名扩展邻居和关系，适合关系探索。
+- `get_entity_detail`：已知实体名时获取详情。
+
+task #32 Phase A 后，Graph 元素响应会携带 `evidence_refs`。每个 ref 至少包含：
+
 ```json
 {
-  "items": [
-    {
-      "id": "collection-id",
-      "title": "知识库标题",
-      "description": "知识库描述"
-    }
-  ]
+  "document_id": "doc_abc",
+  "chunk_id": "chunk_001",
+  "parse_version": "optional"
 }
 ```
 
-### 2. search_collection
+这让 Agent 可以直接调用 `read_document_chunk(collection_id, document_id, chunk_id)` 读取证据原文。不要只依赖裸 `chunk_id`：chunk id 不是全局唯一，必须和 `document_id` 一起使用。
 
-在知识库中搜索，支持多种检索方式。
+## 工具详情
 
-**核心参数**：
+### list_collections
+
+列出当前 API Key 可访问的知识库。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `cursor` | string | null | 分页游标 |
+| `limit` | int | 50 | 每页数量 |
+| `sort_by` | string | `created_at` | 排序字段：`created_at` / `updated_at` / `title` |
+| `sort_order` | string | `desc` | `asc` / `desc` |
+| `title_filter` | string | null | 标题过滤 |
+
+### get_collection_metadata
+
+读取单个知识库元数据，包括可用索引模式和文档数。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+
+### list_documents
+
+分页列出知识库内文档。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `cursor` | string | null | 分页游标 |
+| `limit` | int | 50 | 每页数量 |
+| `sort_by` | string | `created_at` | `created_at` / `title` / `size_bytes` |
+| `sort_order` | string | `desc` | `asc` / `desc` |
+| `title_filter` | string | null | 标题过滤 |
+| `type_filter` | list[string] | null | MIME type 过滤 |
+| `indexed_only` | bool | false | 只返回已完成索引的文档 |
+
+### get_document_metadata
+
+读取单个文档元数据，包括索引状态、chunk 数、媒体类型。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `document_id` | string | 必需 | 文档 ID |
+
+### vector_search
+
+向量语义检索，返回 chunk-level `SearchResult`。
+
+**参数**
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `collection_id` | string | 必需 | 知识库 ID |
 | `query` | string | 必需 | 搜索问题 |
-| `use_vector_index` | bool | true | 向量检索（语义搜索） |
-| `use_fulltext_index` | bool | true | 全文检索（关键词匹配） |
-| `use_graph_index` | bool | true | 图谱检索（关系查询） |
-| `use_summary_index` | bool | true | 摘要检索 |
-| `use_vision_index` | bool | true | 视觉检索（图片搜索） |
-| `topk` | int | 5 | 每种方式返回的结果数 |
+| `top_k` | int | 5 | 最大返回数量 |
+| `similarity_threshold` | float | null | 最小相似度，null 表示使用知识库默认阈值 |
 
-**返回格式**：
-```json
-{
-  "query": "你的问题",
-  "items": [
-    {
-      "rank": 1,
-      "score": 0.95,
-      "content": "相关内容片段",
-      "source": "文档名称",
-      "recall_type": "vector_search|graph_search|fulltext_search|summary_search",
-      "metadata": {
-        "page_idx": 0,
-        "document_id": "doc-id",
-        "collection_id": "col-id",
-        "indexer": "text|vision"
-      }
-    }
-  ]
-}
-```
+### fulltext_search
 
-**图片处理**：
+全文关键词检索，返回 chunk-level `SearchResult`。
 
-如果 `metadata.indexer == "vision"`，表示这是一张图片：
-- `content` 为空：通过多模态向量检索
-- `content` 不为空：包含图片的文字描述
-
-显示图片的 URL 格式：
-```python
-m = item.metadata
-asset_url = f"asset://{m['asset_id']}?document_id={m['document_id']}&collection_id={m['collection_id']}&mime_type={m['mimetype']}"
-```
-
-**使用示例**：
-
-```python
-# 默认搜索（推荐）- 启用所有检索方式
-results = search_collection(
-    collection_id="abc123",
-    query="如何部署应用？"
-)
-
-# 仅向量+图谱检索
-results = search_collection(
-    collection_id="abc123",
-    query="部署策略",
-    use_vector_index=True,
-    use_fulltext_index=False,
-    use_graph_index=True,
-    use_summary_index=False,
-    topk=10
-)
-```
-
-### 3. search_chat_files
-
-在聊天会话的临时文件中搜索。
-
-**何时使用**：
-- ✅ 用户在当前对话中上传了文件
-- ✅ 需要分析聊天中的临时文档
-- ❌ 不要用于搜索持久化的知识库（应该用 `search_collection`）
-
-**参数**：
+**参数**
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `chat_id` | string | 必需 | 聊天 ID |
+| `collection_id` | string | 必需 | 知识库 ID |
 | `query` | string | 必需 | 搜索问题 |
-| `use_vector_index` | bool | true | 向量检索 |
-| `use_fulltext_index` | bool | true | 全文检索 |
-| `topk` | int | 5 | 返回结果数 |
+| `top_k` | int | 5 | 最大返回数量 |
+| `keywords` | list[string] | null | 显式关键词；为空时由后端从 query 提取 |
 
-**返回格式**：与 `search_collection` 相同
+### graph_search
 
-### 4. web_search
+图谱相关 chunk 检索，返回 chunk-level `SearchResult`。它适合直接获取原文证据，不适合作为实体/关系浏览工具。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `query` | string | 必需 | 搜索问题 |
+| `top_k` | int | 5 | 最大返回数量 |
+
+### query_graph_entities
+
+按自然语言在 Graph 实体上做语义查询，返回实体列表。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `query` | string | 必需 | 实体查询 |
+| `top_k` | int | 10 | 最大返回实体数 |
+
+### expand_graph_subgraph
+
+从一个或多个实体名扩展邻居和关系。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `entity_names` | list[string] | 必需 | 起点实体名 |
+| `hops` | int | 1 | 扩展跳数，后端会限制最大值和结果量 |
+
+### get_entity_detail
+
+按实体名读取单个 Graph 实体详情。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `name` | string | 必需 | 实体规范名 |
+
+### read_document_chunk
+
+按 stable chunk id 读取原文 chunk。调用时必须同时提供 `document_id`，因为 `chunk_id` 不保证全局唯一。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `document_id` | string | 必需 | 文档 ID |
+| `chunk_id` | string | 必需 | Chunk ID |
+
+### read_document
+
+读取整篇解析后的 Markdown。可选 byte range 只是 best-effort，不保证跨 parse version 稳定。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `document_id` | string | 必需 | 文档 ID |
+| `range_start` | int | null | 起始 byte offset |
+| `range_end` | int | null | 结束 byte offset |
+
+### read_document_outline
+
+读取文档标题树，用于章节导航。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `document_id` | string | 必需 | 文档 ID |
+
+### read_document_section
+
+按 section path 或 heading anchor 读取章节。
+
+**参数**
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `collection_id` | string | 必需 | 知识库 ID |
+| `document_id` | string | 必需 | 文档 ID |
+| `section_path` | string | null | 章节路径，优先使用 |
+| `heading_anchor` | string | null | 标题 anchor |
+
+### web_search
 
 搜索互联网内容。
 
-**参数**：
+**参数**
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `query` | string | "" | 搜索关键词 |
-| `max_results` | int | 5 | 返回结果数 |
-| `source` | string | "" | 指定域名（如 `vercel.com`） |
+| `query` | string | 必需 | 搜索关键词 |
+| `top_k` | int | 5 | 返回结果数 |
+| `source` | string | null | 指定域名或 URL |
 | `timeout` | int | 30 | 超时时间（秒） |
-| `locale` | string | "en-US" | 语言地区 |
+| `locale` | string | `en-US` | 语言地区 |
 
-**使用模式**：
-
-```python
-# 常规搜索
-web_search(query="ApeRAG 2025")
-
-# 指定网站搜索
-web_search(query="部署文档", source="vercel.com")
-
-```
-
-### 5. web_read
+### web_read
 
 读取网页内容。
 
-**参数**：
+**参数**
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `url_list` | list[str] | 必需 | URL 列表 |
+| `url_list` | list[string] | 必需 | URL 列表 |
 | `timeout` | int | 30 | 超时时间（秒） |
+| `locale` | string | `en-US` | 浏览器语言地区 |
 | `max_concurrent` | int | 5 | 最大并发数 |
 
-**返回**：
-```json
-{
-  "results": [
-    {
-      "status": "success",
-      "url": "https://example.com",
-      "title": "页面标题",
-      "content": "提取的文本内容",
-      "word_count": 1234
-    }
-  ]
-}
-```
+## 实战链路
 
-**示例**：
+### 从 Graph 实体回到原文证据
+
 ```python
-# 读取单个页面
-web_read(url_list=["https://example.com/article"])
+# 1. 找到相关实体
+entities = query_graph_entities(
+    collection_id="col_1",
+    query="哪些服务和 Kubernetes 部署有关？",
+    top_k=5,
+)
 
-# 批量读取
-web_read(
-    url_list=["https://example.com/page1", "https://example.com/page2"],
-    max_concurrent=2
+# 2. 扩展实体关系
+subgraph = expand_graph_subgraph(
+    collection_id="col_1",
+    entity_names=[entities["entities"][0]["name"]],
+    hops=1,
+)
+
+# 3. 读取实体或关系的原文证据
+ref = entities["entities"][0]["evidence_refs"][0]
+chunk = read_document_chunk(
+    collection_id="col_1",
+    document_id=ref["document_id"],
+    chunk_id=ref["chunk_id"],
 )
 ```
 
-## 实战示例
-
-### 示例 1：知识库问答
+### 组合多种检索方式
 
 ```python
-# 1. 列出所有知识库
-collections = list_collections()
-
-# 2. 选择一个知识库
-collection_id = collections.items[0].id
-
-# 3. 搜索（默认启用所有检索方式）
-results = search_collection(
-    collection_id=collection_id,
-    query="如何优化性能？"
-)
-
-# 4. 处理结果
-for item in results.items:
-    print(f"[{item.recall_type}] {item.content}")
-    print(f"来源: {item.source}, 得分: {item.score}\n")
+vector_hits = vector_search(collection_id="col_1", query="部署策略")
+keyword_hits = fulltext_search(collection_id="col_1", query="kubelet readiness")
+graph_hits = graph_search(collection_id="col_1", query="API 和 indexing worker 的关系")
 ```
 
-### 示例 2：图谱可视化
-
-```python
-# 搜索并获取实体关系数据
-results = search_collection(
-    collection_id="abc123",
-    query="刘备和诸葛亮的关系",
-    use_graph_index=True  # 确保启用图谱检索
-)
-
-# 检查是否包含图谱数据
-if results.graph_search and results.graph_search.entities:
-    print("实体:", results.graph_search.entities)
-    print("关系:", results.graph_search.relationships)
-    # 可以用这些数据生成知识图谱可视化
-```
-
-### 示例 3：混合搜索（知识库 + 互联网）
-
-```python
-# 1. 搜索互联网
-web_results = web_search(query="最新 AI 发展", max_results=3)
-urls = [r.url for r in web_results.results]
-
-# 2. 读取网页内容
-web_content = web_read(url_list=urls)
-
-# 3. 搜索内部知识库
-kb_results = search_collection(
-    collection_id="ai-knowledge",
-    query="AI 发展趋势"
-)
-
-# 4. 综合分析
-print("=== 互联网资讯 ===")
-for r in web_results.results:
-    print(f"{r.title}: {r.url}")
-
-print("\n=== 内部知识 ===")
-for item in kb_results.items:
-    print(f"{item.content[:100]}...")
-```
+Agent 可以同时看三类结果：vector 覆盖语义相近内容，fulltext 覆盖精确词，graph_search 覆盖图谱相关证据。ApeRAG 不再提供 rerank 参数；调用方应根据各工具返回的 `score`、`recall_type` 和证据内容自行组合。
 
 ## 注意事项
 
 ### 性能优化
 
-1. **合理设置 topk**：
-   - 太大会增加 LLM 上下文消耗
-   - 太小可能遗漏重要信息
+1. **合理设置 top_k**：
+   - 太大会增加上下文消耗
+   - 太小可能遗漏重要证据
    - 推荐：5-10
 
-2. **选择性启用检索**：
-   - 不是所有查询都需要全文检索
-   - 全文检索可能返回大量文本
-   - 根据问题类型选择合适的检索方式
+2. **先检索，再精读**：
+   - 先用 `vector_search` / `fulltext_search` / `graph_search` 找 chunk
+   - 再用 `read_document_chunk` 或 `read_document_section` 读取原文
+   - 只有长上下文模型或人工检查全文时才用 `read_document`
 
-3. **超时设置**：
-   - 图谱检索可能较慢（默认 120 秒）
+3. **Graph 工具按粒度选择**：
+   - 要原文证据：用 `graph_search`
+   - 要实体和关系：用 `query_graph_entities` + `expand_graph_subgraph`
+   - 已知实体名：用 `get_entity_detail`
+
+4. **超时设置**：
+   - 图谱检索和网页读取可能较慢
    - 网络搜索建议 30-60 秒
    - 批量 URL 读取建议 60 秒以上
 
 ### 常见问题
 
-**Q: 搜索没有结果？**
+**Q：搜索没有结果？**
 - 检查知识库 ID 是否正确
 - 确认知识库已完成索引构建
-- 尝试不同的检索方式组合
+- 换一种检索方式交叉验证，例如 vector 无结果时尝试 fulltext 或 graph
 
-**Q: 图谱数据为空？**
-- 确认知识库启用了 Graph 索引
-- 某些简单文档可能不包含明显的实体关系
+**Q：Graph 实体结果如何读取原文？**
+- 使用返回的 `evidence_refs[*].document_id` 和 `evidence_refs[*].chunk_id`
+- 调用 `read_document_chunk(collection_id, document_id, chunk_id)`
+- 不要只保存 `chunk_id`，它不是全局唯一
 
-**Q: 图片显示不了？**
+**Q：图片显示不了？**
 - 检查 `metadata.indexer == "vision"`
 - 使用 `asset://` 协议构建 URL
 - 确保包含所有必需参数（asset_id、document_id、collection_id）
@@ -319,8 +384,12 @@ for item in kb_results.items:
 | 工具 | 用途 | 适用场景 |
 |------|------|---------|
 | `list_collections` | 列出知识库 | 查看有哪些可用资源 |
-| `search_collection` | 搜索知识库 | 主要搜索工具，用于持久化知识 |
-| `search_chat_files` | 搜索聊天文件 | 分析用户在对话中上传的临时文件 |
+| `vector_search` | 语义检索 | 模糊自然语言问题 |
+| `fulltext_search` | 关键词检索 | 精确词、编号、短语 |
+| `graph_search` | 图谱相关 chunk 检索 | 需要原文证据的 Graph RAG |
+| `query_graph_entities` | 查询实体 | 找候选实体 |
+| `expand_graph_subgraph` | 扩展关系 | 关系探索 |
+| `read_document_chunk` | 读取 chunk | 读取证据原文 |
 | `web_search` | 搜索互联网 | 获取实时信息或外部资料 |
 | `web_read` | 读取网页 | 提取网页完整内容 |
 

--- a/docs/zh-CN/integration/mcp.md
+++ b/docs/zh-CN/integration/mcp.md
@@ -1,19 +1,19 @@
 ---
 title: MCP 集成指南
-description: ApeRAG 内置 MCP Server，用于让 Claude Desktop、Cursor、Dify 等 AI 客户端直接调用知识库检索与网页抓取能力
+description: ApeRAG 内置 MCP Server，用于让 Claude Desktop、Cursor、Dify 等 AI 客户端直接调用知识库、Graph RAG、文档读取与网页工具
 position: 1
 ---
 
 # MCP 集成指南
 
-ApeRAG 内置了一个 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) Server，与主 API 进程共生，不需要额外部署。任何支持 MCP 协议的客户端（Claude Desktop、Cursor、Dify、Pydantic AI Agent 等）都可以通过 HTTP 直接调用 ApeRAG 的 5 个工具：知识库检索、聊天临时文件检索、网页搜索、网页内容抓取、知识库列表。
+ApeRAG 内置了一个 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) Server，与主 API 进程共生，不需要额外部署。任何支持 MCP 协议的客户端（Claude Desktop、Cursor、Dify、Pydantic AI Agent 等）都可以通过 HTTP 直接调用 ApeRAG 的工具：集合/文档元数据、向量/全文/图谱检索、Graph 实体/关系查询、文档读取、网页搜索与网页抓取。
 
 本文只描述「怎么接入 ApeRAG MCP」和「底层是怎么跑起来的」。每个工具的完整参数、返回 schema 和调优建议，见 [MCP API 参考](./mcp-api.md)。
 
 ## 架构一览
 
 - **进程模型**：MCP Server 是 FastAPI 主进程的子挂载，路径为 `/mcp/`；它通过 [FastMCP](https://github.com/jlowin/fastmcp) 框架实现，运行在 stateless HTTP 模式（与 SSE 兼容），复用同一个 `uvicorn` 进程、同一份 8000 端口。
-- **业务边界**：MCP Server 自己不持有数据层，所有工具都是通过 `httpx` 回调 ApeRAG 自身的 `/api/v1/...` 和 `/api/v2/...` 路由，最终走到 `retrieval` / `knowledge_base` / `web_access` 等 domain；这样客户端走 MCP 和走 REST API 看到的语义一致。
+- **业务边界**：MCP Server 自己不持有数据层，所有工具都是通过 `httpx` 回调 ApeRAG 自身的 `/api/v1/...` 和 `/api/v2/...` 路由，或通过租户校验后的 domain service 读取数据；这样客户端走 MCP 和走 REST API 看到的语义一致。
 - **共享基础设施**：`aperag/mcp/` 在后端模块化划分里属于 "shared infrastructure"，不是独立 domain。详见 [`docs/modularization/architecture.md`](../../modularization/architecture.md) 第 F10 条「跨域共享基础设施」相关条目。
 - **内部复用**：ApeRAG 的 Agent Runtime V3 自身也会把同一 MCP Server 当作 toolset 注入到 Agent Turn 里，启动时通过环境变量 `APERAG_MCP_URL`（默认 `http://localhost:8000/mcp/`）引用。
 
@@ -61,7 +61,7 @@ MCP Server 有两条认证通道，按优先级读取：
 }
 ```
 
-远程部署时把 `http://localhost:8000/mcp/` 替换成你的实际地址（`https://<你的域名>/mcp/`）。保存后重启 Claude Desktop 即可在对话中看到 `list_collections`、`search_collection` 等工具。
+远程部署时把 `http://localhost:8000/mcp/` 替换成你的实际地址（`https://<你的域名>/mcp/`）。保存后重启 Claude Desktop 即可在对话中看到 ApeRAG 暴露的集合、检索、Graph、文档读取和网页工具。
 
 ### Cursor
 
@@ -79,20 +79,39 @@ Dify 的工作流 Agent 节点支持 "MCP Server" 工具类型。配置方法详
 
 完整参数与返回 schema 见 [MCP API 参考](./mcp-api.md)。概览如下：
 
-| 工具 | 作用 | 典型场景 |
-|------|------|---------|
-| `list_collections` | 列出当前 API Key 可访问的知识库 | 让 Agent 在多个知识库之间自动选择 |
-| `search_collection` | 在指定知识库中做混合检索（向量 / 全文 / 图谱 / 摘要 / 视觉） | 主流 RAG 问答 |
-| `search_chat_files` | 在一次对话中临时上传的文件里检索 | 即时分析用户上传的简历、论文等 |
-| `web_search` | 互联网搜索（JINA / DuckDuckGo） | 补充时效性信息 |
-| `web_read` | 抓取给定 URL 列表并返回正文 | 读取引用链接的原文 |
+| 工具 | 粒度 | 作用 | 典型场景 |
+|------|------|------|---------|
+| `list_collections` | collection | 列出当前 API Key 可访问的知识库 | 让 Agent 在多个知识库之间自动选择 |
+| `get_collection_metadata` | collection | 读取单个知识库的索引模式、文档数等元数据 | 判断是否启用了 vector / fulltext / graph |
+| `list_documents` | document | 分页列出知识库文档 | 让 Agent 先盘点文档，再决定读取或检索 |
+| `get_document_metadata` | document | 读取单个文档的索引状态、chunk 数、媒体类型 | 确认文档是否已可检索 |
+| `vector_search` | chunk | 向量语义检索，返回可读取的 chunk evidence | 模糊语义问题、自然语言问答 |
+| `fulltext_search` | chunk | 全文/关键词检索，返回可读取的 chunk evidence | 专有名词、编号、精确短语 |
+| `graph_search` | chunk | 图谱相关 chunk 检索，返回可读取的 chunk evidence | 需要实体/关系语义但最终要原文证据 |
+| `query_graph_entities` | entity | 按自然语言查找相关 Graph 实体 | 先找候选实体，再扩展关系 |
+| `expand_graph_subgraph` | entity/relation | 从实体名扩展邻居和关系 | 做 Graph reasoning 或关系探索 |
+| `get_entity_detail` | entity | 读取单个实体详情 | 已知实体名时查类型、描述和证据引用 |
+| `read_document_chunk` | chunk | 按 `document_id + chunk_id` 读取 chunk 原文 | 读取 search / Graph evidence 的原文 |
+| `read_document` | document | 读取整篇解析后的 Markdown，可带 byte range | 长上下文模型或人工检查全文 |
+| `read_document_outline` | document/section | 读取文档标题树 | 先导航，再选 section |
+| `read_document_section` | section | 按 section path 或 heading anchor 读取章节 | 精读某一章节 |
+| `web_search` | web | 互联网搜索（JINA / DuckDuckGo） | 补充时效性信息 |
+| `web_read` | web | 抓取给定 URL 列表并返回正文 | 读取引用链接的原文 |
+
+## 检索与读取的组合关系
+
+- `vector_search`、`fulltext_search`、`graph_search` 都是 **chunk-level search**：返回的 `items[*].metadata` 应包含 `collection_id`、`document_id`、`chunk_id` 等证据定位信息。拿到命中后，继续调用 `read_document_chunk(collection_id, document_id, chunk_id)` 读取原文。
+- `query_graph_entities`、`expand_graph_subgraph`、`get_entity_detail` 是 **Graph element-level tools**：返回实体 / 关系，而不是直接返回原文 chunk。task #32 Phase A 会让这些响应携带 `evidence_refs`，每个 ref 包含 `document_id`、`chunk_id` 和可选 `parse_version`，这样 Agent 可以直接跳到 `read_document_chunk`。
+- `search_graph` 与 `query_graph_entities` 不等价：前者服务「我要相关原文证据」，后者服务「我要理解哪些实体/关系相关」。复杂问题通常先用 `query_graph_entities` 找实体，再用 `expand_graph_subgraph` 看关系，最后用 `evidence_refs` 或 `graph_search` 跳回 chunk 证据。
+- `list_documents` / `get_document_metadata` 用于盘点和确认索引状态；`read_document_outline` / `read_document_section` 用于按结构导航；`read_document` 适合长上下文模型读取全文。
+- rerank 已从 MCP 接口面删除。各索引工具保留自己的排序语义：vector 用相似度，fulltext 用关键词相关性，graph 用图谱证据。
 
 附带一项 MCP Resource `aperag://usage-guide` 提供给客户端作为 Agent 使用的提示词素材；以及一项 MCP Prompt `search_assistant`，供客户端复用。
 
 ## 常见问题
 
 **Q：MCP 可以独立部署吗？**
-不行。MCP Server 与 ApeRAG 主进程绑定在同一个 FastAPI 应用上，所有工具都通过内部回调走 REST API，拆出来反而需要额外的服务发现。
+不行。MCP Server 与 ApeRAG 主进程绑定在同一个 FastAPI 应用上，所有工具都通过内部回调走 REST API 或复用主进程 domain service，拆出来反而需要额外的服务发现。
 
 **Q：启动时没看到 MCP Server 挂上？**
 启动日志里会打印 FastMCP 的初始化信息；如果只看到 uvicorn 启动但没有 FastMCP 输出，检查是否能访问 `http://localhost:8000/mcp/`（正常会返回 MCP 协议响应，不是 404）。
@@ -106,6 +125,6 @@ Dify 的工作流 Agent 节点支持 "MCP Server" 工具类型。配置方法详
 ## 相关链接
 
 - [MCP 协议规范](https://modelcontextprotocol.io/)
-- [MCP API 参考](./mcp-api.md) — 5 个工具的完整参数/返回 schema
+- [MCP API 参考](./mcp-api.md) — 工具的完整参数/返回 schema
 - [Dify 集成](./dify.md) — 在 Dify Agent 里接入 ApeRAG MCP
 - [`docs/modularization/architecture.md`](../../modularization/architecture.md) — 后端模块化边界（MCP 归属「共享基础设施」）


### PR DESCRIPTION
## Summary
- Replace stale 5-tool MCP docs with the current split tool surface across mcp.md, mcp-api.md, and dify.md
- Document chunk-level search vs Graph element tools, including task #32 evidence_refs composite-key flow into read_document_chunk
- Remove stale search_collection/search_chat_files and rerank docs from the user-facing MCP integration pages

## Validation
- rg "5 个|五个|5 tools|five tools|search_collection|search_chat_files" docs/zh-CN/integration/mcp.md docs/zh-CN/integration/mcp-api.md docs/zh-CN/integration/dify.md -> no hits
- git diff --check