### PR TITLE
refactor(model-platform): drop residual RERANK capability + provider presets (task #47)

### DIFF
--- a/aperag/domains/model_platform/db/models.py
+++ b/aperag/domains/model_platform/db/models.py
@@ -26,7 +26,6 @@ class ModelCapability(str, Enum):
     CHAT = "chat"
     COMPLETION = "completion"
     EMBEDDING = "embedding"
-    RERANK = "rerank"
 
 
 class ModelAccountStatus(str, Enum):

--- a/aperag/domains/model_platform/schemas.py
+++ b/aperag/domains/model_platform/schemas.py
@@ -15,7 +15,6 @@ class ModelCapability(str, Enum):
     CHAT = "chat"
     COMPLETION = "completion"
     EMBEDDING = "embedding"
-    RERANK = "rerank"
 
 
 class ModelUseScenario(str, Enum):

--- a/aperag/domains/model_platform/service/model_service.py
+++ b/aperag/domains/model_platform/service/model_service.py
@@ -36,7 +36,6 @@ CAPABILITY_SCENARIOS: dict[ModelCapability, tuple[ModelUseScenario, ...]] = {
         ModelUseScenario.BACKGROUND_TASK,
     ),
     ModelCapability.EMBEDDING: (ModelUseScenario.COLLECTION_EMBEDDING,),
-    ModelCapability.RERANK: (),
 }
 
 SCENARIO_CAPABILITY: dict[ModelUseScenario, ModelCapability] = {
@@ -128,14 +127,14 @@ BUILTIN_PROVIDERS = [
     ModelProvider(
         provider_type="dashscope",
         display_name="阿里百炼",
-        supported_capabilities=[ModelCapability.CHAT, ModelCapability.EMBEDDING, ModelCapability.RERANK],
+        supported_capabilities=[ModelCapability.CHAT, ModelCapability.EMBEDDING],
         default_base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
         sort_order=20,
     ),
     ModelProvider(
         provider_type="jina",
         display_name="Jina AI",
-        supported_capabilities=[ModelCapability.EMBEDDING, ModelCapability.RERANK],
+        supported_capabilities=[ModelCapability.EMBEDDING],
         default_base_url="https://api.jina.ai/v1",
         sort_order=30,
     ),

--- a/aperag/migration/versions/20260430034600-3c7d2f81b5e9.py
+++ b/aperag/migration/versions/20260430034600-3c7d2f81b5e9.py
@@ -1,0 +1,33 @@
+"""drop rerank capability from model rows
+
+Revision ID: 3c7d2f81b5e9
+Revises: a8f4c2d9e1b7
+Create Date: 2026-04-30 03:46:00.000000
+
+Task #47 fix-forward to task #35: the previous migration
+``a8f4c2d9e1b7`` removed the ``retrieval_rerank`` ``model_use`` rows;
+this one removes the underlying ``model.capability='rerank'`` rows so
+the next ``ModelCapability`` enum hard-cut (which drops the
+``"rerank"`` value entirely) does not fail to deserialise existing
+rows.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3c7d2f81b5e9"
+down_revision: Union[str, None] = "a8f4c2d9e1b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Remove model rows with rerank capability before the enum hard-cut."""
+    op.execute("DELETE FROM model WHERE capability = 'rerank'")
+
+
+def downgrade() -> None:
+    """The deleted rerank model rows cannot be reconstructed safely."""
+    pass

--- a/tests/unit_test/test_model_platform_v2_contract.py
+++ b/tests/unit_test/test_model_platform_v2_contract.py
@@ -64,13 +64,13 @@ def test_model_account_and_model_create_are_user_level_concepts():
     )
     model = ModelCreate(
         account_id="acct_1",
-        provider_model_id="gte-rerank-v2",
-        display_name="通义重排",
-        capability=ModelCapability.RERANK,
+        provider_model_id="text-embedding-v3",
+        display_name="通义嵌入",
+        capability=ModelCapability.EMBEDDING,
     )
 
     assert account.provider_type == "dashscope"
-    assert model.capability == ModelCapability.RERANK
+    assert model.capability == ModelCapability.EMBEDDING
     assert "dialect" not in account.model_dump()
     assert "custom_llm_provider" not in model.model_dump()
 
@@ -154,7 +154,6 @@ def test_allowed_scenarios_default_by_capability():
     assert default_allowed_scenarios(ModelCapability.EMBEDDING) == [
         ModelUseScenario.COLLECTION_EMBEDDING,
     ]
-    assert default_allowed_scenarios(ModelCapability.RERANK) == []
 
 
 def test_allowed_scenarios_missing_key_uses_default_but_empty_list_is_explicit():

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -5119,7 +5119,7 @@ export interface components {
          * ModelCapability
          * @enum {string}
          */
-        ModelCapability: "chat" | "completion" | "embedding" | "rerank";
+        ModelCapability: "chat" | "completion" | "embedding";
         /** ModelCreate */
         ModelCreate: {
             /** Account Id */


### PR DESCRIPTION
## Summary
Task #47 fix-forward to task #35 (rerank deletion). huangzhangshu's task #40 verification (msg=23e67c4d) found that the previous PRs left the `model_platform` domain `ModelCapability.RERANK` enum value, the dashscope / jina built-in provider presets that listed it, the generated TypeScript schema, and one unit-test contract still treating rerank as a first-class capability. This PR closes those last residues.

PR #1898 (ziang) deleted `ModelUseScenario.RETRIEVAL_RERANK` and the corresponding `model_use` rows. PR #1899 (Bryce) deleted the runtime-side `aperag/llm/runtime/types.py::ModelCapability.RERANK`. PR #1897 (dongdong) cleaned the frontend / docs / `SearchRequest.rerank`.

## What this PR removes
- `aperag/domains/model_platform/schemas.py`: `ModelCapability.RERANK` enum value
- `aperag/domains/model_platform/db/models.py`: `ModelCapability.RERANK` enum value
- `aperag/domains/model_platform/service/model_service.py`: the `CAPABILITY_SCENARIOS[RERANK]` entry, the dashscope `BUILTIN_PROVIDERS` `supported_capabilities=[…, RERANK]`, the jina `BUILTIN_PROVIDERS` `supported_capabilities=[…, RERANK]`
- `web/src/api-v2/schema.d.ts`: drop `"rerank"` from the `ModelCapability` union
- `tests/unit_test/test_model_platform_v2_contract.py`: rewrite the user-level-model-creation test to use `EMBEDDING` (the test's intent was contract semantics, not the specific capability); drop the `default_allowed_scenarios(RERANK) == []` assertion

## What this PR adds
- `aperag/migration/versions/20260430034600-3c7d2f81b5e9.py`: `DELETE FROM model WHERE capability = 'rerank'`. Chained after `a8f4c2d9e1b7` (which removed the `model_use` rows) so the enum hard-cut here deserialises existing rows safely.

## Test plan
- [x] `uvx ruff@0.15.12 check aperag/ tests/` — pass
- [x] `uvx ruff@0.15.12 format --check aperag/ tests/` — pass
- [x] `uv run --extra test python -m pytest tests/unit_test/test_model_platform_v2_contract.py tests/boundaries/test_no_rerank_in_mcp.py tests/boundaries/test_api_no_cleanup.py tests/boundaries/test_worker_di_parity.py tests/unit_test/test_app_lifespan_no_workers.py -q` — 26 passed
- [ ] CI lint-and-unit + e2e-http-smoke + e2e-http-provider
- [ ] huangzhangshu task #40 final grep gate after this lands: zero active hits for `rerank` / `RERANK` in `aperag/` + `tests/` + `web/src/api-v2/` (allowlist = `pipeline.py` historical comment + `test_v1_ghost_guard.py` docstring + `test_no_rerank_in_mcp.py` self-references + the two migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)