### PR TITLE
test(task-61-p1-d1): complete e2e shape matrix

### DIFF
--- a/.github/workflows/e2e-http-pgvector-nebula.yml
+++ b/.github/workflows/e2e-http-pgvector-nebula.yml
@@ -1,0 +1,36 @@
+name: E2E HTTP pgvector + Nebula
+
+# Extended deployment shape: pgvector (vector) + Nebula (graph).
+# Runs on manual dispatch and on PRs that touch backend/shape surfaces.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/workflows/e2e-http-*.yml"
+      - "docker-compose.yml"
+      - "envs/**"
+      - "aperag/config.py"
+      - "tests/e2e_http/**"
+      - "aperag/indexing/**"
+      - "aperag/graph_curation/**"
+      - "aperag/vectorstore/**"
+      - "aperag/domains/retrieval/**"
+      - "aperag/domains/knowledge_graph/**"
+      - "deploy/aperag/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-http-compose:
+    if: ${{ !github.event.pull_request.draft }}
+    uses: ./.github/workflows/e2e-http-shape.yml
+    secrets: inherit
+    with:
+      shape: pgvector-nebula

--- a/.github/workflows/e2e-http-pgvector-neo4j.yml
+++ b/.github/workflows/e2e-http-pgvector-neo4j.yml
@@ -1,0 +1,36 @@
+name: E2E HTTP pgvector + Neo4j
+
+# Extended deployment shape: pgvector (vector) + Neo4j (graph).
+# Runs on manual dispatch and on PRs that touch backend/shape surfaces.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/workflows/e2e-http-*.yml"
+      - "docker-compose.yml"
+      - "envs/**"
+      - "aperag/config.py"
+      - "tests/e2e_http/**"
+      - "aperag/indexing/**"
+      - "aperag/graph_curation/**"
+      - "aperag/vectorstore/**"
+      - "aperag/domains/retrieval/**"
+      - "aperag/domains/knowledge_graph/**"
+      - "deploy/aperag/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-http-compose:
+    if: ${{ !github.event.pull_request.draft }}
+    uses: ./.github/workflows/e2e-http-shape.yml
+    secrets: inherit
+    with:
+      shape: pgvector-neo4j

--- a/.github/workflows/e2e-http-qdrant-postgres.yml
+++ b/.github/workflows/e2e-http-qdrant-postgres.yml
@@ -1,0 +1,36 @@
+name: E2E HTTP Qdrant + PostgreSQL
+
+# Extended deployment shape: Qdrant (vector) + PostgreSQL (graph).
+# Runs on manual dispatch and on PRs that touch backend/shape surfaces.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/workflows/e2e-http-*.yml"
+      - "docker-compose.yml"
+      - "envs/**"
+      - "aperag/config.py"
+      - "tests/e2e_http/**"
+      - "aperag/indexing/**"
+      - "aperag/graph_curation/**"
+      - "aperag/vectorstore/**"
+      - "aperag/domains/retrieval/**"
+      - "aperag/domains/knowledge_graph/**"
+      - "deploy/aperag/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-http-compose:
+    if: ${{ !github.event.pull_request.draft }}
+    uses: ./.github/workflows/e2e-http-shape.yml
+    secrets: inherit
+    with:
+      shape: qdrant-postgres

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ help:
 	@printf "  make test-http-full       Run full HTTP suite against an existing target\n"
 	@printf "  make test-http-up-compose / test-http-down-compose\n"
 	@printf "  make test-http-smoke-compose / test-http-full-compose\n"
-	@printf "  make test-http-smoke-compose-{lite,qdrant-neo4j,qdrant-nebula}   (per-shape shortcuts)\n"
-	@printf "  make test-http-full-compose-{lite,qdrant-neo4j,qdrant-nebula}    (provider-aware per-shape shortcuts)\n"
+	@printf "  make test-http-smoke-compose-{lite,qdrant-postgres,qdrant-neo4j,qdrant-nebula,pgvector-neo4j,pgvector-nebula}   (per-shape shortcuts)\n"
+	@printf "  make test-http-full-compose-{lite,qdrant-postgres,qdrant-neo4j,qdrant-nebula,pgvector-neo4j,pgvector-nebula}    (provider-aware per-shape shortcuts)\n"
 	@printf "  make test-http-up-k8s / test-http-down-k8s\n"
 	@printf "  make test-http-smoke-k8s / test-http-full-k8s\n"
 	@printf "  make benchmark-graph-extraction   Run manual OpenRouter KG extraction benchmark\n\n"
