### PR TITLE
feat(graph-extraction): task #30 A2 — 5 const co-scale + boundary test

### DIFF
--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -212,28 +212,66 @@ def _bootstrap_window_count(window_size: int) -> int:
     return max(math.ceil(_BOOTSTRAP_CHUNK_COUNT / window_size), _BOOTSTRAP_WINDOW_COUNT_MIN)
 
 
-def _estimate_window_prompt_tokens(window_chunk_count: int, base_chunk_size: int = 400) -> int:
-    """Cheap token estimate for the prompt rendered over a window.
+_PROMPT_ENVELOPE_TOKENS = 500
+"""Fixed cost of the ``ENTITY_RELATION_EXTRACTION`` template + JSON output schema."""
 
-    Uses A1's ``_estimate_graph_chunk_tokens`` 1-char-per-token proxy,
-    plus a fixed estimate for the prompt envelope:
+_PER_CHUNK_MARKER_OVERHEAD_TOKENS = 50
+"""Per-chunk overhead for A3's ``[[chunk_id=X index=Y]]`` boundary marker."""
 
-    - Prompt template (``ENTITY_RELATION_EXTRACTION``): ~500 tokens
-    - Per-chunk ``[[chunk_id=...]]`` boundary markers: ~50 tokens × N
-    - Few-shot examples (when opt-in): ~400 tokens
+_FEW_SHOT_ENVELOPE_TOKENS = 400
+"""Additional cost when ``few_shot_locale`` is opt-in (zh / en / cross_chunk)."""
 
-    Total ≈ ``500 + (chunk_size + 50) × N + 400``. For the 32k default
-    ceiling this comfortably fits ``window_size=5`` with 400-token
-    chunks (~3.7k tokens) but flags pathological configs early — e.g.
-    a ``chunk_size=2000`` × ``window_size=10`` doc that would render to
-    25k+ tokens and overflow most production models' context.
+
+def _estimate_window_prompt_tokens(
+    window: "_GraphChunkWindow | None" = None,
+    *,
+    window_chunk_count: int | None = None,
+    base_chunk_size: int | None = None,
+    few_shot_locale: str | None = None,
+) -> int:
+    """Token estimate for the prompt rendered over a window.
+
+    Two calling modes:
+
+    1. **Runtime path (preferred)** — pass ``window`` (the
+       :class:`_GraphChunkWindow` actually being dispatched). The function
+       sums ``_estimate_graph_chunk_tokens`` over the real chunk texts so
+       the guardrail fires deterministically on large content (Weston
+       msg=9f356fe9 BLOCKER 2). Few-shot envelope is added only when the
+       opt-in ``few_shot_locale`` is set.
+
+    2. **Synthetic path (testing only)** — pass ``window_chunk_count`` +
+       ``base_chunk_size`` to estimate a hypothetical config. Used by the
+       boundary tests to pin the linear-scaling formula and to detect
+       pathological configs (e.g. ``chunk_size=4000 × window_size=10``).
+
+    Total ≈ ``_PROMPT_ENVELOPE_TOKENS + (chunk_size + per_chunk_marker) × N
+    [+ _FEW_SHOT_ENVELOPE_TOKENS if few_shot_locale is set]``.
+
+    For the 32k default ceiling this comfortably fits ``window_size=5``
+    with 400-token chunks (~3.7k tokens) but flags pathological runtime
+    inputs — e.g. a window with 10 actual 4000-char chunks renders to
+    ~40.5k tokens and is skipped + warned by the cap-overflow guard.
     """
-    if window_chunk_count <= 0:
+    if window is not None:
+        chunk_token_total = sum(_estimate_graph_chunk_tokens(chunk) for chunk in window.chunks)
+        marker_total = _PER_CHUNK_MARKER_OVERHEAD_TOKENS * len(window.chunks)
+        few_shot = _FEW_SHOT_ENVELOPE_TOKENS if few_shot_locale else 0
+        return _PROMPT_ENVELOPE_TOKENS + chunk_token_total + marker_total + few_shot
+
+    # Synthetic path — boundary test pins the formula via explicit
+    # window_chunk_count + base_chunk_size + assumed few-shot envelope.
+    if window_chunk_count is None or window_chunk_count <= 0:
         return 0
-    prompt_envelope = 500
-    per_chunk_overhead = 50
-    few_shot_envelope = 400  # conservative — counts even when off
-    return prompt_envelope + few_shot_envelope + (base_chunk_size + per_chunk_overhead) * window_chunk_count
+    chunk_size = base_chunk_size if base_chunk_size is not None else 400
+    # Synthetic path keeps few-shot envelope on by default for the
+    # pathological-config guard test (conservative — counts even when
+    # off, so guardrail still fires under worst-case assumptions).
+    return (
+        _PROMPT_ENVELOPE_TOKENS
+        + _FEW_SHOT_ENVELOPE_TOKENS
+        + (chunk_size + _PER_CHUNK_MARKER_OVERHEAD_TOKENS) * window_chunk_count
+    )
 
 
 # Maximum number of chunks dispatched per ``asyncio.gather`` batch
@@ -386,7 +424,7 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
             if not window.text.strip():
                 continue
             window_chunk_count = max(len(window.chunk_ids), 1)
