### PR TITLE
fix(indexing): install runtime in worker CLI

### DIFF
--- a/aperag/cli/indexing_worker.py
+++ b/aperag/cli/indexing_worker.py
@@ -59,6 +59,7 @@ from aperag.indexing.quota import (
     QuotaPolicyRegistry,
     RedisQuotaBackend,
 )
+from aperag.indexing.runtime import IndexingRuntime, set_runtime
 from aperag.indexing.worker_factory import ProductionWorkerFactory
 from aperag.llm.litellm_track import register_custom_llm_track
 from aperag.objectstore.base import get_object_store
@@ -70,6 +71,34 @@ from aperag.observability import (
 from aperag.observability.metrics import shutdown_metrics_provider
 
 logger = logging.getLogger(__name__)
+
+
+def _install_worker_runtime(
+    *,
+    engine,
+    queue,
+    metrics_emitter,
+    quota_backend,
+    worker_factory: ProductionWorkerFactory,
+) -> None:
+    """Install the process-local runtime used by worker-side graph helpers.
+
+    The API installs its own enqueue-only runtime in ``app.py``. The
+    standalone worker process needs the same process-local singleton so
+    graph workers can resolve ``DocumentIndex.tenant_scope_key`` through
+    ``aperag.indexing.worker_factory._resolve_tenant_scope_key``.
+    """
+
+    set_runtime(
+        IndexingRuntime(
+            engine=engine,
+            queue=queue,
+            workers={},
+            metrics_emitter=metrics_emitter,
+            cleanup_worker_factory=worker_factory.build_for_cleanup_row,
+            quota_backend=quota_backend,
+        )
+    )
 
 
 async def _amain() -> None:
@@ -139,6 +168,13 @@ async def _amain() -> None:
     # ProductionWorkerFactory: per-task 懒构造. worker entrypoint 在 BLPOP 出
     # payload 后调用, 按 (collection_id, modality) 构造 ModalityWorker.
     worker_factory = ProductionWorkerFactory(engine=sync_engine)
+    _install_worker_runtime(
+        engine=sync_engine,
+        queue=queue,
+        metrics_emitter=metrics_emitter,
+        quota_backend=quota_backend,
+        worker_factory=worker_factory,
+    )
     worker_kwargs = dict(
         engine=sync_engine,
         queue=queue,
@@ -187,36 +223,39 @@ async def _amain() -> None:
         "graph_vectors/summary/vision/parse/reconciler/cleanup)"
     )
 
-    await shutdown.wait()
-    logger.info("indexing-worker shutdown signal received, draining %d tasks...", len(tasks))
-
-    # cuiwenbo msg=f7868d2c #3 + Weston msg=ce324047 #2: 给 graceful drain 设 25s 上限
-    # (kubelet 默认 30s grace), 超时强制 cancel, 避免某个 worker 不响应 shutdown
-    # event 时挂到 SIGKILL 丢 in-flight 状态.
     try:
-        await asyncio.wait_for(
-            asyncio.gather(*tasks, return_exceptions=True),
-            timeout=25.0,
-        )
-    except asyncio.TimeoutError:
-        logger.warning("indexing-worker shutdown timeout after 25s, cancelling %d tasks", len(tasks))
-        for t in tasks:
-            t.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        await shutdown.wait()
+        logger.info("indexing-worker shutdown signal received, draining %d tasks...", len(tasks))
 
-    # cuiwenbo msg=f7868d2c #2 + Weston msg=ce324047 #1: flush OTLP MeterProvider,
-    # 否则 PeriodicExportingMetricReader 残留样本会随 worker 退出丢失 (跟 app.py
-    # finally 段调 shutdown_metrics_provider 等价).
-    with contextlib.suppress(Exception):
-        await asyncio.to_thread(shutdown_metrics_provider)
+        # cuiwenbo msg=f7868d2c #3 + Weston msg=ce324047 #2: 给 graceful drain 设 25s 上限
+        # (kubelet 默认 30s grace), 超时强制 cancel, 避免某个 worker 不响应 shutdown
+        # event 时挂到 SIGKILL 丢 in-flight 状态.
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=True),
+                timeout=25.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("indexing-worker shutdown timeout after 25s, cancelling %d tasks", len(tasks))
+            for t in tasks:
+                t.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
-    # 关闭 RedisWorkQueue / quota redis. 失败 swallow (跟 app.py 同样模式).
-    if hasattr(queue, "close"):
+        # cuiwenbo msg=f7868d2c #2 + Weston msg=ce324047 #1: flush OTLP MeterProvider,
+        # 否则 PeriodicExportingMetricReader 残留样本会随 worker 退出丢失 (跟 app.py
+        # finally 段调 shutdown_metrics_provider 等价).
         with contextlib.suppress(Exception):