@@ -216,8 +216,12 @@ static-check:
 .PHONY: test-all test-unit test-integration test-e2e test-e2e-perf benchmark-graph-extraction \
 	test-http-bootstrap test-http-smoke test-http-full \
 	test-http-up-compose test-http-down-compose test-http-smoke-compose test-http-full-compose \
-	test-http-smoke-compose-lite test-http-smoke-compose-qdrant-neo4j test-http-smoke-compose-qdrant-nebula \
-	test-http-full-compose-lite test-http-full-compose-qdrant-neo4j test-http-full-compose-qdrant-nebula \
+	test-http-smoke-compose-lite test-http-smoke-compose-qdrant-postgres \
+	test-http-smoke-compose-qdrant-neo4j test-http-smoke-compose-qdrant-nebula \
+	test-http-smoke-compose-pgvector-neo4j test-http-smoke-compose-pgvector-nebula \
+	test-http-full-compose-lite test-http-full-compose-qdrant-postgres \
+	test-http-full-compose-qdrant-neo4j test-http-full-compose-qdrant-nebula \
+	test-http-full-compose-pgvector-neo4j test-http-full-compose-pgvector-nebula \
 	test-http-up-k8s test-http-down-k8s test-http-smoke-k8s test-http-full-k8s
 test-all: test-unit test-integration test-e2e
 
@@ -311,20 +315,38 @@ test-http-full-compose:
 test-http-smoke-compose-lite:
 	@SHAPE=lite ./tests/e2e_http/scripts/run_compose_smoke.sh
 
+test-http-smoke-compose-qdrant-postgres:
+	@SHAPE=qdrant-postgres ./tests/e2e_http/scripts/run_compose_smoke.sh
+
 test-http-smoke-compose-qdrant-neo4j:
 	@SHAPE=qdrant-neo4j ./tests/e2e_http/scripts/run_compose_smoke.sh
 
 test-http-smoke-compose-qdrant-nebula:
 	@SHAPE=qdrant-nebula ./tests/e2e_http/scripts/run_compose_smoke.sh
 
+test-http-smoke-compose-pgvector-neo4j:
+	@SHAPE=pgvector-neo4j ./tests/e2e_http/scripts/run_compose_smoke.sh
+
+test-http-smoke-compose-pgvector-nebula:
+	@SHAPE=pgvector-nebula ./tests/e2e_http/scripts/run_compose_smoke.sh
+
 test-http-full-compose-lite:
 	@SHAPE=lite ./tests/e2e_http/scripts/run_compose_full.sh
+
+test-http-full-compose-qdrant-postgres:
+	@SHAPE=qdrant-postgres ./tests/e2e_http/scripts/run_compose_full.sh
 
 test-http-full-compose-qdrant-neo4j:
 	@SHAPE=qdrant-neo4j ./tests/e2e_http/scripts/run_compose_full.sh
 
 test-http-full-compose-qdrant-nebula:
 	@SHAPE=qdrant-nebula ./tests/e2e_http/scripts/run_compose_full.sh
+
+test-http-full-compose-pgvector-neo4j:
+	@SHAPE=pgvector-neo4j ./tests/e2e_http/scripts/run_compose_full.sh
+
+test-http-full-compose-pgvector-nebula:
+	@SHAPE=pgvector-nebula ./tests/e2e_http/scripts/run_compose_full.sh
 
 test-http-up-k8s:
 	@./tests/e2e_http/runners/k8s/up.sh

--- a/docs/zh-CN/architecture/ci-flake-policy.md
+++ b/docs/zh-CN/architecture/ci-flake-policy.md
@@ -2,7 +2,11 @@
 
 **生效日期**：2026-04-30（task #33 Layer 2 P0 codify）
 
