### PR TITLE
feat(benchmark): task #30 B1 — chunk-window matrix + per-document metrics

### DIFF
--- a/tests/benchmarks/graph_extraction/README.md
+++ b/tests/benchmarks/graph_extraction/README.md
@@ -63,14 +63,65 @@ make benchmark-graph-extraction MODELS='qwen/qwen-plus,moonshotai/kimi-k2.6'
 ## Scoring
 
 Each sample has a short hand-written expected entity list and relation endpoint
-list. The runner computes:
+list. The runner aggregates **per-document** (per task #30 spec § 6.3 +
+Planetegg msg=ea7efa7b acceptance criteria) across all windows for that
+document/model/window-size combination:
 
-- JSON parse success
-- entity hit rate
-- relation endpoint hit rate
-- latency
-- output tokens per second
-- estimated cost from OpenRouter usage/pricing
+1. `llm_call_count` — total LLM calls per document
+2. `input_tokens_total` + `output_tokens_total`
+3. `wall_time_s` — sum of per-window latencies
+4. `timeout_or_failure_count` — any window that errored or returned non-JSON
+5. `entities_count` + `relations_count` — extraction totals (raw)
+6. `duplicate_entity_count` + `duplicate_relation_count` — normalized-name dups
+7. `source_chunk_ids_valid` / `source_chunk_ids_total` — fraction of records
+   whose `source_chunk_ids` are a non-empty subset of the window's chunk_ids
+   (per task #30 §3.1.3 hard requirement #2)
 
-The scores are directional. They are intended to compare model/prompt changes
-against the same sample set, not to be a complete graph-quality judge.
+Plus the legacy directional scores (`entity_hit_rate`, `relation_hit_rate`,
+`json_ok_rate`, `estimated_cost_usd`).
+
+The scores are directional. They are intended to compare model/prompt/window
+changes against the same sample set, not to be a complete graph-quality judge.
+
+## Chunk window matrix (task #30 B1)
+
+The harness simulates the production `_GraphChunkWindow` (PR #1918 commit
+`3255fa56`) by splitting each sample text into `--pseudo-chunks-per-doc`
+(default `4`) pseudo-chunks and grouping them into non-overlapping windows
+of size `--chunk-window-size`. The rendered prompt uses the new
+`render_extraction_prompt(window_chunks=...)` API (PR #1920 commit
+`01b45196`) so each window carries `[[chunk_id=<id> index=<n>]]` boundary
+markers.
+
+Single-shape run:
+
+```bash
+uv run python tests/benchmarks/graph_extraction/runner.py \
+    --models qwen/qwen3-30b-a3b-instruct-2507 \
+    --chunk-window-size 3
+```
+
+Matrix sweep (one run, many results blocks):
+
+```bash
+uv run python tests/benchmarks/graph_extraction/runner.py \
+    --models qwen/qwen3-30b-a3b-instruct-2507,google/gemini-2.5-flash \
+    --matrix 1,2,3,5
+```
+
+Dry-run schema check (no provider call, used by B2 for ingestion verify
+per Planetegg msg=cbe84223):
+
+```bash
+uv run python tests/benchmarks/graph_extraction/runner.py \
+    --dry-run --matrix 1,2,3,5 --output /tmp/b1_dry_run.json
+```
+
+For real multi-chunk documents, raise `--pseudo-chunks-per-doc` (B2 may
+add larger samples than the current 3 when comparing window>1 effects on
+real-world-sized payloads).
+
+The harness structural pieces (chunking, windowing, validity counting,
+per-document aggregation) are unit-tested in
+`test_runner_units.py` so the matrix output schema stays pinned even
+though the benchmark itself runs out-of-CI.

--- a/tests/benchmarks/graph_extraction/README.md
+++ b/tests/benchmarks/graph_extraction/README.md
@@ -12,14 +12,15 @@ make benchmark-graph-extraction
 ```
 
 The default run uses the current ApeRAG graph extraction prompt via
-`aperag.indexing.llm.render_extraction_prompt` and does not send
-`response_format`. That matches current graph indexing behavior and gives a
-prompt-only baseline.
+`aperag.indexing.llm.render_extraction_prompt` **and sends
+`response_format={"type":"json_object"}` on every call** — task #30 A3
+PR #1920 (`01b45196`) made JSON-mode a graph extractor production
+invariant, so the benchmark mirrors production by default.
 
-To simulate the proposed JSON-mode fix:
+To explicitly compare against the legacy non-JSON-mode behavior:
 
 ```bash
-make benchmark-graph-extraction RESPONSE_FORMAT_JSON=1
+uv run python tests/benchmarks/graph_extraction/runner.py --no-response-format-json
 ```
 
 Results are written to:

--- a/tests/benchmarks/graph_extraction/runner.py
+++ b/tests/benchmarks/graph_extraction/runner.py
@@ -3,7 +3,14 @@
 
 This is intentionally not part of the default pytest or CI suite: it calls
 external LLM providers and consumes API credits. Run it only when comparing
-models, prompts, or JSON-mode changes.
+models, prompts, JSON-mode changes, or chunk-window matrices.
+
+task #30 B1 (msg=cecae5ed): supports the graph chunk window matrix
+(``--chunk-window-size`` / ``--matrix``). The harness aggregates 7
+metrics per-document (per Planetegg msg=ea7efa7b acceptance criteria
+echoed in spec § 6.3): LLM call count, input+output tokens, wall time,
+timeout/failure rate, entity+relation totals, duplicate rate, and
+``source_chunk_ids`` validity rate.
 """
 
 from __future__ import annotations
@@ -129,6 +136,57 @@ def parse_args() -> argparse.Namespace:
         "--response-format-json",
         action="store_true",
         help='Also send response_format={"type":"json_object"}. Current ApeRAG graph indexing does not do this yet.',
+    )
+    parser.add_argument(
+        "--chunk-window-size",
+        type=int,
+        default=1,
+        help=(
+            "Number of consecutive pseudo-chunks the harness groups into a "
+            "single graph extraction window per LLM call (task #30 §3.1.1). "
+            "Default 1 = legacy single-chunk behavior. Cannot be combined "
+            "with --matrix."
+        ),
+    )
+    parser.add_argument(
+        "--matrix",
+        default="",
+        help=(
+            "Comma-separated list of chunk-window sizes to sweep in one "
+            "run (e.g. --matrix 1,2,3,5). Each window size produces an "
+            "independent results block tagged in the output JSON. Cannot "
+            "be combined with --chunk-window-size."
+        ),
+    )
+    parser.add_argument(
+        "--pseudo-chunks-per-doc",
+        type=int,
+        default=4,
+        help=(
+            "How many pseudo-chunks each sample text is split into before "
+            "being grouped into windows. Default 4 keeps short benchmark "
+            "samples interpretable across window sizes 1/2/3/5 — for "
+            "real multi-chunk documents B2 should add larger samples "
+            "and raise this."
+        ),
+    )
+    parser.add_argument(
+        "--few-shot-locale",
+        default=None,
+        help=(
+            "Optional few-shot example locale (zh / en / cross_chunk) "
+            "passed through to render_extraction_prompt. Default None = "
+            "no extra example (task #30 §3.1.3 default-off)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Skip provider calls; print the harness output schema with "
+            "synthetic placeholder result rows. Used by Planetegg B2 "
+            "baseline connectivity check (msg=cbe84223)."
+        ),
     )
     return parser.parse_args()
 
@@ -293,8 +351,71 @@ def parse_extraction(raw: str) -> tuple[bool, str | None, list[dict[str, Any]], 
     return True, None, entities, relations
 
 
+def split_into_pseudo_chunks(text: str, k: int, *, sample_id: str) -> list[dict[str, str]]:
+    """Split ``text`` into ``k`` evenly-sized pseudo-chunks.
+
+    The graph extractor uses a real chunker (parser-driven) in production;
+    for benchmark reproducibility we just slice on character boundaries
+    and let the LLM see synthetic boundary markers via
+    ``[[chunk_id=<id> index=<n>]]``. ``k`` is clamped to ``1`` for empty
+    text and to ``len(text)`` for very short text so each pseudo-chunk
+    holds at least one character.
+    """
+    text = text or ""
+    k = max(1, min(int(k), max(1, len(text))))
+    if k == 1:
+        return [{"chunk_id": f"{sample_id}.c0", "text": text}]
+    base = len(text) // k
+    remainder = len(text) % k
+    chunks: list[dict[str, str]] = []
+    cursor = 0
+    for i in range(k):
+        size = base + (1 if i < remainder else 0)
+        chunks.append({"chunk_id": f"{sample_id}.c{i}", "text": text[cursor : cursor + size]})
+        cursor += size
+    return chunks
+
+
+def build_windows(chunks: list[dict[str, str]], window_size: int) -> list[list[dict[str, str]]]:
+    """Group consecutive ``chunks`` into non-overlapping windows of size
+    ``window_size`` (task #30 §3.1.1 #1: ``window_overlap=0`` first
+    version). The last window may be smaller than ``window_size`` when
+    ``len(chunks) % window_size != 0``.
+    """
+    n = max(1, int(window_size))
+    return [chunks[i : i + n] for i in range(0, len(chunks), n)]
+
+
+def source_chunk_ids_validity(
+    entities: list[dict[str, Any]],
+    relations: list[dict[str, Any]],
+    allowed_chunk_ids: set[str],
+) -> tuple[int, int]:
+    """Count entities + relations whose ``source_chunk_ids`` are a
+    non-empty subset of ``allowed_chunk_ids`` (task #30 §3.1.3 #2 +
+    spec § 6.3 ``source_chunk_ids`` validity rate).
+
+    Returns ``(valid, total)`` so callers can aggregate ratios across
+    multiple windows / samples / models.
+    """
+    valid = 0
+    total = 0
+    for record in [*entities, *relations]:
+        total += 1
+        ids = record.get("source_chunk_ids")
+        if not isinstance(ids, list) or not ids:
+            continue
+        if all(isinstance(cid, str) and cid in allowed_chunk_ids for cid in ids):
+            valid += 1
+    return valid, total
+
+
 def score_result(
-    sample: dict[str, Any], entities: list[dict[str, Any]], relations: list[dict[str, Any]]
+    sample: dict[str, Any],
+    entities: list[dict[str, Any]],
+    relations: list[dict[str, Any]],
+    *,
+    allowed_chunk_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     actual_names = {normalize_name(entity.get("name")) for entity in entities}
     entity_hits = sum(1 for expected in sample["expected_entities"] if entity_hit(expected, actual_names))
@@ -302,6 +423,13 @@ def score_result(
     entity_descriptions = [str(entity.get("description") or "").strip() for entity in entities]
     relation_descriptions = [str(relation.get("description") or "").strip() for relation in relations]
     descriptions = entity_descriptions + relation_descriptions
+    duplicate_entity_count = len(entities) - len({normalize_name(entity.get("name")) for entity in entities})
+    duplicate_relation_count = len(relations) - len(
+        {(normalize_name(relation.get("source")), normalize_name(relation.get("target"))) for relation in relations}
+    )
+    valid_refs = total_refs = 0
+    if allowed_chunk_ids is not None:
+        valid_refs, total_refs = source_chunk_ids_validity(entities, relations, allowed_chunk_ids)
     return {
         "entity_hits": entity_hits,
         "entity_total": len(sample["expected_entities"]),
@@ -309,6 +437,10 @@ def score_result(
         "relation_total": len(sample["expected_relations"]),
         "entities_count": len(entities),
         "relations_count": len(relations),
+        "duplicate_entity_count": max(0, duplicate_entity_count),
+        "duplicate_relation_count": max(0, duplicate_relation_count),
+        "source_chunk_ids_valid": valid_refs,
+        "source_chunk_ids_total": total_refs,
         "avg_entity_description_chars": round(
             sum(len(description) for description in entity_descriptions) / max(1, len(entity_descriptions)),
             1,
@@ -354,11 +486,21 @@ def call_openrouter(
     return response, latency
 
 
-def run_one(
+def _scale_for_window(base: int, window_chunks: list[dict[str, str]]) -> int:
+    """Scale per-chunk caps to per-window caps, mirroring task #30 §3.1.2
+    A2 ``base * len(window_chunks)`` co-scale formula. Used for the
+    benchmark prompt rendering only — production code path is owned by
+    ``aperag.indexing.graph_extractor`` (PR #1921 commit 9b4770ae).
+    """
+    return max(1, int(base) * max(1, len(window_chunks)))
+
+
+def run_window(
     *,
     api_key: str,
     model: str,
     sample: dict[str, Any],
+    window_chunks: list[dict[str, str]],
     prices: dict[str, ModelPrice],
     timeout: float,
     attempts: int,
@@ -366,14 +508,21 @@ def run_one(
     max_entities: int,
     max_relations: int,
     response_format_json: bool,
+    few_shot_locale: str | None,
 ) -> dict[str, Any]:
+    """Render + dispatch one extraction window for one (model, sample)
+    combination. Returns a per-window result row that callers aggregate
+    into per-document metrics via :func:`aggregate_sample`.
+    """
     prompt = render_extraction_prompt(
-        input_text=sample["text"],
+        window_chunks=window_chunks,
         entity_types=DEFAULT_ENTITY_TYPES,
         language=sample["language"],
-        max_entities=max_entities,
-        max_relations=max_relations,
+        max_entities=_scale_for_window(max_entities, window_chunks),
+        max_relations=_scale_for_window(max_relations, window_chunks),
+        few_shot_locale=few_shot_locale,
     )
+    allowed_ids = {chunk["chunk_id"] for chunk in window_chunks}
     try:
         response, latency = call_openrouter(
             api_key=api_key,
@@ -386,139 +535,336 @@ def run_one(
         )
     except Exception as exc:
         return {
-            "model": model,
-            "sample": sample["id"],
             "ok": False,
             "error": str(exc),
+            "window_chunk_ids": sorted(allowed_ids),
+            "entities": [],
+            "relations": [],
+            "latency_s": 0.0,
+            "input_tokens": 0,
+            "output_tokens": 0,
         }
 
     content = response["choices"][0]["message"].get("content") or ""
     usage = response.get("usage") or {}
     json_ok, parse_error, entities, relations = parse_extraction(content)
-    score = score_result(sample, entities, relations)
     input_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
     output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
-    price = prices.get(model, ModelPrice())
-    estimated_cost = usage.get("cost")
-    if estimated_cost is None:
-        estimated_cost = input_tokens * price.input_per_token + output_tokens * price.output_per_token
     return {
-        "model": model,
-        "sample": sample["id"],
         "ok": True,
         "json_ok": json_ok,
         "parse_error": parse_error,
-        **score,
-        "latency_s": round(latency, 2),
+        "window_chunk_ids": sorted(allowed_ids),
+        "entities": entities,
+        "relations": relations,
+        "latency_s": round(latency, 4),
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
-        "tokens_per_s": round(output_tokens / latency, 2) if output_tokens and latency else None,
-        "estimated_cost_usd": round(float(estimated_cost), 8),
-        "raw_preview": content[:300],
+        "raw_preview": content[:200],
     }
 
 
-def summarize(models: list[str], prices: dict[str, ModelPrice], results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def aggregate_sample(
+    *,
+    model: str,
+    sample: dict[str, Any],
+    window_size: int,
+    pseudo_chunks_per_doc: int,
+    window_results: list[dict[str, Any]],
+    prices: dict[str, ModelPrice],
+) -> dict[str, Any]:
+    """Aggregate per-window results into one per-document row with the
+    7 metrics required by spec § 6.3 (per Planetegg msg=ea7efa7b):
+    LLM call count, input+output tokens, wall time, timeout/failure,
+    entity+relation totals, duplicate rate, ``source_chunk_ids``
+    validity rate.
+    """
+    all_entities: list[dict[str, Any]] = []
+    all_relations: list[dict[str, Any]] = []
+    allowed_ids: set[str] = set()
+    timeouts_or_failures = 0
+    json_ok_count = 0
+    total_latency = 0.0
+    total_input_tokens = 0
+    total_output_tokens = 0
+    parse_errors: list[str] = []
+    for row in window_results:
+        if not row.get("ok"):
+            timeouts_or_failures += 1
+            continue
+        if not row.get("json_ok"):
+            timeouts_or_failures += 1
+            if row.get("parse_error"):
+                parse_errors.append(str(row["parse_error"]))
+        else:
+            json_ok_count += 1
+        all_entities.extend(row.get("entities") or [])
+        all_relations.extend(row.get("relations") or [])
+        allowed_ids.update(row.get("window_chunk_ids") or [])
+        total_latency += float(row.get("latency_s") or 0.0)
+        total_input_tokens += int(row.get("input_tokens") or 0)
+        total_output_tokens += int(row.get("output_tokens") or 0)
+
+    score = score_result(sample, all_entities, all_relations, allowed_chunk_ids=allowed_ids)
+    price = prices.get(model, ModelPrice())
+    estimated_cost = total_input_tokens * price.input_per_token + total_output_tokens * price.output_per_token
+
+    llm_call_count = len(window_results)
+    sample_ok = timeouts_or_failures == 0 and llm_call_count > 0
+
+    return {
+        "model": model,
+        "sample": sample["id"],
+        "window_size": window_size,
+        "pseudo_chunks_per_doc": pseudo_chunks_per_doc,
+        "ok": sample_ok,
+        "llm_call_count": llm_call_count,
+        "json_ok_count": json_ok_count,
+        "timeout_or_failure_count": timeouts_or_failures,
+        "wall_time_s": round(total_latency, 2),
+        "input_tokens_total": total_input_tokens,
+        "output_tokens_total": total_output_tokens,
+        "estimated_cost_usd": round(float(estimated_cost), 8),
+        "parse_errors": parse_errors[:3],
+        **score,
+    }
+
+
+def summarize(
+    models: list[str],
+    window_sizes: list[int],
+    prices: dict[str, ModelPrice],
+    results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Per-(model, window_size) summary that surfaces the spec § 6.3
+    decision-relevant aggregates: ``llm_call_count_total`` for cost
+    framing, hit-rate for quality framing, ``source_chunk_ids_valid_rate``
+    for provenance framing.
+    """
     summary = []
     for model in models:
-        rows = [row for row in results if row["model"] == model]
-        ok_rows = [row for row in rows if row.get("ok")]
-        price = prices.get(model, ModelPrice())
-        entity_total = sum(row.get("entity_total", 0) for row in ok_rows)
-        relation_total = sum(row.get("relation_total", 0) for row in ok_rows)
-        speed_rows = [row for row in ok_rows if row.get("tokens_per_s") is not None]
-        parsed_rows = [row for row in ok_rows if row.get("json_ok")]
-        summary.append(
-            {
-                "model": model,
-                "price_per_m_input": round(price.input_per_token * 1_000_000, 4),
-                "price_per_m_output": round(price.output_per_token * 1_000_000, 4),
-                "context_length": price.context_length,
-                "runs": len(rows),
-                "success_runs": len(ok_rows),
-                "json_ok_runs": sum(1 for row in ok_rows if row.get("json_ok")),
-                "entity_hit_rate": round(
-                    sum(row.get("entity_hits", 0) for row in ok_rows) / max(1, entity_total),
-                    3,
-                ),
-                "relation_hit_rate": round(
-                    sum(row.get("relation_hits", 0) for row in ok_rows) / max(1, relation_total),
-                    3,
-                ),
-                "avg_latency_s": round(
-                    sum(row.get("latency_s", 0) for row in ok_rows) / max(1, len(ok_rows)),
-                    2,
-                ),
-                "avg_tokens_per_s": round(
-                    sum(row.get("tokens_per_s") or 0 for row in speed_rows) / max(1, len(speed_rows)),
-                    2,
-                ),
-                "avg_cost_usd": round(
-                    sum(row.get("estimated_cost_usd", 0) for row in ok_rows) / max(1, len(ok_rows)),
-                    8,
-                ),
-                "avg_entity_description_chars": round(
-                    sum(row.get("avg_entity_description_chars", 0) for row in parsed_rows) / max(1, len(parsed_rows)),
-                    1,
-                ),
-                "avg_relation_description_chars": round(
-                    sum(row.get("avg_relation_description_chars", 0) for row in parsed_rows) / max(1, len(parsed_rows)),
-                    1,
-                ),
-                "empty_description_count": sum(row.get("empty_description_count", 0) for row in parsed_rows),
-                "errors": [row.get("error") for row in rows if not row.get("ok")],
-            }
-        )
+        for window_size in window_sizes:
+            rows = [row for row in results if row["model"] == model and row.get("window_size") == window_size]
+            ok_rows = [row for row in rows if row.get("ok")]
+            entity_total = sum(row.get("entity_total", 0) for row in rows)
+            relation_total = sum(row.get("relation_total", 0) for row in rows)
+            source_ids_valid = sum(row.get("source_chunk_ids_valid", 0) for row in rows)
+            source_ids_total = sum(row.get("source_chunk_ids_total", 0) for row in rows)
+            price = prices.get(model, ModelPrice())
+            summary.append(
+                {
+                    "model": model,
+                    "window_size": window_size,
+                    "price_per_m_input": round(price.input_per_token * 1_000_000, 4),
+                    "price_per_m_output": round(price.output_per_token * 1_000_000, 4),
+                    "context_length": price.context_length,
+                    "samples_run": len(rows),
+                    "samples_ok": len(ok_rows),
+                    "llm_call_count_total": sum(row.get("llm_call_count", 0) for row in rows),
+                    "timeout_or_failure_count_total": sum(row.get("timeout_or_failure_count", 0) for row in rows),
+                    "input_tokens_total": sum(row.get("input_tokens_total", 0) for row in rows),
+                    "output_tokens_total": sum(row.get("output_tokens_total", 0) for row in rows),
+                    "wall_time_s_total": round(sum(row.get("wall_time_s", 0) for row in rows), 2),
+                    "estimated_cost_usd_total": round(sum(row.get("estimated_cost_usd", 0) for row in rows), 8),
+                    "entity_hit_rate": round(
+                        sum(row.get("entity_hits", 0) for row in rows) / max(1, entity_total),
+                        3,
+                    ),
+                    "relation_hit_rate": round(
+                        sum(row.get("relation_hits", 0) for row in rows) / max(1, relation_total),
+                        3,
+                    ),
+                    "duplicate_entity_count_total": sum(row.get("duplicate_entity_count", 0) for row in rows),
+                    "duplicate_relation_count_total": sum(row.get("duplicate_relation_count", 0) for row in rows),
+                    "source_chunk_ids_valid_rate": round(source_ids_valid / max(1, source_ids_total), 3),
+                    "source_chunk_ids_total": source_ids_total,
+                    "json_ok_rate": round(
+                        sum(row.get("json_ok_count", 0) for row in rows)
+                        / max(1, sum(row.get("llm_call_count", 0) for row in rows)),
+                        3,
+                    ),
+                }
+            )
     return summary
+
+
+def _resolve_window_sizes(args: argparse.Namespace) -> list[int]:
+    if args.matrix and args.chunk_window_size != 1:
+        raise SystemExit("--matrix and --chunk-window-size are mutually exclusive")
+    if args.matrix:
+        sizes = [int(token.strip()) for token in args.matrix.split(",") if token.strip()]
+        if not sizes:
+            raise SystemExit("--matrix produced an empty list")
+        return sizes
+    return [int(args.chunk_window_size)]
+
+
+def _dry_run_payload(
+    *,
+    models: list[str],
+    window_sizes: list[int],
+    samples: list[dict[str, Any]],
+    pseudo_chunks_per_doc: int,
+) -> dict[str, Any]:
+    """Synthetic payload for ``--dry-run``: same schema as a real run
+    but every metric is ``0`` / placeholder. B2 (Planetegg msg=cbe84223)
+    uses this to verify their downstream tooling can ingest the matrix
+    output before paying for a real provider run.
+    """
+    placeholder_results = []
+    for model in models:
+        for window_size in window_sizes:
+            for sample in samples:
+                placeholder_results.append(
+                    {
+                        "model": model,
+                        "sample": sample["id"],
+                        "window_size": window_size,
+                        "pseudo_chunks_per_doc": pseudo_chunks_per_doc,
+                        "ok": False,
+                        "llm_call_count": 0,
+                        "json_ok_count": 0,
+                        "timeout_or_failure_count": 0,
+                        "wall_time_s": 0.0,
+                        "input_tokens_total": 0,
+                        "output_tokens_total": 0,
+                        "estimated_cost_usd": 0.0,
+                        "parse_errors": [],
+                        "entity_hits": 0,
+                        "entity_total": len(sample["expected_entities"]),
+                        "relation_hits": 0,
+                        "relation_total": len(sample["expected_relations"]),
+                        "entities_count": 0,
+                        "relations_count": 0,
+                        "duplicate_entity_count": 0,
+                        "duplicate_relation_count": 0,
+                        "source_chunk_ids_valid": 0,
+                        "source_chunk_ids_total": 0,
+                        "avg_entity_description_chars": 0.0,
+                        "avg_relation_description_chars": 0.0,
+                        "empty_description_count": 0,
+                        "_dry_run": True,
+                    }
+                )
+    return {
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "provider": "openrouter",
+        "mode": "dry_run",
+        "models": models,
+        "window_sizes": window_sizes,
+        "pseudo_chunks_per_doc": pseudo_chunks_per_doc,
+        "samples": [sample["id"] for sample in samples],
+        "summary": [],
+        "results": placeholder_results,
+        "note": (
+            "Dry-run skeleton — no provider calls were made. Real runs "
+            "populate every metric and add a non-empty 'summary' block."
+        ),
+    }
 
 
 def main() -> int:
     args = parse_args()
-    api_key = require_key()
     models = [model.strip() for model in args.models.split(",") if model.strip()]
+    window_sizes = _resolve_window_sizes(args)
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     samples = load_samples(Path(args.samples_dir))
+
+    if args.dry_run:
+        payload = _dry_run_payload(
+            models=models,
+            window_sizes=window_sizes,
+            samples=samples,
+            pseudo_chunks_per_doc=args.pseudo_chunks_per_doc,
+        )
+        output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"mode": "dry_run", "results_count": len(payload["results"])}, ensure_ascii=False))
+        print(f"wrote {output_path}", file=sys.stderr)
+        return 0
+
+    api_key = require_key()
     prices = fetch_model_prices(api_key, args.timeout, args.attempts)
 
-    work_items = [(model, sample) for model in models for sample in samples]
+    work_items: list[tuple[str, dict[str, Any], int, list[list[dict[str, str]]]]] = []
+    for sample in samples:
+        chunks = split_into_pseudo_chunks(sample["text"], args.pseudo_chunks_per_doc, sample_id=sample["id"])
+        for window_size in window_sizes:
+            windows = build_windows(chunks, window_size)
+            for model in models:
+                work_items.append((model, sample, window_size, windows))
+
     results: list[dict[str, Any]] = []
     max_workers = max(1, args.concurrency)
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {}
-        for model, sample in work_items:
-            print(f"running model={model} sample={sample['id']}", file=sys.stderr)
-            future = executor.submit(
-                run_one,
-                api_key=api_key,
-                model=model,
-                sample=sample,
-                prices=prices,
-                timeout=args.timeout,
-                attempts=args.attempts,
-                max_tokens=args.max_tokens,
-                max_entities=args.max_entities,
-                max_relations=args.max_relations,
-                response_format_json=args.response_format_json,
-            )
-            futures[future] = (model, sample["id"])
-        for future in concurrent.futures.as_completed(futures):
-            model, sample_id = futures[future]
-            try:
-                results.append(future.result())
-            except Exception as exc:
-                results.append(
-                    {
-                        "model": model,
-                        "sample": sample_id,
-                        "ok": False,
-                        "error": repr(exc),
-                    }
+        future_map: dict[concurrent.futures.Future[Any], tuple[str, str, int, int]] = {}
+        for model, sample, window_size, windows in work_items:
+            for window_index, window_chunks in enumerate(windows):
+                print(
+                    f"running model={model} sample={sample['id']} window_size={window_size} "
+                    f"window={window_index + 1}/{len(windows)}",
+                    file=sys.stderr,
                 )
+                future = executor.submit(
+                    run_window,
+                    api_key=api_key,
+                    model=model,
+                    sample=sample,
+                    window_chunks=window_chunks,
+                    prices=prices,
+                    timeout=args.timeout,
+                    attempts=args.attempts,
+                    max_tokens=args.max_tokens,
+                    max_entities=args.max_entities,
+                    max_relations=args.max_relations,
+                    response_format_json=args.response_format_json,
+                    few_shot_locale=args.few_shot_locale,
+                )
+                future_map[future] = (model, sample["id"], window_size, window_index)
+
+        per_sample_buckets: dict[tuple[str, str, int], list[tuple[int, dict[str, Any]]]] = {}
+        for future in concurrent.futures.as_completed(future_map):
+            model, sample_id, window_size, window_index = future_map[future]
+            try:
+                row = future.result()
+            except Exception as exc:
+                row = {
+                    "ok": False,
+                    "error": repr(exc),
+                    "window_chunk_ids": [],
+                    "entities": [],
+                    "relations": [],
+                    "latency_s": 0.0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                }
+            per_sample_buckets.setdefault((model, sample_id, window_size), []).append((window_index, row))
+
+    sample_by_id = {sample["id"]: sample for sample in samples}
+    for (model, sample_id, window_size), bucket in per_sample_buckets.items():
+        bucket.sort(key=lambda item: item[0])
+        window_results = [row for _, row in bucket]
+        results.append(
+            aggregate_sample(
+                model=model,
+                sample=sample_by_id[sample_id],
+                window_size=window_size,
+                pseudo_chunks_per_doc=args.pseudo_chunks_per_doc,
+                window_results=window_results,
+                prices=prices,
+            )
+        )
 
     sample_order = {sample["id"]: index for index, sample in enumerate(samples)}
     model_order = {model: index for index, model in enumerate(models)}
-    results.sort(key=lambda row: (model_order.get(row["model"], 9999), sample_order.get(row["sample"], 9999)))
+    window_order = {size: index for index, size in enumerate(window_sizes)}
+    results.sort(
+        key=lambda row: (
+            model_order.get(row["model"], 9999),
+            window_order.get(row.get("window_size"), 9999),
+            sample_order.get(row["sample"], 9999),
+        )
+    )
 
     payload = {
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
@@ -529,8 +875,10 @@ def main() -> int:
             "API keys are intentionally excluded from this artifact."
         ),
         "models": models,
+        "window_sizes": window_sizes,
+        "pseudo_chunks_per_doc": args.pseudo_chunks_per_doc,
         "samples": [sample["id"] for sample in samples],
-        "summary": summarize(models, prices, results),
+        "summary": summarize(models, window_sizes, prices, results),
         "results": results,
     }
     output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")

--- a/tests/benchmarks/graph_extraction/runner.py
+++ b/tests/benchmarks/graph_extraction/runner.py
@@ -134,8 +134,24 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--response-format-json",
+        dest="response_format_json",
         action="store_true",
-        help='Also send response_format={"type":"json_object"}. Current ApeRAG graph indexing does not do this yet.',
+        default=True,
+        help=(
+            "Send response_format={'type':'json_object'} on every call "
+            "(default ON — task #30 A3 PR #1920 made this a graph "
+            "extractor production invariant)."
+        ),
+    )
+    parser.add_argument(
+        "--no-response-format-json",
+        dest="response_format_json",
+        action="store_false",
+        help=(
+            "Disable JSON-mode (legacy comparison only — production "
+            "graph extractor always sets response_format=json_object "
+            "post task #30 A3)."
+        ),
     )
     parser.add_argument(
         "--chunk-window-size",
@@ -414,9 +430,17 @@ def score_result(
     sample: dict[str, Any],
     entities: list[dict[str, Any]],
     relations: list[dict[str, Any]],
-    *,
-    allowed_chunk_ids: set[str] | None = None,
 ) -> dict[str, Any]:
+    """Per-document scoring (hit-rate / dup count / description shape).
+
+    NOTE: ``source_chunk_ids`` validity intentionally lives on the
+    per-window result row (``run_window``) and is summed into the
+    per-document aggregate by :func:`aggregate_sample`. This is the
+    A3 parser invariant: each record's ``source_chunk_ids`` must be a
+    subset of **the window the record was produced in**, never of the
+    document-level union (BLOCKER fix per @ziang msg=56912dae +
+    @huangzhangshu msg=cda4dc75).
+    """
     actual_names = {normalize_name(entity.get("name")) for entity in entities}
     entity_hits = sum(1 for expected in sample["expected_entities"] if entity_hit(expected, actual_names))
     relation_hits = sum(1 for expected in sample["expected_relations"] if relation_hit(expected, relations))
@@ -427,9 +451,6 @@ def score_result(
     duplicate_relation_count = len(relations) - len(
         {(normalize_name(relation.get("source")), normalize_name(relation.get("target"))) for relation in relations}
     )
-    valid_refs = total_refs = 0
-    if allowed_chunk_ids is not None:
-        valid_refs, total_refs = source_chunk_ids_validity(entities, relations, allowed_chunk_ids)
     return {
         "entity_hits": entity_hits,
         "entity_total": len(sample["expected_entities"]),
@@ -439,8 +460,6 @@ def score_result(
         "relations_count": len(relations),
         "duplicate_entity_count": max(0, duplicate_entity_count),
         "duplicate_relation_count": max(0, duplicate_relation_count),
-        "source_chunk_ids_valid": valid_refs,
-        "source_chunk_ids_total": total_refs,
         "avg_entity_description_chars": round(
             sum(len(description) for description in entity_descriptions) / max(1, len(entity_descriptions)),
             1,
@@ -540,6 +559,8 @@ def run_window(
             "window_chunk_ids": sorted(allowed_ids),
             "entities": [],
             "relations": [],
+            "source_chunk_ids_valid": 0,
+            "source_chunk_ids_total": 0,
             "latency_s": 0.0,
             "input_tokens": 0,
             "output_tokens": 0,
@@ -550,6 +571,7 @@ def run_window(
     json_ok, parse_error, entities, relations = parse_extraction(content)
     input_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
     output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+    valid_refs, total_refs = source_chunk_ids_validity(entities, relations, allowed_ids)
     return {
         "ok": True,
         "json_ok": json_ok,
@@ -557,6 +579,8 @@ def run_window(
         "window_chunk_ids": sorted(allowed_ids),
         "entities": entities,
         "relations": relations,
+        "source_chunk_ids_valid": valid_refs,
+        "source_chunk_ids_total": total_refs,
         "latency_s": round(latency, 4),
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
@@ -581,13 +605,14 @@ def aggregate_sample(
     """
     all_entities: list[dict[str, Any]] = []
     all_relations: list[dict[str, Any]] = []
-    allowed_ids: set[str] = set()
     timeouts_or_failures = 0
     json_ok_count = 0
     total_latency = 0.0
     total_input_tokens = 0
     total_output_tokens = 0
     parse_errors: list[str] = []
+    source_chunk_ids_valid = 0
+    source_chunk_ids_total = 0
     for row in window_results:
         if not row.get("ok"):
             timeouts_or_failures += 1
@@ -600,12 +625,19 @@ def aggregate_sample(
             json_ok_count += 1
         all_entities.extend(row.get("entities") or [])
         all_relations.extend(row.get("relations") or [])
-        allowed_ids.update(row.get("window_chunk_ids") or [])
+        # source_chunk_ids validity is window-scoped (A3 parser
+        # invariant: each record's source_chunk_ids must be a non-empty
+        # subset of the window the record was produced in, never the
+        # document-level union — BLOCKER fix per @ziang msg=56912dae +
+        # @huangzhangshu msg=cda4dc75). Per-window valid/total is
+        # computed in run_window and only summed here.
+        source_chunk_ids_valid += int(row.get("source_chunk_ids_valid") or 0)
+        source_chunk_ids_total += int(row.get("source_chunk_ids_total") or 0)
         total_latency += float(row.get("latency_s") or 0.0)
         total_input_tokens += int(row.get("input_tokens") or 0)
         total_output_tokens += int(row.get("output_tokens") or 0)
 
-    score = score_result(sample, all_entities, all_relations, allowed_chunk_ids=allowed_ids)
+    score = score_result(sample, all_entities, all_relations)
     price = prices.get(model, ModelPrice())
     estimated_cost = total_input_tokens * price.input_per_token + total_output_tokens * price.output_per_token
 
@@ -626,6 +658,8 @@ def aggregate_sample(
         "output_tokens_total": total_output_tokens,
         "estimated_cost_usd": round(float(estimated_cost), 8),
         "parse_errors": parse_errors[:3],
+        "source_chunk_ids_valid": source_chunk_ids_valid,
+        "source_chunk_ids_total": source_chunk_ids_total,
         **score,
     }
 

--- a/tests/benchmarks/graph_extraction/test_runner_units.py
+++ b/tests/benchmarks/graph_extraction/test_runner_units.py
@@ -76,6 +76,10 @@ def test_source_chunk_ids_validity_subset_only():
 
 
 def test_aggregate_sample_per_document_metrics():
+    """Per-window ``source_chunk_ids_valid`` / ``source_chunk_ids_total``
+    are produced inside :func:`run_window`; ``aggregate_sample`` only
+    sums them. We pre-populate the per-window counts here.
+    """
     sample = _sample()
     window_results = [
         {
@@ -96,6 +100,8 @@ def test_aggregate_sample_per_document_metrics():
                     "source_chunk_ids": ["syn_cn.c0", "syn_cn.c1"],
                 },
             ],
+            "source_chunk_ids_valid": 4,
+            "source_chunk_ids_total": 4,
             "latency_s": 1.5,
             "input_tokens": 100,
             "output_tokens": 50,
@@ -110,6 +116,8 @@ def test_aggregate_sample_per_document_metrics():
                 {"name": "D", "description": "fourth", "source_chunk_ids": ["bad_id"]},
             ],
             "relations": [],
+            "source_chunk_ids_valid": 1,
+            "source_chunk_ids_total": 2,
             "latency_s": 1.2,
             "input_tokens": 80,
             "output_tokens": 40,
@@ -139,6 +147,60 @@ def test_aggregate_sample_per_document_metrics():
     assert row["relation_hits"] == 1
     assert row["source_chunk_ids_total"] == 6
     assert row["source_chunk_ids_valid"] == 5
+
+
+def test_aggregate_sample_source_chunk_ids_is_window_scoped_not_union():
+    """A record produced in window-0 that references a chunk_id from
+    window-1 must NOT be counted as valid by the per-document aggregate.
+    Validity is computed inside ``run_window`` against the window's own
+    ``allowed_chunk_ids`` (BLOCKER fix per @ziang msg=56912dae +
+    @huangzhangshu msg=cda4dc75). ``aggregate_sample`` only sums.
+    """
+    sample = _sample()
+    # Window-0 records all 1 entity that incorrectly references c1 (a
+    # chunk_id that only exists in window-1). Per-window scoring marks
+    # it as invalid: 0/1. Window-1 has one valid record: 1/1.
+    # If aggregate were to compute on the *union* {c0, c1}, the
+    # window-0 record would be misjudged valid → 2/2. The window-scoped
+    # path correctly returns 1/2 valid_total.
+    window_results = [
+        {
+            "ok": True,
+            "json_ok": True,
+            "window_chunk_ids": ["c0"],
+            "entities": [{"name": "A", "source_chunk_ids": ["c1"]}],  # ghost ref
+            "relations": [],
+            "source_chunk_ids_valid": 0,  # produced by run_window vs {"c0"}
+            "source_chunk_ids_total": 1,
+            "latency_s": 0.5,
+            "input_tokens": 10,
+            "output_tokens": 5,
+        },
+        {
+            "ok": True,
+            "json_ok": True,
+            "window_chunk_ids": ["c1"],
+            "entities": [{"name": "B", "source_chunk_ids": ["c1"]}],
+            "relations": [],
+            "source_chunk_ids_valid": 1,
+            "source_chunk_ids_total": 1,
+            "latency_s": 0.5,
+            "input_tokens": 10,
+            "output_tokens": 5,
+        },
+    ]
+
+    row = runner.aggregate_sample(
+        model="m",
+        sample=sample,
+        window_size=1,
+        pseudo_chunks_per_doc=2,
+        window_results=window_results,
+        prices={},
+    )
+
+    assert row["source_chunk_ids_valid"] == 1
+    assert row["source_chunk_ids_total"] == 2
 
 
 def test_aggregate_sample_marks_failure_when_any_window_errors():

--- a/tests/benchmarks/graph_extraction/test_runner_units.py
+++ b/tests/benchmarks/graph_extraction/test_runner_units.py
@@ -1,0 +1,178 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the manual graph-extraction benchmark harness.
+
+The benchmark itself runs against real OpenRouter providers and is gated
+out of CI (manual run with ``OPENROUTER_API_KEY``). These unit tests
+exercise the **structural** pieces — chunking, windowing, validity
+counting, per-document aggregation — so that the matrix harness keeps
+producing the schema documented in spec § 6.3 even when the benchmark
+itself is not run in CI.
+
+task #30 B1 (msg=cecae5ed). Sister to PR #1909 / PR #1912 (task #32
+Phase A) — same testing-lane pattern: fixture-isolated structural test
+that pins the contract a downstream consumer (here ``B2`` real-provider
+runs) needs without paying provider cost.
+"""
+
+from __future__ import annotations
+
+from tests.benchmarks.graph_extraction import runner
+
+
+def _sample(sample_id: str = "syn_cn", text: str = "AAABBBCCCDDD") -> dict[str, object]:
+    return {
+        "id": sample_id,
+        "language": "Chinese",
+        "text": text,
+        "expected_entities": ["A", "B", "C", "D"],
+        "expected_relations": [["A", "B"], ["C", "D"]],
+    }
+
+
+def test_split_into_pseudo_chunks_returns_k_chunks_with_distinct_ids():
+    chunks = runner.split_into_pseudo_chunks("AAAABBBBCCCC", k=3, sample_id="syn_cn")
+    assert [chunk["chunk_id"] for chunk in chunks] == ["syn_cn.c0", "syn_cn.c1", "syn_cn.c2"]
+    assert "".join(chunk["text"] for chunk in chunks) == "AAAABBBBCCCC"
+    assert all(chunk["text"] for chunk in chunks)
+
+
+def test_split_into_pseudo_chunks_handles_short_text():
+    chunks = runner.split_into_pseudo_chunks("ab", k=5, sample_id="syn_cn")
+    assert len(chunks) == 2
+    assert "".join(chunk["text"] for chunk in chunks) == "ab"
+
+
+def test_build_windows_non_overlapping():
+    chunks = [{"chunk_id": f"c{i}", "text": "x"} for i in range(5)]
+    assert runner.build_windows(chunks, 1) == [[chunks[i]] for i in range(5)]
+    assert runner.build_windows(chunks, 2) == [chunks[0:2], chunks[2:4], chunks[4:5]]
+    assert runner.build_windows(chunks, 3) == [chunks[0:3], chunks[3:5]]
+    assert runner.build_windows(chunks, 5) == [chunks[0:5]]
+
+
+def test_source_chunk_ids_validity_subset_only():
+    allowed = {"c0", "c1"}
+    entities = [
+        {"name": "A", "source_chunk_ids": ["c0"]},
+        {"name": "B", "source_chunk_ids": ["c1", "c0"]},
+        {"name": "C", "source_chunk_ids": ["c2"]},
+        {"name": "D", "source_chunk_ids": []},
+        {"name": "E"},
+    ]
+    relations = [
+        {"source": "A", "target": "B", "source_chunk_ids": ["c0", "c1"]},
+        {"source": "C", "target": "D", "source_chunk_ids": ["c0", "ghost"]},
+    ]
+    valid, total = runner.source_chunk_ids_validity(entities, relations, allowed)
+    assert total == 7
+    assert valid == 3
+
+
+def test_aggregate_sample_per_document_metrics():
+    sample = _sample()
+    window_results = [
+        {
+            "ok": True,
+            "json_ok": True,
+            "parse_error": None,
+            "window_chunk_ids": ["syn_cn.c0", "syn_cn.c1"],
+            "entities": [
+                {"name": "A", "description": "anchor", "source_chunk_ids": ["syn_cn.c0"]},
+                {"name": "B", "description": "neighbor", "source_chunk_ids": ["syn_cn.c1"]},
+                {"name": "A", "description": "duplicate", "source_chunk_ids": ["syn_cn.c1"]},
+            ],
+            "relations": [
+                {
+                    "source": "A",
+                    "target": "B",
+                    "description": "links",
+                    "source_chunk_ids": ["syn_cn.c0", "syn_cn.c1"],
+                },
+            ],
+            "latency_s": 1.5,
+            "input_tokens": 100,
+            "output_tokens": 50,
+        },
+        {
+            "ok": True,
+            "json_ok": True,
+            "parse_error": None,
+            "window_chunk_ids": ["syn_cn.c2", "syn_cn.c3"],
+            "entities": [
+                {"name": "C", "description": "third", "source_chunk_ids": ["syn_cn.c2"]},
+                {"name": "D", "description": "fourth", "source_chunk_ids": ["bad_id"]},
+            ],
+            "relations": [],
+            "latency_s": 1.2,
+            "input_tokens": 80,
+            "output_tokens": 40,
+        },
+    ]
+
+    row = runner.aggregate_sample(
+        model="m",
+        sample=sample,
+        window_size=2,
+        pseudo_chunks_per_doc=4,
+        window_results=window_results,
+        prices={},
+    )
+
+    assert row["ok"] is True
+    assert row["llm_call_count"] == 2
+    assert row["json_ok_count"] == 2
+    assert row["timeout_or_failure_count"] == 0
+    assert row["wall_time_s"] == 2.7
+    assert row["input_tokens_total"] == 180
+    assert row["output_tokens_total"] == 90
+    assert row["entities_count"] == 5
+    assert row["relations_count"] == 1
+    assert row["duplicate_entity_count"] == 1
+    assert row["entity_hits"] == 4
+    assert row["relation_hits"] == 1
+    assert row["source_chunk_ids_total"] == 6
+    assert row["source_chunk_ids_valid"] == 5
+
+
+def test_aggregate_sample_marks_failure_when_any_window_errors():
+    sample = _sample()
+    window_results = [
+        {
+            "ok": True,
+            "json_ok": True,
+            "window_chunk_ids": ["syn_cn.c0"],
+            "entities": [],
+            "relations": [],
+            "latency_s": 0.5,
+            "input_tokens": 10,
+            "output_tokens": 5,
+        },
+        {
+            "ok": False,
+            "error": "boom",
+            "window_chunk_ids": ["syn_cn.c1"],
+            "entities": [],
+            "relations": [],
+            "latency_s": 0.0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+        },
+    ]
+    row = runner.aggregate_sample(
+        model="m",
+        sample=sample,
+        window_size=1,
+        pseudo_chunks_per_doc=2,
+        window_results=window_results,
+        prices={},
+    )
+    assert row["ok"] is False
+    assert row["timeout_or_failure_count"] == 1
+    assert row["llm_call_count"] == 2


### PR DESCRIPTION
## Summary

task #30 sub-task B1（PM 派单 msg=cecae5ed → task #56）— 扩展 `tests/benchmarks/graph_extraction/` (PR #1863 framework) 支持 graph chunk window matrix benchmark。

Phase A 三 PR 入仓后 (`render_extraction_prompt` 已改为 `window_chunks=...` API)，旧 runner.py 直接断（per Planetegg msg=9489efdb 实证）。本 PR 修 API drift + 补 matrix runner + 7-metric per-document aggregation，让 B2 (Planetegg @ task #55) 可以正式跑数据。

## 改动

3 文件 / +685 / -108：

* `tests/benchmarks/graph_extraction/runner.py` — refactor:
  - 新 API `render_extraction_prompt(window_chunks=...)` (跟 PR #1920 `01b45196` align)
  - `--chunk-window-size N` 单 shape 模式
  - `--matrix N1,N2,...` batch 矩阵模式（与 `--chunk-window-size` 互斥）
  - `--pseudo-chunks-per-doc K` 控制每个 sample 切几个 pseudo-chunk（default 4，B2 加大 sample 时调）
  - `--few-shot-locale {zh|en|cross_chunk}` 透传 A3 default-off opt-in (per PR #1920)
  - `--dry-run` 输出 schema placeholder（Planetegg B2 msg=cbe84223 ingestion verify 用）
  - `_scale_for_window` 镜像 A2 5 const co-scale 公式 (`base * len(window_chunks)`，per PR #1921 `9b4770ae`)
  - `aggregate_sample` 把 N 个 window 的结果 fold 成 1 个 per-document row
  - `summarize` 输出按 (model, window_size) 二维聚合，含 `llm_call_count_total` / `source_chunk_ids_valid_rate` / `entity_hit_rate` / `relation_hit_rate` 等

* `tests/benchmarks/graph_extraction/test_runner_units.py` — 新建 6 单测钉 harness 结构契约：
  - `split_into_pseudo_chunks` 切片正确 + 短文本兜底
  - `build_windows` 非重叠分组
  - `source_chunk_ids_validity` 子集判定（含 ghost id / 空列表 / 缺字段）
  - `aggregate_sample` 多 window 聚合 + 7 metric + duplicate 计数
  - failure-window 把整 doc 标 `ok=False` 的 invariant

* `tests/benchmarks/graph_extraction/README.md` — 文档化 7 metric 含义、`--matrix` / `--dry-run` 用法、跟 PR #1918 / #1920 / #1921 的对应关系，以及单测落点。

## 设计要点（cite spec § 6.3 + 团队 sediment）

1. **per-document 聚合**（per Planetegg msg=ea7efa7b + spec § 6.3）— 不只看单次 LLM 调用 token / latency，而是 `wall_time_s_total` / `llm_call_count_total` / `estimated_cost_usd_total` 整 doc 维度，避免「单次调用变慢但总调用数减少」效应被抹平。

2. **`source_chunk_ids` 有效率**（task #30 §3.1.3 #2 + Lesson #12 v7.1 composite key invariant）— 验证 LLM 输出的 `source_chunk_ids` 是当前 window 的 `chunk_ids` 非空子集（防 ghost id / 缺字段），跟 task #32 PR #1909 `GraphEvidenceRef` schema 同源契约。

3. **matrix mode 互斥** — `--chunk-window-size` 和 `--matrix` 互斥，避免 caller 误同时给两个 sweep 维度（`_resolve_window_sizes` 守护）。

4. **`--dry-run` schema-only** — 给 B2 (Planetegg) 跑 baseline ingestion verify，无 provider cost。

5. **B1 sequential 依赖 A1+A2+A3** — A1 `_GraphChunkWindow` shape / A2 5 const co-scale / A3 prompt v2 全部已 in main，B1 直接复用 `render_extraction_prompt` runtime 入口（不 mock，避免 metrics 失真，per @ziang msg=75683721）。

6. **不在 CI 跑** — benchmark 本身 manual + 烧 provider token，但结构契约 6 单测进 CI（`test_runner_units.py`），保证未来 prompt / cap / window assembler 改动不破坏 harness 输出 schema。

## CR 请求

- @符炫炜 architect ratify — harness 边界 + 跟 spec § 6.3 metrics 一致性
- @ziang implementation CR — runtime 路径是否真走 A1/A2/A3 而非 mock（per msg=75683721）
- @Planetegg B2 owner verify — `--dry-run` schema 跟你 B2 ingestion 工具兼容 + 7 metric 命名跟你成本/指标模板对齐（per msg=cbe84223）
- @huangheng Lesson framework 应用 + cr-checklist 5 cross-check
- @huangzhangshu testing lane primary CR — 6 单测覆盖度 + harness 结构契约钉死

## Test plan

- [x] `uv run python -m pytest tests/benchmarks/graph_extraction/test_runner_units.py -v` → **6 passed**
- [x] `uv run python tests/benchmarks/graph_extraction/runner.py --dry-run --matrix 1,2,3,5 --output /tmp/b1_dry_run.json` → 12 placeholder rows，schema 完整
- [x] `make lint` (pre-commit) ✅
- [ ] CI: lint-and-unit / e2e workflows
- [ ] B2 (Planetegg) 用 `--dry-run` schema 验证后跑真实 1/2/3/5 × 多 model 矩阵
- [ ] B2 数据出来后 → B3 default-value lock + spec amend

🤖 Generated with [Claude Code](https://claude.com/claude-code)