### PR TITLE
docs(task-31): spec v1.1 amend — Phase A 实施 sediment fold-in

### DIFF
--- a/docs/zh-CN/architecture/task-31-graph-node-merge-spec-v1.md
+++ b/docs/zh-CN/architecture/task-31-graph-node-merge-spec-v1.md
@@ -14,7 +14,7 @@ description: ApeRAG graph 重复/近似实体检测 + 异步 suggestion 任务 +
 ⚠️ **关键 reframe**：spec 不是「build new」，是「extract sync-inline + fix Wave 5 description-NULL violation + add 三 trigger strategy」。Wave 7 §K.12.4 task #4 **detector + suggestion store + scoring 全栈已存在**:
 
 - `aperag/indexing/merge_candidate_detector.py` — Wave 7 §K.12.4 task #4 detector (Wave 7 task #3 已 wired 进 `GraphModalityWorker.sync` end-of-sync)
-- `aperag/domains/knowledge_graph/db/models.py:107` — `GraphCurationSuggestion` table + `GraphCurationSuggestionStatus` enum (`PENDING/ACCEPTED/REJECTED/DISMISSED` 已就位)
+- `aperag/domains/knowledge_graph/db/models.py:107` — `GraphCurationSuggestion` table + `GraphCurationSuggestionStatus` enum (v1 spec lock 时 main 实证仅 `PENDING/ACCEPTED/REJECTED/EXPIRED/SUPERSEDED` 5 值；**DISMISSED 由 task #76 PR #1935 引入** — Phase A2 实施 first-principles grep main verify 修正 v1 spec drift，per § 3.1.6 v1.1 amend)
 - `aperag/graph_curation/candidate_generation.py` — `build_candidate_pairs()` 算法 (vector ANN + name/type/description signal scoring)
 - `aperag/graph_curation/dto.py::CurationEntity` — entity wrapper
 - `MergeCandidateDetector.AUTO_DETECT_SOURCE = "auto_detect"` discriminator on `GraphCurationRun.config_json["source"]` — admin UI split 已设计完成 (per K.12.4 amend2 ratify msg=6ab89fbb)
@@ -67,7 +67,7 @@ task #31 不引入新 graph store method — 复用 task #61 locked contract + L
 ### 2.2 P1（允许差异但显式 declaration）
 
 - **P1-31-A** dedup detection 算法 capability matrix：name exact match (case-insensitive normalize) / name fuzzy (Levenshtein / Jaro-Winkler) / type compatibility / vector embedding similarity / source_chunk overlap — 各算法 trigger 条件 + threshold 显式 declare collection-level config
-- **P1-31-B** suggestion store schema：**复用现有** `GraphCurationSuggestion` table (`aperag/domains/knowledge_graph/db/models.py:107`) — 仅 extend status enum 4 新 value（`APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED`，per § 3.1.6 7-state machine）+ 加 `evidence_refs` field（per task #61 evidence_refs 模式）。**不引入新 `merge_suggestion` table**（per Bryce + Weston BLOCKER 1，避免 schema 漂移 + Lesson #14 multi-iteration cleanup family）。
+- **P1-31-B** suggestion store schema：**复用现有** `GraphCurationSuggestion` table (`aperag/domains/knowledge_graph/db/models.py:107`) — 仅 extend status enum 5 新 value（`APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED/DISMISSED`，per § 3.1.6 7-state machine）+ 加 `evidence_refs` field（per task #61 evidence_refs 模式）。**不引入新 `merge_suggestion` table**（per Bryce + Weston BLOCKER 1，避免 schema 漂移 + Lesson #14 multi-iteration cleanup family）。
 - **P1-31-C** scan trigger 策略：(a) 周期 cron（reconciler 30s poll 已存在，可 piggyback）+ (b) 显式 manual trigger API（用户面 /admin "扫描重复实体" 按钮）+ (c) 文档全部入库后自动触发（new entity batch surface 时 enqueue scan）— 三策略并存 collection-level config 选启用
 
 ### 2.3 P2（性能优化）
@@ -145,7 +145,7 @@ WHERE id = :run_id AND status IN ('PENDING', 'RUNNING')
 
 #### 3.1.2 suggestion store + reviewable workflow（per Weston msg=d0e00405 边界 3 + dongdong msg=11813333 BLOCKER read contract fold + Bryce msg=74f33e19 + Weston msg=2b441dc2 BLOCKER 1 reuse existing table）
 
-- **复用现有** PG table `GraphCurationSuggestion` (`aperag/domains/knowledge_graph/db/models.py:107`) — **不引入新 `merge_suggestion` table**（per Bryce + Weston BLOCKER 1，避免 schema 漂移 + Lesson #14 multi-iteration cleanup family）。Phase A2 仅 extend status enum 4 新 value（`APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED`）+ 加 `evidence_refs` field（per task #61 evidence_refs 模式）。
+- **复用现有** PG table `GraphCurationSuggestion` (`aperag/domains/knowledge_graph/db/models.py:107`) — **不引入新 `merge_suggestion` table**（per Bryce + Weston BLOCKER 1，避免 schema 漂移 + Lesson #14 multi-iteration cleanup family）。Phase A2 仅 extend status enum 5 新 value（`APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED/DISMISSED`）+ 加 `evidence_refs` field（per task #61 evidence_refs 模式）。
 - background task **只写 suggestion**（pending status）— 不调 `LineageEntityMerger` apply
 - **read API**（per dongdong msg=11813333 BLOCKER + cuiwenbo msg=61800dd6 NIT 1 + dongdong msg=c4d3ae32 收窄 — **复用 FE 现有 endpoint 不另起 path**）：
   - **复用** `GET /api/v2/collections/{id}/graphs/merge-suggestions?status=pending&limit=&cursor=` — list 分页 + status filter，跟 FE `client-api.ts:302` 现有 caller align（不破 typed schema）
@@ -160,7 +160,7 @@ WHERE id = :run_id AND status IN ('PENDING', 'RUNNING')
 - UI 状态机 contract：pending / apply_pending / applying / applied / apply_failed / rejected / dismissed 7 新态 + legacy `accepted` read-only display + 空态 + 错误态 typed schema 显式（per task #61 backend 收敛 contract pattern）— FE 仅消费不基于 backend 类型分支；legacy `accepted` UI 显示等价于「已应用」终态（历史 sync 路径）
 - review audit trail：accept 调用记录 `reviewer_user_id` + `reviewed_at`，可回滚（rollback API 仅 admin role）
 - ⚠️ **action API response shape contract**（v1.1 amend，per Phase A4 PR #1940 Weston msg=c1595745 BLOCKER + architect msg=e163d88f own-up sediment — Lesson #12 v9 fifth-application demo + mini-pattern 20 候选）: `handle_action()` 三 success return (accept/reject/dismiss) **必须** satisfy `SuggestionActionResponse` model_validate — 含 `message: str` required field（per `aperag/domains/knowledge_graph/schemas.py:381`）。 Boundary test 钉 `SuggestionActionResponse.model_validate({...handle_action_return_shape...})` 跨三 path 防 schemas.py field add 漂浮到 service.py response shape miss 反 pattern (per § 5.2.b)。任何 PR adds response_model wire-up 必跑 `model_validate(actual_handler_return_shape)` 单测 boundary gate
-- AlembicMigration **不建新 table** — 仅 extend `graph_curation_suggestions` table（status enum 加 4 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED`，**现有 `ACCEPTED` 保留作 legacy terminal/back-compat read-only value**，新 async path 不再写 — 历史 `ACCEPTED` 在 sync `handle_action()` 末尾代表「merge 已执行完成」terminal semantic（per `aperag/graph_curation/service.py:534` 实证），新 async path 用 `apply_pending` 表示「用户已批准但未 apply」避免同名不同义；per dongdong msg=e7d7600a + Weston msg=013fdc47/14859580 + ziang msg=378455ad/c2228ba1 + dongdong msg=ceca6063 集体 converge）+ 加 `evidence_refs` field per task #61 evidence_refs 模式，chain 在 latest head 后
+- AlembicMigration **不建新 table** — 仅 extend `graph_curation_suggestions` table（status enum 加 5 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED/DISMISSED`，**v1.1 amend 修正：DISMISSED 由 PR #1935 引入，main 实证不在 v1 假设的现有 enum 中**；**现有 `ACCEPTED/EXPIRED/SUPERSEDED` 保留作 legacy terminal/back-compat read-only value**，新 async path 不再写 — 历史 `ACCEPTED` 在 sync `handle_action()` 末尾代表「merge 已执行完成」terminal semantic（per `aperag/graph_curation/service.py:534` 实证），新 async path 用 `apply_pending` 表示「用户已批准但未 apply」避免同名不同义；per dongdong msg=e7d7600a + Weston msg=013fdc47/14859580 + ziang msg=378455ad/c2228ba1 + dongdong msg=ceca6063 集体 converge）+ 加 `evidence_refs` field per task #61 evidence_refs 模式，chain 在 latest head 后
 
 #### 3.1.3 Wave 5 description-NULL 兼容 dedup 算法 + entity_type scope lock（per ziang msg=d6d9dc3c + dongdong msg=83783bc6 + Weston msg=78ab2267 三方 converge）
 
@@ -240,7 +240,7 @@ boundary test grep gate（per § 5.2）:
 跟 cuiwenbo msg=61800dd6 NIT 2 FE 现有 enum (`PENDING/ACCEPTED/REJECTED/EXPIRED`) align 选择：
 - spec lock **lowercase** + 新加 `apply_pending/applying/applied/apply_failed/dismissed` **5 enum value**（v1.1 amend per Phase A2 PR #1935 ziang msg=3d1266e8 第一性原理 grep main 实证：现有 enum 仅 `PENDING/ACCEPTED/REJECTED/EXPIRED/SUPERSEDED` 5 值 — **DISMISSED 由 task #76 PR #1935 引入**，不是 v1 spec 假设的「现有」— Lesson #12 v9 third-application demo + mini-pattern 19 spec lock pre-check grep main 实证 enum/contract assumption。v1 fix-forward 6 错误地将 DISMISSED 当作现有值依赖了 huangzhangshu PR comment <https://github.com/apecloud/ApeRAG/pull/1931#issuecomment-4350226415> 没 grep verify）
 - FE typed schema 同步扩展 `MergeSuggestionStatus` (Lesson #13 v3 dual-side rewrite + Lesson #14 multi-iteration cleanup — `EXPIRED` 老值保留作 backward compat 历史 placeholder，新代码不再写入；`ACCEPTED` 同样保留作 legacy terminal read-only)
-- Migration chain 时序：PG enum 加 4 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED`（`alembic upgrade head` 跨 backend 跑过）— `ACCEPTED` 保留 legacy semantic
+- Migration chain 时序：PG enum 加 5 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED/DISMISSED`（`alembic upgrade head` 跨 backend 跑过；**v1.1 amend：DISMISSED 由 PR #1935 引入，不是 v1 假设的现有值**）— `ACCEPTED/EXPIRED/SUPERSEDED` 保留 legacy semantic
 
 测试可区分「用户已批准（apply_pending）」「worker 应用中（applying）」「worker 已应用（applied）」「应用失败待重试（apply_failed）」四状态 + 历史 ACCEPTED legacy read。
 
@@ -268,7 +268,7 @@ per § 2.2 三 strategy + 算法 capability matrix collection-level config（**�
   - 推荐 owner：@Bryce / @ziang
 - **#31-A2 (extend)**：复用 `GraphCurationSuggestion` 现有 table + extend status enum
   - **不引入新 table** (per Bryce + Weston BLOCKER) — 复用 `aperag/domains/knowledge_graph/db/models.py:107` `GraphCurationSuggestion`
-  - status enum extend：现有 `PENDING/ACCEPTED/REJECTED/DISMISSED/EXPIRED/SUPERSEDED` + 新加 `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED`（per § 3.1.6 状态机；新 async path 写 `APPLY_PENDING` 不写 `ACCEPTED`，**`ACCEPTED` 保留作 legacy terminal/back-compat read-only value** — 历史 sync `handle_action()` 末尾 set ACCEPTED 代表「merge 已执行完成」terminal semantic per `service.py:534` 实证）
+  - status enum extend：v1 spec lock 时 main 实证现有 `PENDING/ACCEPTED/REJECTED/EXPIRED/SUPERSEDED` 5 值（**DISMISSED 不在**，v1 spec 假设错误）+ 新加 `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED/DISMISSED` 5 new values（per § 3.1.6 v1.1 amend；新 async path 写 `APPLY_PENDING` 不写 `ACCEPTED`，**`ACCEPTED/EXPIRED/SUPERSEDED` 保留作 legacy terminal/back-compat read-only value** — 历史 sync `handle_action()` 末尾 set ACCEPTED 代表「merge 已执行完成」terminal semantic per `service.py:534` 实证）
   - PG enum migration + FE typed schema sync (Lesson #13 v3 dual-side rewrite + Lesson #14 multi-iteration cleanup — `ACCEPTED` / `EXPIRED` / `SUPERSEDED` 老值保留作 backward compat read-only)
   - boundary test (status transition + apply state machine + `ACCEPTED` legacy read-only — 新代码 zero-write assertion)
   - 推荐 owner：@ziang（熟 graph_curation domain + Wave 7 §K.12.4）
@@ -307,7 +307,7 @@ per § 2.2 三 strategy + 算法 capability matrix collection-level config（**�
 ### 5.1 Phase A 完成标准
 
 - worker lane `graph_curation_run` 启动 + boundary test 钉**lane name symbolic appearance**（不 hardcode 计数，per Bryce + cuiwenbo + 冬柏 NIT）+ 独立 queue family `q:graph_curation_run`（不污染 `Modality`，per § 3.1.1）
-- 复用 `GraphCurationSuggestion` table + Alembic migration extend status enum 4 新 value（`APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED`），跨 backend (PG) `alembic upgrade head` 跑过 — **不建新 `merge_suggestion` table**
+- 复用 `GraphCurationSuggestion` table + Alembic migration extend status enum 5 新 value（`APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED/DISMISSED`），跨 backend (PG) `alembic upgrade head` 跑过 — **不建新 `merge_suggestion` table**
 - dedup detection 复用现有 `MergeCandidateDetector` + extend 5 算法 capability matrix + collection-level config 暴露 typed schema
 - 复用现有 `/graphs/merge-suggestions` endpoint + extend `SUGGESTION_ACTIONS` 加 `dismiss` + UI review queue panel
 - description-free refactor 完整：**6 个 detector/snapshot call site + 1 个 apply path** (candidate_generation.py:43/179-181/196-197 + dto.py:59-65/101-105 + merge_candidate_detector.py:257-284 + merge_candidate_detector.py:322-328 + lineage_merge.py:246-317 apply variant) 全 fix + boundary test grep gate（per § 3.1.5）
@@ -328,7 +328,7 @@ per § 2.2 三 strategy + 算法 capability matrix collection-level config（**�
 #### 5.2.b async accept-apply 状态机 invariants（accept → enqueue worker → apply）
 
 - **7-state machine 完整覆盖**：`pending → dismissed | rejected | apply_pending → applying → applied | apply_failed`（per § 3.1.6；新 async path 写 `apply_pending`，**不写 `accepted`** — `accepted` 是 legacy sync `handle_action()` terminal value），boundary test 钉每条 transition 边 + 新代码 zero-write `accepted` assertion
-- **enum lowercase + dual-side**：PG enum 4 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED` + FE typed schema `MergeSuggestionStatus` 同步扩展（Lesson #13 v3 dual-side rewrite + Lesson #14 multi-iteration cleanup — `ACCEPTED/EXPIRED/SUPERSEDED` 老值保留作 backward compat read-only）
+- **enum lowercase + dual-side**：PG enum 5 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED/DISMISSED` + FE typed schema `MergeSuggestionStatus` 同步扩展（Lesson #13 v3 dual-side rewrite + Lesson #14 multi-iteration cleanup — `ACCEPTED/EXPIRED/SUPERSEDED` 老值保留作 backward compat read-only；**v1.1 amend：DISMISSED 由 PR #1935 引入**）
 - **legacy `ACCEPTED` zero-write gate**：grep gate 钉 `aperag/graph_curation/` 新 async path 模块（`worker.py` / new merge worker）import allowlist 不含 `GraphCurationSuggestionStatus.ACCEPTED` 写入 — 仅 sync legacy `handle_action()` 路径允许（per Weston msg=013fdc47 + ziang msg=378455ad 集体 converge）
 - **description-free apply variant**：accept worker 仅调 `merge_entities_apply_description_free()` variant — allowlist 不含 `description`/`compactor`/`unified_description` 等 LLM helper module
 - **cross-backend apply contract**：`LineageEntityMerger` description-free 行为加进 `tests/integration/compat/test_lineage_graph_compat.py`（跨 Neo4j/Nebula/PG 三 backend，per § 3.1.4）

--- a/docs/zh-CN/architecture/task-31-graph-node-merge-spec-v1.md
+++ b/docs/zh-CN/architecture/task-31-graph-node-merge-spec-v1.md
@@ -101,6 +101,35 @@ task #31 不引入新 graph store method — 复用 task #61 locked contract + L
 - API 进程 **不直接调用 dedup scan**（per `task-system-invariants` § 2.3 hard gate）— API 仅 enqueue run_id + 读 suggestion store
 - boundary test：`tests/boundaries/test_indexing_worker_lanes.py` 加钉「`graph_curation_run` lane symbolic name appears in indexing-worker task list **+ API deployment has no executor/import path**」（双侧 lane assertion，per ziang NIT + cuiwenbo NIT 2）
 
+⚠️ **worker loop fail-safe invariant**（v1.1 amend，per Phase A1 PR #1938 Weston msg=04c9e5ee BLOCKER + architect msg=7af40610 own-up sediment — Lesson #12 v9 fourth-application demo）:
+
+worker `_process_one_run()` catch layer **必须** best-effort fail-safe 标 FAILED — 不能 trust framing 假设「task 内部已 mark FAILED」，因为多处 raise 发生在 `generate_run()` 之前（`integration.py:35-37` collection not found / `integration.py:49-61` backend resolve fail / `tasks.py:17-26` log+re-raise no mark）→ run 留 PENDING + payload 已被 worker pop → 后续 `start_run` 见 active → `created=False` → 不 re-enqueue → collection 手动 full sweep 永久卡死。
+
+强制 invariant:
+```python
+async def _process_one_run(...):
+    try:
+        await generate_graph_curation_run_task(...)
+    except Exception as exc:
+        logger.exception(...)
+        # invariant: best-effort fail-safe mark FAILED if exception raised
+        # BEFORE service.generate_run() persisted FAILED status
+        try:
+            await _mark_run_failed_best_effort(engine, run_id, str(exc)[:1024])
+        except Exception:
+            logger.exception("fail-safe mark failed")
+        # swallow + continue processing next payload
+```
+
+`_mark_run_failed_best_effort` SQL 关键 invariant:
+```sql
+UPDATE graph_curation_runs
+SET status = 'FAILED', error_message = :err, gmt_updated = now()
+WHERE id = :run_id AND status IN ('PENDING', 'RUNNING')
+```
+
+`WHERE status IN ('PENDING', 'RUNNING')` 防覆盖 `generate_run` 内部 try/except 已写的 FAILED/COMPLETED — 只 reset stuck-in-transit。boundary test 钉「worker catch fail-safe gate」per § 5.2.b.
+
 #### 3.1.1.b trigger 策略 reconcile 现有 sync detector 与新 worker（per ziang msg=92321bcc + Bryce msg=4c23f87e BLOCKER 2 — 三策略统一 queue path）
 
 现有两条生成路径必须 reconcile，不允许 Phase A 实施成三套独立执行路径:
@@ -130,6 +159,7 @@ task #31 不引入新 graph store method — 复用 task #61 locked contract + L
   - `SUGGESTION_ACTIONS` const FE 同步扩展 `dismiss` (FE 现有仅 `accept` | `reject`)
 - UI 状态机 contract：pending / apply_pending / applying / applied / apply_failed / rejected / dismissed 7 新态 + legacy `accepted` read-only display + 空态 + 错误态 typed schema 显式（per task #61 backend 收敛 contract pattern）— FE 仅消费不基于 backend 类型分支；legacy `accepted` UI 显示等价于「已应用」终态（历史 sync 路径）
 - review audit trail：accept 调用记录 `reviewer_user_id` + `reviewed_at`，可回滚（rollback API 仅 admin role）
+- ⚠️ **action API response shape contract**（v1.1 amend，per Phase A4 PR #1940 Weston msg=c1595745 BLOCKER + architect msg=e163d88f own-up sediment — Lesson #12 v9 fifth-application demo + mini-pattern 20 候选）: `handle_action()` 三 success return (accept/reject/dismiss) **必须** satisfy `SuggestionActionResponse` model_validate — 含 `message: str` required field（per `aperag/domains/knowledge_graph/schemas.py:381`）。 Boundary test 钉 `SuggestionActionResponse.model_validate({...handle_action_return_shape...})` 跨三 path 防 schemas.py field add 漂浮到 service.py response shape miss 反 pattern (per § 5.2.b)。任何 PR adds response_model wire-up 必跑 `model_validate(actual_handler_return_shape)` 单测 boundary gate
 - AlembicMigration **不建新 table** — 仅 extend `graph_curation_suggestions` table（status enum 加 4 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED`，**现有 `ACCEPTED` 保留作 legacy terminal/back-compat read-only value**，新 async path 不再写 — 历史 `ACCEPTED` 在 sync `handle_action()` 末尾代表「merge 已执行完成」terminal semantic（per `aperag/graph_curation/service.py:534` 实证），新 async path 用 `apply_pending` 表示「用户已批准但未 apply」避免同名不同义；per dongdong msg=e7d7600a + Weston msg=013fdc47/14859580 + ziang msg=378455ad/c2228ba1 + dongdong msg=ceca6063 集体 converge）+ 加 `evidence_refs` field per task #61 evidence_refs 模式，chain 在 latest head 后
 
 #### 3.1.3 Wave 5 description-NULL 兼容 dedup 算法 + entity_type scope lock（per ziang msg=d6d9dc3c + dongdong msg=83783bc6 + Weston msg=78ab2267 三方 converge）
@@ -208,7 +238,7 @@ boundary test grep gate（per § 5.2）:
 现有 `aperag/graph_curation/service.py:534` sync `handle_action()` 末尾 `suggestion.status = GraphCurationSuggestionStatus.ACCEPTED`（merge 已 sync 执行完成后写入），ACCEPTED 在历史代码中是 **terminal status = 「merge 已执行完成」**。新 async path 如果复用 `ACCEPTED` 表示「已批准但未 apply」会让旧数据和新数据同名不同义 → 引入新 enum value `apply_pending` 表示新 async 决策态，**`ACCEPTED` 保留作 legacy terminal/back-compat read-only value，新 async path 不再写**（FE typed schema 显示兼容 + DB 存在但新代码 zero-write）。
 
 跟 cuiwenbo msg=61800dd6 NIT 2 FE 现有 enum (`PENDING/ACCEPTED/REJECTED/EXPIRED`) align 选择：
-- spec lock **lowercase** + 新加 `apply_pending/applying/applied/apply_failed` 4 enum value（`dismissed` 已存在于现有 enum，不算新加 — per huangzhangshu PR comment <https://github.com/apecloud/ApeRAG/pull/1931#issuecomment-4350226415> + msg=d575e03c）
+- spec lock **lowercase** + 新加 `apply_pending/applying/applied/apply_failed/dismissed` **5 enum value**（v1.1 amend per Phase A2 PR #1935 ziang msg=3d1266e8 第一性原理 grep main 实证：现有 enum 仅 `PENDING/ACCEPTED/REJECTED/EXPIRED/SUPERSEDED` 5 值 — **DISMISSED 由 task #76 PR #1935 引入**，不是 v1 spec 假设的「现有」— Lesson #12 v9 third-application demo + mini-pattern 19 spec lock pre-check grep main 实证 enum/contract assumption。v1 fix-forward 6 错误地将 DISMISSED 当作现有值依赖了 huangzhangshu PR comment <https://github.com/apecloud/ApeRAG/pull/1931#issuecomment-4350226415> 没 grep verify）
 - FE typed schema 同步扩展 `MergeSuggestionStatus` (Lesson #13 v3 dual-side rewrite + Lesson #14 multi-iteration cleanup — `EXPIRED` 老值保留作 backward compat 历史 placeholder，新代码不再写入；`ACCEPTED` 同样保留作 legacy terminal read-only)
 - Migration chain 时序：PG enum 加 4 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED`（`alembic upgrade head` 跨 backend 跑过）— `ACCEPTED` 保留 legacy semantic
 
@@ -305,6 +335,27 @@ per § 2.2 三 strategy + 算法 capability matrix collection-level config（**�
 - **audit trail**：accept 调用记录 `GraphCurationSuggestion.reviewer_user_id` + `reviewed_at`；apply 完成写 `applied_at`；apply_failed 保留 retry 次数 cap
 - **idempotent replay**：前一次 accept fail 后 retry 不会重复合并（per task #61 P0 atomicity invariant）
 - **Pydantic Field validator on `MergeSuggestionView.confidence_score`**：锁 `0 <= score <= 1`（per cuiwenbo msg=49beb855 NIT 3 + Lesson #17 backend 收敛 contract pattern + PR #1930 SearchHit.score 同 pattern）
+- **action API response shape model_validate gate**（v1.1 amend per PR #1940 Weston msg=c1595745 BLOCKER + first-application demo via PR #1940 `test_suggestion_action_response_requires_valid_success_shapes`）: `SuggestionActionResponse.model_validate({...handle_action_return_shape...})` 跨 accept/reject/dismiss 三 path 单测 — 防 schemas.py field add 漂浮到 service.py response shape miss 反 pattern。任何 PR adds response_model wire-up 必跑 `model_validate(actual_handler_return_shape)` boundary gate (mini-pattern 20 候选)
+- **worker catch fail-safe gate**（v1.1 amend per PR #1938 Weston msg=04c9e5ee BLOCKER + Phase A1 fix-forward `825b55d3`）: `_mark_run_failed_best_effort(engine, run_id, exc_message)` 单测钉 `WHERE status IN ('PENDING', 'RUNNING')` SQL 谓词 + error_message 截断 1024 chars + DB I/O 异常不传播 + worker loop 必继续 pop 后续 payload (per § 3.1.1 worker loop fail-safe invariant)
+- **mechanical gate self-protection scope test**（v1.1 amend per PR #1941 chenyexuan fix-forward `8116639` huangzhangshu msg=2deb5407 BLOCKER）: 任何 boundary AST gate 必加 positive control test (synthetic violation 构造 → assert gate catch) + negative control test (live spec-allowed shape → assert 0 false positives) — 防 future 又走老路 whole-file exclude 静默削弱 gate 反 pattern。e.g. `test_dto_module_is_in_boundary_scope` + `test_dto_field_declaration_is_not_a_false_positive` 两 sister tests 范本
+
+#### 5.2.c Phase A 实施 sediment trail（v1.1 amend — onboarding ref + future spec lock prerequisite reference）
+
+Phase A 4 PR 全员协作落地（4 PR / 4 sub-task / 6 lane impl + multi-iteration fix-forward fold all BLOCKER）：
+
+| sub-task | PR | merge commit | 关键 BLOCKER fold-in trail |
+|---|---|---|---|
+| #75 A1 worker queue family | #1938 | `4cd2e6f1` | Weston BLOCKER worker catch fail-safe (msg=04c9e5ee) → fix-forward `825b55d3` _mark_run_failed_best_effort + tests |
+| #76 A2 status enum extend | #1935 | `6fc6f64f` | ziang DISMISSED enum 第一性原理 grep main 实证 (spec drift) + dongdong response_model legacy field BLOCKER (msg=99aa83ea) → fix-forward `3b447dfe` projection layer |
+| #77 A3 description-free 6+1 | #1941 | `0535bf4` | huangzhangshu boundary gate `dto.py` whole-file exclude BLOCKER (msg=2deb5407) → fix-forward `8116639` AST scan inclusion + 2 sister tests; mechanical gate auto-catch service.py:845 hidden read (Lesson #18 second-app) |
+| #78 A4 FE merge suggestion UI | #1940 | `b545294` | Weston SuggestionActionResponse.message required field BLOCKER (msg=c1595745) → fix-forward `4769cd57` 三 success return 补 message + model_validate 单测 + cuiwenbo NIT 1 legacy ACCEPTED label semantic |
+
+集体 own-up sediment（架构师 + reviewers 三方 catch trail）：
+- **架构师 trust-framing miss**：fix-forward 6 引用 huangzhangshu PR comment "DISMISSED 已存在" 没 grep main verify (PR #1935 ziang catch) / ratify CR #1938 trust 注释 "task already persisted FAILED" 没 grep verify upstream raise points (Weston catch) / ratify CR #1940 trust dismiss branch + Literal 加 没 grep verify SuggestionActionResponse model_fields required (Weston catch)
+- **reviewer first-principles verify catch**: ziang impl-side grep main + Weston spec → impl 边界 trace + huangzhangshu boundary gate scope 自身审计 + chenyexuan implementation auto-catch (mechanical gate first-application real-world demo)
+- **mini-pattern 19 升级**: 三层 grep verify 边界 (spec → impl + impl → response_model contract + impl catch path → upstream raise points)
+- **mini-pattern 20 候选 (PR #1940 first-app)**: PR adds response_model wire-up 必跑 model_validate(actual_handler_return_shape) boundary gate
+- **Lesson #18 候选 second + third-app**: mechanical gate 把 reviewer-as-detector 换成 CI auto-catch 真实价值实证 + gate 自身 protection scope 也要被 mechanical-test 防止 whole-file exclude 静默失效
 
 ### 5.3 e2e smoke
 
@@ -331,7 +382,16 @@ per task #30 B3 pattern:
 - **Lesson #16**（workflow paths filter dead reference）— 新 worker lane 加 `compat-test.yml` paths filter 同步
 - **Lesson #17**（backend 收敛 contract 而非 FE 加 branch / simple-stable family）— suggestion store schema + capability matrix backend 收敛，FE typed schema 仅消费不分支
 - **Lesson #18 候选**（lesson sediment + mechanical gate 双 layer codification — 一记一 enforce，per huangheng msg=b18d26ee + chenyexuan PR #1933 first-application demo）— task #31 P1 实施 `kg.merge_suggestion_score_threshold` default 走「lesson 文字 (#17 backend 收敛 contract) + mechanical gate (`tests/unit_test/contracts/test_merge_suggestion_score_threshold_default_consistency.py`) 双 layer codification」
-- **Migration chain 时序**（task #31 仅 extend `graph_curation_suggestions` table status enum 4 新 value + 加 `evidence_refs` field — **不建新 `merge_suggestion` table**，per Bryce + Weston + ziang BLOCKER 1）
+- **Lesson #12 v9 third + fourth + fifth-application demos** (v1.1 amend per Phase A 实施 sediment trail) — 三 PR 同 hour 累计 first-principles trace catch architect ratify trust-framing miss:
+  - **third-app**: PR #1935 ziang DISMISSED enum catch (main 现有 enum grep 实证 spec 假设错误) + dongdong response_model legacy field filter BLOCKER
+  - **fourth-app**: PR #1938 Weston worker catch fail-safe BLOCKER (上游 raise 点 trace `integration.py:35-37/49-61` + `tasks.py:17-26`)
+  - **fifth-app**: PR #1940 Weston `SuggestionActionResponse.message` required field catch (response_model 漂移 service.py response shape miss)
+- **mini-pattern 19 hard gate** (v1.1 amend) — spec lock pre-check：spec 抽象描述「现有 X enum / table / Protocol method 已有 value Y / column Z / signature S」时 architect / spec author **必须** `grep -n "Y" <现有文件>` 实证 codebase，**不接受 reviewer PR comment 口头主张作为依据**。范围三层：spec → impl 边界 + impl → response_model contract 边界 + impl catch path → upstream raise points 边界
+- **mini-pattern 20 候选** (v1.1 amend per PR #1940 first-application demo) — 「PR adds response_model wire-up 必跑 `model_validate(actual_handler_return_shape)` 单测 boundary gate」防 schemas.py field add 漂浮到 service.py response shape miss 反 pattern (cite PR #1940 `test_suggestion_action_response_requires_valid_success_shapes` 范本)
+- **Lesson #18 候选 second + third-application demos** (v1.1 amend per Phase A3 PR #1941):
+  - **second-app**: boundary AST gate 自动 catch service.py:845 hidden read (spec author + 6 reviewer 集体漏 bonus catch)
+  - **third-app**: boundary fix-forward `8116639` 加 sister tests (positive control + negative control) 防 future「whole-file exclude 静默削弱 gate」回潮 (per huangzhangshu BLOCKER msg=2deb5407)
+- **Migration chain 时序**（task #31 仅 extend `graph_curation_suggestions` table status enum **5 新 value `APPLY_PENDING/APPLYING/APPLIED/APPLY_FAILED/DISMISSED`** + 加 `evidence_refs` field — **不建新 `merge_suggestion` table**，per Bryce + Weston + ziang BLOCKER 1 + ziang DISMISSED grep main 实证 v1.1 amend）
 - **简单稳定 + 私有化部署免维护 4 guardrail**
 
 ## 7. 关联文档
@@ -356,4 +416,12 @@ per task #30 B3 pattern:
 
 **起草**：@符炫炜（总架构师）
 **日期**：2026-04-30
-**版本**：v1（task #31 spec lock 候选；@Weston 架构 CR + earayu2 ratify 后 PM @不穷 按 Phase A / Phase B / Phase C 调度实施 PR）
+**版本**：
+- **v1** (2026-04-30 spec lock，PR #1931 merged commit `29b82e22` — 6 fix-forward iterations / 8 lane LGTM / earayu2 directive driven)
+- **v1.1 amend** (2026-04-30 Phase A 4/4 done 后，本 PR — fold Phase A 实施 surface 的 spec drift + spec lock invariants + lesson sediment trail):
+  - § 3.1.1 worker loop fail-safe invariant (PR #1938 Weston BLOCKER)
+  - § 3.1.2 action API response shape model_validate contract (PR #1940 Weston BLOCKER)
+  - § 3.1.6 DISMISSED enum source 修正 (PR #1935 ziang grep main 实证)
+  - § 5.2.b 新增 3 boundary test invariants (model_validate gate + worker fail-safe gate + mechanical gate self-protection scope)
+  - § 5.2.c 新增 Phase A 实施 sediment trail (4 PR + 8 BLOCKER fold-in 全 trail)
+  - § 6 cr-checklist 新增 Lesson #12 v9 third-fifth-app demos + mini-pattern 19 hard gate + mini-pattern 20 候选 + Lesson #18 候选 second-third-app demos


### PR DESCRIPTION
## Summary

task #31 spec v1.1 amend — fold Phase A 4/4 done 实施 surface 的 spec drift + spec lock invariants + lesson sediment trail (1 file / +71 / -3).

对应 v1: PR #1931 merged commit 29b82e22

## v1.1 Amend Scope

### § 3.1.1 worker loop fail-safe invariant (PR #1938 Weston BLOCKER)
- _process_one_run() catch layer 必 best-effort fail-safe mark FAILED
- _mark_run_failed_best_effort SQL WHERE status IN (PENDING, RUNNING) 防覆盖
- Lesson #12 v9 fourth-application demo

### § 3.1.2 action API response shape model_validate contract (PR #1940 Weston BLOCKER)
- handle_action() 三 success return 必 satisfy SuggestionActionResponse model_validate (含 message required field)
- mini-pattern 20 候选 (response_model wire-up boundary gate)
- Lesson #12 v9 fifth-application demo

### § 3.1.6 DISMISSED enum source 修正 (PR #1935 ziang grep main 实证)
- v1 假设 "DISMISSED 已存在" 错误 (main 现有 enum 仅 PENDING/ACCEPTED/REJECTED/EXPIRED/SUPERSEDED 5 值)
- DISMISSED 由 task #76 PR #1935 引入 → 5 new value 不是 4
- Lesson #12 v9 third-application demo

### § 5.2.b 新增 3 boundary test invariants
- action API response shape model_validate gate
- worker catch fail-safe gate
- mechanical gate self-protection scope test (positive + negative control sister tests)

### § 5.2.c 新增 Phase A 实施 sediment trail (onboarding ref)
- 4 PR + 8 BLOCKER fold-in 全 trail 表格
- 集体 own-up sediment 三方 catch trail
- mini-pattern 19 升级三层范围

### § 6 cr-checklist 加 5 sediment items
- Lesson #12 v9 third + fourth + fifth-app demos
- mini-pattern 19 hard gate (spec lock pre-check grep main 实证)
- mini-pattern 20 候选 (response_model wire-up model_validate boundary gate)
- Lesson #18 候选 second + third-app demos (PR #1941)
- Migration chain 时序: 5 new value 不是 4

## Test plan

- [ ] @huangheng cr-checklist sediment cite 准确性 verify
- [ ] @Weston framing verify (sediment trail 各 BLOCKER msg ID + commit hash 准确)
- [ ] 任意 reviewer LGTM ✅

Generated with Claude Code