-**适用范围**：所有 PR 的 `.github/workflows/e2e-http-{lite,qdrant-nebula,qdrant-neo4j}.yml` 三 variant CI。
+**适用范围**：
+- baseline PR-trigger CI：`.github/workflows/e2e-http-{lite,qdrant-nebula,qdrant-neo4j}.yml` 三 variant。
+- extended targeted/manual CI（task #61 P1-D1）：`.github/workflows/e2e-http-{qdrant-postgres,pgvector-neo4j,pgvector-nebula}.yml` 三 variant。它们只在 workflow 手动触发或 backend/shape surface 相关 PR 触发。
+
+下文 §1 的 fail-rate 数据和 §2.2 人工放行白名单只覆盖已有历史样本的 baseline Nebula / Neo4j shape；新增 extended shapes 暂无历史白名单，失败时必须 rerun 或定位，不直接套用 §2.2。
 
 **编辑历史**：
 - 2026-04-30 chenyexuan 初版 — fold-in Planetegg msg=46a0c5de gate wording + huangheng / Weston / ziang 多 PR cross-check forensics 实证。

--- a/tests/e2e_http/README.md
+++ b/tests/e2e_http/README.md
@@ -82,8 +82,11 @@ Provider-aware local flow for a named deployment shape:
 export E2E_ALIBABACLOUD_API_KEY=...
 export E2E_OPENROUTER_API_KEY=...
 make test-http-full-compose-lite
+make test-http-full-compose-qdrant-postgres
 make test-http-full-compose-qdrant-nebula
 make test-http-full-compose-qdrant-neo4j
+make test-http-full-compose-pgvector-neo4j
+make test-http-full-compose-pgvector-nebula
 ```
 
 Typical local flow against a Kubernetes-backed environment:

--- a/tests/e2e_http/runners/compose/README.md
+++ b/tests/e2e_http/runners/compose/README.md
@@ -20,9 +20,12 @@ This runner is intentionally replaceable. The suite must remain runnable against
 ApeRAG supports several real production deployment forms — different choices of vector backend (Qdrant or pgvector) and graph backend (PostgreSQL, Neo4j, or Nebula). Each named combination is a *shape*.
 
 ```
