### PR TITLE
ci(compat): trigger Backend-Compat-Test on real graph_storage path

### DIFF
--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -4,8 +4,20 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'aperag/domains/knowledge_graph/graphindex/**'
+      # Real graph store implementations (Neo4j / Nebula / PG).
+      # The legacy ``aperag/domains/knowledge_graph/graphindex`` tree
+      # has been gradually migrated under ``aperag/indexing/graph_storage``;
+      # without this entry, Backend-Compat-Test does NOT trigger when a
+      # PR modifies neo4j.py / nebula.py / postgres.py — exactly the
+      # invariant this workflow exists to defend.
+      - 'aperag/indexing/graph_storage/**'
+      # Vector store adapters (PGVector / Qdrant).
       - 'aperag/vectorstore/**'
+      # Legacy graphindex shim path kept as a defensive trigger; the
+      # active backend code now lives under aperag/indexing/graph_storage/
+      # but follow-up commits may still touch this tree, and removing
+      # the entry could miss those.
+      - 'aperag/domains/knowledge_graph/graphindex/**'
       - 'tests/integration/compat/**'
       - '.github/workflows/compat-test.yml'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

\`compat-test.yml\` \`pull_request\` paths filter watches \`aperag/domains/knowledge_graph/graphindex/**\` and \`aperag/vectorstore/**\`, but the actual graph store backends were moved to \`aperag/indexing/graph_storage/{neo4j,nebula,postgres}.py\`. **Any PR touching those files therefore bypassed Backend-Compat-Test** — exactly the workflow that exists to catch cross-adapter regressions.

This is task #61 P0 surfaced by chenyexuan workflow-gate audit (msg=f298011e).

## Why this matters

冬柏 (msg=f6416178) flagged \`GET /graphs/labels\` Neo4j 500 vs Nebula/PG pass as the canonical P0 candidate for task #61. That regression should have been caught by Backend-Compat-Test, but the workflow never ran for the relevant PRs because of this stale filter. Today's edits to \`aperag/indexing/graph_storage/neo4j.py\` (mtime 2026-04-30) similarly skipped the gate.

## Change

Add \`aperag/indexing/graph_storage/**\` to the paths filter. Keep the legacy \`aperag/domains/knowledge_graph/graphindex/**\` entry as a defensive fallback for any follow-up commits that still touch the old tree (low cost, removes a footgun).

## Test plan

- [x] Pure CI configuration change; no test logic, no production code.
- [x] git diff --check pass.
- [x] Architect msg=edbdd2b4 standing ratify (small fix, meta-quality issue, 0 risk).
- [x] Sediment candidate Lesson #16 / Lesson #15 v2 (workflow path drift bypass) noted; huangheng follow-up sub-PR will fold.

## CR

- @符炫炜 architect ratify (already endorsed standing)
- @huangheng standby cross-link
- @ziang task #64 / @Bryce task #69 backend audit will benefit from this gate firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)