### PR TITLE
fix(mcp): restore default search and chunk reads

### DIFF
--- a/aperag/domains/knowledge_base/service/document_service.py
+++ b/aperag/domains/knowledge_base/service/document_service.py
@@ -38,7 +38,7 @@ import logging
 import mimetypes
 import os
 import re
-from typing import List
+from typing import Any, List
 
 from fastapi import HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
@@ -1101,73 +1101,64 @@ class DocumentService:
 
         # Use database operations with proper session management
         async def _get_document_chunks(session):
-            # Wave 3 §F.1 schema migration: legacy
-            # ``DocumentIndex.index_data`` JSON blob (which used to
-            # carry ``context_ids``) is gone. The chunk id list now
-            # lives in the ``derived/parse_<v>/chunks.jsonl`` artifact
-            # on the object store, addressed by the row's
-            # ``derived_artifact_path``. Plumbing the object-store
-            # read path into this HTTP handler is a chenyexuan T3.1
-            # commit 4b follow-up; for now we exercise the §F.1
-            # partial-unique invariant via a serving-row probe and
-            # return an empty chunk list (degraded but safe — clients
-            # see "no chunks indexed" until the read path lands).
             stmt = select(DocumentIndex.derived_artifact_path).filter(
+                DocumentIndex.collection_id == collection_id,
                 DocumentIndex.document_id == document_id,
                 DocumentIndex.modality == Modality.VECTOR.value,
                 DocumentIndex.is_serving.is_(True),
             )
             result = await session.execute(stmt)
-            _ = result.scalars().first()
-            ctx_ids: list[str] = []
-            if not ctx_ids:
+            chunks_path = result.scalars().first()
+            if not chunks_path:
                 return []
 
-            # 2. Retrieve chunks via the vector-store connector. We go through
-            # the connector (not the raw qdrant client) because in multitenant
-            # mode it (a) routes to the correct global Qdrant collection based
-            # on vector_size and (b) enforces the tenant-id guard.
             try:
-                collection_obj = await self.db_ops.query_collection(user_id, collection_id)
-                vector_size = None
-                if collection_obj is not None:
+                async_obj_store = get_async_object_store()
+                get_result = await async_obj_store.get(chunks_path)
+                if not get_result:
+                    return []
+
+                stream, _ = get_result
+                body = b""
+                async for data in stream:
+                    body += data
+
+                chunks: list[Chunk] = []
+                for line_no, raw_line in enumerate(body.decode("utf-8", errors="replace").splitlines(), start=1):
+                    if not raw_line.strip():
+                        continue
                     try:
-                        from aperag.llm.embed.base_embedding import get_collection_embedding_service_sync
-
-                        _, vector_size = get_collection_embedding_service_sync(collection_obj)
-                    except Exception:
-                        vector_size = None
-
-                from aperag.config import get_vector_db_connector as _get_vdb
-
-                vector_store_adaptor = _get_vdb(
-                    collection=generate_vector_db_collection_name(collection_id=collection_id),
-                    vector_size=vector_size,
-                )
-                points = vector_store_adaptor.connector.retrieve(ids=ctx_ids)
-
-                # 3. Format the response using the shared payload flattener,
-                # which understands both the modern {text, metadata} shape
-                # and the legacy LlamaIndex _node_content JSON blob.
-                from aperag.vectorstore.dto import flatten_node_payload
-
-                chunks = []
-                for point in points:
-                    flat = flatten_node_payload(point.payload or {})
+                        record: dict[str, Any] = json.loads(raw_line)
+                    except json.JSONDecodeError:
+                        logger.warning("Skipping malformed chunks.jsonl line %s at %s", line_no, chunks_path)
+                        continue
+                    chunk_id = record.get("chunk_id") or record.get("id")
+                    if not chunk_id:
+                        logger.warning("Skipping chunk without chunk_id at %s line %s", chunks_path, line_no)
+                        continue
+                    metadata = {
+                        key: value
+                        for key, value in {
+                            "section_path": record.get("section_path"),
+                            "heading_anchor": record.get("heading_anchor"),
+                            "page_idx": record.get("page_idx"),
+                        }.items()
+                        if value is not None
+                    }
+                    raw_metadata = record.get("metadata")
+                    if isinstance(raw_metadata, dict):
+                        metadata.update(raw_metadata)
                     chunks.append(
                         Chunk(
-                            id=point.id,
-                            text=flat.get("text") or "",
-                            metadata=flat.get("metadata") or {},
+                            id=str(chunk_id),
+                            text=str(record.get("text") or ""),
+                            metadata=metadata,
                         )
                     )
-
                 return chunks
             except Exception as e:
-                logger.error(
-                    f"Failed to retrieve chunks from vector store for document {document_id}: {e}", exc_info=True
-                )
-                raise HTTPException(status_code=500, detail="Failed to retrieve chunks from vector store")
+                logger.error("Failed to read chunks.jsonl for document %s at %s: %s", document_id, chunks_path, e)
+                raise HTTPException(status_code=500, detail="Failed to retrieve document chunks")
 
         # Execute query with proper session management
         return await self.db_ops._execute_query(_get_document_chunks)

--- a/aperag/domains/retrieval/pipeline.py
+++ b/aperag/domains/retrieval/pipeline.py
@@ -57,6 +57,9 @@ from aperag.utils.utils import generate_vector_db_collection_name
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SEARCH_TOP_K = 5
+DEFAULT_VECTOR_SIMILARITY = 0.5
+
 
 class CollectionRow(Protocol):
     """Structural view of the legacy ``aperag.db.models.Collection``
@@ -73,6 +76,18 @@ class CollectionRow(Protocol):
     id: str
     user: str
     config: Any
+
+
+def _top_k_or_default(value: Optional[int]) -> int:
+    if value is None:
+        return DEFAULT_SEARCH_TOP_K
+    return max(1, int(value))
+
+
+def _similarity_or_default(value: Optional[float]) -> float:
+    if value is None:
+        return DEFAULT_VECTOR_SIMILARITY
+    return float(value)
 
 
 def _render_graph_context_text(entities: list[Any], relations: list[Any]) -> str:
@@ -284,11 +299,13 @@ class SearchPipelineService:
         self,
         collection: CollectionRow,
         query: str,
-        top_k: int,
-        similarity_threshold: float,
+        top_k: Optional[int],
+        similarity_threshold: Optional[float],
         chat_id: Optional[str] = None,
     ) -> List[DocumentWithScore]:
         try:
+            resolved_top_k = _top_k_or_default(top_k)
+            resolved_similarity = _similarity_or_default(similarity_threshold)
             collection_name = generate_vector_db_collection_name(collection.id)
             embedding_model, vector_size = get_collection_embedding_service_sync(collection)
             vectordb_ctx = build_vector_db_context(collection_name, vector_size=vector_size)
@@ -298,8 +315,8 @@ class SearchPipelineService:
             query_fn = partial(
                 context_manager.query,
                 query,
-                score_threshold=similarity_threshold,
-                topk=top_k,
+                score_threshold=resolved_similarity,
+                topk=resolved_top_k,
                 vector=vector,
                 index_types=["vector"],
                 chat_id=chat_id,
@@ -324,7 +341,7 @@ class SearchPipelineService:
         self,
         collection: CollectionRow,
         query: str,
-        top_k: int,
+        top_k: Optional[int],
         keywords: Optional[List[str]],
         user_id: str,
         chat_id: Optional[str] = None,
@@ -351,8 +368,10 @@ class SearchPipelineService:
             logger.info("Skipping fulltext search for collection %s because enable_fulltext=false", collection.id)
             return []
 
+        resolved_top_k = _top_k_or_default(top_k)
         index_name = generate_fulltext_index_name(collection.id)
         final_keywords = list(keywords or [])
+        explicit_keywords = bool(final_keywords)
         if not final_keywords:
             extractor_ctx = {
                 "index_name": index_name,
@@ -363,13 +382,17 @@ class SearchPipelineService:
             }
             final_keywords = await extract_keywords(query, extractor_ctx)
 
-        final_keywords = list(set(final_keywords))
+        final_keywords = list(dict.fromkeys(final_keywords))
         if not final_keywords:
             logger.warning(
                 "Fulltext keyword extraction degraded for collection %s; falling back to raw query token",
                 collection.id,
             )
             final_keywords = [query]
+
+        raw_query = query.strip()
+        if raw_query and raw_query not in final_keywords:
+            final_keywords.append(raw_query)
 
         es_config = {
             "request_timeout": settings.es_timeout,
@@ -387,7 +410,7 @@ class SearchPipelineService:
                 "bool": {
                     "should": [{"match": {"content": kw}} for kw in final_keywords]
                     + [{"match": {"title": kw}} for kw in final_keywords],
-                    "minimum_should_match": "80%",
+                    "minimum_should_match": "80%" if explicit_keywords else 1,
                     "filter": [{"term": {"collection_id": str(collection.id)}}],
                 }
             }
@@ -408,7 +431,7 @@ class SearchPipelineService:
                 index=index_name,
                 query=es_query,
                 sort=[{"_score": {"order": "desc"}}],
-                size=top_k * 3,
+                size=resolved_top_k * 3,
                 routing=str(collection.id),
             )
             hits = resp.body["hits"]["hits"]
@@ -429,9 +452,15 @@ class SearchPipelineService:
         for hit in hits:
             source = hit.get("_source", {})
             metadata = {
+                "collection_id": source.get("collection_id"),
                 "source": source.get("name", ""),
                 "document_id": source.get("document_id"),
+                "parse_version": source.get("parse_version"),
                 "chunk_id": source.get("chunk_id"),
+                "section_path": source.get("section_path"),
+                "heading_anchor": source.get("heading_anchor"),
+                "page_idx": source.get("page_idx"),
+                "index_modality": "fulltext",
                 "recall_type": "fulltext_search",
             }
             if source.get("title"):
@@ -452,7 +481,7 @@ class SearchPipelineService:
         self,
         collection: CollectionRow,
         query: str,
-        top_k: int,
+        top_k: Optional[int],
     ) -> List[DocumentWithScore]:
         """Knowledge-graph retrieval path via :class:`GraphSearchService`.
 