-SHAPE=lite          ./tests/e2e_http/runners/compose/up.sh
-SHAPE=qdrant-neo4j  ./tests/e2e_http/runners/compose/up.sh
-SHAPE=qdrant-nebula ./tests/e2e_http/runners/compose/up.sh
+SHAPE=lite              ./tests/e2e_http/runners/compose/up.sh
+SHAPE=qdrant-postgres   ./tests/e2e_http/runners/compose/up.sh
+SHAPE=qdrant-neo4j      ./tests/e2e_http/runners/compose/up.sh
+SHAPE=qdrant-nebula     ./tests/e2e_http/runners/compose/up.sh
+SHAPE=pgvector-neo4j    ./tests/e2e_http/runners/compose/up.sh
+SHAPE=pgvector-nebula   ./tests/e2e_http/runners/compose/up.sh
 ```
 
 Each shape file under `tests/e2e_http/shapes/<shape>.env` declares:
@@ -41,8 +44,17 @@ Adding a new shape = adding one new file. The runner / Makefile / CI all referen
 Shapes are named `<vector>-<graph>`, with **lite** as the special name for the single-PG (pgvector + PG-graph) ApeRAG-Lite deployment:
 
 - **lite** — single-PG ApeRAG-Lite: pgvector + PG-graph, no qdrant/neo4j/nebula containers
+- **qdrant-postgres** — distributed vector, PG graph: Qdrant + PostgreSQL graph
 - **qdrant-neo4j** — distributed: Qdrant + Neo4j
 - **qdrant-nebula** — distributed: Qdrant + Nebula
+- **pgvector-neo4j** — mixed: pgvector + Neo4j
+- **pgvector-nebula** — mixed: pgvector + Nebula
+
+The six shapes cover the full 2 x 3 backend matrix: vector backend
+(`qdrant` / `pgvector`) crossed with graph backend (`postgresql` /
+`neo4j` / `nebula`). The extended mixed shapes run from manual or
+backend-surface-targeted CI workflows so everyday PRs keep the original
+lite + qdrant graph-backend signal cost.
 
 ### Backward compatibility
 

--- a/tests/e2e_http/shapes/pgvector-nebula.env
+++ b/tests/e2e_http/shapes/pgvector-nebula.env
@@ -1,0 +1,9 @@
+# SHAPE: pgvector-nebula — pgvector + Nebula.
+#
+# Postgres holds relational data and pgvector vector data. Graph data
+# lives in Nebula (activated via the "nebula" compose profile). This
+# validates that Nebula does not imply Qdrant.
+SHAPE_VECTOR_DB_TYPE=pgvector
+SHAPE_GRAPH_DB_TYPE=nebula
+SHAPE_COMPOSE_SERVICES="postgres redis es api indexing-worker"
+SHAPE_COMPOSE_PROFILES="--profile nebula"

--- a/tests/e2e_http/shapes/pgvector-neo4j.env
+++ b/tests/e2e_http/shapes/pgvector-neo4j.env
@@ -1,0 +1,9 @@
+# SHAPE: pgvector-neo4j — pgvector + Neo4j.
+#
+# Postgres holds relational data and pgvector vector data. Graph data
+# lives in Neo4j (activated via the "neo4j" compose profile). This
+# validates that Neo4j does not imply Qdrant.
+SHAPE_VECTOR_DB_TYPE=pgvector
+SHAPE_GRAPH_DB_TYPE=neo4j
+SHAPE_COMPOSE_SERVICES="postgres redis es api indexing-worker"
+SHAPE_COMPOSE_PROFILES="--profile neo4j"

--- a/tests/e2e_http/shapes/qdrant-postgres.env
+++ b/tests/e2e_http/shapes/qdrant-postgres.env
@@ -1,0 +1,9 @@
+# SHAPE: qdrant-postgres — distributed vector with PostgreSQL graph.
+#
+# Postgres holds relational data and graph lineage data. Vector data
+# lives in Qdrant. This validates the non-lite form where Qdrant is
+# selected while the graph backend remains PostgreSQL.
+SHAPE_VECTOR_DB_TYPE=qdrant
+SHAPE_GRAPH_DB_TYPE=postgresql
+SHAPE_COMPOSE_SERVICES="postgres redis es qdrant api indexing-worker"
+SHAPE_COMPOSE_PROFILES=""

--- a/tests/unit_test/test_e2e_http_workflow_contract.py
+++ b/tests/unit_test/test_e2e_http_workflow_contract.py
@@ -1,4 +1,5 @@
 import re
+import shlex
 from pathlib import Path
 
 # After PR splitting the suite by deployment shape, the per-shape logic
@@ -6,11 +7,17 @@ from pathlib import Path
 # `e2e-http-shape.yml` and per-shape callers (e2e-http-lite.yml etc.)
 # bind it via workflow_call.
 SHAPE_WORKFLOW_PATH = Path(".github/workflows/e2e-http-shape.yml")
-SHAPE_CALLER_PATHS = [
-    Path(".github/workflows/e2e-http-lite.yml"),
-    Path(".github/workflows/e2e-http-qdrant-neo4j.yml"),
-    Path(".github/workflows/e2e-http-qdrant-nebula.yml"),
-]
+SHAPES_DIR = Path("tests/e2e_http/shapes")
+EXPECTED_SHAPE_BACKENDS = {
+    "lite": ("pgvector", "postgresql"),
+    "qdrant-postgres": ("qdrant", "postgresql"),
+    "qdrant-neo4j": ("qdrant", "neo4j"),
+    "qdrant-nebula": ("qdrant", "nebula"),
+    "pgvector-neo4j": ("pgvector", "neo4j"),
+    "pgvector-nebula": ("pgvector", "nebula"),
+}
+SHAPE_CALLER_PATHS = [Path(f".github/workflows/e2e-http-{shape}.yml") for shape in EXPECTED_SHAPE_BACKENDS]
+EXTENDED_SHAPES = {"qdrant-postgres", "pgvector-neo4j", "pgvector-nebula"}
 
 
 def _job_section(workflow_text: str, job_name: str) -> str:
@@ -21,6 +28,17 @@ def _job_section(workflow_text: str, job_name: str) -> str:
     )
     assert match is not None, f"Missing workflow job: {job_name}"
     return match.group("body")
+
+
+def _shape_env(shape: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for line in (SHAPES_DIR / f"{shape}.env").read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, value = stripped.split("=", 1)
+        result[key] = shlex.split(value)[0]
+    return result
 
 
 def test_e2e_http_shape_workflow_splits_smoke_from_provider_suite():
@@ -42,3 +60,42 @@ def test_each_shape_caller_invokes_shape_workflow_with_a_shape_input():
         text = caller.read_text()
         assert "uses: ./.github/workflows/e2e-http-shape.yml" in text, f"{caller} must invoke the shared shape workflow"
         assert re.search(r"^\s+shape:\s+\S+", text, flags=re.MULTILINE), f"{caller} must pass a `shape` input"
+
+
+def test_e2e_http_shape_files_cover_full_vector_graph_matrix():
+    actual_shapes = {path.stem for path in SHAPES_DIR.glob("*.env")}
+    assert actual_shapes == set(EXPECTED_SHAPE_BACKENDS)
+
+    for shape, (vector_backend, graph_backend) in EXPECTED_SHAPE_BACKENDS.items():
+        env = _shape_env(shape)
+        assert env["SHAPE_VECTOR_DB_TYPE"] == vector_backend
+        assert env["SHAPE_GRAPH_DB_TYPE"] == graph_backend
+
+        services = env["SHAPE_COMPOSE_SERVICES"].split()
+        profiles = env["SHAPE_COMPOSE_PROFILES"].split()
+
+        if vector_backend == "qdrant":
+            assert "qdrant" in services, f"{shape} must start qdrant"
+        else:
+            assert "qdrant" not in services, f"{shape} must not start qdrant in pgvector mode"
+
+        if graph_backend == "neo4j":
+            assert profiles == ["--profile", "neo4j"]
+        elif graph_backend == "nebula":
+            assert profiles == ["--profile", "nebula"]
+        else:
+            assert profiles == []
+
+
+def test_extended_shape_callers_are_backend_surface_targeted():
+    for shape in EXTENDED_SHAPES:
+        text = Path(f".github/workflows/e2e-http-{shape}.yml").read_text()
+        assert "workflow_dispatch:" in text
+        assert "paths:" in text, f"{shape} must not run on every PR"
+        assert "tests/e2e_http/**" in text
+        assert "envs/**" in text
+        assert "aperag/config.py" in text
+        assert "aperag/vectorstore/**" in text
+        assert "aperag/indexing/**" in text
+        assert "aperag/graph_curation/**" in text
+        assert "aperag/domains/knowledge_graph/**" in text


### PR DESCRIPTION
## Summary

Implements task #61 P1-D1 by completing the HTTP E2E deployment-shape matrix.

Added the 3 missing vector/graph combinations:
- `qdrant-postgres` = Qdrant vector + PostgreSQL graph
- `pgvector-neo4j` = pgvector + Neo4j
- `pgvector-nebula` = pgvector + Nebula

## Scope

- Adds 3 `tests/e2e_http/shapes/*.env` files.
- Adds 3 targeted/manual workflow callers that reuse `.github/workflows/e2e-http-shape.yml`.
  - These run on `workflow_dispatch` and on PRs touching backend/shape surfaces, not every PR.
- Adds Makefile smoke/full shortcuts for the new shapes.
- Updates compose runner docs and HTTP E2E docs.
- Updates `ci-flake-policy.md` to distinguish baseline always-on shapes from new targeted/manual extended shapes. The existing flake waiver does not automatically apply to new shapes.
- Extends `tests/unit_test/test_e2e_http_workflow_contract.py` to pin the full 2 x 3 matrix and ensure extended workflow callers stay backend-surface-targeted.

## Validation

- `uv run --extra test pytest tests/unit_test/test_e2e_http_workflow_contract.py -q` -> 4 passed
- `make -n test-http-smoke-compose-qdrant-postgres test-http-smoke-compose-pgvector-neo4j test-http-smoke-compose-pgvector-nebula test-http-full-compose-qdrant-postgres test-http-full-compose-pgvector-neo4j test-http-full-compose-pgvector-nebula`
- `make lint`
- `git diff --check`

## Notes

This PR does not run the full Docker E2E locally. The new workflow callers are the executable CI/manual entry points for those shapes.
