### PR TITLE
feat(mcp): expose graph evidence refs

### DIFF
--- a/aperag/domains/knowledge_graph/schemas.py
+++ b/aperag/domains/knowledge_graph/schemas.py
@@ -360,6 +360,20 @@ class SuggestionActionResponse(BaseModel):
 # only) these are read-only shapes — no mutation surface.
 
 
+class GraphEvidenceRef(BaseModel):
+    """Lightweight source chunk reference for graph entity/relation evidence.
+
+    ``read_document_chunk`` is document-scoped, so MCP callers need both
+    ``document_id`` and ``chunk_id`` to follow graph evidence back to source
+    content. ``parse_version`` is carried when available to disambiguate
+    lineage across document re-parses.
+    """
+
+    document_id: str = Field(..., description="Source document ID")
+    chunk_id: str = Field(..., description="Source chunk ID")
+    parse_version: Optional[str] = Field(None, description="Parse version that produced this evidence ref")
+
+
 class GraphSearchEntity(BaseModel):
     """Entity returned by ``/graphs/entities/search`` and
     ``/graphs/entities/{name}``.
@@ -385,6 +399,10 @@ class GraphSearchEntity(BaseModel):
         examples=[3],
         ge=0,
     )
+    evidence_refs: list[GraphEvidenceRef] = Field(
+        default_factory=list,
+        description="Bounded source chunk refs for follow-up read_document_chunk calls",
+    )
 
 
 class GraphRelationView(BaseModel):
@@ -396,6 +414,16 @@ class GraphRelationView(BaseModel):
         ...,
         description="Compacted description if available, otherwise joined description parts",
         examples=["李明华经营墨香居"],
+    )
+    source_chunk_count: int = Field(
+        0,
+        description="Number of source chunks supporting this relationship",
+        examples=[2],
+        ge=0,
+    )
+    evidence_refs: list[GraphEvidenceRef] = Field(
+        default_factory=list,
+        description="Bounded source chunk refs for follow-up read_document_chunk calls",
     )
 
 
@@ -571,6 +599,7 @@ __all__ = [
     "SuggestionActionRequest",
     "SuggestionActionMergeResult",
     "SuggestionActionResponse",
+    "GraphEvidenceRef",
     "GraphSearchEntity",
     "GraphRelationView",
     "GraphEntitiesSearchResponse",

--- a/aperag/domains/knowledge_graph/service.py
+++ b/aperag/domains/knowledge_graph/service.py
@@ -51,10 +51,13 @@ from aperag.domains.knowledge_graph.ports import CollectionRow
 from aperag.domains.knowledge_graph.schemas import GraphLabelsResponse, KnowledgeGraph
 from aperag.exceptions import CollectionNotFoundException
 
+_DEFAULT_GRAPH_EVIDENCE_REF_LIMIT = 10
+
 if TYPE_CHECKING:
     from aperag.domains.knowledge_graph.schemas import (
         GraphEmbeddingMapResponse,
         GraphEntitiesSearchResponse,
+        GraphEvidenceRef,
         GraphEvidenceResponse,
         GraphHybridResponse,
         GraphRelationView,
@@ -1364,6 +1367,35 @@ def _count_source_chunks(members: list[Any]) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _lineage_to_evidence_refs(
+    members: Any, *, limit: int = _DEFAULT_GRAPH_EVIDENCE_REF_LIMIT
+) -> list["GraphEvidenceRef"]:
+    """Project lineage members into bounded read_document_chunk refs."""
+    from aperag.domains.knowledge_graph.schemas import GraphEvidenceRef
+
+    bounded_limit = max(0, int(limit))
+    refs: list[GraphEvidenceRef] = []
+    seen: set[tuple[str, str, str]] = set()
+    for member in sorted(members or (), key=lambda m: (str(m.document_id), str(m.parse_version))):
+        for chunk_id in getattr(member, "chunk_ids", ()) or ():
+            parse_version = getattr(member, "parse_version", None)
+            parse_version_ref = None if parse_version is None else str(parse_version)
+            ref_key = (str(member.document_id), parse_version_ref or "", str(chunk_id))
+            if ref_key in seen:
+                continue
+            seen.add(ref_key)
+            if len(refs) >= bounded_limit:
+                continue
+            refs.append(
+                GraphEvidenceRef(
+                    document_id=str(member.document_id),
+                    chunk_id=str(chunk_id),
+                    parse_version=parse_version_ref,
+                )
+            )
+    return refs
+
+
 def _entity_to_search_view(entity: Any) -> "GraphSearchEntity":
     """Project an :class:`EntityWithLineage` to the public search shape.
 
@@ -1379,18 +1411,16 @@ def _entity_to_search_view(entity: Any) -> "GraphSearchEntity":
         getattr(entity, "compacted_description", None),
         entity.description_parts or (),
     )
