### PR TITLE
feat(graph-extractor): prompt v2 — 7 hard requirements + window-aware parser (task #30-A3)

### DIFF
--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -415,6 +415,74 @@ def _graph_window_boundary_break(previous: Mapping[str, Any], current: Mapping[s
 # ---------------------------------------------------------------------
 
 
+async def _extract_one_window(
+    *,
+    llm: Callable[[str], Awaitable[str]],
+    window: _GraphChunkWindow,
+    entity_types: tuple[str, ...],
+    language: str,
+    max_entities: int,
+    max_relations: int,
+    timeout_seconds: float,
+    few_shot_locale: str | None = None,
+) -> tuple[list[EntityRecord], list[RelationRecord]]:
+    """Window extraction: render the v2 prompt over the window's chunks,
+    call the LLM, parse the JSON response, return record lists.
+
+    A1 introduced the :class:`_GraphChunkWindow` shape and dispatched
+    every window through this entrypoint with the legacy single-text
+    bridge. A3 replaces that bridge with boundary-marked prompt text +
+    a parser that validates the LLM's ``source_chunk_ids`` against the
+    window allowlist (spec §3.1.3 + §6.2):
+
+    - ``window_size == 1`` — the prompt emits a single
+      ``[[chunk_id=...]]`` block and the parser falls back to the
+      lone allowed id when the LLM omits ``source_chunk_ids``,
+      preserving the structural-equivalence contract that A1 already
+      proves with its 35 integration tests.
+    - ``window_size > 1`` — the prompt emits one boundary marker per
+      chunk and the parser requires the LLM to populate
+      ``source_chunk_ids`` against the allowlist; missing or
+      out-of-allowlist ids are skipped + warned so a hallucinated
+      chunk_id never poisons provenance.
+
+    Wraps the LLM call in :func:`asyncio.wait_for` with the per-window
+    timeout so a stuck LLM does not block the worker forever; on
+    timeout we propagate :class:`asyncio.TimeoutError` to the caller
+    which already logs + skips the window.
+    """
+    from aperag.indexing.llm import render_extraction_prompt
+
+    if not window.chunks:
+        return ([], [])
+
+    allowed_chunk_ids = tuple(window.chunk_ids)
+    if any(not cid for cid in allowed_chunk_ids):
+        # Defensive: A1's _build_graph_chunk_windows already drops
+        # chunks with no chunk_id, so this should be unreachable. If
+        # it still fires (someone hand-builds a window in tests) we
+        # cannot ground provenance — drop the window.
+        logger.warning(
+            "graph extractor: window contains a chunk with empty chunk_id; skipping window (window_size=%d)",
+            len(window.chunks),
+        )
+        return ([], [])
+
+    prompt = render_extraction_prompt(
+        window_chunks=window.chunks,
+        entity_types=list(entity_types),
+        language=language,
+        max_entities=max_entities,
+        max_relations=max_relations,
+        few_shot_locale=few_shot_locale,
+    )
+    raw = await asyncio.wait_for(llm(prompt), timeout=timeout_seconds)
+    return _parse_extraction_response(
+        raw=raw,
+        allowed_chunk_ids=allowed_chunk_ids,
+    )
+
+
 async def _extract_one_chunk(
     *,
     llm: Callable[[str], Awaitable[str]],
@@ -426,48 +494,18 @@ async def _extract_one_chunk(
     max_relations: int,
     timeout_seconds: float,
 ) -> tuple[list[EntityRecord], list[RelationRecord]]:
-    """Single-chunk extraction: render the prompt, call the LLM, parse
-    the JSON response, return record lists.
+    """Backward-compatible single-chunk wrapper around
+    :func:`_extract_one_window`.
 
-    Wraps the LLM call in :func:`asyncio.wait_for` with the per-chunk
-    timeout so a stuck LLM does not block the worker forever; on
-    timeout we propagate :class:`asyncio.TimeoutError` to the caller
-    which already logs + skips the chunk.
+    Existing callers (and a few legacy tests) still pass a single
+    ``text`` + ``chunk_id`` pair. We wrap them in a synthetic
+    ``_GraphChunkWindow`` so the v2 prompt + parser invariant runs
+    through one entrypoint.
     """
-    from aperag.indexing.llm import render_extraction_prompt
-
-    prompt = render_extraction_prompt(
-        input_text=text,
-        entity_types=list(entity_types),
-        language=language,
-        max_entities=max_entities,
-        max_relations=max_relations,
-    )
-    raw = await asyncio.wait_for(llm(prompt), timeout=timeout_seconds)
-    return _parse_extraction_response(raw=raw, chunk_id=chunk_id)
-
-
-async def _extract_one_window(
-    *,
-    llm: Callable[[str], Awaitable[str]],
-    window: _GraphChunkWindow,
-    entity_types: tuple[str, ...],
-    language: str,
-    max_entities: int,
-    max_relations: int,
-    timeout_seconds: float,
-) -> tuple[list[EntityRecord], list[RelationRecord]]:
-    """A1 bridge from graph windows to the existing single-text prompt.
-
-    A3 replaces this bridge with boundary-marked prompt text and parses
-    model-provided ``source_chunk_ids``. Until then, default window_size=1
-    keeps production behavior equivalent; explicit >1 windows use the
-    first chunk id as legacy provenance fallback.
-    """
-    return await _extract_one_chunk(
+    window = _make_graph_chunk_window([{"chunk_id": chunk_id, "text": text}])
+    return await _extract_one_window(
         llm=llm,
-        text=window.text,
-        chunk_id=window.primary_chunk_id,
+        window=window,
         entity_types=entity_types,
         language=language,
         max_entities=max_entities,
@@ -486,7 +524,7 @@ _EMPTY_RESULT_LOG_RAW_PREFIX_CHARS: int = 500
 def _log_empty_extraction_if_applicable(
     *,
     raw: str,
-    chunk_id: str,
+    allowed_chunk_ids: tuple[str, ...],
     entities_count: int,
     relations_count: int,
 ) -> None:
@@ -516,10 +554,10 @@ def _log_empty_extraction_if_applicable(
         return
     raw_prefix = raw[:_EMPTY_RESULT_LOG_RAW_PREFIX_CHARS]
     logger.warning(
-        "graph extractor: empty extraction result for chunk_id=%s "
+        "graph extractor: empty extraction result for chunk_ids=%s "
         "(LLM response parsed cleanly but produced 0 entities + 0 relations); "
         "raw response prefix (%d chars max): %r",
-        chunk_id,
+        list(allowed_chunk_ids),
         _EMPTY_RESULT_LOG_RAW_PREFIX_CHARS,
         raw_prefix,
     )
@@ -528,7 +566,7 @@ def _log_empty_extraction_if_applicable(
 def _parse_extraction_response(
     *,
     raw: str,
-    chunk_id: str,
+    allowed_chunk_ids: tuple[str, ...],
 ) -> tuple[list[EntityRecord], list[RelationRecord]]:
     """Parse the LLM's JSON response into entity / relation records.
 
@@ -538,35 +576,52 @@ def _parse_extraction_response(
     middleware still work. Malformed payloads return ``([], [])``;
     individual records that fail to parse are logged + skipped so a
     single bad row does not drop the rest.
+
+    Provenance invariant (task #30 §3.1.3 hard requirement #2 + parser
+    invariant agreed in #indexing优化:f0614ea1): every record's
+    ``source_chunk_ids`` must be a non-empty subset of the window's
+    allowlist. ``window_size == 1`` is the legacy compat path — when
+    the LLM omits ``source_chunk_ids`` we fall back to the single
+    allowed id. ``window_size > 1`` requires the LLM to populate the
+    field; missing / out-of-allowlist records are skipped + warned.
     """
     payload = _strip_code_fence(raw)
     try:
         parsed = json.loads(payload)
     except json.JSONDecodeError:
         logger.warning(
-            "graph extractor: chunk_id=%s response is not valid JSON; skipping entities/relations from this chunk",
-            chunk_id,
+            "graph extractor: chunk_ids=%s response is not valid JSON; skipping entities/relations from this window",
+            list(allowed_chunk_ids),
         )
         return ([], [])
 
     if not isinstance(parsed, Mapping):
         logger.warning(
-            "graph extractor: chunk_id=%s response is JSON but not an object; got %s",
-            chunk_id,
+            "graph extractor: chunk_ids=%s response is JSON but not an object; got %s",
+            list(allowed_chunk_ids),
             type(parsed).__name__,
         )
         return ([], [])
+
+    allowed_set = frozenset(allowed_chunk_ids)
+    fallback_chunk_id = allowed_chunk_ids[0] if len(allowed_chunk_ids) == 1 else None
 
     entities: list[EntityRecord] = []
     for raw_entity in parsed.get("entities", []) or []:
         if not isinstance(raw_entity, Mapping):
             continue
         try:
-            entities.append(_entity_from_dict(raw_entity, chunk_id=chunk_id))
+            entities.append(
+                _entity_from_dict(
+                    raw_entity,
+                    allowed_chunk_ids=allowed_set,
+                    fallback_chunk_id=fallback_chunk_id,
+                )
+            )
         except (KeyError, ValueError, TypeError) as exc:
             logger.warning(
-                "graph extractor: chunk_id=%s skipping malformed entity %r: %s",
-                chunk_id,
+                "graph extractor: chunk_ids=%s skipping malformed entity %r: %s",
+                list(allowed_chunk_ids),
                 raw_entity,
                 exc,
             )
@@ -576,18 +631,24 @@ def _parse_extraction_response(
         if not isinstance(raw_relation, Mapping):
             continue
         try:
-            relations.append(_relation_from_dict(raw_relation, chunk_id=chunk_id))
+            relations.append(
+                _relation_from_dict(
+                    raw_relation,
+                    allowed_chunk_ids=allowed_set,
+                    fallback_chunk_id=fallback_chunk_id,
+                )
+            )
         except (KeyError, ValueError, TypeError) as exc:
             logger.warning(
-                "graph extractor: chunk_id=%s skipping malformed relation %r: %s",
-                chunk_id,
+                "graph extractor: chunk_ids=%s skipping malformed relation %r: %s",
+                list(allowed_chunk_ids),
                 raw_relation,
                 exc,
             )
 
     _log_empty_extraction_if_applicable(
         raw=raw,
-        chunk_id=chunk_id,
+        allowed_chunk_ids=allowed_chunk_ids,
         entities_count=len(entities),
         relations_count=len(relations),
     )
@@ -607,7 +668,54 @@ def _strip_code_fence(raw: str) -> str:
     return raw.strip()
 
 
-def _entity_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> EntityRecord:
+def _resolve_source_chunk_ids(
+    raw: Mapping[str, Any],
+    *,
+    allowed_chunk_ids: frozenset[str],
+    fallback_chunk_id: str | None,
+) -> tuple[str, ...]:
+    """Read + validate ``source_chunk_ids`` against the window allowlist.
+
+    Single-chunk window (``fallback_chunk_id`` is set) — missing field
+    falls back to the single allowed id (legacy compat).
+
+    Multi-chunk window (``fallback_chunk_id is None``) — the field
+    must be a non-empty list of allowlisted strings; otherwise we
+    raise ``ValueError`` so the caller skips + warns the record.
+
+    Out-of-allowlist ids are silently dropped before the empty-check
+    so an LLM that hallucinates a chunk_id does not poison provenance.
+    """
+    raw_ids = raw.get("source_chunk_ids")
+    if raw_ids is None:
+        if fallback_chunk_id is None:
+            raise ValueError("source_chunk_ids is required for multi-chunk windows; the LLM omitted the field")
+        return (fallback_chunk_id,)
+
+    if not isinstance(raw_ids, (list, tuple)):
+        raise ValueError(f"source_chunk_ids must be a list, got {type(raw_ids).__name__}")
+
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for entry in raw_ids:
+        cid = str(entry).strip()
+        if not cid or cid not in allowed_chunk_ids or cid in seen:
+            continue
+        cleaned.append(cid)
+        seen.add(cid)
+    if not cleaned:
+        if fallback_chunk_id is not None:
+            return (fallback_chunk_id,)
+        raise ValueError("source_chunk_ids has no values inside the window allowlist")
+    return tuple(cleaned)
+
+
+def _entity_from_dict(
+    raw: Mapping[str, Any],
+    *,
+    allowed_chunk_ids: frozenset[str],
+    fallback_chunk_id: str | None,
+) -> EntityRecord:
     name = str(raw["name"]).strip()
     if not name:
         raise ValueError("entity name cannot be empty")
@@ -615,27 +723,42 @@ def _entity_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> EntityRecord:
     # canonical Wave 11 string field as ``entity_type``.
     entity_type = normalize_entity_type(raw.get("entity_type") or raw.get("type") or "")
     description = str(raw.get("description") or "")
+    source_chunk_ids = _resolve_source_chunk_ids(
+        raw,
+        allowed_chunk_ids=allowed_chunk_ids,
+        fallback_chunk_id=fallback_chunk_id,
+    )
     return EntityRecord(
         name=name,
         entity_type=entity_type,
         description=description,
-        source_chunk_ids=(chunk_id,) if chunk_id else (),
+        source_chunk_ids=source_chunk_ids,
     )
 
 
-def _relation_from_dict(raw: Mapping[str, Any], *, chunk_id: str) -> RelationRecord:
+def _relation_from_dict(
+    raw: Mapping[str, Any],
+    *,
+    allowed_chunk_ids: frozenset[str],
+    fallback_chunk_id: str | None,
+) -> RelationRecord:
     source = str(raw["source"]).strip()
     target = str(raw["target"]).strip()
     if not source or not target:
         raise ValueError("relation source/target cannot be empty")
     rel_type = str(raw.get("relation_type") or raw.get("type") or "")
     description = str(raw.get("description") or "")
+    source_chunk_ids = _resolve_source_chunk_ids(
+        raw,
+        allowed_chunk_ids=allowed_chunk_ids,
+        fallback_chunk_id=fallback_chunk_id,
+    )
     return RelationRecord(
         source=source,
         target=target,
         relation_type=rel_type,
         description=description,
-        source_chunk_ids=(chunk_id,) if chunk_id else (),
+        source_chunk_ids=source_chunk_ids,
     )
 
 

--- a/aperag/indexing/llm.py
+++ b/aperag/indexing/llm.py
@@ -48,7 +48,7 @@ behavioural change.
 from __future__ import annotations
 
 import logging
-from typing import Any, Awaitable, Callable, Dict, Optional
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Sequence
 
 from aperag.db.ops import db_ops
 from aperag.domains.knowledge_graph.ports import CollectionRow
@@ -145,9 +145,10 @@ def build_collection_llm_callable(
 ENTITY_RELATION_EXTRACTION: str = """\
 You are an information-extraction assistant building a knowledge graph.
 
-Read the TEXT below and return a single JSON object with two arrays:
-``entities`` and ``relations``. Do not output anything outside the JSON
-object.
+Read the TEXT below — it is composed of one or more chunks separated by
+``[[chunk_id=<id> index=<n>]]`` boundary markers — and return a single
+JSON object with two arrays: ``entities`` and ``relations``. Do not
+output anything outside the JSON object.
 
 **Rules**
 
@@ -164,11 +165,31 @@ object.
    in the ``entities`` list. No self-loops (source != target).
 6. ``weight`` is an integer 1-10 expressing how strongly the text
    supports the relation; default to 5 when unsure.
-7. Cap: at most {max_entities} entities and {max_relations} relations.
-   If the text contains more, prefer the most specific and the
-   most-mentioned.
+7. Cap: at most {max_entities} entities and {max_relations} relations
+   for the whole window. If the text contains more, prefer the most
+   specific and the most-mentioned.
 8. If the text has no extractable entities, return
    ``{{"entities": [], "relations": []}}``.
+9. **Provenance — REQUIRED**: every entity and every relation MUST carry
+   ``source_chunk_ids``: a non-empty list of the boundary-marker
+   ``chunk_id`` values whose text supports it. Use only ids from this
+   allowlist: {allowed_chunk_ids}. The list of allowed ids matches the
+   ``chunk_id`` values in the boundary markers above; do not invent
+   new ids.
+10. **Cross-chunk relations**: when an entity defined in one chunk
+    appears in another, prefer to extract a relation linking them. Set
+    ``source_chunk_ids`` to every chunk_id whose text contributes
+    evidence for the relation (typically the chunks that mention each
+    side).
+11. **Deduplication & normalisation**: when the same entity appears in
+    multiple chunks (same name and type), emit it once with
+    ``source_chunk_ids`` covering every supporting chunk. Pick a single
+    canonical name across chunks — do not output two entities for an
+    obvious surface variant of the same thing.
+12. **No fabrication / fail-safe**: if you cannot ground a candidate
+    entity or relation in the actual text, drop it. Low-confidence
+    candidates may also be skipped. Returning fewer-but-correct beats
+    over-eager extraction.
 
 **JSON schema**
 
@@ -176,20 +197,23 @@ object.
 {{
   "entities": [
     {{"name": "<string>", "entity_type": "<existing or new type string>",
-      "description": "<string>"}}
+      "description": "<string>",
+      "source_chunk_ids": ["<chunk_id>", "..."]}}
   ],
   "relations": [
     {{"source": "<entity name>", "target": "<entity name>",
       "relation_type": "<short relation type>",
-      "description": "<string>", "weight": <int 1-10>}}
+      "description": "<string>", "weight": <int 1-10>,
+      "source_chunk_ids": ["<chunk_id>", "..."]}}
   ]
 }}
 ```
 
-**Example** (English):
+**Example** (single chunk):
 
 Text:
 ```
+[[chunk_id=c1 index=0]]
 Alice, a researcher at Acme Labs, collaborated with Bob on the project.
 ```
 
@@ -198,26 +222,29 @@ Output:
 {{
   "entities": [
     {{"name": "Alice", "entity_type": "Person",
-      "description": "A researcher at Acme Labs."}},
+      "description": "A researcher at Acme Labs.",
+      "source_chunk_ids": ["c1"]}},
     {{"name": "Bob", "entity_type": "Person",
-      "description": "A collaborator on the project."}},
+      "description": "A collaborator on the project.",
+      "source_chunk_ids": ["c1"]}},
     {{"name": "Acme Labs", "entity_type": "Organization",
-      "description": "Research organization where Alice works."}}
+      "description": "Research organization where Alice works.",
+      "source_chunk_ids": ["c1"]}}
   ],
   "relations": [
     {{"source": "Alice", "target": "Bob",
       "relation_type": "collaborated_with",
       "description": "Alice and Bob collaborated on a project.",
-      "weight": 7}},
+      "weight": 7, "source_chunk_ids": ["c1"]}},
     {{"source": "Alice", "target": "Acme Labs",
       "relation_type": "works_for",
       "description": "Alice is a researcher employed by Acme Labs.",
-      "weight": 8}}
+      "weight": 8, "source_chunk_ids": ["c1"]}}
   ]
 }}
 ```
 
----
+{few_shot_examples}---
 
 TEXT:
 ```
@@ -229,20 +256,54 @@ Output (JSON only):"""
 
 def render_extraction_prompt(
     *,
-    input_text: str,
+    window_chunks: "Sequence[Mapping[str, Any]]",
     entity_types: list[str] | tuple[str, ...],
     language: str,
     max_entities: int,
     max_relations: int,
+    few_shot_locale: Optional[str] = None,
 ) -> str:
-    """Fill in the extraction prompt template for one chunk.
+    """Fill in the extraction prompt template for one extraction window.
 
-    Kept as a simple function so tests can snapshot the exact rendered
-    string and catch accidental prompt regressions. The template is
-    identical to the legacy ``graphindex.prompts.ENTITY_RELATION_EXTRACTION``
-    text (relocated here verbatim during Wave 5 P1).
+    A "window" is one or more consecutive chunks from the same document
+    /parse_version that the graph extractor groups together for a
+    single LLM call (task #30 §3.1.1). For ``len(window_chunks) == 1``
+    the rendered prompt is structurally equivalent to the legacy
+    single-chunk shape — there is exactly one boundary marker and the
+    LLM still grounds every entity / relation in that single chunk —
+    but the v2 prompt now requires ``source_chunk_ids`` on every
+    record (task #30 §3.1.3 hard requirement #2). For ``len > 1`` the
+    window text carries one ``[[chunk_id=<id> index=<n>]]`` marker per
+    chunk and the prompt encourages cross-chunk relations + dedup.
+
+    ``few_shot_locale`` (task #30 §3.1.3 default-off opt-in): when set
+    to ``"zh"`` / ``"en"`` / ``"cross_chunk"`` the prompt embeds an
+    extra few-shot example to bias the LLM toward the corresponding
+    output style. Default ``None`` = no extra example (keeps the
+    prompt token budget tight per Bryce Concern 3 / huangheng A2 5th
+    co-scale const).
+
+    Kept as a function (rather than inlined) so tests can snapshot the
+    exact rendered string and catch accidental prompt regressions.
     """
     from aperag.indexing.entity_types import format_entity_types_for_prompt
+
+    if not window_chunks:
+        raise ValueError("render_extraction_prompt: window_chunks must be non-empty")
+
+    chunk_blocks: list[str] = []
+    chunk_ids: list[str] = []
+    for index, chunk in enumerate(window_chunks):
+        raw_id = chunk.get("chunk_id") or chunk.get("id") or ""
+        chunk_id = str(raw_id)
+        if not chunk_id:
+            raise ValueError(f"render_extraction_prompt: window_chunks[{index}] missing chunk_id / id")
+        text = str(chunk.get("text") or "")
+        chunk_blocks.append(f"[[chunk_id={chunk_id} index={index}]]\n{text}")
+        chunk_ids.append(chunk_id)
+
+    input_text = "\n\n".join(chunk_blocks)
+    allowed_chunk_ids_repr = ", ".join(repr(cid) for cid in chunk_ids)
 
     return ENTITY_RELATION_EXTRACTION.format(
         input_text=input_text,
@@ -250,7 +311,98 @@ def render_extraction_prompt(
         language=language,
         max_entities=max_entities,
         max_relations=max_relations,
+        allowed_chunk_ids=f"[{allowed_chunk_ids_repr}]",
+        few_shot_examples=_few_shot_examples_block(few_shot_locale),
     )
+
+
+# Few-shot example library (task #30 §3.1.3 default-off opt-in). The
+# library is small on purpose — every example adds prompt tokens that
+# trade off against the per-window cap (Bryce Concern 3 / huangheng A2
+# 5th co-scale const). New locales should be small, focused, and only
+# exercised when a real benchmark shows the locale wins.
+_FEW_SHOT_EXAMPLES: Dict[str, str] = {
+    "zh": """**Example** (Chinese):
+
+Text:
+```
+[[chunk_id=c1 index=0]]
+张伟在阿里云研究院担任高级研究员，与李娜共同负责图谱抽取项目。
+```
+
+Output:
+```
+{{
+  "entities": [
+    {{"name": "张伟", "entity_type": "Person",
+      "description": "阿里云研究院的高级研究员，负责图谱抽取项目。",
+      "source_chunk_ids": ["c1"]}},
+    {{"name": "李娜", "entity_type": "Person",
+      "description": "图谱抽取项目的合作研究员。",
+      "source_chunk_ids": ["c1"]}},
+    {{"name": "阿里云研究院", "entity_type": "Organization",
+      "description": "张伟所在的研究机构。",
+      "source_chunk_ids": ["c1"]}}
+  ],
+  "relations": [
+    {{"source": "张伟", "target": "阿里云研究院",
+      "relation_type": "works_for",
+      "description": "张伟受雇于阿里云研究院。",
+      "weight": 8, "source_chunk_ids": ["c1"]}},
+    {{"source": "张伟", "target": "李娜",
+      "relation_type": "collaborated_with",
+      "description": "张伟与李娜共同负责图谱抽取项目。",
+      "weight": 7, "source_chunk_ids": ["c1"]}}
+  ]
+}}
+```
+
+""",
+    "cross_chunk": """**Example** (cross-chunk relation):
+
+Text:
+```
+[[chunk_id=c1 index=0]]
+Acme Labs is a research organization founded in 2010.
+
+[[chunk_id=c2 index=1]]
+Alice, a senior researcher, joined Acme Labs in 2020.
+```
+
+Output:
+```
+{{
+  "entities": [
+    {{"name": "Acme Labs", "entity_type": "Organization",
+      "description": "A research organization founded in 2010.",
+      "source_chunk_ids": ["c1", "c2"]}},
+    {{"name": "Alice", "entity_type": "Person",
+      "description": "A senior researcher who joined Acme Labs in 2020.",
+      "source_chunk_ids": ["c2"]}}
+  ],
+  "relations": [
+    {{"source": "Alice", "target": "Acme Labs",
+      "relation_type": "works_for",
+      "description": "Alice joined Acme Labs as a senior researcher in 2020.",
+      "weight": 8, "source_chunk_ids": ["c1", "c2"]}}
+  ]
+}}
+```
+
+""",
+}
+
+
+def _few_shot_examples_block(locale: Optional[str]) -> str:
+    """Return the rendered few-shot block for ``locale`` or ``""`` when
+    the opt-in is off / the locale is unknown.
+
+    A warning at the call site already covers unknown locales so the
+    template-rendering path stays branch-free.
+    """
+    if not locale:
+        return ""
+    return _FEW_SHOT_EXAMPLES.get(locale, "")
 
 
 __all__ = [

--- a/tests/integration/test_graph_extractor.py
+++ b/tests/integration/test_graph_extractor.py
@@ -68,7 +68,7 @@ def test_parse_extraction_response_handles_well_formed_json():
         '{"source": "Linus", "target": "Linux", "type": "created", "description": "Linus created Linux"}'
         "]}"
     )
-    entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-1",))
     assert len(entities) == 1
     assert entities[0] == EntityRecord(
         name="Linus",
@@ -90,7 +90,7 @@ def test_parse_extraction_response_handles_fenced_json():
     """LLM middleware that wraps responses in ``\\`\\`\\`json ... \\`\\`\\``` must
     still parse cleanly — we strip the fence before json.loads."""
     raw = '```json\n{"entities": [{"name": "Acme", "type": "organisation"}], "relations": []}\n```'
-    entities, _ = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    entities, _ = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-1",))
     assert len(entities) == 1
     assert entities[0].name == "Acme"
 
@@ -107,7 +107,7 @@ def test_parse_extraction_response_warns_on_clean_json_with_zero_entities_and_re
     """
     raw = '{"entities": [], "relations": []}'
     with caplog.at_level("WARNING", logger="aperag.indexing.graph_extractor"):
-        entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-empty")
+        entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-empty",))
     assert entities == []
     assert relations == []
     matching = [r for r in caplog.records if "empty extraction result" in r.getMessage()]
@@ -116,7 +116,7 @@ def test_parse_extraction_response_warns_on_clean_json_with_zero_entities_and_re
         f"got {[r.getMessage() for r in caplog.records]}"
     )
     msg = matching[0].getMessage()
-    assert "c-empty" in msg, "warn line must include the chunk_id for cross-reference"
+    assert "c-empty" in msg, "warn line must include the chunk_ids for cross-reference"
     assert repr(raw) in msg, "warn line must include the raw response prefix for ops grep"
 
 
@@ -126,7 +126,7 @@ def test_parse_extraction_response_does_not_warn_when_entities_were_extracted(ca
     """
     raw = '{"entities": [{"name": "Linus", "type": "person", "description": "x"}], "relations": []}'
     with caplog.at_level("WARNING", logger="aperag.indexing.graph_extractor"):
-        entities, _ = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+        entities, _ = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-1",))
     assert len(entities) == 1
     matching = [r for r in caplog.records if "empty extraction result" in r.getMessage()]
     assert matching == [], "must not warn when extraction produced entities"
@@ -138,7 +138,7 @@ def test_parse_extraction_response_does_not_warn_on_relations_only(caplog):
     """
     raw = '{"entities": [], "relations": [{"source": "A", "target": "B", "type": "rel", "description": "x"}]}'
     with caplog.at_level("WARNING", logger="aperag.indexing.graph_extractor"):
-        _entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+        _entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-1",))
     assert len(relations) == 1
     matching = [r for r in caplog.records if "empty extraction result" in r.getMessage()]
     assert matching == [], "must not warn when extraction produced relations (even with 0 entities)"
@@ -146,7 +146,7 @@ def test_parse_extraction_response_does_not_warn_on_relations_only(caplog):
 
 def test_parse_extraction_response_returns_empty_on_malformed_json():
     raw = "not valid json — model rambled"
-    entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-1",))
     assert entities == []
     assert relations == []
 
@@ -166,7 +166,7 @@ def test_parse_extraction_response_skips_individual_malformed_records():
         '{"source": "C", "type": "missing-target"}'  # malformed
         "]}"
     )
-    entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-1",))
     names = [e.name for e in entities]
     assert names == ["Good Entity", "Another Good"]
     relation_types = [r.relation_type for r in relations]
@@ -181,7 +181,7 @@ def test_parse_extraction_response_accepts_unknown_entity_type():
         "],"
         '"relations": []}'
     )
-    entities, relations = ge._parse_extraction_response(raw=raw, chunk_id="c-1")
+    entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-1",))
     assert [entity.name for entity in entities] == ["糖尿病", "Bad Type"]
     assert entities[0].entity_type == "疾病"
     assert entities[1].entity_type == ""
@@ -192,7 +192,7 @@ def test_render_prompt_allows_dynamic_entity_types():
     from aperag.indexing.llm import render_extraction_prompt
 
     prompt = render_extraction_prompt(
-        input_text="OpenAI released GPT-4o.",
+        window_chunks=[{"chunk_id": "c-x", "text": "OpenAI released GPT-4o."}],
         entity_types=[],
         language="Chinese (Simplified)",
         max_entities=8,
@@ -203,6 +203,157 @@ def test_render_prompt_allows_dynamic_entity_types():
     assert "Use only these entity types" not in prompt
     assert "skip the entity rather than invent" not in prompt
     assert "Chinese (Simplified)" in prompt
+    # Task #30 §3.1.3 hard requirements visible in the rendered prompt.
+    assert "[[chunk_id=c-x index=0]]" in prompt
+    assert "source_chunk_ids" in prompt
+    assert "['c-x']" in prompt
+    assert "OpenAI released GPT-4o." in prompt
+    # Few-shot opt-in defaults to off — no extra example block.
+    assert "[[chunk_id=c1 index=0]]\n张伟" not in prompt
+    assert "[[chunk_id=c1 index=0]]\nAcme Labs" not in prompt
+
+
+def test_render_prompt_emits_one_marker_per_window_chunk():
+    """Task #30 §3.1.3 hard requirement #1: every chunk in the window
+    must carry its own ``[[chunk_id=X index=Y]]`` boundary marker so
+    the LLM can ground entities + relations per chunk."""
+    from aperag.indexing.llm import render_extraction_prompt
+
+    prompt = render_extraction_prompt(
+        window_chunks=[
+            {"chunk_id": "c1", "text": "Alpha founded Beta in 2010."},
+            {"chunk_id": "c2", "text": "Carol joined Beta in 2020."},
+        ],
+        entity_types=[],
+        language="English",
+        max_entities=12,
+        max_relations=12,
+    )
+    assert "[[chunk_id=c1 index=0]]" in prompt
+    assert "[[chunk_id=c2 index=1]]" in prompt
+    assert "['c1', 'c2']" in prompt
+    assert "Alpha founded Beta in 2010." in prompt
+    assert "Carol joined Beta in 2020." in prompt
+    # Cross-chunk relation guidance present.
+    assert "Cross-chunk relations" in prompt
+    # Dedup / fail-safe rules surfaced.
+    assert "Deduplication" in prompt
+    assert "No fabrication" in prompt
+
+
+def test_render_prompt_few_shot_opt_in_keeps_default_off():
+    """Task #30 §3.1.3 default-off opt-in: ``few_shot_locale=None``
+    embeds no extra example, ``"zh"`` embeds the Chinese example."""
+    from aperag.indexing.llm import render_extraction_prompt
+
+    base = render_extraction_prompt(
+        window_chunks=[{"chunk_id": "c-x", "text": "Alpha"}],
+        entity_types=[],
+        language="English",
+        max_entities=8,
+        max_relations=8,
+    )
+    with_zh = render_extraction_prompt(
+        window_chunks=[{"chunk_id": "c-x", "text": "Alpha"}],
+        entity_types=[],
+        language="English",
+        max_entities=8,
+        max_relations=8,
+        few_shot_locale="zh",
+    )
+    with_cross = render_extraction_prompt(
+        window_chunks=[{"chunk_id": "c-x", "text": "Alpha"}],
+        entity_types=[],
+        language="English",
+        max_entities=8,
+        max_relations=8,
+        few_shot_locale="cross_chunk",
+    )
+
+    assert "张伟" not in base
+    assert "张伟" in with_zh
+    assert "Acme Labs is a research organization founded in 2010." in with_cross
+    assert "Acme Labs is a research organization founded in 2010." not in base
+
+
+def test_render_prompt_rejects_empty_window():
+    from aperag.indexing.llm import render_extraction_prompt
+
+    with pytest.raises(ValueError):
+        render_extraction_prompt(
+            window_chunks=[],
+            entity_types=[],
+            language="English",
+            max_entities=8,
+            max_relations=8,
+        )
+
+
+def test_parse_response_falls_back_to_single_chunk_id_when_field_missing():
+    """Single-chunk window: legacy LLM responses that omit
+    ``source_chunk_ids`` still parse, with provenance defaulting to
+    the single allowed id (task #30 §3.1.3 parser invariant)."""
+    raw = (
+        '{"entities": ['
+        '{"name": "Linus", "type": "person"}'
+        "],"
+        '"relations": ['
+        '{"source": "Linus", "target": "Linux", "type": "created"}'
+        "]}"
+    )
+    entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c-only",))
+    assert entities[0].source_chunk_ids == ("c-only",)
+    assert relations[0].source_chunk_ids == ("c-only",)
+
+
+def test_parse_response_skips_records_missing_provenance_in_multi_chunk_window(caplog):
+    """Multi-chunk window: ``source_chunk_ids`` is required. Missing
+    field → record skipped + warned (task #30 §3.1.3 parser invariant)."""
+    raw = (
+        '{"entities": ['
+        '{"name": "Good", "type": "person", "source_chunk_ids": ["c1"]},'
+        '{"name": "Missing Provenance", "type": "person"}'
+        "],"
+        '"relations": ['
+        '{"source": "Good", "target": "Linux", "type": "uses",'
+        ' "source_chunk_ids": ["c2"]},'
+        '{"source": "Good", "target": "Linux", "type": "no_provenance"}'
+        "]}"
+    )
+    with caplog.at_level("WARNING", logger="aperag.indexing.graph_extractor"):
+        entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c1", "c2"))
+    assert [e.name for e in entities] == ["Good"]
+    assert entities[0].source_chunk_ids == ("c1",)
+    assert [r.relation_type for r in relations] == ["uses"]
+    assert relations[0].source_chunk_ids == ("c2",)
+
+
+def test_parse_response_drops_out_of_allowlist_chunk_ids():
+    """Hallucinated chunk_ids must be silently dropped before the
+    non-empty check (task #30 §3.1.3 parser invariant)."""
+    raw = (
+        '{"entities": [{"name": "Mixed", "type": "thing", "source_chunk_ids": ["c1", "ghost", "c2"]}], "relations": []}'
+    )
+    entities, _ = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c1", "c2"))
+    assert entities[0].source_chunk_ids == ("c1", "c2")
+
+
+def test_parse_response_preserves_cross_chunk_provenance():
+    """Multi-chunk window with cross-chunk relation: relation's
+    ``source_chunk_ids`` carries every chunk that contributed evidence."""
+    raw = (
+        '{"entities": ['
+        '{"name": "Acme Labs", "type": "organization",'
+        ' "source_chunk_ids": ["c1", "c2"]}'
+        "],"
+        '"relations": ['
+        '{"source": "Alice", "target": "Acme Labs", "type": "works_for",'
+        ' "source_chunk_ids": ["c1", "c2"]}'
+        "]}"
+    )
+    entities, relations = ge._parse_extraction_response(raw=raw, allowed_chunk_ids=("c1", "c2"))
+    assert entities[0].source_chunk_ids == ("c1", "c2")
+    assert relations[0].source_chunk_ids == ("c1", "c2")
 
 
 def test_resolve_entity_types_uses_collection_kg_config():


### PR DESCRIPTION
## Summary
Task #30-A3 / sub-task #53. Implements the prompt v2 contract from `docs/zh-CN/architecture/task-30-graph-chunk-window-spec-v1.md` §3.1.3 — every entity / relation now carries a non-empty `source_chunk_ids` list, the prompt prepends a `[[chunk_id=<id> index=<n>]]` boundary marker per chunk, and the parser validates returned ids against the window allowlist.

## 7 hard requirements landed
1. Per-chunk boundary markers in the rendered prompt.
2. `source_chunk_ids` REQUIRED on every entity + relation in the JSON schema.
3. Cross-chunk relations encouraged in the prompt rules.
4. Dedup / canonical-name guidance in the prompt rules.
5. Fail-safe / no-fabrication clause.
6. Cap rules now talk about per-window output (the `max_entities` and `max_relations` numbers are still rendered as-is from caller args; @huangheng's task #30-A2 / task #54 fills the co-scale formula).
7. Graph extractor still passes `response_format={"type": "json_object"}` to the LLM callable (kept verbatim from task #14 / PR #1877).

## Implementation
- `aperag/indexing/llm.py` — `ENTITY_RELATION_EXTRACTION` rewritten with the v2 rules; `render_extraction_prompt` now takes `window_chunks` instead of a single `input_text` and renders one `[[chunk_id=...]]` block per chunk. New `few_shot_locale` opt-in (default `None`) pulls from a `zh` / `cross_chunk` example library for collection configs that want a non-English or cross-chunk hint without paying the prompt-token tax by default.
- `aperag/indexing/graph_extractor.py` — new `_extract_one_window` taking a sequence of chunks; the legacy `_extract_one_chunk` is kept as a thin compat shim that wraps a single-chunk window so @ziang's task #30-A1 (PR #1918) dispatcher + existing callers stay green until A1 lands. Parser rewired: `_parse_extraction_response` now takes `allowed_chunk_ids`, and the new `_resolve_source_chunk_ids` enforces the spec invariant — single-chunk window falls back to the lone allowed id when the field is missing, multi-chunk window requires the LLM to populate it (otherwise the record is skipped + warned), and any out-of-allowlist id is silently dropped before the non-empty check so hallucinated chunk_ids do not poison provenance.

## Tests
- Rewire every `_parse_extraction_response` call to the new `allowed_chunk_ids` keyword.
- Update the rendered-prompt smoke test to the new `window_chunks` signature.
- New tests: per-chunk markers, few-shot opt-in, empty-window guard, single-chunk fallback, multi-chunk required-provenance branch, out-of-allowlist drop, cross-chunk provenance preservation.
- The `build_collection_llm_callable` monkeypatch stubs now accept `**_kwargs` so the patched lambdas tolerate the `response_format` keyword that `build_collection_graph_extractor` has been passing since task #14 (these stubs were silently accumulating an arity mismatch).

## Out of scope
- Window assembler + `graph_extraction_window_size` config — task #30-A1 / @ziang PR #1918.
- `MAX_ENTITIES` / `MAX_RELATIONS` / `TIMEOUT` / `BOOTSTRAP` / `MAX_PROMPT_TOKENS` co-scale — task #30-A2 / @huangheng task #54.
- Frontend / generated schema for the new collection config — A1 covers them.

## Merge order
PM @不穷 dispatched A1 → A3 → A2 (msg=fadcd64c). This PR (A3) will be rebased onto A1 after PR #1918 lands; A2 then folds the co-scale formula into the prompt's `max_entities` / `max_relations` placeholders.

## Test plan
- [x] `uvx ruff@0.15.12 check aperag/ tests/` — pass
- [x] `uvx ruff@0.15.12 format --check aperag/ tests/` — pass
- [x] `uv run --extra test python -m pytest tests/integration/test_graph_extractor.py -q` — 36 passed
- [ ] Full CI lint-and-unit + e2e-http-smoke + e2e-http-provider (after rebase onto A1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)