### PR TITLE
fix(chart): derive ES_HOST from elasticsearch values

### DIFF
--- a/deploy/aperag/templates/aperag-secret.yaml
+++ b/deploy/aperag/templates/aperag-secret.yaml
@@ -60,7 +60,11 @@ stringData:
     PGVECTOR_HNSW_EF_SEARCH={{ .Values.api.env.PGVECTOR_HNSW_EF_SEARCH }}
 
     # Fulltext search
-    ES_HOST={{ .Values.api.env.ES_HOST }}
+    {{- $esHost := .Values.api.env.ES_HOST }}
+    {{- if and (not $esHost) .Values.elasticsearch.enabled }}
+    {{- $esHost = printf "%s://%s:%s" (.Values.elasticsearch.ES_PROTOCOL | default "http") .Values.elasticsearch.ES_HOST (.Values.elasticsearch.ES_PORT | default "9200") }}
+    {{- end }}
+    ES_HOST={{ $esHost }}
     ES_TIMEOUT={{ .Values.api.env.ES_TIMEOUT }}
     ES_MAX_RETRIES={{ .Values.api.env.ES_MAX_RETRIES }}
     ES_FULLTEXT_NUMBER_OF_SHARDS={{ .Values.api.env.ES_FULLTEXT_NUMBER_OF_SHARDS }}


### PR DESCRIPTION
## Summary
- make the generated `aperag-env` `.env` derive `ES_HOST` from top-level `elasticsearch.{ES_PROTOCOL,ES_HOST,ES_PORT}` when `api.env.ES_HOST` is empty
- keep explicit `api.env.ES_HOST` as the highest-priority override

## Why
During the Singapore upgrade, the container env had `ES_HOST_NAME`, but ApeRAG runtime reads `ES_HOST` from the mounted `.env`. With `api.env.ES_HOST` empty, fulltext fell back to the app default instead of the configured Elasticsearch service.

## Validation
- `helm template aperag deploy/aperag | sed -n '/name: aperag-env/,/---/p' | rg 'ES_HOST='` -> `ES_HOST=http://es-cluster-mdit-http:9200`
- `helm template aperag deploy/aperag --set api.env.ES_HOST=http://custom-es:9200 | sed -n '/name: aperag-env/,/---/p' | rg 'ES_HOST='` -> `ES_HOST=http://custom-es:9200`
- `git diff --check`