-    # ``source_chunk_count`` aggregates chunk ids across all lineage
-    # members (per :class:`LineageMember.chunk_ids`). Description parts
-    # only carry text, not chunk ids — those live on the lineage side.
-    chunk_ids: set[str] = set()
-    for member in entity.source_lineage or ():
-        for cid in getattr(member, "chunk_ids", ()) or ():
-            chunk_ids.add(str(cid))
+    # ``source_chunk_count`` aggregates composite document/parse/chunk
+    # refs across all lineage members (per :class:`LineageMember`).
+    # Description parts only carry text — chunk refs live on lineage.
+    source_lineage = entity.source_lineage or ()
     return GraphSearchEntity(
         name=entity.name,
         entity_type=entity.entity_type or "entity",
         description=description,
-        source_chunk_count=len(chunk_ids),
+        source_chunk_count=_count_source_chunks(list(source_lineage)),
+        evidence_refs=_lineage_to_evidence_refs(source_lineage),
     )
 
 
@@ -1403,10 +1433,13 @@ def _relation_to_view(relation: Any) -> "GraphRelationView":
         getattr(relation, "compacted_description", None),
         relation.description_parts or (),
     )
+    evidence_lineage = relation.evidence_lineage or ()
     return GraphRelationView(
         source=relation.source,
         target=relation.target,
         description=description,
+        source_chunk_count=_count_source_chunks(list(evidence_lineage)),
+        evidence_refs=_lineage_to_evidence_refs(evidence_lineage),
     )
 
 

--- a/aperag/mcp/tools/graph_tools.py
+++ b/aperag/mcp/tools/graph_tools.py
@@ -26,9 +26,11 @@ Wire shape:
 
 * :func:`query_graph_entities` — vector recall over entity names /
   descriptions; returns the top-K matching entities with
-  compacted-or-fallback descriptions.
+  compacted-or-fallback descriptions plus bounded evidence refs for
+  follow-up ``read_document_chunk`` calls.
 * :func:`expand_graph_subgraph` — n-hop expansion from anchor entity
-  names via :meth:`LineageGraphStore.expand_neighbors_n_hops`.
+  names via :meth:`LineageGraphStore.expand_neighbors_n_hops`; both
+  returned entities and relations carry bounded evidence refs.
 * :func:`get_entity_detail` — single entity lookup by canonical name.
 
 Per spec §K.12 invariant #11 (D-3 candidate detection writes only)
@@ -95,7 +97,10 @@ async def query_graph_entities(
 
     Returns:
         ``{"entities": [{"name", "entity_type", "description",
-        "source_chunk_count"}, ...]}``.
+        "source_chunk_count", "evidence_refs"}, ...]}``, where each
+        evidence ref includes ``document_id`` + ``chunk_id`` for direct
+        ``read_document_chunk(collection_id, document_id, chunk_id)``
+        follow-up.
     """
     try:
         api_key = get_api_key()
@@ -138,8 +143,10 @@ async def expand_graph_subgraph(
     Do not use this when:
     - You only need to look up a single entity; use
       ``get_entity_detail``.
-    - You want chunk-level evidence; use ``vector_search`` or
-      ``fulltext_search`` against the original chunks.
+    - You want ranked chunk-level recall; use ``graph_search``,
+      ``vector_search`` or ``fulltext_search`` against the original
+      chunks. This tool returns bounded source refs for returned graph
+      elements, not ranked chunk search results.
 
     Args:
         collection_id: The ID of the collection to traverse.
@@ -151,7 +158,8 @@ async def expand_graph_subgraph(
 
     Returns:
         ``{"entities": [...], "relations": [...]}`` where ``relations``
-        carries ``source`` / ``target`` entity names and a description.
+        carries ``source`` / ``target`` entity names, a description,
+        ``source_chunk_count`` and bounded ``evidence_refs``.
     """
     try:
         api_key = get_api_key()