@@ -504,7 +533,7 @@ class SearchPipelineService:
             )
             return []
 
-        anchors = await service.search_entities(query=query, top_k=top_k)
+        anchors = await service.search_entities(query=query, top_k=_top_k_or_default(top_k))
         if not anchors:
             return []
         anchor_names = [e.name for e in anchors]
@@ -518,10 +547,12 @@ class SearchPipelineService:
         self,
         collection: CollectionRow,
         query: str,
-        top_k: int,
-        similarity_threshold: float,
+        top_k: Optional[int],
+        similarity_threshold: Optional[float],
     ) -> List[DocumentWithScore]:
         try:
+            resolved_top_k = _top_k_or_default(top_k)
+            resolved_similarity = _similarity_or_default(similarity_threshold)
             collection_name = generate_vector_db_collection_name(collection.id)
             embedding_model, vector_size = get_collection_embedding_service_sync(collection)
             vectordb_ctx = build_vector_db_context(collection_name, vector_size=vector_size)
@@ -531,8 +562,8 @@ class SearchPipelineService:
             query_fn = partial(
                 context_manager.query,
                 query,
-                score_threshold=similarity_threshold,
-                topk=top_k,
+                score_threshold=resolved_similarity,
+                topk=resolved_top_k,
                 vector=vector,
                 index_types=["summary"],
             )
@@ -556,21 +587,23 @@ class SearchPipelineService:
         self,
         collection: CollectionRow,
         query: str,
-        top_k: int,
-        similarity_threshold: float,
+        top_k: Optional[int],
+        similarity_threshold: Optional[float],
     ) -> List[DocumentWithScore]:
         try:
+            resolved_top_k = _top_k_or_default(top_k)
+            resolved_similarity = _similarity_or_default(similarity_threshold)
             collection_name = generate_vector_db_collection_name(collection.id)
             embedding_model, vector_size = get_collection_embedding_service_sync(collection)
             vectordb_ctx = build_vector_db_context(collection_name, vector_size=vector_size)
             context_manager = ContextManager(collection_name, embedding_model, settings.vector_db_type, vectordb_ctx)
 
             vector = await asyncio.to_thread(embedding_model.embed_query, query)
