### PR TITLE
fix(helm): pass Neo4j credentials to indexing worker

### DIFF
--- a/deploy/aperag/templates/indexing-worker-deployment.yaml
+++ b/deploy/aperag/templates/indexing-worker-deployment.yaml
@@ -83,6 +83,28 @@ spec:
               value: {{ .Values.indexingWorker.dbPoolSize | quote }}
             - name: DB_MAX_OVERFLOW
               value: {{ .Values.indexingWorker.dbMaxOverflow | quote }}
+            {{- if .Values.neo4j.enabled }}
+            - name: NEO4J_URI
+              value: {{ .Values.neo4j.NEO4J_URI | quote }}
+            - name: NEO4J_USERNAME
+              {{- if .Values.neo4j.NEO4J_CREDENTIALS_SECRET_NAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.neo4j.NEO4J_CREDENTIALS_SECRET_NAME }}
+                  key: username
+              {{- else }}
+              value: {{ .Values.neo4j.NEO4J_USERNAME | default "neo4j" | quote }}
+              {{- end }}
+            - name: NEO4J_PASSWORD
+              {{- if .Values.neo4j.NEO4J_CREDENTIALS_SECRET_NAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.neo4j.NEO4J_CREDENTIALS_SECRET_NAME }}
+                  key: password
+              {{- else }}
+              value: {{ .Values.neo4j.NEO4J_PASSWORD | default "neo4j" | quote }}
+              {{- end }}
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           name: aperag-indexing-worker
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
## Summary

Fix a Helm deploy config drift where the API deployment received Neo4j credentials from `.Values.neo4j.*`, but the indexing-worker deployment did not. With `neo4j.enabled=true`, API graph reads could be configured correctly while worker graph writes still fell back to blank `.env` Neo4j values from `api.env.*`.

This mirrors the API deployment's Neo4j env/secret injection into `indexing-worker-deployment.yaml` so worker-side graph indexing uses the same configured Neo4j endpoint and credentials.

## Validation

- `helm lint ./deploy/aperag --set neo4j.enabled=true --set api.env.GRAPH_DB_TYPE=neo4j`
- `helm template aperag ./deploy/aperag --set neo4j.enabled=true --set api.env.GRAPH_DB_TYPE=neo4j | rg -n -C 4 "NEO4J_URI|NEO4J_USERNAME|NEO4J_PASSWORD|aperag-indexing-worker"`
  - rendered indexing-worker includes `NEO4J_URI=bolt://neo4j-cluster-neo4j:7687`
  - rendered indexing-worker includes `NEO4J_USERNAME` / `NEO4J_PASSWORD` secret refs to `neo4j-cluster-neo4j-account-neo4j`
- `git diff --check`

## Review

Task #61 / task #71 deploy P0. Requesting @符炫炜 architect ratify and @huangheng CR / squash merge per thread dispatch.