-            await queue.close()
-    if quota_redis is not None:
-        with contextlib.suppress(Exception):
-            await quota_redis.aclose()
+            await asyncio.to_thread(shutdown_metrics_provider)
+
+        # 关闭 RedisWorkQueue / quota redis. 失败 swallow (跟 app.py 同样模式).
+        if hasattr(queue, "close"):
+            with contextlib.suppress(Exception):
+                await queue.close()
+        if quota_redis is not None:
+            with contextlib.suppress(Exception):
+                await quota_redis.aclose()
+    finally:
+        set_runtime(None)
     logger.info("indexing-worker shutdown complete")
 
 

--- a/tests/unit_test/indexing/test_worker_runtime_install.py
+++ b/tests/unit_test/indexing/test_worker_runtime_install.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from aperag.cli.indexing_worker import _install_worker_runtime
+from aperag.indexing import InMemoryWorkQueue, NoopMetricsEmitter
+from aperag.indexing.models import DocumentIndex, IndexStatus, Modality
+from aperag.indexing.orchestrator import DispatchPayload
+from aperag.indexing.quota import InMemoryQuotaBackend, QuotaPolicyRegistry
+from aperag.indexing.runtime import set_runtime
+from aperag.indexing.worker_factory import ProductionWorkerFactory, _resolve_tenant_scope_key
+
+
+def test_cli_worker_installs_runtime_for_graph_tenant_scope_resolution():
+    """Standalone indexing-worker must install runtime before graph workers build."""
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    DocumentIndex.metadata.create_all(engine, tables=[DocumentIndex.__table__])
+    queue = InMemoryWorkQueue()
+    quota_backend = InMemoryQuotaBackend(QuotaPolicyRegistry())
+    worker_factory = ProductionWorkerFactory(engine=engine, object_store=object())
+
+    with Session(engine) as session, session.begin():
+        row = DocumentIndex(
+            document_id="doc-hotfix",
+            parse_version="parse-v1",
+            modality=Modality.GRAPH.value,
+            status=IndexStatus.PENDING.value,
+            tenant_scope_key="tenant:hotfix",
+            collection_id="col-hotfix",
+            source_path="graph.jsonl",
+            is_serving=False,
+        )
+        session.add(row)
+        session.flush()
+        row_id = int(row.id)
+
+    _install_worker_runtime(
+        engine=engine,
+        queue=queue,
+        metrics_emitter=NoopMetricsEmitter(),
+        quota_backend=quota_backend,
+        worker_factory=worker_factory,
+    )
+    try:
+        payload = DispatchPayload(
+            index_id=row_id,
+            document_id="doc-hotfix",
+            parse_version="parse-v1",
+            modality=Modality.GRAPH,
+            source_path="graph.jsonl",
+            collection_id="col-hotfix",
+        )
+
+        assert _resolve_tenant_scope_key(payload=payload) == "tenant:hotfix"
+    finally:
+        set_runtime(None)


### PR DESCRIPTION
## Summary

Hotfix for split-process graph indexing failures:

- install worker-side `IndexingRuntime` in `python -m aperag.cli.indexing_worker` after queue/quota/metrics/`ProductionWorkerFactory` are constructed
- wire `cleanup_worker_factory=worker_factory.build_for_cleanup_row` in the worker runtime, while keeping API `cleanup_worker_factory=None`
- clear the process-local runtime on worker shutdown via `set_runtime(None)`
- add regression coverage that the CLI-equivalent runtime install lets graph worker factory resolve `DocumentIndex.tenant_scope_key` instead of raising `IndexingRuntime is not installed (lifespan never ran)`

## Boundary

This does not move heavy worker logic back into the API process. API-side hard-cut tests remain unchanged and passing.

## Verification

- `uv run pytest tests/unit_test/indexing/test_worker_runtime_install.py tests/unit_test/test_app_lifespan_no_workers.py tests/boundaries/test_worker_di_parity.py`
- `uv run ruff check aperag/cli/indexing_worker.py tests/unit_test/indexing/test_worker_runtime_install.py`
- `uv run ruff format --check aperag/cli/indexing_worker.py tests/unit_test/indexing/test_worker_runtime_install.py`