-            expanded_top_k = top_k * 2
+            expanded_top_k = resolved_top_k * 2
             query_fn = partial(
                 context_manager.query,
                 query,
-                score_threshold=similarity_threshold,
+                score_threshold=resolved_similarity,
                 topk=expanded_top_k,
                 vector=vector,
                 index_types=["vision"],

--- a/tests/unit_test/retrieval/test_mcp_search_defaults.py
+++ b/tests/unit_test/retrieval/test_mcp_search_defaults.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aperag.domains.retrieval import pipeline as pipeline_module
+from aperag.domains.retrieval.pipeline import SearchPipelineService
+
+
+@pytest.mark.asyncio
+async def test_vector_search_defaults_optional_mcp_params(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class _Embedding:
+        def embed_query(self, query: str) -> list[float]:
+            assert query == "充电联盟"
+            return [0.1, 0.2]
+
+    class _ContextManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def query(self, query, *, score_threshold, topk, vector, index_types, chat_id):
+            captured.update(
+                {
+                    "score_threshold": score_threshold,
+                    "topk": topk,
+                    "vector": vector,
+                    "index_types": index_types,
+                    "chat_id": chat_id,
+                }
+            )
+            return []
+
+    monkeypatch.setattr(pipeline_module, "get_collection_embedding_service_sync", lambda collection: (_Embedding(), 2))
+    monkeypatch.setattr(pipeline_module, "build_vector_db_context", lambda *args, **kwargs: object())
+    monkeypatch.setattr(pipeline_module, "ContextManager", _ContextManager)
+
+    result = await SearchPipelineService()._vector_search(
+        collection=SimpleNamespace(id="col-1", config={}),
+        query="充电联盟",
+        top_k=None,
+        similarity_threshold=None,
+    )
+
+    assert result == []
+    assert captured == {
+        "score_threshold": 0.5,
+        "topk": 5,
+        "vector": [0.1, 0.2],
+        "index_types": ["vector"],
+        "chat_id": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fulltext_search_includes_raw_query_when_keywords_are_extracted(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _extract_keywords(query: str, ctx: dict) -> list[str]:
+        assert query == "充电联盟"
+        return ["充电", "联盟"]
+
+    class _ExistsResponse:
+        body = True
+
+    class _SearchResponse:
+        body = {"hits": {"hits": []}}
+
+    class _AsyncElasticsearch:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @property
+        def indices(self):
+            return self
+
+        async def exists(self, index):
+            return _ExistsResponse()
+
+        async def search(self, *, index, query, sort, size, routing):
+            captured.update({"query": query, "size": size, "routing": routing})
+            return _SearchResponse()
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr("aperag.indexing.keyword_extract.extract_keywords", _extract_keywords)
+    monkeypatch.setattr("elasticsearch.AsyncElasticsearch", _AsyncElasticsearch)
+
+    result = await SearchPipelineService()._fulltext_search(
+        collection=SimpleNamespace(id="col-1", config="{}"),
+        query="充电联盟",
+        top_k=None,
+        keywords=None,
+        user_id="user-1",
+    )
+
+    assert result == []
+    should = captured["query"]["bool"]["should"]
+    match_terms = [clause["match"][field] for clause in should for field in clause["match"]]
+    assert "充电联盟" in match_terms
+    assert captured["query"]["bool"]["minimum_should_match"] == 1
+    assert captured["size"] == 15
+    assert captured["routing"] == "col-1"

--- a/tests/unit_test/service/test_document_service_chunks.py
+++ b/tests/unit_test/service/test_document_service_chunks.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from aperag.domains.knowledge_base.service import document_service as document_service_module
+from aperag.domains.knowledge_base.service.document_service import DocumentService
+
+
+class _ScalarResult:
+    def __init__(self, value: str | None):
+        self._value = value
+
+    def first(self):
+        return self._value
+
+
+class _ExecuteResult:
+    def __init__(self, value: str | None):
+        self._value = value
+
+    def scalars(self):
+        return _ScalarResult(self._value)
+
+
+class _Session:
+    async def execute(self, stmt):
+        return _ExecuteResult("collections/col/documents/doc/derived/parse_v/chunks.jsonl")
+
+
+class _DbOps:
+    async def _execute_query(self, fn):
+        return await fn(_Session())
+
+
+class _Stream:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    async def __aiter__(self):
+        yield self._body
+
+
+class _ObjectStore:
+    async def get(self, path: str):
+        assert path == "collections/col/documents/doc/derived/parse_v/chunks.jsonl"
+        body = (
+            b'{"chunk_id":"c1","text":"first","section_path":"1","heading_anchor":"#first","page_idx":0}\n'
+            b'{"chunk_id":"c2","text":"second","metadata":{"source":"doc.pdf"}}\n'
+        )
+        return _Stream(body), {}
+
+
+@pytest.mark.asyncio
+async def test_get_document_chunks_reads_serving_chunks_jsonl(monkeypatch):
+    monkeypatch.setattr(document_service_module, "get_async_object_store", lambda: _ObjectStore())
+
+    service = DocumentService()
+    service.db_ops = _DbOps()
+
+    chunks = await service.get_document_chunks("user", "col", "doc")
+
+    assert [chunk.id for chunk in chunks] == ["c1", "c2"]
+    assert [chunk.text for chunk in chunks] == ["first", "second"]
+    assert chunks[0].metadata == {
+        "section_path": "1",
+        "heading_anchor": "#first",
+        "page_idx": 0,
+    }
+    assert chunks[1].metadata == {"source": "doc.pdf"}


### PR DESCRIPTION
## Summary\n- default optional search params before they reach vector/summary/vision ContextManager calls, fixing MCP vector_search calls that omit similarity_threshold\n- make fulltext auto-keyword search include the raw query fallback and use a permissive minimum_should_match for auto-extracted keywords\n- restore read_document_chunk by reading the serving vector row's chunks.jsonl from object storage, including chunk metadata handles\n\n## Tests\n- uv run --extra test python -m pytest tests/unit_test/retrieval/test_mcp_search_defaults.py tests/unit_test/service/test_document_service_chunks.py tests/integration/test_graph_evidence_refs_chain.py -q\n- uv run ruff check aperag/domains/retrieval/pipeline.py aperag/domains/knowledge_base/service/document_service.py tests/unit_test/retrieval/test_mcp_search_defaults.py tests/unit_test/service/test_document_service_chunks.py