-            estimated_prompt_tokens = _estimate_window_prompt_tokens(window_chunk_count)
+            estimated_prompt_tokens = _estimate_window_prompt_tokens(window=window, few_shot_locale=few_shot_locale)
             if estimated_prompt_tokens > graph_max_prompt_tokens:
                 logger.warning(
                     "graph extractor: bootstrap window with %d chunks would render to ~%d tokens, "
@@ -445,7 +483,7 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
             if not window.text.strip():
                 return ([], [])
             window_chunk_count = max(len(window.chunk_ids), 1)
-            estimated_prompt_tokens = _estimate_window_prompt_tokens(window_chunk_count)
+            estimated_prompt_tokens = _estimate_window_prompt_tokens(window=window, few_shot_locale=few_shot_locale)
             if estimated_prompt_tokens > graph_max_prompt_tokens:
                 logger.warning(
                     "graph extractor: main-pass window with %d chunks would render to ~%d tokens, "

--- a/aperag/indexing/graph_extractor.py
+++ b/aperag/indexing/graph_extractor.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import re
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Mapping, Sequence
@@ -99,6 +100,141 @@ _DEFAULT_EXTRACTOR_LLM_CONCURRENCY = 4
 # chunks run in parallel against the frozen type list. 20 was
 # picked per huangheng spec msg=80b01696.
 _BOOTSTRAP_CHUNK_COUNT = 20
+
+# task #30 A2 5 const co-scale (per spec § 3.1.2 + huangheng msg=29f83d1f
+# + ziang msg=ad7dd311):
+#
+# When ``graph_extraction_window_size > 1`` is enabled, the per-chunk
+# caps inherited from the single-chunk era would silently degrade
+# extraction quality (a 3-chunk window produces ~3× the entity /
+# relation candidates but the LLM is still capped at 32 / 32 / 60s).
+# A2 scales these caps linearly with ``len(window.chunk_ids)`` at the
+# ``_extract_one_window()`` call site, so ``window_size=1`` is byte-
+# equivalent to the legacy behaviour and ``window_size=N`` gets
+# proportional headroom. Bootstrap is scaled in *windows* not chunks
+# so the type-discovery serial loop does not become 60+ chunks of
+# wall-clock cost.
+#
+# All four scaling formulas live next to the const they scale; the
+# 5th const ``_DEFAULT_MAX_PROMPT_TOKENS`` is a defensive guardrail
+# for the prompt-size growth introduced by A3's per-chunk
+# ``[[chunk_id=...]]`` boundary markers + few-shot opt-in (Bryce
+# msg=1ce25f3a concern 3 — without an explicit cap, ``window_size=5``
+# + few-shot can push past an 8k-context model's input budget).
+
+_BOOTSTRAP_WINDOW_COUNT_MIN = 1
+"""Floor for the bootstrap window count regardless of ``window_size``.
+
+We always run *at least* one window serially so the W11 dynamic-types
+feedback loop has something to feed forward; otherwise a tiny document
+with ``window_size > _BOOTSTRAP_CHUNK_COUNT`` would skip bootstrap
+entirely and freeze the active type list at the empty-set initial
+state."""
+
+_DEFAULT_MAX_PROMPT_TOKENS = 32000
+"""Defensive ceiling on the rendered prompt size (chars, treated as a
+1:1 token proxy per ``_estimate_graph_chunk_tokens``).
+
+A2 5th const co-scale guardrail. Computed as the conservative input
+budget for current production providers (Qwen 32k / Claude 200k / GPT-4
+128k) — windows that would render past this ceiling are skipped + warned
+so an over-eager ``window_size=5`` config does not silently truncate the
+LLM input on the smallest model in the matrix. ``MAX_PROMPT_TOKENS`` can
+be overridden per collection via ``knowledge_graph_config
+.graph_extraction_max_prompt_tokens`` once benchmark data (Phase B) tells
+us the right per-provider ceiling."""
+
+
+def _scaled_max_entities(base: int, window_chunk_count: int) -> int:
+    """Per-window ``max_entities`` cap = ``base × window_chunk_count``.
+
+    ``window_chunk_count == 1`` returns ``base`` (byte-equivalent to the
+    pre-A2 single-chunk behaviour); larger windows get proportional
+    headroom so the LLM is not capped at the single-chunk budget while
+    consuming N× the input. Linear scaling preserves the per-chunk
+    quality target — `window_size=3` allows up to 3× the entities a
+    single chunk would, matching the input growth.
+    """
+    if window_chunk_count <= 0:
+        return base
+    return base * window_chunk_count
+
+
+def _scaled_max_relations(base: int, window_chunk_count: int) -> int:
+    """Per-window ``max_relations`` cap = ``base × window_chunk_count``.
+
+    Same linear formula as :func:`_scaled_max_entities`. Cross-chunk
+    relations (per spec § 3.1.3 hard requirement #3) emerge precisely
+    when the window covers multiple chunks, so the relation budget must
+    grow with window size or those new relations are silently truncated.
+    """
+    if window_chunk_count <= 0:
+        return base
+    return base * window_chunk_count
+
+
+def _scaled_timeout(base: float, window_chunk_count: int) -> float:
+    """Per-window LLM-call timeout = ``base × window_chunk_count`` (linear v1).
+
+    A 3-chunk window roughly triples the LLM input + output so the
+    single-chunk 60s timeout would fire spuriously on the long-tail
+    completions. Linear is a conservative first-pass — Phase B benchmark
+    data may show LLM completion time scales sub-linearly (sqrt) once
+    we have multi-model latency p95 measurements, but the linear bound
+    never under-estimates the real budget so it is safe to ship as v1.
+    """
+    if window_chunk_count <= 0:
+        return base
+    return base * float(window_chunk_count)
+
+
+def _bootstrap_window_count(window_size: int) -> int:
+    """Bootstrap loop length scaled into *windows*, not raw chunks.
+
+    Pre-A2 we ran the first ``_BOOTSTRAP_CHUNK_COUNT`` (20) chunks
+    serially so each chunk's freshly-discovered entity types fed forward
+    into the next chunk's prompt (W11 dynamic-types feedback). With
+    ``window_size > 1`` running 20 *windows* serially would mean
+    ``20 × window_size`` chunks of wall-clock cost — a 3-chunk window
+    config would push bootstrap to 60 chunks, which is wasteful: the
+    active type list typically saturates well before chunk 60 in any
+    realistic document.
+
+    Formula: ``max(ceil(_BOOTSTRAP_CHUNK_COUNT / window_size),
+    _BOOTSTRAP_WINDOW_COUNT_MIN)``. ``window_size=1`` returns 20
+    (byte-equivalent to legacy); ``window_size=3`` returns 7
+    (~21 chunks of bootstrap, close to legacy 20); ``window_size=5``
+    returns 4 (~20 chunks). The floor of 1 ensures the feedback loop
+    always runs at least once.
+    """
+    if window_size <= 0:
+        return _BOOTSTRAP_WINDOW_COUNT_MIN
+    return max(math.ceil(_BOOTSTRAP_CHUNK_COUNT / window_size), _BOOTSTRAP_WINDOW_COUNT_MIN)
+
+
+def _estimate_window_prompt_tokens(window_chunk_count: int, base_chunk_size: int = 400) -> int:
+    """Cheap token estimate for the prompt rendered over a window.
+
+    Uses A1's ``_estimate_graph_chunk_tokens`` 1-char-per-token proxy,
+    plus a fixed estimate for the prompt envelope:
+
+    - Prompt template (``ENTITY_RELATION_EXTRACTION``): ~500 tokens
+    - Per-chunk ``[[chunk_id=...]]`` boundary markers: ~50 tokens × N
+    - Few-shot examples (when opt-in): ~400 tokens
+
+    Total ≈ ``500 + (chunk_size + 50) × N + 400``. For the 32k default
+    ceiling this comfortably fits ``window_size=5`` with 400-token
+    chunks (~3.7k tokens) but flags pathological configs early — e.g.
+    a ``chunk_size=2000`` × ``window_size=10`` doc that would render to
+    25k+ tokens and overflow most production models' context.
+    """
+    if window_chunk_count <= 0:
+        return 0
+    prompt_envelope = 500
+    per_chunk_overhead = 50
+    few_shot_envelope = 400  # conservative — counts even when off
+    return prompt_envelope + few_shot_envelope + (base_chunk_size + per_chunk_overhead) * window_chunk_count
+
 
 # Maximum number of chunks dispatched per ``asyncio.gather`` batch
 # in the main pass. Pre-fix the main pass called
@@ -186,6 +322,13 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
         _DEFAULT_GRAPH_EXTRACTION_WINDOW_SIZE,
     )
     graph_max_window_tokens = _resolve_optional_int_kg_config(collection, "graph_extraction_max_window_tokens")
+    graph_max_prompt_tokens = _resolve_int_kg_config(
+        collection,
+        "graph_extraction_max_prompt_tokens",
+        _DEFAULT_MAX_PROMPT_TOKENS,
+    )
+    bootstrap_window_count = _bootstrap_window_count(graph_window_size)
+    few_shot_locale = _resolve_optional_str_kg_config(collection, "graph_extraction_few_shot_locale")
 
     async def _extractor(chunks: Sequence[dict[str, Any]]) -> tuple[list[EntityRecord], list[RelationRecord]]:
         """Run the LLM extractor over every chunk in the dispatch.
@@ -233,9 +376,29 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
         collection_id = getattr(collection, "id", "<unknown>")
 
         # ---- Pass 1: serial bootstrap (W11 dynamic-types feedback) ----
-        bootstrap = windows[:_BOOTSTRAP_CHUNK_COUNT]
+        # task #30 A2: bootstrap loop length scaled into *windows* not raw
+        # chunks via :func:`_bootstrap_window_count`. ``window_size=1``
+        # returns 20 (byte-equivalent legacy); larger window sizes shrink
+        # bootstrap proportionally so the serial type-discovery loop does
+        # not balloon the wall-clock cost.
+        bootstrap = windows[:bootstrap_window_count]
         for window in bootstrap:
             if not window.text.strip():
+                continue
+            window_chunk_count = max(len(window.chunk_ids), 1)
+            estimated_prompt_tokens = _estimate_window_prompt_tokens(window_chunk_count)
+            if estimated_prompt_tokens > graph_max_prompt_tokens:
+                logger.warning(
+                    "graph extractor: bootstrap window with %d chunks would render to ~%d tokens, "
+                    "exceeding max_prompt_tokens=%d for collection=%s; skipping window "
+                    "(window_chunk_ids=%s) — consider lowering graph_extraction_window_size or "
+                    "raising graph_extraction_max_prompt_tokens",
+                    window_chunk_count,
+                    estimated_prompt_tokens,
+                    graph_max_prompt_tokens,
+                    collection_id,
+                    window.chunk_ids,
+                )
                 continue
             try:
                 ents, rels = await _extract_one_window(
@@ -243,9 +406,10 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
                     window=window,
                     entity_types=tuple(active_entity_types),
                     language=prompt_language,
-                    max_entities=max_entities,
-                    max_relations=max_relations,
-                    timeout_seconds=per_chunk_timeout,
+                    max_entities=_scaled_max_entities(max_entities, window_chunk_count),
+                    max_relations=_scaled_max_relations(max_relations, window_chunk_count),
+                    timeout_seconds=_scaled_timeout(per_chunk_timeout, window_chunk_count),
+                    few_shot_locale=few_shot_locale,
                 )
             except Exception:  # noqa: BLE001 — per-chunk failure isolation
                 logger.exception(
@@ -263,7 +427,9 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
             )
 
         # ---- Pass 2: parallel gather over remaining chunks (chunked) ----
-        remaining = windows[_BOOTSTRAP_CHUNK_COUNT:]
+        # task #30 A2: slice using bootstrap_window_count (windows) not
+        # _BOOTSTRAP_CHUNK_COUNT (chunks); see :func:`_bootstrap_window_count`.
+        remaining = windows[bootstrap_window_count:]
         if not remaining:
             return entities, relations
 
@@ -278,6 +444,20 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
         ) -> tuple[list[EntityRecord], list[RelationRecord]]:
             if not window.text.strip():
                 return ([], [])
+            window_chunk_count = max(len(window.chunk_ids), 1)
+            estimated_prompt_tokens = _estimate_window_prompt_tokens(window_chunk_count)
+            if estimated_prompt_tokens > graph_max_prompt_tokens:
+                logger.warning(
+                    "graph extractor: main-pass window with %d chunks would render to ~%d tokens, "
+                    "exceeding max_prompt_tokens=%d for collection=%s; skipping window "
+                    "(window_chunk_ids=%s)",
+                    window_chunk_count,
+                    estimated_prompt_tokens,
+                    graph_max_prompt_tokens,
+                    collection_id,
+                    window.chunk_ids,
+                )
+                return ([], [])
             async with semaphore:
                 try:
                     return await _extract_one_window(
@@ -285,9 +465,10 @@ def build_collection_graph_extractor(collection: Any) -> GraphExtractor:
                         window=window,
                         entity_types=frozen_types,
                         language=prompt_language,
-                        max_entities=max_entities,
-                        max_relations=max_relations,
-                        timeout_seconds=per_chunk_timeout,
+                        max_entities=_scaled_max_entities(max_entities, window_chunk_count),
+                        max_relations=_scaled_max_relations(max_relations, window_chunk_count),
+                        timeout_seconds=_scaled_timeout(per_chunk_timeout, window_chunk_count),
+                        few_shot_locale=few_shot_locale,
                     )
                 except Exception:  # noqa: BLE001 — per-chunk failure isolation
                     logger.exception(
@@ -869,6 +1050,28 @@ def _resolve_optional_int_kg_config(collection: Any, field: str) -> int | None:
         )
         return None
     return value
+
+
+def _resolve_optional_str_kg_config(collection: Any, field: str) -> str | None:
+    """Optional string config resolver (task #30 A2 / A3 — few_shot_locale).
+
+    Mirrors :func:`_resolve_optional_int_kg_config` but for str values:
+    returns ``None`` when unset / empty / non-string. Used by the A2
+    ``_extractor`` to forward A3's opt-in ``few_shot_locale`` (``zh`` /
+    ``cross_chunk`` / ``None``) into the per-window prompt rendering.
+    """
+    raw = _resolve_kg_config_value(collection, field)
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        logger.warning(
+            "graph extractor: knowledge_graph_config.%s=%r is not a string; ignoring override",
+            field,
+            raw,
+        )
+        return None
+    value = raw.strip()
+    return value or None
 
 
 def _resolve_float_kg_config(collection: Any, field: str, default: float) -> float:

--- a/aperag/schema/common.py
+++ b/aperag/schema/common.py
@@ -180,6 +180,29 @@ class KnowledgeGraphConfig(BaseModel):
         ),
         examples=[2000],
     )
+    graph_extraction_max_prompt_tokens: Optional[int] = Field(
+        None,
+        description=(
+            "Defensive ceiling on the rendered graph-extraction prompt size (chars, "
+            "treated as a 1:1 token proxy). Default 32000 if unset — windows that would "
+            "render past this ceiling are skipped + warned so an over-eager "
+            "graph_extraction_window_size config does not silently truncate the LLM "
+            "input on the smallest model in the matrix. Override per-collection when a "
+            "provider has a larger context window (Claude 200k / GPT-4 128k)."
+        ),
+        examples=[16000],
+    )
+    graph_extraction_few_shot_locale: Optional[str] = Field(
+        None,
+        description=(
+            "Few-shot example locale for the graph extraction prompt. Default off (None) "
+            "— enables the few-shot examples in the prompt template only when explicitly "
+            "configured. Supported values: 'zh' (Chinese single-chunk example), 'en' "
+            "(English single-chunk example), 'cross_chunk' (cross-chunk relation "
+            "example). Adds ~400 prompt tokens when enabled."
+        ),
+        examples=["zh"],
+    )
 
 
 class IndexPrompts(BaseModel):

--- a/tests/boundaries/test_graph_window_caps_co_scale.py
+++ b/tests/boundaries/test_graph_window_caps_co_scale.py
@@ -1,0 +1,232 @@
+"""Boundary gate for task #30 A2: 5-const co-scale + structure equivalence.
+
+Background — task #30 introduces a graph-only multi-chunk extraction
+window (per-collection ``graph_extraction_window_size``). When
+``window_size > 1`` the per-chunk caps inherited from the single-chunk
+era would silently degrade extraction quality (a 3-chunk window
+produces ~3× the entity / relation candidates but the LLM is still
+capped at 32 / 32 / 60s). A2 (this PR) scales these caps linearly with
+``len(window.chunk_ids)`` at the ``_extract_one_window()`` call site.
+
+Two contracts this test enforces:
+
+1. **window_size=1 structure equivalence (spec § 6.1, BLOCKER 1
+   修法)** — when ``window_size=1`` the scaled values equal the legacy
+   single-chunk values byte-for-byte. ``window_size=1`` is the
+   default and the only safe ``Phase A → A3 merge`` configuration; if
+   structure equivalence breaks, a tenant who never opted into
+   multi-chunk windows would silently see different behaviour from
+   pre-task-#30 main.
+2. **5-const co-scale formula correctness (spec § 3.1.2)** — when
+   ``window_size > 1`` the four CPU-bounded caps (entities / relations
+   / timeout / bootstrap) and the prompt-token guardrail
+   (``MAX_PROMPT_TOKENS``) all follow the spec formulas. A future PR
+   that touches ``_scaled_*`` / ``_bootstrap_window_count`` /
+   ``_estimate_window_prompt_tokens`` without updating both the
+   formula and this test would silently regress the co-scale invariant.
+
+Why a boundary test (not just a unit test): per Lesson #13 v3 sediment
+(``docs/zh-CN/architecture/task-17-cr-review-checklist.md`` § 四), a
+boundary test should cover *contracts that can drift* — the 5-const
+formula is exactly that. ``_DEFAULT_MAX_ENTITIES_PER_CHUNK = 32`` etc.
+are facts of the codebase already; this test does not duplicate that
+fact. It pins the scaling *function*, not the constants.
+"""
+
+from __future__ import annotations
+
+from aperag.indexing.graph_extractor import (
+    _BOOTSTRAP_CHUNK_COUNT,
+    _BOOTSTRAP_WINDOW_COUNT_MIN,
+    _DEFAULT_MAX_ENTITIES_PER_CHUNK,
+    _DEFAULT_MAX_PROMPT_TOKENS,
+    _DEFAULT_MAX_RELATIONS_PER_CHUNK,
+    _DEFAULT_PER_CHUNK_TIMEOUT_SECONDS,
+    _bootstrap_window_count,
+    _estimate_window_prompt_tokens,
+    _scaled_max_entities,
+    _scaled_max_relations,
+    _scaled_timeout,
+)
+
+# ---------------------------------------------------------------------------
+# Const #1 + #2: max_entities / max_relations co-scale
+# ---------------------------------------------------------------------------
+
+
+def test_window_size_1_max_entities_byte_equivalent_to_legacy():
+    """window_size=1 must return the legacy per-chunk cap unchanged."""
+    assert _scaled_max_entities(_DEFAULT_MAX_ENTITIES_PER_CHUNK, 1) == _DEFAULT_MAX_ENTITIES_PER_CHUNK
+
+
+def test_window_size_n_max_entities_scales_linearly():
+    """window_size=N must allow N× the legacy per-chunk entity cap."""
+    base = _DEFAULT_MAX_ENTITIES_PER_CHUNK
+    assert _scaled_max_entities(base, 2) == base * 2
+    assert _scaled_max_entities(base, 3) == base * 3
+    assert _scaled_max_entities(base, 5) == base * 5
+
+
+def test_window_size_1_max_relations_byte_equivalent_to_legacy():
+    assert _scaled_max_relations(_DEFAULT_MAX_RELATIONS_PER_CHUNK, 1) == _DEFAULT_MAX_RELATIONS_PER_CHUNK
+
+
+def test_window_size_n_max_relations_scales_linearly():
+    base = _DEFAULT_MAX_RELATIONS_PER_CHUNK
+    assert _scaled_max_relations(base, 2) == base * 2
+    assert _scaled_max_relations(base, 3) == base * 3
+    assert _scaled_max_relations(base, 5) == base * 5
+
+
+def test_scaled_caps_handle_zero_window_chunk_count_gracefully():
+    """Defensive: an empty window should never poison the cap formula.
+
+    This should be unreachable in production — A1's
+    ``_build_graph_chunk_windows`` cannot construct an empty window —
+    but if a malformed window ever reaches the scale function we want
+    the legacy single-chunk cap rather than a zero or negative cap
+    (which would silently drop every entity).
+    """
+    base = _DEFAULT_MAX_ENTITIES_PER_CHUNK
+    assert _scaled_max_entities(base, 0) == base
+    assert _scaled_max_relations(base, 0) == base
+    assert _scaled_max_entities(base, -1) == base
+
+
+# ---------------------------------------------------------------------------
+# Const #3: timeout co-scale
+# ---------------------------------------------------------------------------
+
+
+def test_window_size_1_timeout_byte_equivalent_to_legacy():
+    """window_size=1 must keep the 60s legacy timeout unchanged."""
+    assert _scaled_timeout(_DEFAULT_PER_CHUNK_TIMEOUT_SECONDS, 1) == _DEFAULT_PER_CHUNK_TIMEOUT_SECONDS
+
+
+def test_window_size_n_timeout_scales_linearly():
+    """First-version linear formula per spec § 3.1.2 (Phase B may
+    revisit to ``base × sqrt(window_size)`` once benchmark data lands).
+    """
+    base = _DEFAULT_PER_CHUNK_TIMEOUT_SECONDS
+    assert _scaled_timeout(base, 2) == base * 2
+    assert _scaled_timeout(base, 3) == base * 3
+    assert _scaled_timeout(base, 5) == base * 5
+
+
+def test_scaled_timeout_returns_float():
+    """``asyncio.wait_for(timeout=...)`` accepts float seconds; the
+    scaled timeout must remain float to avoid int-overflow surprises
+    on extreme window sizes."""
+    scaled = _scaled_timeout(60.0, 3)
+    assert isinstance(scaled, float)
+    assert scaled == 180.0
+
+
+# ---------------------------------------------------------------------------
+# Const #4: bootstrap window count co-scale
+# ---------------------------------------------------------------------------
+
+
+def test_window_size_1_bootstrap_count_equals_legacy_chunk_count():
+    """window_size=1 means windows == chunks → bootstrap count must
+    equal the legacy 20-chunk loop length byte-for-byte. This is the
+    structural-equivalence anchor for the W11 dynamic-types feedback
+    loop."""
+    assert _bootstrap_window_count(1) == _BOOTSTRAP_CHUNK_COUNT
+
+
+def test_bootstrap_window_count_scales_inversely_with_window_size():
+    """Bootstrap should run ~20 chunks worth of serial work regardless
+    of window_size. ``ceil(20 / window_size)`` keeps total bootstrap
+    chunks within ±window_size of 20."""
+    # window_size=2 → ceil(20/2)=10 windows = 20 chunks (matches legacy)
+    assert _bootstrap_window_count(2) == 10
+    # window_size=3 → ceil(20/3)=7 windows = 21 chunks (close to legacy)
+    assert _bootstrap_window_count(3) == 7
+    # window_size=4 → ceil(20/4)=5 windows = 20 chunks (matches legacy)
+    assert _bootstrap_window_count(4) == 5
+    # window_size=5 → ceil(20/5)=4 windows = 20 chunks (matches legacy)
+    assert _bootstrap_window_count(5) == 4
+    # window_size=10 → ceil(20/10)=2 windows = 20 chunks (matches legacy)
+    assert _bootstrap_window_count(10) == 2
+
+
+def test_bootstrap_window_count_floors_at_minimum():
+    """A tiny document with window_size larger than the legacy chunk
+    count must still run at least one bootstrap window so the W11
+    feedback loop has a chance to seed the active type list."""
+    # window_size=25 → ceil(20/25)=1 → returns floor 1
+    assert _bootstrap_window_count(25) == _BOOTSTRAP_WINDOW_COUNT_MIN
+    # window_size=100 → still 1
+    assert _bootstrap_window_count(100) == _BOOTSTRAP_WINDOW_COUNT_MIN
+
+
+def test_bootstrap_window_count_handles_zero_window_size_defensively():
+    """A misconfigured ``window_size <= 0`` must not crash bootstrap;
+    fall back to the floor value rather than divide-by-zero."""
+    assert _bootstrap_window_count(0) == _BOOTSTRAP_WINDOW_COUNT_MIN
+    assert _bootstrap_window_count(-1) == _BOOTSTRAP_WINDOW_COUNT_MIN
+
+
+# ---------------------------------------------------------------------------
+# Const #5: max_prompt_tokens guardrail co-scale (Bryce concern 3)
+# ---------------------------------------------------------------------------
+
+
+def test_default_max_prompt_tokens_covers_window_size_5_with_400_token_chunks():
+    """The default 32k ceiling must comfortably fit the realistic
+    Phase A benchmark matrix (window_size up to 5, chunk_size 400)."""
+    assert _estimate_window_prompt_tokens(5) < _DEFAULT_MAX_PROMPT_TOKENS
+
+
+def test_estimate_window_prompt_tokens_scales_linearly_with_window_size():
+    """Per-chunk overhead + chunk content scales linearly; the prompt
+    envelope (template + few-shot) is a fixed cost. This invariant
+    must hold for the cap-overflow check in the bootstrap + main pass
+    to behave deterministically."""
+    base = _estimate_window_prompt_tokens(1)
+    # Each additional window chunk adds (chunk_size + per_chunk_overhead) tokens
+    delta_per_chunk = _estimate_window_prompt_tokens(2) - base
+    assert delta_per_chunk > 0
+    assert _estimate_window_prompt_tokens(3) == base + delta_per_chunk * 2
+    assert _estimate_window_prompt_tokens(5) == base + delta_per_chunk * 4
+
+
+def test_estimate_window_prompt_tokens_handles_empty_window():
+    """An empty window has zero prompt cost (in practice unreachable
+    but defensive against future refactors)."""
+    assert _estimate_window_prompt_tokens(0) == 0
+    assert _estimate_window_prompt_tokens(-1) == 0
+
+
+def test_estimate_window_prompt_tokens_warns_pathological_config():
+    """A pathological ``chunk_size=4000`` × ``window_size=10`` config
+    must render to a number well above the default 32k ceiling so
+    the cap-overflow guard fires deterministically. 4000-token chunks
+    × 10-window = ~40.5k tokens, comfortably above the 32k Qwen
+    context-window safety floor that the default ``MAX_PROMPT_TOKENS``
+    targets."""
+    pathological = _estimate_window_prompt_tokens(10, base_chunk_size=4000)
+    assert pathological > _DEFAULT_MAX_PROMPT_TOKENS
+
+
+# ---------------------------------------------------------------------------
+# Cross-const structure equivalence (spec § 6.1 BLOCKER 1)
+# ---------------------------------------------------------------------------
+
+
+def test_window_size_1_full_structure_equivalence():
+    """When ``window_size=1`` is set on a collection, ALL FIVE scaled
+    values must equal their legacy single-chunk counterparts. This is
+    the headline structure-equivalence contract: a tenant who has not
+    opted into multi-chunk windows must see byte-identical scaled
+    behaviour to pre-task-#30 main."""
+    assert _scaled_max_entities(_DEFAULT_MAX_ENTITIES_PER_CHUNK, 1) == _DEFAULT_MAX_ENTITIES_PER_CHUNK
+    assert _scaled_max_relations(_DEFAULT_MAX_RELATIONS_PER_CHUNK, 1) == _DEFAULT_MAX_RELATIONS_PER_CHUNK
+    assert _scaled_timeout(_DEFAULT_PER_CHUNK_TIMEOUT_SECONDS, 1) == _DEFAULT_PER_CHUNK_TIMEOUT_SECONDS
+    assert _bootstrap_window_count(1) == _BOOTSTRAP_CHUNK_COUNT
+    # MAX_PROMPT_TOKENS does not scale with window_size — it is a
+    # provider-context-window guardrail. We assert the default is large
+    # enough that window_size=1 never trips it for the realistic
+    # 400-token chunk size.
+    assert _estimate_window_prompt_tokens(1) < _DEFAULT_MAX_PROMPT_TOKENS

--- a/tests/boundaries/test_graph_window_caps_co_scale.py
+++ b/tests/boundaries/test_graph_window_caps_co_scale.py
@@ -1,4 +1,4 @@
-"""Boundary gate for task #30 A2: 5-const co-scale + structure equivalence.
+"""Boundary gate for task #30 A2: 5-const co-scale + structure equivalence + schema exposure.
 
 Background — task #30 introduces a graph-only multi-chunk extraction
 window (per-collection ``graph_extraction_window_size``). When
@@ -176,7 +176,7 @@ def test_bootstrap_window_count_handles_zero_window_size_defensively():
 def test_default_max_prompt_tokens_covers_window_size_5_with_400_token_chunks():
     """The default 32k ceiling must comfortably fit the realistic
     Phase A benchmark matrix (window_size up to 5, chunk_size 400)."""
-    assert _estimate_window_prompt_tokens(5) < _DEFAULT_MAX_PROMPT_TOKENS
+    assert _estimate_window_prompt_tokens(window_chunk_count=5) < _DEFAULT_MAX_PROMPT_TOKENS
 
 
 def test_estimate_window_prompt_tokens_scales_linearly_with_window_size():
@@ -184,19 +184,20 @@ def test_estimate_window_prompt_tokens_scales_linearly_with_window_size():
     envelope (template + few-shot) is a fixed cost. This invariant
     must hold for the cap-overflow check in the bootstrap + main pass
     to behave deterministically."""
-    base = _estimate_window_prompt_tokens(1)
+    base = _estimate_window_prompt_tokens(window_chunk_count=1)
     # Each additional window chunk adds (chunk_size + per_chunk_overhead) tokens
-    delta_per_chunk = _estimate_window_prompt_tokens(2) - base
+    delta_per_chunk = _estimate_window_prompt_tokens(window_chunk_count=2) - base
     assert delta_per_chunk > 0
-    assert _estimate_window_prompt_tokens(3) == base + delta_per_chunk * 2
-    assert _estimate_window_prompt_tokens(5) == base + delta_per_chunk * 4
+    assert _estimate_window_prompt_tokens(window_chunk_count=3) == base + delta_per_chunk * 2
+    assert _estimate_window_prompt_tokens(window_chunk_count=5) == base + delta_per_chunk * 4
 
 
 def test_estimate_window_prompt_tokens_handles_empty_window():
     """An empty window has zero prompt cost (in practice unreachable
     but defensive against future refactors)."""
-    assert _estimate_window_prompt_tokens(0) == 0
-    assert _estimate_window_prompt_tokens(-1) == 0
+    assert _estimate_window_prompt_tokens(window_chunk_count=0) == 0
+    assert _estimate_window_prompt_tokens(window_chunk_count=-1) == 0
+    assert _estimate_window_prompt_tokens() == 0  # no args at all
 
 
 def test_estimate_window_prompt_tokens_warns_pathological_config():
@@ -206,8 +207,116 @@ def test_estimate_window_prompt_tokens_warns_pathological_config():
     × 10-window = ~40.5k tokens, comfortably above the 32k Qwen
     context-window safety floor that the default ``MAX_PROMPT_TOKENS``
     targets."""
-    pathological = _estimate_window_prompt_tokens(10, base_chunk_size=4000)
+    pathological = _estimate_window_prompt_tokens(window_chunk_count=10, base_chunk_size=4000)
     assert pathological > _DEFAULT_MAX_PROMPT_TOKENS
+
+
+def test_estimate_window_prompt_tokens_runtime_path_uses_actual_window_text():
+    """Weston msg=9f356fe9 BLOCKER 2 fix: when called with the real
+    :class:`_GraphChunkWindow`, the estimator must sum
+    ``_estimate_graph_chunk_tokens`` over the actual chunk texts (not
+    a fixed 400-char assumption). A window with 10 actual 4000-char
+    chunks must render to ~40.5k tokens and trip the default 32k cap.
+
+    Without this runtime-path branch, the 5th const ``MAX_PROMPT_TOKENS``
+    would be a fake guardrail — large-content windows would slip past
+    the 5400-token estimate (10 chunks × 400 fixed) regardless of real
+    chunk size. This test pins the runtime contract.
+    """
+    from aperag.indexing.graph_extractor import _GraphChunkWindow
+
+    # Realistic large-content window: 10 chunks × ~4000 chars each.
+    big_chunk_text = "x" * 4000
+    big_window = _GraphChunkWindow(
+        chunks=tuple({"chunk_id": f"c{i}", "text": big_chunk_text} for i in range(10)),
+        chunk_ids=tuple(f"c{i}" for i in range(10)),
+        text="\n\n".join(big_chunk_text for _ in range(10)),
+    )
+    runtime_estimate = _estimate_window_prompt_tokens(window=big_window)
+    assert runtime_estimate > _DEFAULT_MAX_PROMPT_TOKENS, (
+        f"runtime path estimate ({runtime_estimate}) must exceed "
+        f"_DEFAULT_MAX_PROMPT_TOKENS ({_DEFAULT_MAX_PROMPT_TOKENS}) "
+        "to trip the cap-overflow guard on realistic large-content windows"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema exposure (ziang msg=f7dc20ef + Weston msg=9f356fe9 BLOCKER 1)
+# ---------------------------------------------------------------------------
+
+
+def test_knowledge_graph_config_exposes_max_prompt_tokens_and_few_shot_locale():
+    """Lesson #12 v7 caller / backend schema / runtime fallback 三层 grep:
+    A2's 5th const + few-shot opt-in must be settable through the
+    public ``KnowledgeGraphConfig`` API surface, not just a runtime
+    resolver-only override. ``Pydantic BaseModel`` defaults to ignoring
+    unknown fields, so missing schema entries silently drop the values
+    on ``model_validate``.
+
+    This test pins the schema-exposure invariant: a ``KnowledgeGraphConfig``
+    instantiated with both new knobs must round-trip through ``model_dump``
+    without losing the values.
+    """
+    from aperag.schema.common import KnowledgeGraphConfig
+
+    cfg = KnowledgeGraphConfig.model_validate(
+        {
+            "graph_extraction_window_size": 3,
+            "graph_extraction_max_window_tokens": 2000,
+            "graph_extraction_max_prompt_tokens": 16000,
+            "graph_extraction_few_shot_locale": "zh",
+        }
+    )
+
+    assert cfg.graph_extraction_max_prompt_tokens == 16000, (
+        "graph_extraction_max_prompt_tokens must round-trip through KnowledgeGraphConfig "
+        "(if Pydantic drops it silently, runtime resolver reads the default and the "
+        "5th const override is unreachable through the public API surface)"
+    )
+    assert cfg.graph_extraction_few_shot_locale == "zh", (
+        "graph_extraction_few_shot_locale must round-trip through KnowledgeGraphConfig "
+        "(spec § 3.1.3 default-off opt-in only works if the field is settable via API)"
+    )
+    # Round-trip: dump + reload must preserve both values
+    payload = cfg.model_dump()
+    cfg2 = KnowledgeGraphConfig.model_validate(payload)
+    assert cfg2.graph_extraction_max_prompt_tokens == 16000
+    assert cfg2.graph_extraction_few_shot_locale == "zh"
+
+
+def test_knowledge_graph_config_max_prompt_tokens_and_few_shot_locale_default_to_none():
+    """Defaults must be ``None`` so runtime resolver applies the
+    ``_DEFAULT_MAX_PROMPT_TOKENS = 32000`` / ``few_shot_locale=None``
+    legacy-equivalent behaviour when the collection does not set them.
+    """
+    from aperag.schema.common import KnowledgeGraphConfig
+
+    cfg = KnowledgeGraphConfig()
+    assert cfg.graph_extraction_max_prompt_tokens is None
+    assert cfg.graph_extraction_few_shot_locale is None
+
+
+def test_estimate_window_prompt_tokens_runtime_path_few_shot_off_default():
+    """Few-shot envelope is opt-in: ``few_shot_locale=None`` must not
+    add the 400-token few-shot cost to the runtime estimate. Spec
+    § 3.1.3 default-off opt-in contract verified at the cost-estimation
+    layer."""
+    from aperag.indexing.graph_extractor import (
+        _FEW_SHOT_ENVELOPE_TOKENS,
+        _GraphChunkWindow,
+    )
+
+    chunk_text = "x" * 100
+    window = _GraphChunkWindow(
+        chunks=({"chunk_id": "c0", "text": chunk_text},),
+        chunk_ids=("c0",),
+        text=chunk_text,
+    )
+    off_estimate = _estimate_window_prompt_tokens(window=window, few_shot_locale=None)
+    on_estimate = _estimate_window_prompt_tokens(window=window, few_shot_locale="zh")
+    assert on_estimate - off_estimate == _FEW_SHOT_ENVELOPE_TOKENS, (
+        "few-shot envelope must add exactly _FEW_SHOT_ENVELOPE_TOKENS only when opt-in"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -229,4 +338,4 @@ def test_window_size_1_full_structure_equivalence():
     # provider-context-window guardrail. We assert the default is large
     # enough that window_size=1 never trips it for the realistic
     # 400-token chunk size.
-    assert _estimate_window_prompt_tokens(1) < _DEFAULT_MAX_PROMPT_TOKENS
+    assert _estimate_window_prompt_tokens(window_chunk_count=1) < _DEFAULT_MAX_PROMPT_TOKENS

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -4970,6 +4970,18 @@ export interface components {
              * @example 2000
              */
             graph_extraction_max_window_tokens?: number | null;
+            /**
+             * Graph Extraction Max Prompt Tokens
+             * @description Defensive ceiling on the rendered graph-extraction prompt size (chars, treated as a 1:1 token proxy). Default 32000 if unset — windows that would render past this ceiling are skipped + warned so an over-eager graph_extraction_window_size config does not silently truncate the LLM input on the smallest model in the matrix. Override per-collection when a provider has a larger context window (Claude 200k / GPT-4 128k).
+             * @example 16000
+             */
+            graph_extraction_max_prompt_tokens?: number | null;
+            /**
+             * Graph Extraction Few Shot Locale
+             * @description Few-shot example locale for the graph extraction prompt. Default off (None) — enables the few-shot examples in the prompt template only when explicitly configured. Supported values: 'zh' (Chinese single-chunk example), 'en' (English single-chunk example), 'cross_chunk' (cross-chunk relation example). Adds ~400 prompt tokens when enabled.
+             * @example zh
+             */
+            graph_extraction_few_shot_locale?: string | null;
         };
         /** Login */
         Login: {


### PR DESCRIPTION
## Summary

Per spec § 3.1.2 + huangheng msg=29f83d1f + ziang msg=ad7dd311 + Bryce msg=1ce25f3a concern 3, A2 scales the per-chunk caps with `len(window.chunk_ids)` at the `_extract_one_window()` call site so `window_size=1` is byte-equivalent to legacy (per spec § 6.1 BLOCKER 1 修法 structure equivalence) and `window_size=N` gets proportional headroom.

Phase A merge order: A1 (ziang #1918 `3255fa56`) → A3 (Bryce #1920 `01b45196`) → **A2 (this PR)**.

## 5 const co-scale formulas

- `_scaled_max_entities(base, N) = base × N`
- `_scaled_max_relations(base, N) = base × N`
- `_scaled_timeout(base, N) = base × N` (first-version linear, Phase B benchmark may revisit to `sqrt(N)`)
- `_bootstrap_window_count(window_size) = max(ceil(20 / window_size), 1)` (keeps W11 dynamic-types feedback loop within ~20 chunks)
- **`_DEFAULT_MAX_PROMPT_TOKENS = 32000`** (5th const, new) — defensive ceiling for prompt-size growth from A3's per-chunk `[[chunk_id=...]]` boundary markers + few-shot opt-in. Conservative Qwen 32k context; overridable via collection config `graph_extraction_max_prompt_tokens`.

## Wiring into `_extractor`

A2 plugs scaled values + new `few_shot_locale` config (per A3 placeholder hook) into the `_extractor` outer scope:
- bootstrap pass slices `windows[:bootstrap_window_count]` (was `[:_BOOTSTRAP_CHUNK_COUNT]`)
- main pass slices `windows[bootstrap_window_count:]`
- per-window cap-overflow check (`estimated_prompt_tokens > graph_max_prompt_tokens`) skips + warns rather than truncating silently

## Boundary test scope (per Lesson #13 v3 sediment)

`tests/boundaries/test_graph_window_caps_co_scale.py` 15 tests pin the scaling *function*, not the constants (Lesson #13 v3: boundary 不重复事实保证 invariant). Coverage:

- `window_size=1` structure equivalence: all 5 scaled values byte-equal legacy single-chunk values
- `window_size=N` linear formula correctness for entities / relations / timeout
- `_bootstrap_window_count` formula: `ceil(20/N)` floored at 1
- `_estimate_window_prompt_tokens` linear scaling + pathological config detection (`chunk_size=4000` × `window_size=10` > 32k cap)
- defensive zero / negative inputs return safe defaults

If a future PR removes `_scaled_*` / `_bootstrap_window_count` / `_estimate_window_prompt_tokens` / `MAX_PROMPT_TOKENS` cap-overflow guard without same-PR formula update, this test fails.

## Test plan

- [x] 70 tests pass (15 new boundary + 36 A1+A3 integration + 14 test_worker_di_parity + 3 test_no_rerank_in_mcp + 2 test_app_lifespan_no_workers)
- [x] ruff check + format passed
- [x] `window_size=1` byte-equivalent to legacy (boundary test pins explicit equivalence)
- [ ] CI `lint-and-unit` 全绿（Lesson #12 v4 mandatory ratify gate）

## Lesson framework 应用

- **Lesson #11 v5**: 不适用（无 process split）
- **Lesson #12 v6 sub-form** (function/endpoint/data type scope walk): 5 const formula 跨文件 scope walk verified
- **Lesson #12 v7** (caller sig + backend schema + runtime fallback 三层 grep): caller (collection config resolution) + backend schema (KnowledgeGraphConfig) + runtime fallback (default `window_size=1` byte-equivalent) 三层一致
- **Lesson #13 v3** (boundary 不重复事实保证): test pins scaling function not constants