### PR TITLE
feat(vectorstore): cross-adapter filter fail-loud + score normalization (task #61 P0-A + P0-B)

### DIFF
--- a/aperag/domains/retrieval/context/context.py
+++ b/aperag/domains/retrieval/context/context.py
@@ -49,6 +49,10 @@ class ContextManager(ABC):
     def query(
         self,
         query,
+        # ``score_threshold`` is on the normalized [0, 1] similarity scale
+        # per task #61 P0-B (``aperag.vectorstore.base.normalize_score``).
+        # 0.5 is a permissive cosine-grade default — non-cosine collections
+        # may want to override.
         score_threshold: float = 0.5,
         topk: int = 3,
         vector: Optional[List[float]] = None,

--- a/aperag/graph_curation/service.py
+++ b/aperag/graph_curation/service.py
@@ -55,6 +55,13 @@ DEFAULT_MAX_PAIRS_PER_ENTITY = 6
 DEFAULT_MAX_CANDIDATE_PAIRS = 240
 DEFAULT_MAX_SUGGESTIONS = 32
 DEFAULT_VECTOR_TOP_K = 4
+# Threshold is on the normalized [0, 1] similarity scale per task #61
+# P0-B (``aperag.vectorstore.base.normalize_score``). 0.72 was tuned on
+# cosine-distance embeddings, where 0.72 ≈ "strongly similar". The
+# normalize layer makes this number directly comparable across adapters
+# but the *intent* is still cosine-grade strictness; collections that
+# choose ``euclid`` or ``dot`` distance may want to override this default
+# (see follow-up: metric-aware defaults, Lesson #12 v7.3).
 DEFAULT_VECTOR_SCORE_THRESHOLD = 0.72
 DEFAULT_LLM_CONCURRENCY = 4
 

--- a/aperag/indexing/merge_candidate_detector.py
+++ b/aperag/indexing/merge_candidate_detector.py
@@ -72,6 +72,11 @@ AUTO_DETECT_REASON: str = "auto_detected"
 # detection share the same scoring frontier — divergence here would let
 # one path silently surface candidates the other rejects.
 DEFAULT_VECTOR_TOP_K: int = 4
+# Threshold is on the normalized [0, 1] similarity scale per task #61
+# P0-B (``aperag.vectorstore.base.normalize_score``). 0.72 was tuned on
+# cosine-distance embeddings; non-cosine collections may want to
+# override (see ``aperag.graph_curation.service.DEFAULT_VECTOR_SCORE_THRESHOLD``
+# for the matching tunable on the user-triggered path).
 DEFAULT_VECTOR_SCORE_THRESHOLD: float = 0.72
 DEFAULT_MAX_PAIRS_PER_ENTITY: int = 6
 DEFAULT_MAX_TOTAL_PAIRS: int = 240

--- a/aperag/vectorstore/base.py
+++ b/aperag/vectorstore/base.py
@@ -28,6 +28,15 @@ their signature. A concrete implementation (``QdrantVectorStoreConnector``,
    a no-op or filtered-out, never a data leak.
 4. ``ensure_collection()`` is idempotent and safe to call on every
    connector instantiation.
+5. **Score normalization (task #61 P0-B)**: ``SearchHit.score`` is a
+   uniform similarity in ``[0, 1]`` where higher is better, regardless
+   of the underlying distance metric (cosine / euclid / dot). Callers and
+   FE/MCP/API integrations do not branch on metric to interpret the
+   score. ``QueryRequest.score_threshold`` is on the same scale.
+6. **Filter fail-loud (task #61 P0-A)**: an unsupported ``VectorFilter``
+   shape is a programmer error and must raise
+   :class:`UnsupportedFilterError` synchronously; backends never silently
+   drop the filter and return unfiltered results.
 
 Everything else (index construction knobs, connection pooling, payload
 serialization quirks) is the backend's implementation detail.
@@ -35,6 +44,7 @@ serialization quirks) is the backend's implementation detail.
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Sequence
 
@@ -46,6 +56,119 @@ from aperag.vectorstore.dto import (
     VectorShape,
 )
 from aperag.vectorstore.filters import VectorFilter
+
+# ---------------------------------------------------------------------------
+# Cross-adapter exception types
+# ---------------------------------------------------------------------------
+
+
+class UnsupportedFilterError(TypeError):
+    """Raised when a ``VectorFilter`` node is not supported by the backend.
+
+    Per task #61 P0-A: every backend translator MUST raise this (rather
+    than silently logging + returning an unfiltered query) when it
+    encounters a filter shape it cannot translate. Subclassing
+    :class:`TypeError` keeps backwards compatibility with callers that
+    already ``except TypeError`` from the pgvector translator.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Cross-adapter score normalization (task #61 P0-B)
+# ---------------------------------------------------------------------------
+#
+# Backends return raw similarity / distance numbers in their own units:
+#
+# * cosine   — pgvector ``1 - <=>`` and Qdrant native both yield similarity
+#              already (≈[0, 1] for unit-norm embeddings, [-1, 1] in general).
+# * euclid   — pgvector ``-(<->)`` and Qdrant native both yield "negative L2
+#              distance" so that higher = closer; range is ``(-inf, 0]``.
+# * dot      — pgvector ``-(<#>)`` and Qdrant native both yield raw inner
+#              product, range ``(-inf, +inf)``.
+#
+# To honour the §5 contract above we squash all three onto ``[0, 1]`` with
+# higher = better. The transforms below preserve the ranking (monotone in
+# the underlying score) so callers / tests can rely on top-k order being
+# unchanged versus the raw form.
+
+_SCORE_FLOOR = 0.0
+_SCORE_CEIL = 1.0
+
+
+def normalize_score(distance: str, raw: float) -> float:
+    """Map a backend's raw search score to ``[0, 1]``, higher = better.
+
+    The transformation is monotone non-decreasing per metric, so
+    *ordering* is preserved — callers that only care about top-k get the
+    same set in the same order regardless of normalization.
+
+    Cosine
+        Pass-through, clamped to ``[0, 1]`` to absorb float drift /
+        non-unit-norm inputs that occasionally produce tiny negatives or
+        slight overshoots above 1.0.
+
+    Euclid
+        Input is "negative L2 distance" (≤ 0). Map to ``(0, 1]`` via
+        ``1 / (1 + L2_distance)`` which approaches 1 as the points
+        coincide and 0 as they grow apart.
+
+    Dot
+        Input is the raw inner product on ``(-inf, +inf)``. Map via the
+        logistic sigmoid ``1 / (1 + exp(-x))`` which is bijective onto
+        ``(0, 1)`` and monotone, so ranking is preserved while keeping
+        the score on the same scale as cosine / euclid.
+    """
+    if distance == "cosine":
+        return max(_SCORE_FLOOR, min(_SCORE_CEIL, float(raw)))
+    if distance == "euclid":
+        # raw should be ≤ 0 (negated distance); guard against drift.
+        l2 = max(0.0, -float(raw))
+        return 1.0 / (1.0 + l2)
+    if distance == "dot":
+        # Sigmoid; numerically stable for large |x|.
+        x = float(raw)
+        if x >= 0:
+            ex = math.exp(-x)
+            return 1.0 / (1.0 + ex)
+        ex = math.exp(x)
+        return ex / (1.0 + ex)
+    raise ValueError(f"Unknown distance metric: {distance!r}")
+
+
+def denormalize_threshold_to_native(distance: str, normalized: float) -> float:
+    """Invert :func:`normalize_score` so a backend-native ``score_threshold``
+    pushdown produces the same set of survivors as a Python post-filter
+    on the normalized score.
+
+    Used when the backend's native query supports a fast pre-filter (e.g.
+    Qdrant's ``query_points(score_threshold=...)`` or pgvector's
+    ``WHERE score >= ...``). The point is to keep the network / scan
+    boundary exactly equivalent to ``[h for h in raw_hits if normalize(
+    h.score) >= normalized_threshold]`` while letting the database do
+    the work.
+
+    Returns the raw-score threshold to pass to the backend; clamping /
+    pinning at infinity is done so the caller can pass it verbatim.
+    """
+    n = max(_SCORE_FLOOR, min(_SCORE_CEIL, float(normalized)))
+    if distance == "cosine":
+        # Cosine raw == cosine normalized for our purposes (clamp).
+        return n
+    if distance == "euclid":
+        # normalize = 1/(1+l2), raw = -l2 → raw = -(1/n - 1) = (n - 1)/n.
+        if n <= 0.0:
+            return -math.inf  # threshold is "anything ≥ 0", L2 ≤ +inf
+        if n >= 1.0:
+            return 0.0  # threshold is exactly "L2 == 0"
+        return (n - 1.0) / n
+    if distance == "dot":
+        # normalize = sigmoid(raw) → raw = log(n / (1-n)).
+        if n <= 0.0:
+            return -math.inf
+        if n >= 1.0:
+            return math.inf
+        return math.log(n / (1.0 - n))
+    raise ValueError(f"Unknown distance metric: {distance!r}")
 
 
 class VectorStoreConnector(ABC):
@@ -127,13 +250,20 @@ class VectorStoreConnector(ABC):
     def search(self, request: QueryRequest) -> List[SearchHit]:
         """Top-k nearest neighbors, optionally constrained by ``request.flt``.
 
-        Score semantics:
-        * Cosine: similarity in [-1, 1] — higher is better.
-        * Dot: raw dot product — higher is better.
-        * Euclid: negative L2 distance — higher is "closer to 0", better.
+        Score semantics (task #61 P0-B contract):
 
-        ``request.score_threshold`` (when set) filters on the same scale,
-        so callers don't have to branch on distance type.
+        * ``SearchHit.score`` is a normalized similarity in ``[0, 1]``,
+          higher = better, regardless of the underlying metric (cosine,
+          euclid, dot). Adapters apply :func:`normalize_score` before
+          returning so callers can compare scores across backends and
+          metrics on a single scale.
+        * ``request.score_threshold`` is on the same ``[0, 1]`` scale.
+          When set, the connector returns only hits with
+          ``hit.score >= score_threshold`` after normalization.
+
+        Raises :class:`UnsupportedFilterError` (a ``TypeError`` subclass)
+        synchronously if ``request.flt`` contains a node the backend
+        cannot translate; backends never silently drop the filter.
         """
 
     @abstractmethod

--- a/aperag/vectorstore/base.py
+++ b/aperag/vectorstore/base.py
@@ -77,14 +77,28 @@ class UnsupportedFilterError(TypeError):
 # Cross-adapter score normalization (task #61 P0-B)
 # ---------------------------------------------------------------------------
 #
-# Backends return raw similarity / distance numbers in their own units:
+# These helpers operate on the **canonical "higher-is-better raw"
+# convention**, which is what pgvector's ``_score_expr`` already produces
+# directly and what Qdrant's native score is for cosine + dot. Qdrant's
+# euclid distance is the asymmetric case — the SDK returns the *positive*
+# L2 distance (smaller = better), so the Qdrant adapter negates at the
+# boundary before feeding the helper (see ``qdrant_connector.search``).
+# Adapters are responsible for converting their backend's raw score to
+# this canonical convention; ``normalize_score`` does the math only.
 #
-# * cosine   — pgvector ``1 - <=>`` and Qdrant native both yield similarity
-#              already (≈[0, 1] for unit-norm embeddings, [-1, 1] in general).
-# * euclid   — pgvector ``-(<->)`` and Qdrant native both yield "negative L2
-#              distance" so that higher = closer; range is ``(-inf, 0]``.
-# * dot      — pgvector ``-(<#>)`` and Qdrant native both yield raw inner
-#              product, range ``(-inf, +inf)``.
+# Canonical raw conventions assumed below:
+#
+# * cosine   — similarity, ≈[0, 1] for unit-norm embeddings, [-1, 1] in
+#              general. Both adapters already produce similarity
+#              directly: pgvector ``1 - <=>``, Qdrant native ``p.score``.
+# * euclid   — *negative* L2 distance, range ``(-inf, 0]``, so that
+#              higher = closer. pgvector emits this via ``-(<->)``;
+#              Qdrant returns positive L2 natively and the adapter
+#              negates at the boundary.
+# * dot      — raw inner product, range ``(-inf, +inf)``. Both adapters
+#              emit this directly: pgvector via ``-(<#>)`` (since the
+#              ``<#>`` operator returns the negated inner product),
+#              Qdrant via native ``p.score``.
 #
 # To honour the §5 contract above we squash all three onto ``[0, 1]`` with
 # higher = better. The transforms below preserve the ranking (monotone in

--- a/aperag/vectorstore/dto.py
+++ b/aperag/vectorstore/dto.py
@@ -184,12 +184,33 @@ class SearchHit:
     reconstruction) is the caller's responsibility, implemented via the
     ``flatten_node_payload`` helper so neither the connector nor each
     call site has to know about LlamaIndex internals.
+
+    ``score`` is the **normalized similarity** in ``[0, 1]`` where higher
+    is better, regardless of which distance metric (cosine / euclid /
+    dot) the underlying backend used. Adapters apply
+    :func:`aperag.vectorstore.base.normalize_score` before constructing
+    this DTO. The validator below enforces the range so a backend that
+    forgets to normalize is caught at the boundary instead of silently
+    polluting downstream score-threshold logic (task #61 P0-B).
     """
 
     id: str
     score: float
     payload: Dict[str, Any] = field(default_factory=dict)
     vector: Optional[List[float]] = None
+
+    def __post_init__(self) -> None:
+        # NaN comparisons all return False, so the explicit check catches
+        # both "out of range" and "score is NaN" without branching.
+        s = self.score
+        if not isinstance(s, (int, float)):
+            raise TypeError(f"SearchHit.score must be float in [0, 1], got {type(s).__name__}")
+        if not (0.0 <= float(s) <= 1.0):
+            raise ValueError(
+                f"SearchHit.score must lie in the normalized [0, 1] range, got {s!r}; "
+                "adapters must call aperag.vectorstore.base.normalize_score before "
+                "constructing SearchHit (task #61 P0-B contract)."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/aperag/vectorstore/pgvector_connector.py
+++ b/aperag/vectorstore/pgvector_connector.py
@@ -71,7 +71,12 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
-from aperag.vectorstore.base import VectorStoreConnector
+from aperag.vectorstore.base import (
+    UnsupportedFilterError,
+    VectorStoreConnector,
+    denormalize_threshold_to_native,
+    normalize_score,
+)
 from aperag.vectorstore.dto import (
     QueryRequest,
     SearchHit,
@@ -252,7 +257,7 @@ class _SqlFilter:
             return "(" + " OR ".join(parts) + ")"
         if isinstance(flt, Not):
             return f"NOT ({self._walk(flt.inner)})"
-        raise TypeError(
+        raise UnsupportedFilterError(
             f"Unsupported VectorFilter node: {type(flt).__name__}. "
             "Add a branch in aperag.vectorstore.pgvector_connector._SqlFilter._walk"
         )
@@ -542,9 +547,18 @@ class PgvectorVectorStoreConnector(VectorStoreConnector):
             params.update(flt_params)
 
         score_expr = self._score_expr
+        # ``request.score_threshold`` is on the normalized [0, 1] scale per
+        # base.py P0-B contract. Push it down by inverting back to the
+        # raw-score range so pgvector can prune via WHERE before LIMIT,
+        # then re-apply the equivalent cutoff after normalization to
+        # absorb any inverse-roundoff. Caller-visible behaviour is
+        # identical to a Python post-filter.
         if request.score_threshold is not None:
-            where_parts.append(f"({score_expr}) >= :score_threshold")
-            params["score_threshold"] = float(request.score_threshold)
+            native_threshold = denormalize_threshold_to_native(self._shape.canonical, float(request.score_threshold))
+            # ``-inf`` means "all rows pass", skip the SQL filter entirely.
+            if native_threshold != float("-inf"):
+                where_parts.append(f"({score_expr}) >= :score_threshold")
+                params["score_threshold"] = native_threshold
 
         select_vector = "embedding" if request.with_vectors else "NULL AS embedding"
         sql = (
@@ -572,10 +586,16 @@ class PgvectorVectorStoreConnector(VectorStoreConnector):
                 vec = None
                 if request.with_vectors and row.embedding is not None:
                     vec = _parse_vector(row.embedding)
+                normalized = normalize_score(self._shape.canonical, float(row.score))
+                # Belt-and-braces: if the inverse-threshold roundoff lets a
+                # row through, drop it on the Python side so the contract
+                # holds exactly.
+                if request.score_threshold is not None and normalized < float(request.score_threshold):
+                    continue
                 hits.append(
                     SearchHit(
                         id=str(row.id),
-                        score=float(row.score),
+                        score=normalized,
                         payload=_ensure_dict(row.payload),
                         vector=vec,
                     )

--- a/aperag/vectorstore/qdrant_connector.py
+++ b/aperag/vectorstore/qdrant_connector.py
@@ -49,7 +49,12 @@ import qdrant_client
 from qdrant_client import models as rest
 from qdrant_client.http.exceptions import UnexpectedResponse
 
-from aperag.vectorstore.base import VectorStoreConnector
+from aperag.vectorstore.base import (
+    UnsupportedFilterError,
+    VectorStoreConnector,
+    denormalize_threshold_to_native,
+    normalize_score,
+)
 from aperag.vectorstore.dto import (
     QueryRequest,
     SearchHit,
@@ -284,6 +289,12 @@ def _normalize_filter_input(flt: Any) -> Optional[rest.Filter]:
     script (``scripts/migrate_qdrant_multitenancy.py``) which hand-rolls
     native filters. Once the script stops doing that this branch can go.
     Normal production callers go through the DSL path.
+
+    Per task #61 P0-A contract: an unsupported shape raises
+    :class:`UnsupportedFilterError` synchronously rather than being
+    silently dropped. Returning ``None`` here would degrade the search
+    into an unfiltered full-collection scan — a correctness footgun, not
+    a graceful degradation.
     """
     if flt is None:
         return None
@@ -291,11 +302,11 @@ def _normalize_filter_input(flt: Any) -> Optional[rest.Filter]:
         return flt
     if isinstance(flt, (Eq, In, IsEmpty, And, Or, Not)):
         return _translate_filter(flt)
-    logger.warning(
-        "qdrant: ignoring filter of unsupported type %s (expected VectorFilter DSL)",
-        type(flt).__name__,
+    raise UnsupportedFilterError(
+        f"qdrant: unsupported filter input of type {type(flt).__name__}; "
+        "expected one of VectorFilter DSL nodes (Eq/In/IsEmpty/And/Or/Not), "
+        "an already-translated qdrant_client.models.Filter, or None."
     )
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -615,6 +626,22 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
             )
         consistency = hints.get("consistency", "majority")
 
+        # ``request.score_threshold`` is on the normalized [0, 1] scale per
+        # base.py P0-B contract; invert it to Qdrant's raw-score units so
+        # the server-side cutoff matches what a Python post-filter on the
+        # normalized score would produce.
+        native_threshold: Optional[float] = None
+        if request.score_threshold is not None:
+            inv = denormalize_threshold_to_native(self._shape.canonical, float(request.score_threshold))
+            # Qdrant rejects ``inf``; ``-inf`` means "all rows pass" so
+            # we just omit the param.
+            if inv == float("inf"):
+                # Threshold of 1.0 on dot/euclid → unreachable in raw
+                # scale. Return empty without an RPC.
+                return []
+            if inv != float("-inf"):
+                native_threshold = inv
+
         resp = self.client.query_points(
             collection_name=self.collection_name,
             query=list(request.embedding),
@@ -623,16 +650,21 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
             limit=request.top_k,
             consistency=consistency,
             search_params=search_params,
-            score_threshold=request.score_threshold,
+            score_threshold=native_threshold,
             query_filter=filter_obj,
         )
 
         hits: List[SearchHit] = []
         for p in resp.points:
+            normalized = normalize_score(self._shape.canonical, float(p.score))
+            # Belt-and-braces: drop rows where inverse-threshold roundoff
+            # let a hit slip through, so the [0, 1] contract holds exactly.
+            if request.score_threshold is not None and normalized < float(request.score_threshold):
+                continue
             hits.append(
                 SearchHit(
                     id=_coerce_point_id(p.id),
-                    score=float(p.score),
+                    score=normalized,
                     payload=dict(p.payload or {}),
                     vector=_extract_vector(p) if request.with_vectors else None,
                 )

--- a/aperag/vectorstore/qdrant_connector.py
+++ b/aperag/vectorstore/qdrant_connector.py
@@ -630,6 +630,16 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
         # base.py P0-B contract; invert it to Qdrant's raw-score units so
         # the server-side cutoff matches what a Python post-filter on the
         # normalized score would produce.
+        #
+        # Convention asymmetry caught by Weston (msg=86e05a8e): the shared
+        # ``normalize_score`` / ``denormalize_threshold_to_native`` helpers
+        # assume **higher-is-better raw**, which matches Qdrant's native
+        # convention for cosine + dot but not euclid — Qdrant returns
+        # positive L2 distance (lower = better) and ``score_threshold``
+        # is interpreted as an *upper* bound for euclid. So we negate at
+        # the Qdrant boundary for the euclid case only: the raw score
+        # before normalize, and the native threshold before the RPC.
+        is_euclid = self._shape.canonical == "euclid"
         native_threshold: Optional[float] = None
         if request.score_threshold is not None:
             inv = denormalize_threshold_to_native(self._shape.canonical, float(request.score_threshold))
@@ -640,7 +650,11 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
                 # scale. Return empty without an RPC.
                 return []
             if inv != float("-inf"):
-                native_threshold = inv
+                # For euclid, the helper returns "negative L2" but Qdrant
+                # wants "positive L2 upper bound". Flip sign at the
+                # boundary so server-side pruning agrees with the
+                # normalized [0, 1] contract.
+                native_threshold = -inv if is_euclid else inv
 
         resp = self.client.query_points(
             collection_name=self.collection_name,
@@ -656,7 +670,11 @@ class QdrantVectorStoreConnector(VectorStoreConnector):
 
         hits: List[SearchHit] = []
         for p in resp.points:
-            normalized = normalize_score(self._shape.canonical, float(p.score))
+            # See note above: Qdrant returns positive L2 for euclid.
+            raw = float(p.score)
+            if is_euclid:
+                raw = -raw
+            normalized = normalize_score(self._shape.canonical, raw)
             # Belt-and-braces: drop rows where inverse-threshold roundoff
             # let a hit slip through, so the [0, 1] contract holds exactly.
             if request.score_threshold is not None and normalized < float(request.score_threshold):

--- a/tests/integration/compat/test_vector_compat.py
+++ b/tests/integration/compat/test_vector_compat.py
@@ -207,3 +207,112 @@ def test_retrieve_by_ids(connector):
     ids = {r.id for r in results}
     assert _point_id("ret1") in ids, f"[{name}] ret1 not retrieved"
     assert _point_id("ret2") in ids, f"[{name}] ret2 not retrieved"
+
+
+# ---------------------------------------------------------------------------
+# task #61 P0-A: filter fail-loud (cross-backend invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_search_unsupported_filter_raises_unsupported_filter_error(connector):
+    """Both backends must raise the cross-adapter ``UnsupportedFilterError``
+    when the caller hands a filter shape neither translator understands.
+    Silent fall-through to an unfiltered query is a correctness footgun
+    (task #61 P0-A)."""
+    name, conn = connector
+    from aperag.vectorstore.base import UnsupportedFilterError
+    from aperag.vectorstore.dto import QueryRequest
+
+    class _BogusNode:
+        pass
+
+    with pytest.raises(UnsupportedFilterError):
+        conn.search(
+            QueryRequest(
+                embedding=[0.1] * VECTOR_SIZE,
+                top_k=5,
+                flt=_BogusNode(),  # type: ignore[arg-type]
+                score_threshold=0.0,
+            )
+        )
+
+    # Subclass of TypeError, so existing ``except TypeError`` callers
+    # keep working.
+    with pytest.raises(TypeError):
+        conn.search(
+            QueryRequest(
+                embedding=[0.1] * VECTOR_SIZE,
+                top_k=5,
+                flt=_BogusNode(),  # type: ignore[arg-type]
+                score_threshold=0.0,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# task #61 P0-B: score normalization (cross-backend invariant on cosine)
+# ---------------------------------------------------------------------------
+
+
+def test_search_score_in_unit_interval(connector):
+    """Per the §5 normalized-score contract, every ``SearchHit.score`` must
+    lie in ``[0, 1]`` regardless of the underlying distance metric. The
+    SearchHit DTO validator already enforces this, but we keep the
+    assertion here so a regression that bypassed the DTO (e.g. a future
+    direct-build code path) would surface in compat-test rather than
+    quietly drifting."""
+    name, conn = connector
+    from aperag.vectorstore.dto import QueryRequest
+
+    points = [
+        _point("sc1", 0.1, indexer="vector"),
+        _point("sc2", 0.9, indexer="vector"),
+    ]
+    conn.upsert(points)
+
+    hits = conn.search(QueryRequest(embedding=[0.1] * VECTOR_SIZE, top_k=5, score_threshold=0.0))
+    assert hits, f"[{name}] expected non-empty hits"
+    for h in hits:
+        assert 0.0 <= h.score <= 1.0, f"[{name}] score {h.score} outside [0, 1]"
+
+
+def test_search_score_threshold_filters_low_scores(connector):
+    """``score_threshold`` is on the same normalized [0, 1] scale; raising
+    it must monotonically reduce or preserve the result count, never
+    expand it. Pinned cross-backend so PGVector / Qdrant agree on the
+    direction of the threshold."""
+    name, conn = connector
+    from aperag.vectorstore.dto import QueryRequest
+
+    points = [
+        _point("th_close", 0.10, indexer="vector"),
+        _point("th_far", 0.90, indexer="vector"),
+    ]
+    conn.upsert(points)
+
+    lo = conn.search(QueryRequest(embedding=[0.10] * VECTOR_SIZE, top_k=10, score_threshold=0.0))
+    hi = conn.search(QueryRequest(embedding=[0.10] * VECTOR_SIZE, top_k=10, score_threshold=0.99))
+    # Higher threshold must shrink (or preserve) the result set.
+    assert len(hi) <= len(lo), f"[{name}] threshold direction inverted"
+    # Every survivor of the high-threshold filter must clear the cutoff.
+    for h in hi:
+        assert h.score >= 0.99, f"[{name}] threshold not enforced (score={h.score})"
+
+
+def test_search_top_k_ranking_higher_is_better(connector):
+    """Ranking is monotone in normalized score: the top hit is the most
+    similar, scores decrease (or stay equal) with rank. Cross-backend
+    pinned because score-direction confusion was the root cause of
+    cuiwenbo's FE display regression (task #70)."""
+    name, conn = connector
+    from aperag.vectorstore.dto import QueryRequest
+
+    points = [_point(f"r{i}", 0.1 * i, indexer="vector") for i in range(1, 6)]
+    conn.upsert(points)
+
+    hits = conn.search(QueryRequest(embedding=[0.10] * VECTOR_SIZE, top_k=5, score_threshold=0.0))
+    assert len(hits) >= 2, f"[{name}] need at least 2 hits to assert ordering"
+    scores = [h.score for h in hits]
+    assert scores == sorted(scores, reverse=True), (
+        f"[{name}] top-k ordering must be descending in normalized score, got {scores}"
+    )

--- a/tests/unit_test/vectorstore/test_pgvector_translator.py
+++ b/tests/unit_test/vectorstore/test_pgvector_translator.py
@@ -137,10 +137,19 @@ def test_translate_context_manager_shape():
 
 
 def test_translate_rejects_unknown_node_loudly():
+    """Pinned by task #61 P0-A: pgvector translator must raise the same
+    cross-adapter ``UnsupportedFilterError`` (subclass of ``TypeError`` so
+    the existing ``except TypeError`` callers keep working)."""
+    from aperag.vectorstore.base import UnsupportedFilterError
+
     class Bogus:
         pass
 
-    with pytest.raises(TypeError, match="Unsupported VectorFilter node"):
+    with pytest.raises(UnsupportedFilterError, match="Unsupported VectorFilter node"):
+        _translate_filter(Bogus())  # type: ignore[arg-type]
+
+    # Backwards-compat: TypeError parent still catches it.
+    with pytest.raises(TypeError):
         _translate_filter(Bogus())  # type: ignore[arg-type]
 
 

--- a/tests/unit_test/vectorstore/test_qdrant_filter_translation.py
+++ b/tests/unit_test/vectorstore/test_qdrant_filter_translation.py
@@ -45,12 +45,19 @@ def test_normalize_passes_through_raw_qdrant_filter():
     assert qc._normalize_filter_input(raw) is raw
 
 
-def test_normalize_unknown_type_returns_none_with_warning(caplog):
+def test_normalize_unknown_type_raises_unsupported_filter_error():
     """Any value that is neither DSL nor Qdrant Filter must be refused
-    gracefully — never silently translated into something nonsensical."""
-    with caplog.at_level("WARNING"):
-        assert qc._normalize_filter_input({"garbage": True}) is None
-    assert any("unsupported type" in r.message for r in caplog.records)
+    fail-loud — never silently dropped (which would degrade into an
+    unfiltered full-collection scan, a correctness bug, not a graceful
+    degradation). Pinned by task #61 P0-A."""
+    from aperag.vectorstore.base import UnsupportedFilterError
+
+    with pytest.raises(UnsupportedFilterError, match="unsupported filter input"):
+        qc._normalize_filter_input({"garbage": True})
+
+    # Backwards-compat: callers that ``except TypeError`` keep working.
+    with pytest.raises(TypeError):
+        qc._normalize_filter_input(object())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/vectorstore/test_score_normalization.py
+++ b/tests/unit_test/vectorstore/test_score_normalization.py
@@ -1,0 +1,136 @@
+# Copyright 2025 ApeCloud, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the cross-adapter score-normalization helpers.
+
+Pinned by task #61 P0-B. The contract:
+
+* :func:`normalize_score` always returns a float in ``[0, 1]`` with
+  higher = better.
+* The transform is monotone non-decreasing per metric, so top-k ordering
+  is preserved compared to the raw score.
+* :func:`denormalize_threshold_to_native` is a true inverse, modulo the
+  clamp endpoints — round-tripping a normalized threshold back to the
+  raw scale and forward through normalize_score reproduces the input
+  to within float-precision drift.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from aperag.vectorstore.base import (
+    UnsupportedFilterError,
+    denormalize_threshold_to_native,
+    normalize_score,
+)
+
+# ---------------------------------------------------------------------------
+# normalize_score range invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "metric,raw",
+    [
+        ("cosine", 0.0),
+        ("cosine", 0.5),
+        ("cosine", 1.0),
+        ("cosine", -0.3),  # drift below 0 should clamp
+        ("cosine", 1.2),  # drift above 1 should clamp
+        ("euclid", 0.0),
+        ("euclid", -0.5),
+        ("euclid", -10.0),
+        ("euclid", -1e6),
+        ("dot", 0.0),
+        ("dot", 5.0),
+        ("dot", -5.0),
+        ("dot", 1e3),
+        ("dot", -1e3),
+    ],
+)
+def test_normalize_score_in_unit_interval(metric, raw):
+    s = normalize_score(metric, raw)
+    assert isinstance(s, float)
+    assert 0.0 <= s <= 1.0
+
+
+def test_normalize_score_unknown_metric_raises():
+    with pytest.raises(ValueError, match="Unknown distance metric"):
+        normalize_score("hamming", 0.5)
+
+
+# ---------------------------------------------------------------------------
+# monotone ordering: more-similar must produce a higher (or equal) score
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "metric,better,worse",
+    [
+        ("cosine", 0.95, 0.20),
+        ("euclid", -0.10, -2.50),  # smaller L2 distance ⇒ larger negated raw
+        ("dot", 8.0, 0.5),
+        ("dot", -0.5, -3.0),
+    ],
+)
+def test_normalize_score_preserves_ordering(metric, better, worse):
+    sb = normalize_score(metric, better)
+    sw = normalize_score(metric, worse)
+    assert sb > sw, f"{metric}: normalize({better})={sb} should exceed normalize({worse})={sw}"
+
+
+# ---------------------------------------------------------------------------
+# denormalize_threshold_to_native is the inverse on the open interval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("metric", ["cosine", "euclid", "dot"])
+@pytest.mark.parametrize("normalized", [0.05, 0.25, 0.50, 0.72, 0.95])
+def test_denormalize_then_normalize_roundtrip(metric, normalized):
+    raw = denormalize_threshold_to_native(metric, normalized)
+    back = normalize_score(metric, raw)
+    assert math.isclose(back, normalized, rel_tol=1e-9, abs_tol=1e-9)
+
+
+def test_denormalize_endpoints():
+    # n = 0 → all rows pass; we encode that as -inf so callers know to skip
+    # the SQL/Qdrant pushdown clause entirely.
+    assert denormalize_threshold_to_native("cosine", 0.0) == pytest.approx(0.0)
+    assert denormalize_threshold_to_native("euclid", 0.0) == -math.inf
+    assert denormalize_threshold_to_native("dot", 0.0) == -math.inf
+
+    # n = 1 → only an exact match passes.
+    assert denormalize_threshold_to_native("cosine", 1.0) == pytest.approx(1.0)
+    assert denormalize_threshold_to_native("euclid", 1.0) == pytest.approx(0.0)
+    assert denormalize_threshold_to_native("dot", 1.0) == math.inf
+
+
+def test_denormalize_unknown_metric_raises():
+    with pytest.raises(ValueError, match="Unknown distance metric"):
+        denormalize_threshold_to_native("hamming", 0.5)
+
+
+# ---------------------------------------------------------------------------
+# UnsupportedFilterError typing
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_filter_error_subclasses_typeerror():
+    """Backwards-compat: callers that ``except TypeError`` must keep working
+    after the cross-adapter rename."""
+    err = UnsupportedFilterError("nope")
+    assert isinstance(err, TypeError)

--- a/tests/unit_test/vectorstore/test_score_normalization.py
+++ b/tests/unit_test/vectorstore/test_score_normalization.py
@@ -134,3 +134,142 @@ def test_unsupported_filter_error_subclasses_typeerror():
     after the cross-adapter rename."""
     err = UnsupportedFilterError("nope")
     assert isinstance(err, TypeError)
+
+
+# ---------------------------------------------------------------------------
+# Backend-native raw-direction regression: pinned by Weston msg=86e05a8e
+# ---------------------------------------------------------------------------
+#
+# The shared ``normalize_score`` helper assumes "higher-is-better raw" input,
+# which matches Qdrant's native convention for cosine + dot but NOT for
+# euclid — Qdrant returns positive L2 distance (lower = better). The Qdrant
+# adapter therefore negates ``p.score`` for euclid before calling the helper.
+# These tests pin the end-to-end behaviour against a real Qdrant ``:memory:``
+# client so a future refactor that drops the boundary conversion fails fast.
+
+
+def _qdrant_local_search_scores(distance: str, queries_and_points):
+    """Run a tiny Qdrant ``:memory:`` round-trip and return the connector's
+    normalized scores. Returns a dict keyed by the input id so tests can
+    pin per-point scores without depending on top-k ordering.
+    """
+    pytest.importorskip("qdrant_client")
+
+    import uuid as _uuid
+
+    from aperag.vectorstore.dto import VectorPoint
+    from aperag.vectorstore.qdrant_connector import QdrantVectorStoreConnector
+
+    ctx = {
+        "url": ":memory:",
+        "collection": f"unit_eu_{_uuid.uuid4().hex[:8]}",
+        "vector_size": 4,
+        "distance": distance,
+        "multitenant": False,
+    }
+    conn = QdrantVectorStoreConnector(ctx)
+    points = [
+        VectorPoint(id=str(_uuid.uuid5(_uuid.NAMESPACE_URL, name)), vector=vec, payload={"name": name})
+        for name, vec in queries_and_points
+    ]
+    conn.upsert(points)
+    return points, conn
+
+
+def test_qdrant_euclid_normalized_scores_strictly_decreasing_with_distance():
+    """Pinned by Weston msg=86e05a8e: Qdrant returns positive L2 distance
+    natively (smaller = better). The connector must negate at the boundary
+    so the shared helper produces *strictly decreasing* normalized scores
+    as L2 grows."""
+    pytest.importorskip("qdrant_client")
+    from aperag.vectorstore.dto import QueryRequest
+
+    points, conn = _qdrant_local_search_scores(
+        "Euclid",
+        [
+            ("near", [0.0, 0.0, 0.0, 0.0]),  # L2=0 from the query
+            ("mid", [1.0, 0.0, 0.0, 0.0]),  # L2=1
+            ("far", [3.0, 0.0, 0.0, 0.0]),  # L2=3
+        ],
+    )
+    hits = conn.search(QueryRequest(embedding=[0.0, 0.0, 0.0, 0.0], top_k=5, score_threshold=0.0))
+    by_name = {h.payload["name"]: h.score for h in hits}
+    assert "near" in by_name and "mid" in by_name and "far" in by_name
+    # All three in [0, 1].
+    for s in by_name.values():
+        assert 0.0 <= s <= 1.0
+    # Strictly decreasing: near closer than mid closer than far.
+    assert by_name["near"] > by_name["mid"] > by_name["far"], (
+        f"Qdrant euclid normalized scores must decrease with L2; got {by_name}"
+    )
+
+
+def test_qdrant_euclid_score_threshold_filters_far_keeps_near():
+    """Pinned by Weston msg=86e05a8e: ``score_threshold=0.9`` on Qdrant
+    euclid must pass through the boundary conversion so a tight threshold
+    keeps the closest point and drops the far one — not silent-return-empty
+    nor return-all."""
+    pytest.importorskip("qdrant_client")
+    from aperag.vectorstore.dto import QueryRequest
+
+    _, conn = _qdrant_local_search_scores(
+        "Euclid",
+        [
+            ("near", [0.0, 0.0, 0.0, 0.0]),
+            ("mid", [1.0, 0.0, 0.0, 0.0]),
+            ("far", [3.0, 0.0, 0.0, 0.0]),
+        ],
+    )
+    hits = conn.search(QueryRequest(embedding=[0.0, 0.0, 0.0, 0.0], top_k=5, score_threshold=0.9))
+    names = {h.payload["name"] for h in hits}
+    assert "near" in names, "tight threshold must keep the L2=0 point"
+    assert "far" not in names, "tight threshold must drop the L2=3 point"
+
+
+def test_qdrant_dot_normalized_scores_strictly_increasing_with_inner_product():
+    """Sanity-check the other Qdrant convention — dot product. Native
+    Qdrant dot is "higher = better" so the helper convention matches and
+    no boundary negation is needed; this test pins that no future refactor
+    accidentally negates dot too."""
+    pytest.importorskip("qdrant_client")
+    from aperag.vectorstore.dto import QueryRequest
+
+    _, conn = _qdrant_local_search_scores(
+        "Dot",
+        [
+            ("low", [0.1, 0.0, 0.0, 0.0]),
+            ("mid", [0.5, 0.0, 0.0, 0.0]),
+            ("hi", [1.0, 0.0, 0.0, 0.0]),
+        ],
+    )
+    hits = conn.search(QueryRequest(embedding=[1.0, 0.0, 0.0, 0.0], top_k=5, score_threshold=0.0))
+    by_name = {h.payload["name"]: h.score for h in hits}
+    assert "low" in by_name and "mid" in by_name and "hi" in by_name
+    for s in by_name.values():
+        assert 0.0 <= s <= 1.0
+    assert by_name["hi"] > by_name["mid"] > by_name["low"], (
+        f"Qdrant dot normalized scores must increase with inner product; got {by_name}"
+    )
+
+
+def test_qdrant_cosine_normalized_scores_strictly_increasing_with_similarity():
+    """Pin Qdrant cosine — already exercised by the compat fixture but a
+    unit-level pin keeps the contract obvious next to euclid + dot."""
+    pytest.importorskip("qdrant_client")
+    from aperag.vectorstore.dto import QueryRequest
+
+    _, conn = _qdrant_local_search_scores(
+        "Cosine",
+        [
+            ("orth", [0.0, 1.0, 0.0, 0.0]),  # orthogonal to query
+            ("part", [1.0, 1.0, 0.0, 0.0]),  # ~45°
+            ("same", [1.0, 0.0, 0.0, 0.0]),  # parallel to query
+        ],
+    )
+    hits = conn.search(QueryRequest(embedding=[1.0, 0.0, 0.0, 0.0], top_k=5, score_threshold=0.0))
+    by_name = {h.payload["name"]: h.score for h in hits}
+    for s in by_name.values():
+        assert 0.0 <= s <= 1.0
+    assert by_name["same"] > by_name["part"] > by_name["orth"], (
+        f"Qdrant cosine normalized scores must increase with similarity; got {by_name}"
+    )


### PR DESCRIPTION
## Summary

Closes the two task #61 vector-adapter contract gaps PM @不穷 dispatched to me (msg=a387a81e) and architect @符炫炜 ratified (msg=7646eb4f), per Weston contract-matrix scope (msg=8beffab5) + spec PR #1928 § 2.2 / § 5.3 lock.

- **P0-A**: filter fail-loud — `qdrant_connector._normalize_filter_input` no longer logs warning + returns `None` (silent unfiltered scan); both adapters now raise the new cross-adapter `UnsupportedFilterError` (subclass of `TypeError` → existing `except TypeError` callers keep working)
- **P0-B**: score normalization — `SearchHit.score` is now uniformly in `[0, 1]` higher=better across PGVector × Qdrant × cosine/L2/dot, with `score_threshold` on the same scale (pushdown via inverse + Python belt-and-braces)

P0-V1 (Qdrant legacy retrieve cross-tenant filter) intentionally NOT in scope — first-principles verify (msg=23a2f514) confirmed legacy mode is tenant-isolated by physical collection name (`qdrant_connector.py:442-446`), not query filter, so no leak. Architect ratified the reframe to P1-V4 defense-in-depth (msg=7646eb4f).

## Changes

`aperag/vectorstore/base.py`
- New `UnsupportedFilterError(TypeError)` cross-adapter exception
- New `normalize_score(metric, raw)` + inverse `denormalize_threshold_to_native`
  - cosine: clamp to `[0, 1]`
  - euclid: `1 / (1 + L2)` onto `(0, 1]`
  - dot: numerically-stable sigmoid onto `(0, 1)`
  - all monotone → top-k ordering preserved
- `VectorStoreConnector.search()` docstring + class-level invariants spell out §5 / §6 contract

`aperag/vectorstore/dto.py`
- `SearchHit.__post_init__` validates `0.0 <= score <= 1.0` (Pydantic-Field-equivalent for the frozen dataclass)

`aperag/vectorstore/pgvector_connector.py`
- `_SqlFilter._walk` raises `UnsupportedFilterError`
- `search()` pushes threshold down via `denormalize_threshold_to_native` + applies `normalize_score` post-query + Python belt-and-braces

`aperag/vectorstore/qdrant_connector.py`
- `_normalize_filter_input` raises `UnsupportedFilterError` instead of fail-silent `return None`
- `search()` pushes threshold down + applies `normalize_score` + handles `+inf` / `-inf` pushdown edge cases

## Tests

- New `tests/unit_test/vectorstore/test_score_normalization.py` (33 cases): range invariants × 14 raw scores, ordering preservation × 4 metric pairs, denormalize→normalize roundtrip × 15 (3 metric × 5 thresholds), endpoint behaviour, `UnsupportedFilterError isinstance TypeError`
- `tests/unit_test/vectorstore/test_pgvector_translator.py` + `test_qdrant_filter_translation.py` updated to assert `UnsupportedFilterError` while keeping `TypeError` back-compat assertion
- `tests/integration/compat/test_vector_compat.py` extended with 4 new cross-backend cases:
  - `test_search_unsupported_filter_raises_unsupported_filter_error`
  - `test_search_score_in_unit_interval`
  - `test_search_score_threshold_filters_low_scores`
  - `test_search_top_k_ranking_higher_is_better`

Local: `uv run pytest tests/unit_test/vectorstore/ tests/unit_test/indexing/ tests/unit_test/graph_curation/` → **518 passed, 10 skipped**.

## Test plan

- [x] Local unit tests pass (vectorstore / indexing / graph_curation)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI lint-and-unit green
- [ ] Backend-Compat-Test green (PR #1926 merged → compat-test now triggers on `aperag/vectorstore/**`)
- [ ] @huangheng CR (per msg=7d4fbcf2 + msg=05203d11 4-point checklist: base.py contract Pydantic-equivalent / cross-metric enum coverage / cross-adapter parametrize / legacy follow-up)
- [ ] @符炫炜 ratify (standing per msg=7646eb4f)

## Spec / scope alignment

- task #61 spec PR #1928 § 2.2 P0-A + P0-B locked
- P0-B score normalization onto `[0, 1]` per Weston msg=8beffab5 P0 hard layer 3 ("score 方向必须统一")
- cuiwenbo task #70 P0 (FE displays raw score, PGVector cosine_distance vs Qdrant cosine_similarity) folded into P0-B (same root cause)

## Follow-ups (NOT in this PR)

- `huangheng` boundary-test sub-PR extending compat fixture to full PGVector × Qdrant × {cosine, euclid, dot} 6-cell grid (current fixture exercises cosine only)
- `legacy mode` deprecation + delete (Lesson #14 multi-cycle pattern, P1-V4 task #61 cleanup queue)
- cr-checklist follow-up sub-PR `Lesson #12 v9` first-application sediment (huangheng standby per msg=6ca63ae4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)