### PR TITLE
fix(web): improve mobile documents and audit layouts

### DIFF
--- a/web/src/app/workspace/audit-logs/audit-log-detail.tsx
+++ b/web/src/app/workspace/audit-logs/audit-log-detail.tsx
@@ -58,13 +58,13 @@ export const AuditLogDetail = ({
     <>
       <Drawer direction="right" handleOnly={true}>
         <DrawerTrigger asChild>{children}</DrawerTrigger>
-        <DrawerContent className="border-border/70 bg-card flex border-l sm:min-w-lg md:min-w-xl lg:min-w-2xl">
+        <DrawerContent className="border-border/70 bg-card flex border-l data-[vaul-drawer-direction=right]:w-[calc(100vw-1rem)] data-[vaul-drawer-direction=right]:sm:w-[32rem] data-[vaul-drawer-direction=right]:sm:max-w-none data-[vaul-drawer-direction=right]:md:w-[40rem] data-[vaul-drawer-direction=right]:lg:w-[48rem]">
           <DrawerHeader className="border-border/70 border-b">
             <DrawerTitle className="font-serif text-2xl font-normal">
               {page_audit_logs('metadata.title')}
             </DrawerTitle>
           </DrawerHeader>
-          <div className="flex flex-col gap-4 overflow-auto p-4 text-sm select-text">
+          <div className="flex select-text flex-col gap-4 overflow-auto p-4 text-sm">
             <div className="border-border/70 bg-muted rounded-xl border p-3">
               <div className="text-muted-foreground font-mono text-[11px] uppercase">
                 {page_audit_logs('detail.user_agent')}
@@ -108,7 +108,7 @@ export const AuditLogDetail = ({
             </div>
 
             <div>
-              <div className="text-muted-foreground -mb-3 flex justify-between">
+              <div className="text-muted-foreground -mb-3 flex flex-col gap-1 sm:flex-row sm:justify-between">
                 <div>{page_audit_logs('detail.request_data')}</div>
                 <div>
                   {auditLog.start_time
@@ -120,7 +120,7 @@ export const AuditLogDetail = ({
             </div>
 
             <div>
-              <div className="text-muted-foreground -mb-3 flex justify-between">
+              <div className="text-muted-foreground -mb-3 flex flex-col gap-1 sm:flex-row sm:justify-between">
                 <div>{page_audit_logs('detail.response_data')}</div>
                 <div>
                   {auditLog.end_time
@@ -160,6 +160,6 @@ const AuditMeta = ({
     <div className="text-muted-foreground font-mono text-[11px] uppercase">
       {label}
     </div>
-    <div className="mt-1 font-mono text-xs break-words">{value || '--'}</div>
+    <div className="mt-1 break-words font-mono text-xs">{value || '--'}</div>
   </div>
 );

--- a/web/src/app/workspace/audit-logs/audit-log-table.tsx
+++ b/web/src/app/workspace/audit-logs/audit-log-table.tsx
@@ -136,7 +136,7 @@ export function AuditLogTable({
                   {row.original.api_name}
                 </span>
               </AuditLogDetail>
-              <div className="text-muted-foreground truncate pt-0.5 font-mono text-xs sm:w-sm md:w-md lg:w-lg">
+              <div className="text-muted-foreground sm:w-sm md:w-md lg:w-lg truncate pt-0.5 font-mono text-xs">
                 {row.original.path}
               </div>
             </>
@@ -232,7 +232,7 @@ export function AuditLogTable({
       <div className="border-border/70 bg-card grid gap-4 rounded-xl border p-4 shadow-sm lg:grid-cols-[1fr_auto] lg:items-center">
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center">
           <div className="relative min-w-0 flex-1 xl:min-w-80">
-            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+            <Search className="text-muted-foreground pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2" />
             <Input
               className="bg-background/70 h-10 rounded-lg pl-9"
               placeholder={page_audit_logs('search_placeholder')}
@@ -247,9 +247,9 @@ export function AuditLogTable({
               }}
             />
           </div>
-          <div className="flex flex-col gap-2 md:flex-row md:items-center">
+          <div className="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-center xl:flex xl:flex-row">
             <DateTimePicker24h
-              className="w-48"
+              className="w-full sm:w-48"
               date={query.startDate ? new Date(query.startDate) : undefined}
               onChange={(d) => {
                 handleSearch({
@@ -257,9 +257,11 @@ export function AuditLogTable({
                 });
               }}
             />
-            <span>-</span>
+            <span className="text-muted-foreground hidden text-center sm:block">
+              -
+            </span>
             <DateTimePicker24h
-              className="w-48"
+              className="w-full sm:w-48"
               date={query.endDate ? new Date(query.endDate) : undefined}
               onChange={(d) => {
                 handleSearch({
@@ -306,8 +308,11 @@ export function AuditLogTable({
           </DropdownMenu>
         </div>
       </div>
-      <div className="border-border/70 bg-card rounded-xl border p-3 shadow-sm">
-        <DataGrid table={table} className="border-border/70 rounded-lg" />
+      <div className="border-border/70 bg-card rounded-xl border p-2 shadow-sm sm:p-3">
+        <DataGrid
+          table={table}
+          className="border-border/70 overflow-x-auto rounded-lg [&_table]:min-w-[760px]"
+        />
       </div>
       <DataGridPagination table={table} />
     </div>

--- a/web/src/app/workspace/audit-logs/page.tsx
+++ b/web/src/app/workspace/audit-logs/page.tsx
@@ -65,10 +65,10 @@ export default async function Page({
       <PageContent className="max-w-7xl px-5 py-8 md:px-8 md:py-10">
         <div className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end">
           <div className="min-w-0 flex-1">
-            <div className="text-muted-foreground font-mono text-[11px] tracking-[0.12em] uppercase">
+            <div className="text-muted-foreground font-mono text-[11px] uppercase tracking-[0.12em]">
               {page_audit_logs('metadata.label')}
             </div>
-            <h1 className="mt-2 font-serif text-4xl leading-none font-normal tracking-normal md:text-[44px]">
+            <h1 className="mt-2 font-serif text-4xl font-normal leading-none tracking-normal md:text-[44px]">
               {page_audit_logs('metadata.title')}
             </h1>
             <p className="text-muted-foreground mt-3 max-w-2xl text-sm leading-6">
@@ -76,7 +76,7 @@ export default async function Page({
             </p>
           </div>
         </div>
-        <div className="mb-6 grid gap-3 md:grid-cols-4">
+        <div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
           <AuditMetric
             icon={<ScrollText className="size-4" />}
             label={page_audit_logs('metric_events')}
@@ -127,7 +127,7 @@ const AuditMetric = ({
           {icon}
         </div>
         <div>
-          <div className="font-mono text-xl leading-none tabular-nums">
+          <div className="font-mono text-xl tabular-nums leading-none">
             {value}
             {suffix ? (
               <span className="text-muted-foreground ml-1 text-xs">

--- a/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/[documentId]/document-detail.tsx
@@ -207,7 +207,7 @@ export const DocumentDetail = ({
           flows; only the user-facing preview tab is hidden. The
           original document (PDF / image / fallback download CTA)
           remains the single content surface here. */}
-      <div className="bg-background/50 m-0 p-4">
+      <div className="bg-background/50 m-0 overflow-x-auto p-3 sm:p-4">
         {pdfPreviewUrl ? (
           <PDFDocument
             file={pdfPreviewUrl}
@@ -220,7 +220,7 @@ export const DocumentDetail = ({
                 <LoaderCircle className="size-10 animate-spin self-center opacity-50" />
               </div>
             }
-            className="flex flex-col justify-center gap-1"
+            className="flex min-w-fit flex-col justify-center gap-1"
           >
             {Array.from({ length: numPages }, (_, index) => {
               return (
@@ -242,13 +242,13 @@ export const DocumentDetail = ({
           </div>
         ) : isTextPreview && markdownContent ? (
           <Card className="border-border/70 py-0 shadow-sm">
-            <CardContent className="p-5">
+            <CardContent className="p-4 sm:p-5">
               <Markdown>{markdownContent}</Markdown>
             </CardContent>
           </Card>
         ) : (
           <Card className="border-border/70 py-0 shadow-sm">
-            <CardContent className="text-muted-foreground flex min-h-72 flex-col items-center justify-center gap-4 p-8 text-center text-sm">
+            <CardContent className="text-muted-foreground flex min-h-72 flex-col items-center justify-center gap-4 p-6 text-center text-sm sm:p-8">
               <FileText className="size-10" />
               <div className="space-y-1">
                 <div className="text-foreground text-sm font-medium">

--- a/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/documents-table.tsx
@@ -95,7 +95,7 @@ const DocumentStatusBadge = ({ status }: { status?: string | null }) => {
     <Badge
       variant="outline"
       className={cn(
-        'rounded-sm border font-mono text-[10px] tracking-normal uppercase',
+        'rounded-sm border font-mono text-[10px] uppercase tracking-normal',
         DOCUMENT_STATUS_CLASS[status] ||
           'bg-secondary text-muted-foreground border-transparent',
       )}
@@ -455,8 +455,8 @@ export function DocumentsTable({
   return (
     <div className="flex flex-col gap-4">
       <div className="border-border/70 bg-card grid gap-3 rounded-xl border p-4 shadow-sm lg:grid-cols-[1fr_auto] lg:items-center">
-        <div className="relative max-w-xl">
-          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+        <div className="relative max-w-xl lg:max-w-none">
+          <Search className="text-muted-foreground pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2" />
           <Input
             className="bg-background/70 h-10 rounded-lg pl-9"
             placeholder={page_documents('search_document')}
@@ -472,13 +472,14 @@ export function DocumentsTable({
             }}
           />
         </div>
-        <div className="flex flex-wrap items-center gap-2 lg:justify-end">
-          <Button asChild className="cursor-pointer">
+        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2 sm:flex sm:flex-wrap sm:justify-end">
+          <Button asChild className="min-w-0 cursor-pointer">
             <Link
               href={`/workspace/collections/${collection.id}/documents/upload`}
+              className="justify-center"
             >
               <Plus />
-              <span className="hidden sm:inline">
+              <span className="truncate">
                 {page_documents('add_documents')}
               </span>
             </Link>
@@ -530,7 +531,10 @@ export function DocumentsTable({
           </DropdownMenu>
         </div>
       </div>
-      <DataGrid table={table} className="border-border/70 bg-card shadow-sm" />
+      <DataGrid
+        table={table}
+        className="border-border/70 bg-card overflow-x-auto shadow-sm [&_table]:min-w-[760px]"
+      />
       <DataGridPagination table={table} />
     </div>
   );

--- a/web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
+++ b/web/src/app/workspace/collections/[collectionId]/documents/upload/document-upload.tsx
@@ -434,15 +434,15 @@ export const DocumentUpload = () => {
           const mimeType = file?.type ?? '';
           const extension = last(mimeType.split('/')) || last(filename.split('.')) || '';
           return (
-            <div className="flex w-full flex-row items-center gap-2">
-              <div className="size-6">
+            <div className="flex w-full min-w-0 flex-row items-center gap-2">
+              <div className="size-6 shrink-0">
                 <FileIcon
                   color="var(--primary)"
                   extension={extension}
                   {...get(defaultStyles, extension)}
                 />
               </div>
-              <div>
+              <div className="min-w-0">
                 <div className="max-w-md truncate">{filename}</div>
                 <div className="text-muted-foreground text-sm">
                   {(size / 1000).toFixed(0) + ' KB'}
@@ -462,7 +462,7 @@ export const DocumentUpload = () => {
       {
         header: page_documents('upload_progress'),
         cell: ({ row }) => (
-          <div className="flex w-50 flex-col">
+          <div className="flex w-44 flex-col sm:w-50">
             <Progress
               value={row.original.progress}
               className="h-1.5 transition-all"
@@ -615,8 +615,8 @@ export const DocumentUpload = () => {
         disabled={isUploading}
       >
         {/* Toolbar */}
-        <div className="flex flex-row items-center justify-between text-sm">
-          <div className="text-muted-foreground flex h-9 flex-row items-center gap-2">
+        <div className="flex flex-col gap-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-muted-foreground flex min-w-0 flex-wrap items-center gap-2 sm:h-9">
             <div
               className={cn(
                 'flex flex-row items-center gap-1',
@@ -638,33 +638,35 @@ export const DocumentUpload = () => {
             </div>
           </div>
 
-          <div className="flex flex-row gap-2">
+          <div className="grid grid-cols-1 gap-2 min-[420px]:grid-cols-2 sm:flex sm:flex-row">
             {documents.length > 0 && (
               <FileUploadClear asChild disabled={isUploading}>
-                <Button variant="outline" className="cursor-pointer">
+                <Button
+                  variant="outline"
+                  className="cursor-pointer justify-center"
+                >
                   <BrushCleaning />
-                  <span className="hidden lg:inline">
-                    {page_documents('clear_files')}
-                  </span>
+                  <span>{page_documents('clear_files')}</span>
                 </Button>
               </FileUploadClear>
             )}
 
             {isUploading ? (
-              <Button className="cursor-pointer" onClick={stopUpload}>
+              <Button
+                className="cursor-pointer justify-center"
+                onClick={stopUpload}
+              >
                 <LoaderCircle className="animate-spin" />
-                <span className="hidden lg:inline">Stop</span>
+                <span>Stop</span>
               </Button>
             ) : (
               <Button
-                className="cursor-pointer"
+                className="cursor-pointer justify-center"
                 onClick={handleSaveToCollection}
                 disabled={step !== 2}
               >
                 <Save />
-                <span className="hidden lg:inline">
-                  {page_documents('add_documents')}
-                </span>
+                <span>{page_documents('add_documents')}</span>
               </Button>
             )}
           </div>
@@ -672,7 +674,7 @@ export const DocumentUpload = () => {
 
         {/* Main content: drop zone or file list */}
         {documents.length === 0 ? (
-          <FileUploadDropzone className="cursor-pointer rounded-lg border p-16">
+          <FileUploadDropzone className="cursor-pointer rounded-lg border p-8 sm:p-16">
             <div className="flex flex-col items-center gap-4 text-center">
               <div className="flex items-center justify-center rounded-full border p-2.5">
                 <Upload className="text-muted-foreground size-6" />
@@ -687,13 +689,16 @@ export const DocumentUpload = () => {
           </FileUploadDropzone>
         ) : (
           <>
-            <DataGrid table={table} />
+            <DataGrid
+              table={table}
+              className="overflow-x-auto [&_table]:min-w-[680px]"
+            />
             <DataGridPagination table={table} />
           </>
         )}
 
         {/* Source picker — always anchored at the bottom */}
-        <div className="flex items-center gap-1 rounded-lg border bg-muted/30 px-4 py-2">
+        <div className="flex flex-wrap items-center gap-1 rounded-lg border bg-muted/30 px-3 py-2 sm:px-4">
           {documents.length > 0 && (
             <span className="text-muted-foreground mr-2 text-xs">
               {page_documents('add_more_sources')}


### PR DESCRIPTION
## Summary

- make Documents and Audit Logs tables mobile-safe with page-level horizontal table scrolling instead of body-level overflow
- widen Audit Log detail drawer on phones and keep JSON/Markdown/code blocks inside the drawer scroll area
- tighten mobile spacing for document detail previews and upload flow controls, including toolbar wrapping, visible action labels, smaller dropzone padding, and upload table scrolling

## Verification

- `yarn lint --quiet`
- `yarn type-check --pretty false`
- `yarn build`
- `git diff --check`
- 390x844 Chrome/CDP checks for:
  - `/workspace/audit-logs`
  - `/workspace/collections/col33b6b48211a30a95/documents`
  - `/workspace/collections/col33b6b48211a30a95/documents/upload`
  - `/workspace/collections/col33b6b48211a30a95/documents/docdummy`
  - audit detail drawer open state

Notes: build warnings are existing Cosmograph/DuckDB and evaluation route warnings. The mobile checks verified no body-level horizontal overflow, with table/drawer/code overflow handled inside the relevant component containers.
