### PR TITLE
feat(graph-curation): task #31 A2 suggestion status schema

### DIFF
--- a/aperag/domains/knowledge_graph/api/routes.py
+++ b/aperag/domains/knowledge_graph/api/routes.py
@@ -43,7 +43,10 @@ from aperag.domains.knowledge_graph.schemas import (
     GraphSubgraphExpandResponse,
     KnowledgeGraph,
     MergeSuggestionsRequest,
+    MergeSuggestionsResponse,
+    MergeSuggestionsRunResponse,
     SuggestionActionRequest,
+    SuggestionActionResponse,
 )
 from aperag.domains.knowledge_graph.service import graph_service
 from aperag.exceptions import CollectionNotFoundException
@@ -187,6 +190,7 @@ async def merge_nodes_view(
 @router.post(
     "/collections/{collection_id}/graphs/merge-suggestions",
     tags=["graph"],
+    response_model=MergeSuggestionsRunResponse,
 )
 async def merge_suggestions_view(
     request: Request,
@@ -213,6 +217,7 @@ async def merge_suggestions_view(
 @router.get(
     "/collections/{collection_id}/graphs/merge-suggestions",
     tags=["graph"],
+    response_model=MergeSuggestionsResponse,
 )
 async def get_merge_suggestions_view(
     request: Request,
@@ -242,6 +247,7 @@ async def get_merge_suggestions_view(
 @router.post(
     "/collections/{collection_id}/graphs/merge-suggestions/{suggestion_id}/action",
     tags=["graph"],
+    response_model=SuggestionActionResponse,
 )
 async def handle_suggestion_action_view(
     request: Request,

--- a/aperag/domains/knowledge_graph/db/models.py
+++ b/aperag/domains/knowledge_graph/db/models.py
@@ -74,8 +74,13 @@ class GraphCurationRunStatus(str, Enum):
 
 class GraphCurationSuggestionStatus(str, Enum):
     PENDING = "PENDING"
+    APPLY_PENDING = "APPLY_PENDING"
+    APPLYING = "APPLYING"
+    APPLIED = "APPLIED"
+    APPLY_FAILED = "APPLY_FAILED"
     ACCEPTED = "ACCEPTED"
     REJECTED = "REJECTED"
+    DISMISSED = "DISMISSED"
     EXPIRED = "EXPIRED"
     SUPERSEDED = "SUPERSEDED"
 
@@ -127,6 +132,7 @@ class GraphCurationSuggestion(Base):
     confidence_score = Column(Numeric(6, 3), nullable=False)
     reason = Column(Text, nullable=False)
     evidence = Column(JSON, nullable=True)
+    evidence_refs = Column(JSON, nullable=True)
     resolution_note = Column(Text, nullable=True)
     operated_by = Column(String(256), nullable=True)
     gmt_created = Column(DateTime(timezone=True), default=utc_now, nullable=False)

--- a/aperag/domains/knowledge_graph/schemas.py
+++ b/aperag/domains/knowledge_graph/schemas.py
@@ -224,6 +224,15 @@ class GraphMergeSuggestionEntity(BaseModel):
     )
 
 
+class GraphMergeSuggestionTargetEntity(BaseModel):
+    """
+    Legacy FE-compatible target entity projection.
+    """
+
+    entity_name: str = Field(..., description="Recommended target entity display name", examples=["墨香居"])
+    entity_type: str = Field(..., description="Recommended target entity type", examples=["ORGANIZATION"])
+
+
 class GraphMergeSuggestionItem(BaseModel):
     """
     Persisted merge suggestion produced by graph curation.
@@ -231,6 +240,11 @@ class GraphMergeSuggestionItem(BaseModel):
 
     id: str = Field(..., description="Suggestion ID", examples=["gcs_abcd1234efgh5678"])
     run_id: str = Field(..., description="Run that produced this suggestion", examples=["gcr_abcd1234efgh5678"])
+    suggestion_batch_id: str = Field(
+        ...,
+        description="Backward-compatible alias of run_id for the existing FE review panel",
+        examples=["gcr_abcd1234efgh5678"],
+    )
     collection_id: str = Field(..., description="Collection ID", examples=["col123"])
     status: GraphCurationSuggestionStatusLiteral = Field(
         ..., description="Suggestion lifecycle status", examples=["PENDING"]
@@ -249,6 +263,10 @@ class GraphMergeSuggestionItem(BaseModel):
         description="Recommended surviving entity ID if the suggestion is accepted",
         examples=["e_moxiangju"],
     )
+    suggested_target_entity: GraphMergeSuggestionTargetEntity = Field(
+        ...,
+        description="Backward-compatible target entity projection for the existing FE review panel",
+    )
     confidence_score: confloat(ge=0.0, le=1.0) = Field(
         ...,
         description="Aggregated confidence score for this suggestion",
@@ -257,6 +275,11 @@ class GraphMergeSuggestionItem(BaseModel):
     reason: str = Field(
         ...,
         description="Human-readable explanation from pairwise LLM adjudication",
+        examples=["两个实体都在描述同一家旧书店，名称和上下文高度重合。"],
+    )
+    merge_reason: str = Field(
+        ...,
+        description="Backward-compatible alias of reason for the existing FE review panel",
         examples=["两个实体都在描述同一家旧书店，名称和上下文高度重合。"],
     )
     evidence: Optional[dict[str, Any]] = Field(
@@ -611,6 +634,7 @@ __all__ = [
     "MergeSuggestionsRequest",
     "GraphCurationRunSummary",
     "GraphMergeSuggestionEntity",
+    "GraphMergeSuggestionTargetEntity",
     "GraphMergeSuggestionItem",
     "MergeSuggestionsRunResponse",
     "MergeSuggestionsResponse",

--- a/aperag/domains/knowledge_graph/schemas.py
+++ b/aperag/domains/knowledge_graph/schemas.py
@@ -151,6 +151,34 @@ class MergeSuggestionsRequest(BaseModel):
     )
 
 
+class GraphEvidenceRef(BaseModel):
+    """Lightweight source chunk reference for graph entity/relation evidence.
+
+    ``read_document_chunk`` is document-scoped, so MCP callers need both
+    ``document_id`` and ``chunk_id`` to follow graph evidence back to source
+    content. ``parse_version`` is carried when available to disambiguate
+    lineage across document re-parses.
+    """
+
+    document_id: str = Field(..., description="Source document ID")
+    chunk_id: str = Field(..., description="Source chunk ID")
+    parse_version: Optional[str] = Field(None, description="Parse version that produced this evidence ref")
+
+
+GraphCurationSuggestionStatusLiteral = Literal[
+    "PENDING",
+    "APPLY_PENDING",
+    "APPLYING",
+    "APPLIED",
+    "APPLY_FAILED",
+    "ACCEPTED",
+    "REJECTED",
+    "DISMISSED",
+    "EXPIRED",
+    "SUPERSEDED",
+]
+
+
 class GraphCurationRunSummary(BaseModel):
     """
     Summary of an asynchronous graph-curation run.
@@ -204,7 +232,7 @@ class GraphMergeSuggestionItem(BaseModel):
     id: str = Field(..., description="Suggestion ID", examples=["gcs_abcd1234efgh5678"])
     run_id: str = Field(..., description="Run that produced this suggestion", examples=["gcr_abcd1234efgh5678"])
     collection_id: str = Field(..., description="Collection ID", examples=["col123"])
-    status: Literal["PENDING", "ACCEPTED", "REJECTED", "EXPIRED", "SUPERSEDED"] = Field(
+    status: GraphCurationSuggestionStatusLiteral = Field(
         ..., description="Suggestion lifecycle status", examples=["PENDING"]
     )
     entity_ids: list[str] = Field(
@@ -234,6 +262,10 @@ class GraphMergeSuggestionItem(BaseModel):
     evidence: Optional[dict[str, Any]] = Field(
         None,
         description="Structured supporting evidence used to generate the suggestion",
+    )
+    evidence_refs: list[GraphEvidenceRef] = Field(
+        default_factory=list,
+        description="Display-ready source chunk refs supporting this suggestion",
     )
     resolution_note: Optional[str] = Field(
         None,
@@ -334,7 +366,7 @@ class SuggestionActionResponse(BaseModel):
         description="The action that was performed (normalized to lowercase)",
         examples=["accept"],
     )
-    suggestion_status: Literal["ACCEPTED", "REJECTED"] = Field(
+    suggestion_status: GraphCurationSuggestionStatusLiteral = Field(
         ...,
         description="Suggestion status after action processing",
         examples=["ACCEPTED"],
@@ -358,20 +390,6 @@ class SuggestionActionResponse(BaseModel):
 # Per §K.12 invariant #12 (grep-zero on legacy naming) the names are
 # ``Graph*`` only; per invariant #11 (D-3 candidate detection writes
 # only) these are read-only shapes — no mutation surface.
-
-
-class GraphEvidenceRef(BaseModel):
-    """Lightweight source chunk reference for graph entity/relation evidence.
-
-    ``read_document_chunk`` is document-scoped, so MCP callers need both
-    ``document_id`` and ``chunk_id`` to follow graph evidence back to source
-    content. ``parse_version`` is carried when available to disambiguate
-    lineage across document re-parses.
-    """
-
-    document_id: str = Field(..., description="Source document ID")
-    chunk_id: str = Field(..., description="Source chunk ID")
-    parse_version: Optional[str] = Field(None, description="Parse version that produced this evidence ref")
 
 
 class GraphSearchEntity(BaseModel):

--- a/aperag/graph_curation/service.py
+++ b/aperag/graph_curation/service.py
@@ -447,6 +447,7 @@ class GraphCurationService(AsyncBaseRepository):
             "confidence_score": float(suggestion.confidence_score),
             "reason": suggestion.reason,
             "evidence": suggestion.evidence or {},
+            "evidence_refs": list(suggestion.evidence_refs or []),
             "resolution_note": suggestion.resolution_note,
             "created": suggestion.gmt_created.isoformat() if suggestion.gmt_created else None,
             "updated": suggestion.gmt_updated.isoformat() if suggestion.gmt_updated else None,
@@ -586,6 +587,7 @@ class GraphCurationService(AsyncBaseRepository):
                         confidence_score=suggestion["confidence_score"],
                         reason=suggestion["reason"],
                         evidence=suggestion["evidence"],
+                        evidence_refs=suggestion.get("evidence_refs"),
                     )
                 )
             await session.execute(

--- a/aperag/graph_curation/service.py
+++ b/aperag/graph_curation/service.py
@@ -436,22 +436,49 @@ class GraphCurationService(AsyncBaseRepository):
 
     @staticmethod
     def _suggestion_to_dict(suggestion: GraphCurationSuggestion) -> dict[str, Any]:
+        entities = list(suggestion.entity_snapshots or [])
+        target_entity = GraphCurationService._target_entity_projection(
+            entities=entities,
+            target_entity_id=str(suggestion.target_entity_id),
+        )
         return {
             "id": suggestion.id,
             "run_id": suggestion.run_id,
+            "suggestion_batch_id": suggestion.run_id,
             "collection_id": suggestion.collection_id,
             "status": suggestion.status,
             "entity_ids": list(suggestion.entity_ids or []),
-            "entities": list(suggestion.entity_snapshots or []),
+            "entities": entities,
             "target_entity_id": suggestion.target_entity_id,
+            "suggested_target_entity": target_entity,
             "confidence_score": float(suggestion.confidence_score),
             "reason": suggestion.reason,
+            "merge_reason": suggestion.reason,
             "evidence": suggestion.evidence or {},
             "evidence_refs": list(suggestion.evidence_refs or []),
             "resolution_note": suggestion.resolution_note,
             "created": suggestion.gmt_created.isoformat() if suggestion.gmt_created else None,
             "updated": suggestion.gmt_updated.isoformat() if suggestion.gmt_updated else None,
             "operated_at": suggestion.gmt_operated.isoformat() if suggestion.gmt_operated else None,
+        }
+
+    @staticmethod
+    def _target_entity_projection(
+        *,
+        entities: Sequence[dict[str, Any]],
+        target_entity_id: str,
+    ) -> dict[str, str]:
+        for entity in entities:
+            entity_id = str(entity.get("entity_id") or "")
+            entity_name = str(entity.get("entity_name") or entity_id)
+            if target_entity_id in {entity_id, entity_name}:
+                return {
+                    "entity_name": entity_name or target_entity_id,
+                    "entity_type": str(entity.get("entity_type") or ""),
+                }
+        return {
+            "entity_name": target_entity_id,
+            "entity_type": "",
         }
 
     async def _mark_run_running(self, run_id: str) -> None:

--- a/aperag/indexing/merge_candidate_detector.py
+++ b/aperag/indexing/merge_candidate_detector.py
@@ -392,6 +392,7 @@ class MergeCandidateDetector(AsyncBaseRepository):
                         confidence_score=row["confidence_score"],
                         reason=row["reason"],
                         evidence=row["evidence"],
+                        evidence_refs=row.get("evidence_refs"),
                     )
                 )
 

--- a/aperag/migration/versions/20260430070500-7a2b1c3d4e5f.py
+++ b/aperag/migration/versions/20260430070500-7a2b1c3d4e5f.py
@@ -1,0 +1,32 @@
+"""extend graph curation suggestion status surface
+
+Revision ID: 7a2b1c3d4e5f
+Revises: 3c7d2f81b5e9
+Create Date: 2026-04-30 07:05:00.000000
+
+Task #31 Phase A2 reuses the existing ``graph_curation_suggestions``
+table. The status column is stored as a string, so adding lifecycle
+values is a code/schema change; this migration adds the new
+``evidence_refs`` display field used by the review queue.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7a2b1c3d4e5f"
+down_revision: Union[str, None] = "3c7d2f81b5e9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add display-ready evidence refs to existing graph-curation suggestions."""
+    op.add_column("graph_curation_suggestions", sa.Column("evidence_refs", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the display-ready evidence refs column."""
+    op.drop_column("graph_curation_suggestions", "evidence_refs")

--- a/tests/unit_test/contracts/test_graph_curation_suggestion_status_contract.py
+++ b/tests/unit_test/contracts/test_graph_curation_suggestion_status_contract.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from aperag.domains.knowledge_graph.db.models import GraphCurationSuggestionStatus
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_graph_curation_suggestion_status_values_include_async_apply_states():
+    values = {status.value for status in GraphCurationSuggestionStatus}
+
+    assert {
+        "PENDING",
+        "APPLY_PENDING",
+        "APPLYING",
+        "APPLIED",
+        "APPLY_FAILED",
+        "ACCEPTED",
+        "REJECTED",
+        "DISMISSED",
+        "EXPIRED",
+        "SUPERSEDED",
+    } <= values
+
+
+def test_accepted_status_write_is_legacy_service_only():
+    """New async apply code must not reuse legacy ACCEPTED as a pending-apply state."""
+
+    write_pattern = re.compile(r"(?:suggestion\.status|status)\s*=\s*GraphCurationSuggestionStatus\.ACCEPTED")
+    unexpected: list[str] = []
+
+    for path in (ROOT / "aperag").rglob("*.py"):
+        rel = path.relative_to(ROOT).as_posix()
+        if rel.startswith("aperag/migration/"):
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not write_pattern.search(line):
+                continue
+            if rel == "aperag/graph_curation/service.py" and "suggestion.status" in line:
+                continue
+            unexpected.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert unexpected == []

--- a/tests/unit_test/graph_curation/test_service.py
+++ b/tests/unit_test/graph_curation/test_service.py
@@ -119,7 +119,22 @@ def test_suggestion_to_dict_exposes_evidence_refs_and_new_status():
         collection_id="col1",
         status=GraphCurationSuggestionStatus.APPLY_PENDING,
         entity_ids=["e1", "e2"],
-        entity_snapshots=[],
+        entity_snapshots=[
+            {
+                "entity_id": "e1",
+                "entity_name": "墨香居",
+                "entity_type": "ORGANIZATION",
+                "description": "",
+                "source_chunk_count": 1,
+            },
+            {
+                "entity_id": "e2",
+                "entity_name": "旧书店",
+                "entity_type": "ORGANIZATION",
+                "description": "",
+                "source_chunk_count": 1,
+            },
+        ],
         target_entity_id="e1",
         confidence_score=Decimal("0.910"),
         reason="same entity",
@@ -136,6 +151,12 @@ def test_suggestion_to_dict_exposes_evidence_refs_and_new_status():
     out = GraphCurationService._suggestion_to_dict(suggestion)
 
     assert out["status"] == GraphCurationSuggestionStatus.APPLY_PENDING
+    assert out["suggestion_batch_id"] == "gcr_1"
+    assert out["merge_reason"] == "same entity"
+    assert out["suggested_target_entity"] == {
+        "entity_name": "墨香居",
+        "entity_type": "ORGANIZATION",
+    }
     assert out["confidence_score"] == 0.91
     assert out["evidence_refs"] == [
         {"document_id": "doc1", "chunk_id": "chunk1", "parse_version": "v1"},

--- a/tests/unit_test/graph_curation/test_service.py
+++ b/tests/unit_test/graph_curation/test_service.py
@@ -7,6 +7,11 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 
 
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+
+from aperag.domains.knowledge_graph.db.models import GraphCurationSuggestionStatus
 from aperag.domains.knowledge_graph.schemas import SuggestionActionRequest
 from aperag.graph_curation.candidate_generation import CandidatePair
 from aperag.graph_curation.dto import CurationEntity as Entity
@@ -104,3 +109,34 @@ def test_suggestion_action_request_normalizes_case_insensitively():
     request = SuggestionActionRequest(action=" REJECT ")
 
     assert request.action == "reject"
+
+
+def test_suggestion_to_dict_exposes_evidence_refs_and_new_status():
+    created = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    suggestion = SimpleNamespace(
+        id="gcs_1",
+        run_id="gcr_1",
+        collection_id="col1",
+        status=GraphCurationSuggestionStatus.APPLY_PENDING,
+        entity_ids=["e1", "e2"],
+        entity_snapshots=[],
+        target_entity_id="e1",
+        confidence_score=Decimal("0.910"),
+        reason="same entity",
+        evidence={"pair_count": 1},
+        evidence_refs=[
+            {"document_id": "doc1", "chunk_id": "chunk1", "parse_version": "v1"},
+        ],
+        resolution_note=None,
+        gmt_created=created,
+        gmt_updated=created,
+        gmt_operated=None,
+    )
+
+    out = GraphCurationService._suggestion_to_dict(suggestion)
+
+    assert out["status"] == GraphCurationSuggestionStatus.APPLY_PENDING
+    assert out["confidence_score"] == 0.91
+    assert out["evidence_refs"] == [
+        {"document_id": "doc1", "chunk_id": "chunk1", "parse_version": "v1"},
+    ]

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -4697,6 +4697,12 @@ export interface components {
              */
             run_id: string;
             /**
+             * Suggestion Batch Id
+             * @description Backward-compatible alias of run_id for the existing FE review panel
+             * @example gcr_abcd1234efgh5678
+             */
+            suggestion_batch_id: string;
+            /**
              * Collection Id
              * @description Collection ID
              * @example col123
@@ -4729,6 +4735,8 @@ export interface components {
              * @example e_moxiangju
              */
             target_entity_id: string;
+            /** @description Backward-compatible target entity projection for the existing FE review panel */
+            suggested_target_entity: components["schemas"]["GraphMergeSuggestionTargetEntity"];
             /**
              * Confidence Score
              * @description Aggregated confidence score for this suggestion
@@ -4741,6 +4749,12 @@ export interface components {
              * @example 两个实体都在描述同一家旧书店，名称和上下文高度重合。
              */
             reason: string;
+            /**
+             * Merge Reason
+             * @description Backward-compatible alias of reason for the existing FE review panel
+             * @example 两个实体都在描述同一家旧书店，名称和上下文高度重合。
+             */
+            merge_reason: string;
             /**
              * Evidence
              * @description Structured supporting evidence used to generate the suggestion
@@ -4777,6 +4791,24 @@ export interface components {
              * @example 2026-04-23T00:05:00Z
              */
             operated_at?: string | null;
+        };
+        /**
+         * GraphMergeSuggestionTargetEntity
+         * @description Legacy FE-compatible target entity projection.
+         */
+        GraphMergeSuggestionTargetEntity: {
+            /**
+             * Entity Name
+             * @description Recommended target entity display name
+             * @example 墨香居
+             */
+            entity_name: string;
+            /**
+             * Entity Type
+             * @description Recommended target entity type
+             * @example ORGANIZATION
+             */
+            entity_type: string;
         };
         /**
          * GraphNode

--- a/web/src/api-v2/schema.d.ts
+++ b/web/src/api-v2/schema.d.ts
@@ -4212,6 +4212,68 @@ export interface components {
             reference_context?: string | null;
         };
         /**
+         * GraphCurationRunSummary
+         * @description Summary of an asynchronous graph-curation run.
+         */
+        GraphCurationRunSummary: {
+            /**
+             * Id
+             * @description Run ID
+             * @example gcr_abcd1234efgh5678
+             */
+            id: string;
+            /**
+             * Collection Id
+             * @description Collection ID
+             * @example col123
+             */
+            collection_id: string;
+            /**
+             * Status
+             * @description Run lifecycle status
+             * @example COMPLETED
+             * @enum {string}
+             */
+            status: "PENDING" | "RUNNING" | "COMPLETED" | "FAILED";
+            /**
+             * Stats
+             * @description Best-effort execution stats for the latest run
+             */
+            stats?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Error Message
+             * @description Failure message if the run failed
+             * @example LLM adjudication timed out
+             */
+            error_message?: string | null;
+            /**
+             * Created
+             * @description Creation timestamp
+             * @example 2026-04-23T00:00:00Z
+             */
+            created?: string | null;
+            /**
+             * Updated
+             * @description Last update timestamp
+             * @example 2026-04-23T00:02:00Z
+             */
+            updated?: string | null;
+            /**
+             * Started
+             * @description Run start timestamp
+             * @example 2026-04-23T00:00:05Z
+             */
+            started?: string | null;
+            /**
+             * Finished
+             * @description Run finish timestamp
+             * @example 2026-04-23T00:02:00Z
+             */
+            finished?: string | null;
+        };
+        /**
          * GraphEdge
          * @description Knowledge graph edge representing a relationship
          */
@@ -4580,6 +4642,141 @@ export interface components {
              *     ]
              */
             labels: string[];
+        };
+        /**
+         * GraphMergeSuggestionEntity
+         * @description Snapshot of an entity at suggestion-generation time.
+         */
+        GraphMergeSuggestionEntity: {
+            /**
+             * Entity Id
+             * @description Entity ID
+             * @example e_moxiangju
+             */
+            entity_id: string;
+            /**
+             * Entity Name
+             * @description Entity name
+             * @example 墨香居
+             */
+            entity_name: string;
+            /**
+             * Entity Type
+             * @description Entity type
+             * @example ORGANIZATION
+             */
+            entity_type: string;
+            /**
+             * Description
+             * @description Entity description
+             * @example 这条老巷子里唯一的旧书店
+             */
+            description: string;
+            /**
+             * Source Chunk Count
+             * @description Number of source chunks referenced by this entity
+             * @example 3
+             */
+            source_chunk_count: number;
+        };
+        /**
+         * GraphMergeSuggestionItem
+         * @description Persisted merge suggestion produced by graph curation.
+         */
+        GraphMergeSuggestionItem: {
+            /**
+             * Id
+             * @description Suggestion ID
+             * @example gcs_abcd1234efgh5678
+             */
+            id: string;
+            /**
+             * Run Id
+             * @description Run that produced this suggestion
+             * @example gcr_abcd1234efgh5678
+             */
+            run_id: string;
+            /**
+             * Collection Id
+             * @description Collection ID
+             * @example col123
+             */
+            collection_id: string;
+            /**
+             * Status
+             * @description Suggestion lifecycle status
+             * @example PENDING
+             * @enum {string}
+             */
+            status: "PENDING" | "APPLY_PENDING" | "APPLYING" | "APPLIED" | "APPLY_FAILED" | "ACCEPTED" | "REJECTED" | "DISMISSED" | "EXPIRED" | "SUPERSEDED";
+            /**
+             * Entity Ids
+             * @description Entity IDs in the candidate merge set
+             * @example [
+             *       "e_moxiangju",
+             *       "e_old_bookstore"
+             *     ]
+             */
+            entity_ids: string[];
+            /**
+             * Entities
+             * @description Entity snapshots captured when the suggestion was generated
+             */
+            entities: components["schemas"]["GraphMergeSuggestionEntity"][];
+            /**
+             * Target Entity Id
+             * @description Recommended surviving entity ID if the suggestion is accepted
+             * @example e_moxiangju
+             */
+            target_entity_id: string;
+            /**
+             * Confidence Score
+             * @description Aggregated confidence score for this suggestion
+             * @example 0.91
+             */
+            confidence_score: number;
+            /**
+             * Reason
+             * @description Human-readable explanation from pairwise LLM adjudication
+             * @example 两个实体都在描述同一家旧书店，名称和上下文高度重合。
+             */
+            reason: string;
+            /**
+             * Evidence
+             * @description Structured supporting evidence used to generate the suggestion
+             */
+            evidence?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Evidence Refs
+             * @description Display-ready source chunk refs supporting this suggestion
+             */
+            evidence_refs?: components["schemas"]["GraphEvidenceRef"][];
+            /**
+             * Resolution Note
+             * @description System note explaining why the suggestion left pending state
+             * @example superseded_by:gcs_other
+             */
+            resolution_note?: string | null;
+            /**
+             * Created
+             * @description Creation timestamp
+             * @example 2026-04-23T00:02:00Z
+             */
+            created?: string | null;
+            /**
+             * Updated
+             * @description Last update timestamp
+             * @example 2026-04-23T00:05:00Z
+             */
+            updated?: string | null;
+            /**
+             * Operated At
+             * @description User-operation timestamp for accepted/rejected suggestions
+             * @example 2026-04-23T00:05:00Z
+             */
+            operated_at?: string | null;
         };
         /**
          * GraphNode
@@ -5008,6 +5205,38 @@ export interface components {
          * @description Start a new graph-curation analysis run.
          */
         MergeSuggestionsRequest: Record<string, never>;
+        /**
+         * MergeSuggestionsResponse
+         * @description Latest persisted graph-curation run and its suggestions.
+         */
+        MergeSuggestionsResponse: {
+            /** @description Latest graph-curation run for this collection, if any */
+            run?: components["schemas"]["GraphCurationRunSummary"] | null;
+            /**
+             * Suggestions
+             * @description Suggestions from the latest run, ordered by confidence score
+             */
+            suggestions: components["schemas"]["GraphMergeSuggestionItem"][];
+        };
+        /**
+         * MergeSuggestionsRunResponse
+         * @description Response returned when starting a graph-curation run.
+         */
+        MergeSuggestionsRunResponse: {
+            run: components["schemas"]["GraphCurationRunSummary"];
+            /**
+             * Started
+             * @description Whether a new run was actually scheduled
+             * @example true
+             */
+            started: boolean;
+            /**
+             * Message
+             * @description Human-readable status message
+             * @example Graph curation run started
+             */
+            message: string;
+        };
         /**
          * MineruTokenTestRequest
          * @description Request body for POST /collections/test-mineru-token.
@@ -6244,6 +6473,52 @@ export interface components {
             total: number;
         };
         /**
+         * SuggestionActionMergeResult
+         * @description Merge result returned when accepting a graph-curation suggestion.
+         */
+        SuggestionActionMergeResult: {
+            /**
+             * Target Entity Id
+             * @description Surviving entity ID after merge
+             * @example e_moxiangju
+             */
+            target_entity_id: string;
+            /**
+             * Merged Source Ids
+             * @description Merged-away entity IDs
+             * @example [
+             *       "e_old_bookstore"
+             *     ]
+             */
+            merged_source_ids: string[];
+            /**
+             * Description
+             * @description Merged description of the surviving entity
+             */
+            description: string;
+            /**
+             * Source Chunk Ids
+             * @description Source chunk IDs preserved on the surviving entity
+             * @example [
+             *       "chunk_1",
+             *       "chunk_8"
+             *     ]
+             */
+            source_chunk_ids: string[];
+            /**
+             * Edges Redirected
+             * @description Number of redirected edges
+             * @example 5
+             */
+            edges_redirected: number;
+            /**
+             * Edges Collapsed
+             * @description Number of duplicate edges collapsed
+             * @example 2
+             */
+            edges_collapsed: number;
+        };
+        /**
          * SuggestionActionRequest
          * @description Request to take action on a merge suggestion
          */
@@ -6255,6 +6530,47 @@ export interface components {
              * @enum {string}
              */
             action: "accept" | "reject";
+        };
+        /**
+         * SuggestionActionResponse
+         * @description Response containing suggestion action results
+         */
+        SuggestionActionResponse: {
+            /**
+             * Status
+             * @description Status of the action operation
+             * @example success
+             * @enum {string}
+             */
+            status: "success" | "error";
+            /**
+             * Message
+             * @description Detailed message about the action operation
+             * @example Suggestion msug123 has been accepted and merge completed
+             */
+            message: string;
+            /**
+             * Suggestion Id
+             * @description The suggestion ID that was processed
+             * @example msug123
+             */
+            suggestion_id: string;
+            /**
+             * Action
+             * @description The action that was performed (normalized to lowercase)
+             * @example accept
+             * @enum {string}
+             */
+            action: "accept" | "reject";
+            /**
+             * Suggestion Status
+             * @description Suggestion status after action processing
+             * @example ACCEPTED
+             * @enum {string}
+             */
+            suggestion_status: "PENDING" | "APPLY_PENDING" | "APPLYING" | "APPLIED" | "APPLY_FAILED" | "ACCEPTED" | "REJECTED" | "DISMISSED" | "EXPIRED" | "SUPERSEDED";
+            /** @description Merge operation result (only present when action is 'accept') */
+            merge_result?: components["schemas"]["SuggestionActionMergeResult"] | null;
         };
         /** SummarySearchParams */
         SummarySearchParams: {
@@ -8953,9 +9269,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["MergeSuggestionsResponse"];
                 };
             };
             /** @description Validation Error */
@@ -8992,9 +9306,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["MergeSuggestionsRunResponse"];
                 };
             };
             /** @description Validation Error */
@@ -9032,9 +9344,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["SuggestionActionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/src/features/knowledge-graph/types.ts
+++ b/web/src/features/knowledge-graph/types.ts
@@ -20,6 +20,9 @@ export type GraphSearchEntity = NonNullable<
 export type GraphEvidenceResponse = NonNullable<
   components['schemas']['GraphEvidenceResponse']
 >;
+export type GraphEvidenceRef = NonNullable<
+  components['schemas']['GraphEvidenceRef']
+>;
 export type GraphRelationEvidenceRequest = NonNullable<
   components['schemas']['GraphRelationEvidenceRequest']
 >;
@@ -68,9 +71,15 @@ export const SUGGESTION_ACTIONS = [
 // list in lockstep with `aperag/schema/view_models.py::MergeSuggestions*`.
 export type MergeSuggestionStatus =
   | 'PENDING'
+  | 'APPLY_PENDING'
+  | 'APPLYING'
+  | 'APPLIED'
+  | 'APPLY_FAILED'
   | 'ACCEPTED'
   | 'REJECTED'
-  | 'EXPIRED';
+  | 'DISMISSED'
+  | 'EXPIRED'
+  | 'SUPERSEDED';
 
 export interface MergeSuggestionTargetEntity {
   entity_name: string;
@@ -84,9 +93,15 @@ export interface MergeSuggestionItem {
   entity_ids: string[];
   confidence_score: number;
   merge_reason: string;
+  reason?: string;
+  evidence?: Record<string, unknown> | null;
+  evidence_refs?: GraphEvidenceRef[];
   suggested_target_entity: MergeSuggestionTargetEntity;
+  target_entity_id?: string;
   status: MergeSuggestionStatus;
   created: string;
+  updated?: string;
+  resolution_note?: string | null;
   operated_at?: string;
 }
 


### PR DESCRIPTION
## Summary

Task #31 Phase A2 implementation:

- extend existing `GraphCurationSuggestionStatus` with async apply states: `APPLY_PENDING`, `APPLYING`, `APPLIED`, `APPLY_FAILED`
- add `DISMISSED` because current main did not actually have it, while PR #1931 spec/A4 already treat dismiss as part of the review queue status surface
- add `graph_curation_suggestions.evidence_refs` column + model/service persistence and projection
- add response models for `/graphs/merge-suggestions` read/run/action so OpenAPI + FE typed schema expose the curation suggestion contract
- update FE graph merge suggestion status/types and regenerated `web/src/api-v2/schema.d.ts`
- add contract tests for async status values and `ACCEPTED` legacy zero-write guard

## Notes

`status` is stored as `String(50)`, not a native PG enum, so the Alembic migration only needs to add `evidence_refs`. The code/schema update is the status enum extension.

`ACCEPTED` remains the legacy sync terminal status in `GraphCurationService._accept_and_supersede`; the new async path must use `APPLY_PENDING -> APPLYING -> APPLIED|APPLY_FAILED` and is guarded by `test_accepted_status_write_is_legacy_service_only`.

## Verification

- `uv run pytest tests/unit_test/graph_curation/test_service.py tests/unit_test/contracts/test_graph_curation_suggestion_status_contract.py`
- `uv run pytest tests/unit_test/contracts/test_openapi_spec.py tests/unit_test/contracts/test_web_typed_api_contract.py`
- `uv run ruff check aperag/domains/knowledge_graph/api/routes.py aperag/domains/knowledge_graph/db/models.py aperag/domains/knowledge_graph/schemas.py aperag/graph_curation/service.py aperag/indexing/merge_candidate_detector.py tests/unit_test/graph_curation/test_service.py tests/unit_test/contracts/test_graph_curation_suggestion_status_contract.py aperag/migration/versions/20260430070500-7a2b1c3d4e5f.py`
- `uv run ruff format --check aperag/domains/knowledge_graph/api/routes.py aperag/domains/knowledge_graph/db/models.py aperag/domains/knowledge_graph/schemas.py aperag/graph_curation/service.py aperag/indexing/merge_candidate_detector.py tests/unit_test/graph_curation/test_service.py tests/unit_test/contracts/test_graph_curation_suggestion_status_contract.py aperag/migration/versions/20260430070500-7a2b1c3d4e5f.py`
- `make openapi-check`
- `uv run alembic -c aperag/alembic.ini heads`
- `yarn api:v2:types`
- `yarn type-check`