@@ -197,9 +205,10 @@ async def get_entity_detail(
         name: The canonical entity name to look up.
 
     Returns:
-        ``{"name", "entity_type", "description", "source_chunk_count"}``
-        on success, ``{"error": "Entity not found"}`` when the entity
-        is missing from the lineage store.
+        ``{"name", "entity_type", "description",
+        "source_chunk_count", "evidence_refs"}`` on success,
+        ``{"error": "Entity not found"}`` when the entity is missing
+        from the lineage store.
     """
     try:
         api_key = get_api_key()

--- a/tests/unit_test/mcp/test_graph_tools.py
+++ b/tests/unit_test/mcp/test_graph_tools.py
@@ -118,7 +118,17 @@ def _err_response(status: int, text: str = "") -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_query_graph_entities_httpx_call_shape():
-    payload = {"entities": [{"name": "X", "entity_type": "organization", "description": "d", "source_chunk_count": 2}]}
+    payload = {
+        "entities": [
+            {
+                "name": "X",
+                "entity_type": "organization",
+                "description": "d",
+                "source_chunk_count": 2,
+                "evidence_refs": [{"document_id": "doc1", "chunk_id": "c1", "parse_version": "v1"}],
+            }
+        ]
+    }
     response = _ok_response(payload)
     client = _make_async_client(response)
 
@@ -139,7 +149,26 @@ async def test_query_graph_entities_httpx_call_shape():
 
 @pytest.mark.asyncio
 async def test_expand_graph_subgraph_httpx_call_shape():
-    payload = {"entities": [], "relations": []}
+    payload = {
+        "entities": [
+            {
+                "name": "A",
+                "entity_type": "entity",
+                "description": "d",
+                "source_chunk_count": 1,
+                "evidence_refs": [{"document_id": "doc1", "chunk_id": "c1", "parse_version": "v1"}],
+            }
+        ],
+        "relations": [
+            {
+                "source": "A",
+                "target": "B",
+                "description": "rel",
+                "source_chunk_count": 1,
+                "evidence_refs": [{"document_id": "doc1", "chunk_id": "c2", "parse_version": "v1"}],
+            }
+        ],
+    }
     response = _ok_response(payload)
     client = _make_async_client(response)
 
@@ -159,7 +188,13 @@ async def test_expand_graph_subgraph_httpx_call_shape():
 
 @pytest.mark.asyncio
 async def test_get_entity_detail_httpx_call_shape_url_encodes_name():
-    payload = {"name": "墨香居", "entity_type": "organization", "description": "...", "source_chunk_count": 3}
+    payload = {
+        "name": "墨香居",
+        "entity_type": "organization",
+        "description": "...",
+        "source_chunk_count": 3,
+        "evidence_refs": [{"document_id": "doc1", "chunk_id": "c1", "parse_version": "v1"}],
+    }
     response = _ok_response(payload)
     client = _make_async_client(response)
 

--- a/tests/unit_test/service/test_graph_search_service_layer.py
+++ b/tests/unit_test/service/test_graph_search_service_layer.py
@@ -35,7 +35,9 @@ from aperag.domains.knowledge_graph.schemas import (
 )
 from aperag.domains.knowledge_graph.service import (
     GraphService,
+    _count_source_chunks,
     _entity_to_search_view,
+    _lineage_to_evidence_refs,
     _relation_to_view,
 )
 from aperag.indexing.graph import (
@@ -127,7 +129,37 @@ def test_entity_view_source_chunk_count_dedupes_across_lineage():
         ]
     )
     view = _entity_to_search_view(e)
-    assert view.source_chunk_count == 4  # {a,b,c,d}
+    assert view.source_chunk_count == 5  # composite refs, not chunk-id-only refs
+
+
+def test_lineage_evidence_refs_include_document_chunk_and_parse_version():
+    e = _make_entity(
+        chunks=[
+            ("doc1", "v1", ["a", "b", "a"]),
+            ("doc1", "v2", ["b"]),
+            ("doc2", "v1", ["c"]),
+        ]
+    )
+
+    refs = _lineage_to_evidence_refs(e.source_lineage, limit=3)
+
+    assert [ref.model_dump() for ref in refs] == [
+        {"document_id": "doc1", "chunk_id": "a", "parse_version": "v1"},
+        {"document_id": "doc1", "chunk_id": "b", "parse_version": "v1"},
+        {"document_id": "doc1", "chunk_id": "b", "parse_version": "v2"},
+    ]
+    assert _count_source_chunks(list(e.source_lineage)) == 4
+
+
+def test_entity_view_exposes_bounded_evidence_refs_for_read_document_chunk():
+    e = _make_entity(chunks=[("doc1", "v1", [f"c{i}" for i in range(12)])])
+
+    view = _entity_to_search_view(e)
+
+    assert view.source_chunk_count == 12
+    assert len(view.evidence_refs) == 10
+    first = view.evidence_refs[0]
+    assert (first.document_id, first.chunk_id, first.parse_version) == ("doc1", "c0", "v1")
 
 
 def test_relation_view_uses_render_description_rule():
@@ -137,6 +169,10 @@ def test_relation_view_uses_render_description_rule():
     assert view.source == "李明华"
     assert view.target == "墨香居"
     assert view.description == "compacted"
+    assert view.source_chunk_count == 1
+    assert [ref.model_dump() for ref in view.evidence_refs] == [
+        {"document_id": "doc1", "chunk_id": "c1", "parse_version": "v1"}
+    ]
 
 
 # --- search_entities ------------------------------------------------
@@ -165,6 +201,8 @@ async def test_search_entities_projects_graph_search_service_results():
     fake_search_service.search_entities.assert_awaited_once_with(query="hello", top_k=5)
     assert [e.name for e in result.entities] == ["A", "B"]
     assert result.entities[1].description == "B compact"
+    assert result.entities[0].evidence_refs[0].document_id == "doc1"
+    assert result.entities[0].evidence_refs[0].chunk_id == "chunk-a"
 
 
 # --- expand_subgraph ------------------------------------------------
@@ -195,6 +233,8 @@ async def test_expand_subgraph_projects_entities_and_relations():
     assert [e.name for e in result.entities] == ["A", "B"]
     assert len(result.relations) == 1
     assert result.relations[0].source == "A" and result.relations[0].target == "B"
+    assert result.entities[0].evidence_refs
+    assert result.relations[0].evidence_refs
 
 
 # --- get_entity_detail ----------------------------------------------
@@ -224,6 +264,8 @@ async def test_get_entity_detail_returns_view_when_found():
 
     assert isinstance(result, GraphSearchEntity)
     assert result.name == "X"
+    assert result.evidence_refs[0].document_id == "doc1"
+    assert result.evidence_refs[0].chunk_id == "chunk-a"
     fake_store.get_entity.assert_awaited_once_with("X")
 
 

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -4414,6 +4414,32 @@ export interface components {
             page_idx?: number | null;
         };
         /**
+         * GraphEvidenceRef
+         * @description Lightweight source chunk reference for graph entity/relation evidence.
+         *
+         *     ``read_document_chunk`` is document-scoped, so MCP callers need both
+         *     ``document_id`` and ``chunk_id`` to follow graph evidence back to source
+         *     content. ``parse_version`` is carried when available to disambiguate
+         *     lineage across document re-parses.
+         */
+        GraphEvidenceRef: {
+            /**
+             * Document Id
+             * @description Source document ID
+             */
+            document_id: string;
+            /**
+             * Chunk Id
+             * @description Source chunk ID
+             */
+            chunk_id: string;
+            /**
+             * Parse Version
+             * @description Parse version that produced this evidence ref
+             */
+            parse_version?: string | null;
+        };
+        /**
          * GraphEvidenceResponse
          * @description Lazy evidence payload for a graph node or edge.
          */
@@ -4663,6 +4689,18 @@ export interface components {
              * @example 李明华经营墨香居
              */
             description: string;
+            /**
+             * Source Chunk Count
+             * @description Number of source chunks supporting this relationship
+             * @default 0
+             * @example 2
+             */
+            source_chunk_count: number;
+            /**
+             * Evidence Refs
+             * @description Bounded source chunk refs for follow-up read_document_chunk calls
+             */
+            evidence_refs?: components["schemas"]["GraphEvidenceRef"][];
         };
         /**
          * GraphSearchEntity
@@ -4702,6 +4740,11 @@ export interface components {
              * @example 3
              */
             source_chunk_count: number;
+            /**
+             * Evidence Refs
+             * @description Bounded source chunk refs for follow-up read_document_chunk calls
+             */
+            evidence_refs?: components["schemas"]["GraphEvidenceRef"][];
         };
         /** GraphSearchParams */
         GraphSearchParams: {


### PR DESCRIPTION
## Summary

- add `GraphEvidenceRef` (`document_id`, `chunk_id`, `parse_version`) to graph entity/relation responses
- expose bounded `evidence_refs` on `query_graph_entities`, `expand_graph_subgraph` entities + relations, and `get_entity_detail`
- count source chunks by composite document/parse/chunk refs instead of naked chunk IDs
- update MCP graph tool docstrings and regenerate API v2 schema

## Validation

- `uv run --extra test python -m pytest tests/unit_test/service/test_graph_search_service_layer.py tests/unit_test/mcp/test_graph_tools.py tests/unit_test/domains/knowledge_graph/test_service.py tests/unit_test/service/test_search_graph_contract.py -q`
- `uvx ruff@0.15.12 check aperag/domains/knowledge_graph/schemas.py aperag/domains/knowledge_graph/service.py aperag/mcp/tools/graph_tools.py tests/unit_test/mcp/test_graph_tools.py tests/unit_test/service/test_graph_search_service_layer.py`
- `uvx ruff@0.15.12 format --check aperag/domains/knowledge_graph/schemas.py aperag/domains/knowledge_graph/service.py aperag/mcp/tools/graph_tools.py tests/unit_test/mcp/test_graph_tools.py tests/unit_test/service/test_graph_search_service_layer.py`
- `uv run python scripts/export_openapi.py --check`
- `git diff --check`

Task: #44
